### PR TITLE
feat(core): Atom-parity optimizations (runtime helpers, compact ae.layers, handshake guidance, rig controls)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# 更新日志 / What's New
+
+让 AI 操控 After Effects 更稳、更顺、更省心。每项改动都不影响你原来的使用习惯。
+Making AI-driven After Effects more reliable, smoother, and worry-free — without
+changing how you already work.
+
+---
+
+## 中文
+
+### 最新更新
+
+#### ✨ 新增与改进
+- **AI 操作更可靠**——给 AI 配了一套现成的「常用动作工具箱」，它自动生成的脚本更少出错，复杂操作也更容易一次做对。
+- **AI 上手更准**——AI 一连接就会拿到使用说明，从一开始就知道怎么正确用各项功能，少走弯路。
+- **查看图层更快更省**——列图层时支持分页、能直接看到每个图层的类型和父子关系；新的精简显示方式数据量只有原来的约三分之一，再复杂的工程也不拖慢。
+- **自动备份不再拖累你**——万一自动备份出了问题，你的操作照样完成，不会卡住，也不会丢失正在做的修改。
+
+#### 🐛 问题修复
+- 修复了**多步操作有时只做了第一步就停下**的问题——现在每一步都会完整执行。
+- 修复了**预览截图有时显示的不是当前画面**的问题——现在能正确显示。
+- 修复了某些情况下操作会**莫名失败、弹出看不懂的报错**的问题。
+
+---
+
+## English
+
+### Latest update
+
+#### ✨ New & improved
+- **More reliable AI actions** — the AI now has a ready-made toolkit of common
+  building blocks, so the scripts it generates fail less often and complex
+  operations are more likely to work the first time.
+- **The AI gets it right sooner** — it receives a usage guide the moment it
+  connects, so it knows how to use each feature correctly from the start.
+- **Faster, lighter layer listing** — layer lists now page through large comps
+  and show each layer's type and parent at a glance; a new compact view uses
+  about a third of the data, so even heavy projects stay snappy.
+- **Auto-backup no longer gets in your way** — if a background backup hits a
+  snag, your action still goes through. No freezing, no losing the edit you're
+  in the middle of.
+
+#### 🐛 Fixes
+- Fixed **multi-step actions sometimes stopping after only the first step** —
+  every step now runs to completion.
+- Fixed **preview snapshots sometimes showing the wrong frame** — they now show
+  the current frame correctly.
+- Fixed operations that could **fail unexpectedly with a confusing error** in
+  certain cases.

--- a/docs/ATOM_PARITY_ROADMAP.md
+++ b/docs/ATOM_PARITY_ROADMAP.md
@@ -1,0 +1,70 @@
+# AEMCP → Atom Parity: Optimization Roadmap
+
+Synthesized from five per-area audits, with load-bearing facts re-verified against the codebase (`runtime.jsx`, `server.py`, `handlers/core.py` `_run_exec`, `jsx_result.py`, `checkpoint_store.py`). The plan favors changes that ship safely **without a live AE** (pytest + JSX-render-string token assertions) and respects two project-specific hazards from memory: (a) `ae_exec` silently no-ops when `undo_group_name`/`checkpoint_label` are misused, and (b) a thrown script error mid checkpoint/revert can delete unrelated layers — so **JSX must never throw**.
+
+## Verified foundations (drive the ordering)
+- `plugin/jsx/runtime.jsx` is **JSON-polyfill-only** (33 lines, gated on `typeof JSON==='undefined'`). No Array/Object polyfills, no domain helpers. It loads once into the persistent ES3 engine — so anything added there is free for all `ae.exec`/`ae.readProps` user code. **This is why polyfills+helpers rank first.**
+- `server.py::_format_result` (L48-49) **passes a `str` return through verbatim**, so compact text needs **no wire-boundary change** — a pure standalone Python win.
+- `Server("ae")` is built with **no `instructions=` arg** (L62), though mcp 1.27.0 plumbs it to clients at handshake — the cheapest always-on guidance channel is empty.
+- `_run_exec` checkpoint **leak confirmed**: the `_resolve_project_path` probe (L172) and `dst.parent.mkdir` (L178) are **outside** the checkpoint `try/except` (begins L181) — a hung probe or unwritable store aborts the user's edit.
+- `CheckpointStore.__init__` does eager `root.mkdir` (L49); `list_checkpoints` uses unguarded `d.glob` / `d.exists()` (L132-135) — confirmed startup-crash + hang risk on a dead/locked store dir.
+
+## Per-area gaps (summary)
+
+**1. ExtendScript runtime + `ae.exec` envelope.** No ES3 Array/Object polyfills (agent-idiomatic JS throws); no shared path/matchName resolver (copy-pasted `split('/')` loops in `set_property.jsx`, `inspect_property_capabilities.jsx`); `ae.exec` returns only the bare last-expr value — no touched-paths, no failed-mutation attribution, no auto expression-error report; no matchName resolver despite scan/getProperties emitting matchPaths.
+
+**2. Read-verb output format.** Every read verb is forced to verbose JSON at the dispatch boundary; no `format`/`compact` flag anywhere; `ae.layers` has **zero pagination** and omits `type`/parent; `scanPropertyTree` repeats 7 keys per node; `getProperties` pages internally but still emits verbose objects.
+
+**3. Discovery verbs.** `scanPropertyTree` lacks path subtree-root, query filter, and paging (unbounded dump); `getKeyframes.path` is **required** (no scan mode) and single-layer; `getProperties` ranking is near-trivial; bare matchNames with no `#ordinal` so duplicate siblings aren't addressable.
+
+**4. previewFrame.** Screen-grab of the whole AE window, not a render: `scale` is a no-op; no auto-sample/range/count, no maxWidth downscale, no contact-sheet grid, no diff, no comp-space ROI (no comp→pixel map exists); frame `width/height` are window pixels.
+
+**5. createRig.** 4 fixed rig_types; `options:Dict[str,Any]` is opaque in `tools/list`; only slider/angle/checkbox/color; always spawns a new null; every control **must** be wired (4 transform paths only, unknown paths fail **silently**); no defaults/options metadata; no groups; N separate effects not one named pseudo-effect.
+
+**6. init/checkpoint.** `ae.init` returns no guidance and no active_comp_state (bare `activeItemId`); `refresh_only` is a dead param; MCP server instructions unused; checkpoint best-effort guarantee leaks; store construction + listing are fragile. (Genuine advantage: whole-project revert is structurally all-or-nothing — worth keeping + documenting.)
+
+## Ranked roadmap
+
+| # | Title | Area | Lev | Eff | Risk | Depends on |
+|---|-------|------|-----|-----|------|-----------|
+| 1 | ES3 polyfills + AEMCP helper namespace in `runtime.jsx` | runtime | H | S | L | — |
+| 2 | `render_text.py` module + `format:'json'\|'text'` flag | read-format | H | M | L | — |
+| 3 | Static guidance via `Server(instructions=...)` | init/guidance | H | S | L | 1 |
+| 4 | Non-blocking auto-checkpoint in `ae.exec` (wrap probe+mkdir) | checkpoint | H | S | L | — |
+| 5 | `ae.layers` pagination + type/parent | read-format | H | S | L | 2 |
+| 6 | Enrich `ae.init` with active_comp_state + `refresh_only` | init/guidance | H | M | L | 3 |
+| 7 | `maxWidth` downscale (make `scale` real) via Pillow | previewFrame | H | S | L | — |
+| 8 | Model createRig controls in pydantic (drop `Dict[str,Any]`) | createRig | H | S | L | — |
+| 9 | Harden `CheckpointStore` (lazy mkdir + guarded listing) | checkpoint | M | M | M | — |
+| 10 | `scanPropertyTree`: path root + query + paging | discovery | H | M | L | 1 |
+| 11 | SCAN mode for `getKeyframes` (path optional) | discovery | H | M | L | 1 |
+| 12 | Contact-sheet grid for >2 previewFrames | previewFrame | H | M | L | 7 |
+| 13 | Richer `ae.exec` envelope (opt-in touched/failed/expr-errors) | exec envelope | H | M | M | 1, 14 |
+| 14 | Self-attributing `AEMCP.set(...)` touched-path buffer | runtime | M | S | L | 1 |
+| 15 | createRig `control_panel` native builder (7 types + defaults) | createRig | H | M | M | 8 |
+| 16 | Auto-sample previewFrame by duration + range + count | previewFrame | H | M | L | 7, 12 |
+| 17 | Compact flatten renderers (scan/props/keyframes) | read-format | M | S | L | 2 |
+| 18 | Refactor template path-walk → `AEMCP.propByPath` | runtime | M | S | L | 1 |
+| 19 | Strengthen `getProperties` ranking | discovery | M | S | L | — |
+| 20 | createRig wiring map + surface unwired/failed paths | createRig | M | S | L | 15 |
+| 21 | Document/preserve whole-project revert as a guarantee | checkpoint | M | S | L | 3 |
+| 22 | previewFrame diff mode (Pillow `ImageChops`) | previewFrame | M | S | L | 7 |
+| 23 | Shared ES3 query/ordinal matchName resolver in `runtime.jsx` | runtime | M | M | M | 1, 10, 11 |
+| 24 | createRig one-level group nesting (ADBE Group) | createRig | M | M | H | 15 |
+| 25 | previewFrame ROI (window-pixel, NOT comp-space) | previewFrame | L | S | M | 7 |
+
+## Top quick wins
+1. **Item 1** — ES3 polyfills + `AEMCP` namespace: highest leverage, additive with `if(!x)` guards, free for all user JSX, token-asserted unit tests. The foundation.
+2. **Item 2** — Compact text renderer + `format` flag: `_format_result` already passes `str` through, so no boundary/JSX change; default `json` keeps tests green; ~2.9x savings on `ae.layers`.
+3. **Item 3** — `Server(instructions=...)`: one arg, already plumbed by the SDK; mirrors Atom's biggest differentiator at zero per-call cost.
+4. **Item 4** — Non-blocking checkpoint: surgical fix for a confirmed leak; monkeypatch-testable.
+5. **Item 5** — `ae.layers` paging + type/parent: small JSX slice + two fields; caps unbounded replies, feeds item 2's `Page:` line.
+6. **Item 8** — Type createRig controls: makes the verb self-describing in `tools/list` (Atom's core strength) with no JSX/AE change; de-risks item 15.
+
+## Cautions
+- **Build order is load-bearing.** `runtime.jsx` helpers (1) → `AEMCP.set` buffer (14) → richer exec envelope (13): the envelope's `touchedPaths` come from the buffer; build the envelope first and you ship an empty feature. `render_text.py` (2) before the flatten renderers (17). RigControl schema (8) before `control_panel` (15) before wiring (20) before group nesting (24).
+- **Two things are infeasible — scope honestly.** (a) A true before/after `.aep` diff for the exec envelope is expensive over the string bridge and unsafe given the broken checkpoint store — capture a cheap structured signal instead. (b) Comp-coordinate ROI: `capture(main_window=True)` grabs the whole window via `GetWindowRect` with no comp→screen pixel map, so item 25 can only crop the screenshot in window pixels — label it loudly; real comp ROI needs the viewer child HWND + zoom math (separate future work).
+- **`runtime.jsx` is the blast radius.** It loads once at startup, so a syntax error breaks every verb. Keep additions strictly ES3 (`var` only, no arrow/const/template-literals/Array methods), guard polyfills with `if(!x)`, guard the shared matcher (23) with per-template inline fallbacks for stale panels, and add a live smoke test. This is why item 23 is risk=medium despite being mostly cleanup.
+- **Never throw from JSX** (recorded hazard: a mid-checkpoint/revert throw can delete layers). All new fallible JSX — `setPropertyParameters` on pre-2019.1 AE, ADBE Group nesting, the generic wiring walker, control defaults — must `try/catch` and return `{ok,...,note}`, mirroring the existing `checkpointSkipped` pattern. Surface unwired/failed paths (item 20) instead of dropping them silently.
+- **Back-compat or you break the suite.** Every new field defaults to today's behavior (`format='json'`, `report=False`, `offset=0`, `path=None`, `max_width=None`). Existing pytest asserts on dicts and full JSON shapes (incl. keyframe easing tangents) — add keys, never remove.
+- **Live verification is read-only here** (down bridge + broken store). Treat JSX-mutation behavior as unverifiable on this machine: prefer faithful extractions over redesigns, preserve recognizable string tokens for render-token tests, and reserve `tests/live/` for the few items that truly need it (createRig control types).

--- a/packages/core/ae_mcp/handlers/core.py
+++ b/packages/core/ae_mcp/handlers/core.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from string import Template
 from typing import Any, Optional
 
-from ae_mcp import checkpoint_store, progress, schemas
+from ae_mcp import checkpoint_store, progress, render_text, schemas
 from ae_mcp.backends import discovery as _discovery
 from ae_mcp.handlers import register
 from ae_mcp.jsx_result import parse_jsx_result as _try_json
@@ -126,11 +126,16 @@ register("ae.overview", schemas.AeOverviewArgs, _run_overview)
 async def _run_layers(args: schemas.AeLayersArgs, ctx: Any) -> Any:
     from ae_mcp.handlers.typed import _comp_expr  # type: ignore
     tmpl = _load_jsx("get_layers.jsx")
-    jsx = tmpl.substitute(comp_expr=_comp_expr(args.comp_id))
+    jsx = tmpl.substitute(
+        comp_expr=_comp_expr(args.comp_id),
+        offset=int(args.offset),
+        limit=int(args.limit),
+    )
 
     async def _call() -> Any:
         out = await _backend().exec(jsx, timeout_sec=15.0)
-        return _try_json(out)
+        parsed = _try_json(out)
+        return render_text.maybe_render(parsed, args.format, render_text.render_layers)
 
     return await progress.run_with_timeout(
         ctx, _call(), timeout_sec=20.0, start_msg="ae.layers..."
@@ -169,16 +174,23 @@ async def _run_exec(args: schemas.AeExecArgs, ctx: Any) -> Any:
     async def _call() -> Any:
         checkpoint_skipped: Optional[str] = None
         if args.checkpoint_label and not backend.manages_checkpoints:
-            project_path = await _resolve_project_path(ctx)
-            if not project_path:
-                checkpoint_skipped = "untitled-project"
-            else:
-                cid = _store.make_id()
-                dst = _store.aep_path(project_path, cid)
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                tmpl = _load_jsx("checkpoint_create.jsx")
-                jsx_cp = tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
-                try:
+            # Auto-checkpoint is strictly best-effort: a hung path probe, an
+            # unwritable store dir, or a failed snapshot must NEVER abort the
+            # user's edit. The whole block is guarded so any failure degrades
+            # to a `checkpointSkipped` note while the edit still runs. The
+            # probe is time-bounded so a dead bridge can't stall indefinitely.
+            try:
+                project_path = await asyncio.wait_for(
+                    _resolve_project_path(ctx), timeout=15.0
+                )
+                if not project_path:
+                    checkpoint_skipped = "untitled-project"
+                else:
+                    cid = _store.make_id()
+                    dst = _store.aep_path(project_path, cid)
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    tmpl = _load_jsx("checkpoint_create.jsx")
+                    jsx_cp = tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
                     cp_out = await backend.exec(code=jsx_cp, timeout_sec=60.0)
                     cp_parsed = _try_json(cp_out)
                     if isinstance(cp_parsed, dict) and cp_parsed.get("ok"):
@@ -197,9 +209,14 @@ async def _run_exec(args: schemas.AeExecArgs, ctx: Any) -> Any:
                                     size_bytes=size_bytes,
                                 )
                                 _store.prune(project_path)
-                except Exception as e:  # noqa: BLE001
-                    log.warning("auto-checkpoint failed: %s", e)
-                    checkpoint_skipped = f"checkpoint-failed: {e}"
+                    else:
+                        checkpoint_skipped = "checkpoint-failed: bad-result"
+            except asyncio.TimeoutError:
+                log.warning("auto-checkpoint timed out")
+                checkpoint_skipped = "checkpoint-timeout"
+            except Exception as e:  # noqa: BLE001
+                log.warning("auto-checkpoint failed: %s", e)
+                checkpoint_skipped = f"checkpoint-failed: {e}"
         elif args.checkpoint_label and backend.manages_checkpoints:
             checkpoint_skipped = "delegated-to-backend"
 

--- a/packages/core/ae_mcp/handlers/rig.py
+++ b/packages/core/ae_mcp/handlers/rig.py
@@ -26,12 +26,18 @@ def _load_jsx(name: str) -> Template:
 async def _run_create_rig(args: schemas.AeCreateRigArgs, ctx: Any) -> Any:
     from ae_mcp.handlers.typed import _comp_expr  # type: ignore
 
+    # Typed `controls` (if given) flow into the existing options['controls']
+    # path the JSX already understands, taking precedence over a raw value.
+    options = dict(args.options)
+    if args.controls is not None:
+        options["controls"] = [c.model_dump() for c in args.controls]
+
     jsx = _load_jsx("create_rig.jsx").substitute(
         comp_expr=_comp_expr(args.comp_id),
         target_layer_id=json.dumps(args.target_layer_id),
         rig_type=json.dumps(args.rig_type),
         name=json.dumps(args.name, ensure_ascii=False),
-        options=json.dumps(args.options, ensure_ascii=False),
+        options=json.dumps(options, ensure_ascii=False),
     )
 
     async def _call() -> Any:

--- a/packages/core/ae_mcp/instructions.py
+++ b/packages/core/ae_mcp/instructions.py
@@ -1,0 +1,66 @@
+"""Static server-level guidance, surfaced to MCP clients at handshake.
+
+This is the cheapest channel to teach an agent how to drive ae-mcp well — the
+low-level `Server(instructions=...)` payload is delivered once at initialize,
+at zero per-call cost. It mirrors the single biggest differentiator of mature
+AE MCPs: front-loaded operating discipline (phased workflow, ExtendScript ES3
+rules, matchName-path discipline, verification, and safety).
+
+Dynamic, per-project state stays in `ae.init` / `ae.overview`; only durable
+operating rules live here.
+"""
+
+from __future__ import annotations
+
+SERVER_INSTRUCTIONS = """\
+You are driving Adobe After Effects through the ae-mcp tools. Think like a
+motion designer: explore the project, make a change, then prove it landed.
+
+WORKFLOW — every task follows this loop:
+  1. Explore  — ae.init (once per session), then ae.overview / ae.layers.
+                Discover properties with ae.scanPropertyTree (structure /
+                matchName paths) and ae.getProperties (values). Never guess
+                comp or layer ids — read them first.
+  2. Act      — Prefer the typed verbs (ae.createLayer, ae.setProperty,
+                ae.applyEffect, ae.moveLayer, ae.createRig). Drop to ae.exec
+                only for logic the typed verbs can't express.
+  3. Verify   — After writing expressions, run ae.validateExpressions BEFORE
+                visual review; it force-evaluates and reports errors. Then use
+                ae.previewFrame to confirm the change visually. Directional
+                changes (move/rotate/scale) need >=2 sampled times to prove
+                progression; static changes (color/opacity) need one.
+  4. Iterate  — If it's wrong, adjust and re-run. Keep going until it's right.
+
+WRITING ExtendScript (ae.exec / ae.readProps):
+  AE's classic engine is ECMAScript 3. Use `var`, the `function` keyword,
+  traditional for-loops, and string concatenation. Avoid let/const, arrow
+  functions, template literals, destructuring, and classes.
+  The runtime (loaded once at panel startup) provides:
+    - JSON, and ES3 polyfills: Array indexOf/forEach/map/filter/reduce/
+      some/every/includes, Array.isArray, Object.keys/values/entries.
+    - An AEMCP helper namespace you may call directly:
+        AEMCP.compById(id)            -> CompItem or null
+        AEMCP.activeComp()            -> CompItem or null
+        AEMCP.layerById(comp, idx)    -> layer or null
+        AEMCP.propByPath(layer, "Transform/Position")          -> Property
+        AEMCP.propByMatchPath(layer, "ADBE Transform Group#1/ADBE Position#1")
+  End read scripts with a `JSON.stringify(...)` expression so the result is
+  machine-parseable. A script that returns no value surfaces as an error.
+  NEVER let JSX throw: a thrown error mid-edit can corrupt undo/checkpoint
+  state. Guard fallible calls and return structured {ok:false, error:...}.
+
+PROPERTY PATHS:
+  ae.scanPropertyTree and ae.getProperties emit both display-name paths and
+  matchName paths (matchPath). matchName paths with #ordinals
+  ("ADBE Gaussian Blur 2#2") disambiguate duplicate-matchName siblings.
+
+LOCALIZATION:
+  On localized AE, name-based effect references can fail. Prefer index form,
+  e.g. effect("Value")(1) instead of effect("Value")("Slider").
+
+SAFETY & RECOVERY:
+  ae.checkpoint snapshots the whole .aep; ae.revert restores a whole-project
+  snapshot (a full file swap — it cannot partially delete layers). Auto-
+  checkpointing is best-effort: if it is skipped the response says so via
+  `checkpointSkipped`, and your edit still runs.
+"""

--- a/packages/core/ae_mcp/jsx_templates/get_layers.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_layers.jsx
@@ -21,7 +21,10 @@
     var limit = ${limit};
     var total = comp.numLayers;
     var start = offset + 1;                       // AE layers are 1-based
-    var end = Math.min(total, offset + limit);
+    // limit <= 0 means "all": preserves the historical full-enumeration
+    // default so an existing caller that omits limit never silently loses
+    // layers on comps with more than the page size.
+    var end = (limit > 0) ? Math.min(total, offset + limit) : total;
     var layers = [];
     for (var i = start; i <= end; i++) {
         var l = comp.layer(i);
@@ -33,6 +36,7 @@
             inPoint: l.inPoint,
             outPoint: l.outPoint,
             isThreeD: !!l.threeDLayer,
+            hasParent: !!l.parent,
             parent: l.parent ? l.parent.name : null
         });
     }

--- a/packages/core/ae_mcp/jsx_templates/get_layers.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_layers.jsx
@@ -1,20 +1,50 @@
-// ae.layers — list layers in a comp
-// Placeholders: comp_expr (resolves to CompItem or null)
+// ae.layers — list layers in a comp (paginated).
+// Placeholders: comp_expr (resolves to CompItem or null), offset, limit.
 (function() {
     var comp = ${comp_expr};
     if (!comp) return JSON.stringify({ok: false, error: "no comp"});
+
+    function layerType(l) {
+        if (l instanceof CameraLayer) return "camera";
+        if (l instanceof LightLayer) return "light";
+        if (l instanceof TextLayer) return "text";
+        if (l instanceof ShapeLayer) return "shape";
+        if (l.nullLayer) return "null";
+        if (l.adjustmentLayer) return "adjustment";
+        var src = l.source;
+        if (src && src.mainSource && (src.mainSource instanceof SolidSource)) return "solid";
+        if (src) return "footage";
+        return "av";
+    }
+
+    var offset = ${offset};
+    var limit = ${limit};
+    var total = comp.numLayers;
+    var start = offset + 1;                       // AE layers are 1-based
+    var end = Math.min(total, offset + limit);
     var layers = [];
-    for (var i = 1; i <= comp.numLayers; i++) {
+    for (var i = start; i <= end; i++) {
         var l = comp.layer(i);
         layers.push({
             id: i,
             name: l.name,
+            type: layerType(l),
             enabled: l.enabled,
             inPoint: l.inPoint,
             outPoint: l.outPoint,
             isThreeD: !!l.threeDLayer,
-            hasParent: !!l.parent
+            parent: l.parent ? l.parent.name : null
         });
     }
-    return JSON.stringify({ok: true, compId: String(comp.id), layers: layers});
+    return JSON.stringify({
+        ok: true,
+        compId: String(comp.id),
+        compName: comp.name,
+        total: total,
+        offset: offset,
+        limit: limit,
+        returned: layers.length,
+        hasMore: (offset + layers.length) < total,
+        layers: layers
+    });
 })()

--- a/packages/core/ae_mcp/render_text.py
+++ b/packages/core/ae_mcp/render_text.py
@@ -16,8 +16,10 @@ from typing import Any, Callable, Dict
 
 def _page_line(d: Dict[str, Any]) -> str:
     """Atom-style paging summary line for paginated verbs."""
+    limit = d.get("limit", 0)
+    limit_s = limit if limit else "all"
     return (
-        f"Page: offset={d.get('offset', 0)} limit={d.get('limit', 0)} "
+        f"Page: offset={d.get('offset', 0)} limit={limit_s} "
         f"returned={d.get('returned', 0)} total={d.get('total', 0)} "
         f"hasMore={'Y' if d.get('hasMore') else 'N'}"
     )

--- a/packages/core/ae_mcp/render_text.py
+++ b/packages/core/ae_mcp/render_text.py
@@ -1,0 +1,68 @@
+"""Compact human-readable renderers for high-volume read verbs.
+
+Token-efficient, terminal-friendly text (with a paging line) is much cheaper
+than the equivalent JSON for large reads. Handlers call these ONLY when the
+caller passes format='text'; the default stays 'json' so machine consumers and
+the existing dict-asserting test-suite are unaffected.
+
+Each renderer is a pure dict -> str over the JSON envelope a verb already
+returns, so they unit-test with no AE/backend. This module is the home for the
+remaining compact renderers (scan tree / properties / keyframes).
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+def _page_line(d: Dict[str, Any]) -> str:
+    """Atom-style paging summary line for paginated verbs."""
+    return (
+        f"Page: offset={d.get('offset', 0)} limit={d.get('limit', 0)} "
+        f"returned={d.get('returned', 0)} total={d.get('total', 0)} "
+        f"hasMore={'Y' if d.get('hasMore') else 'N'}"
+    )
+
+
+def render_layers(d: Dict[str, Any]) -> str:
+    """Render an ae.layers envelope as a compact table.
+
+    Expected keys: compName/compId, total, offset/limit/returned/hasMore,
+    layers[] of {id,name,type,enabled,isThreeD,parent}.
+    """
+    name = d.get("compName") or d.get("compId") or "?"
+    total = d.get("total", len(d.get("layers", [])))
+    lines = [f'Comp: "{name}" ({total} layers)']
+    if "offset" in d:
+        lines.append(_page_line(d))
+    lines.append("id | name | type | state | parent")
+    for layer in d.get("layers", []):
+        state = []
+        if not layer.get("enabled", True):
+            state.append("off")
+        if layer.get("isThreeD"):
+            state.append("3D")
+        state_s = ",".join(state) if state else "-"
+        lines.append(
+            f"{layer.get('id')} | {layer.get('name')} | "
+            f"{layer.get('type', '?')} | {state_s} | {layer.get('parent') or '-'}"
+        )
+    return "\n".join(lines)
+
+
+def maybe_render(
+    parsed: Any, fmt: str, renderer: Callable[[Dict[str, Any]], str]
+) -> Any:
+    """Return a compact string when fmt=='text' and the verb succeeded.
+
+    Errors and non-dict payloads pass through unchanged so failure shapes stay
+    structured. A renderer bug degrades to the original dict rather than
+    breaking the verb.
+    """
+    if fmt != "text":
+        return parsed
+    if not isinstance(parsed, dict) or not parsed.get("ok"):
+        return parsed
+    try:
+        return renderer(parsed)
+    except Exception:  # noqa: BLE001 — never let presentation break a read
+        return parsed

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -53,7 +53,8 @@ class AeLayersArgs(_StrictModel):
     )
     offset: int = Field(0, ge=0, description="Pagination offset (0-based).")
     limit: int = Field(
-        100, ge=1, le=500, description="Max layers returned (default 100)."
+        0, ge=0, le=10000,
+        description="Max layers to return; 0 (default) returns all (back-compat).",
     )
     format: OutputFormat = Field(
         "json",

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -18,6 +18,7 @@ LayerType = Literal[
 ]
 
 SnapshotMethod = Literal["DesktopCopy", "PrintWindow"]
+OutputFormat = Literal["json", "text"]
 NonNegativeFloat = Annotated[float, Field(ge=0)]
 
 
@@ -45,10 +46,18 @@ class AeOverviewArgs(_StrictModel):
 
 
 class AeLayersArgs(_StrictModel):
-    """ae.layers — list layers in a comp."""
+    """ae.layers — list layers in a comp (paginated)."""
     comp_id: Optional[str] = Field(
         None,
         description="AE comp id. Omit for the active comp.",
+    )
+    offset: int = Field(0, ge=0, description="Pagination offset (0-based).")
+    limit: int = Field(
+        100, ge=1, le=500, description="Max layers returned (default 100)."
+    )
+    format: OutputFormat = Field(
+        "json",
+        description="'json' (default, structured) or 'text' (compact paginated table).",
     )
 
 
@@ -288,6 +297,28 @@ SearchScope = Literal["layers", "expressions", "effects", "comps", "items"]
 SkillTemplateType = Literal["jsx", "prompt"]
 SkillName = constr(pattern=r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 RigType = Literal["transform_controller", "effect_controls", "puppet_pin_nulls", "apply_preset"]
+RigControlType = Literal["slider", "angle", "checkbox", "color"]
+
+
+class RigControl(_StrictModel):
+    """A single expression control for createRig's effect_controls rig.
+
+    Each control becomes a native AE expression-control effect on the
+    controller (Slider/Angle/Checkbox/Color) wired to drive `property`.
+    """
+    name: str = Field(
+        ..., min_length=1, description="Control display name (also the effect name)."
+    )
+    type: RigControlType = Field(
+        "slider", description="Control kind -> native AE expression control."
+    )
+    property: str = Field(
+        "Transform/Opacity",
+        description=(
+            "Target property to drive. Currently wired for the transform paths "
+            "Transform/Position|Scale|Rotation|Opacity."
+        ),
+    )
 
 
 class AeSearchProjectArgs(_StrictModel):
@@ -346,6 +377,14 @@ class AeCreateRigArgs(_StrictModel):
     target_layer_id: int = Field(1, ge=1, description="1-based target layer index.")
     rig_type: RigType = Field("transform_controller", description="Rig workflow to create.")
     name: str = Field("Controller", min_length=1, description="Controller layer/effect name.")
+    controls: Optional[List[RigControl]] = Field(
+        None,
+        description=(
+            "For rig_type='effect_controls': typed list of expression controls to "
+            "build. Merged into options['controls'] (takes precedence over a raw "
+            "options['controls'])."
+        ),
+    )
     options: Dict[str, Any] = Field(default_factory=dict, description="Rig-type-specific options.")
 
 

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -20,6 +20,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.instructions import SERVER_INSTRUCTIONS
 
 log = logging.getLogger("ae_mcp.server")
 
@@ -59,7 +60,7 @@ def build_server() -> Server:
     """Construct the low-level MCP Server with all 15 verbs registered."""
     load_all()
 
-    server: Server = Server("ae")
+    server: Server = Server("ae", instructions=SERVER_INSTRUCTIONS)
 
     @server.list_tools()
     async def _list_tools() -> List[Tool]:

--- a/packages/core/tests/live/test_runtime_helpers.py
+++ b/packages/core/tests/live/test_runtime_helpers.py
@@ -1,0 +1,74 @@
+"""Live tests for the AEMCP runtime helper namespace (plugin/jsx/runtime.jsx).
+
+These verify the helpers are actually loaded into the panel's persistent
+ExtendScript engine and behave per the never-throw invariant. Regression
+guard: compById once threw "{Item Not Found}" on an unknown id because AE
+26.2's itemByID throws instead of returning null.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+
+pytestmark = pytest.mark.live
+
+
+HELPERS_PROBE = r"""
+(function(){
+  var R = {};
+  R.loaded = (typeof AEMCP !== 'undefined');
+  if (!R.loaded) return JSON.stringify(R);
+  var comp = app.project.items.addComp("HelperProbe", 320, 240, 1, 2.0, 24);
+  try {
+    var solid = comp.layers.addSolid([1,0,0], "Box", 100, 100, 1, 2.0);
+    R.version              = AEMCP.version;
+    R.compById_ok          = (AEMCP.compById(comp.id) === comp);
+    R.compById_bad_null    = (AEMCP.compById(987654) === null);   // must NOT throw
+    comp.openInViewer();   // make it the foreground item so activeItem is set
+    R.activeComp_isComp    = (AEMCP.activeComp() === comp);
+    R.layerById_ok         = (AEMCP.layerById(comp, 1) === solid);
+    R.layerById_bad_null   = (AEMCP.layerById(comp, 99) === null);
+    var pPath  = AEMCP.propByPath(solid, "Transform/Position");
+    var pMatch = AEMCP.propByMatchPath(solid, "ADBE Transform Group#1/ADBE Position#1");
+    R.propByPath_ok        = (pPath !== null && typeof pPath.value !== 'undefined');
+    R.propByMatchPath_mn   = pMatch ? pMatch.matchName : null;
+    // prove both refs target the same property via write-through-one/read-other
+    pPath.setValue([123, 45]);
+    R.same_target          = (pMatch.value[0] === 123 && pMatch.value[1] === 45);
+    R.propByPath_bad_null  = (AEMCP.propByPath(solid, "Nope/Nope") === null);
+    R.propByMatch_bad_null = (AEMCP.propByMatchPath(solid, "ADBE No#1/ADBE Nope#1") === null);
+    R.ordinal_overflow     = (AEMCP.propByMatchPath(solid, "ADBE Transform Group#9") === null);
+  } catch (e) { R.ERROR = String(e); }
+  try { comp.remove(); } catch (e) {}
+  return JSON.stringify(R);
+})()
+"""
+
+
+@pytest.fixture
+def helpers(clean_project):
+    out = asyncio.run(clean_project.exec(code=HELPERS_PROBE, timeout_sec=20.0))
+    return json.loads(out)
+
+
+def test_aemcp_namespace_loaded(helpers):
+    assert helpers.get("loaded") is True, "AEMCP namespace not in the engine — is runtime.jsx current?"
+    assert helpers.get("version")
+
+
+def test_aemcp_helpers_resolve_and_never_throw(helpers):
+    assert "ERROR" not in helpers, f"helper threw: {helpers.get('ERROR')}"
+    assert helpers["compById_ok"] is True
+    assert helpers["compById_bad_null"] is True       # regression: itemByID throws on unknown id
+    assert helpers["activeComp_isComp"] is True
+    assert helpers["layerById_ok"] is True
+    assert helpers["layerById_bad_null"] is True
+    assert helpers["propByPath_ok"] is True
+    assert helpers["propByMatchPath_mn"] == "ADBE Position"
+    assert helpers["same_target"] is True
+    assert helpers["propByPath_bad_null"] is True
+    assert helpers["propByMatch_bad_null"] is True
+    assert helpers["ordinal_overflow"] is True

--- a/packages/core/tests/test_handlers_core.py
+++ b/packages/core/tests/test_handlers_core.py
@@ -48,6 +48,32 @@ async def test_layers_passes_comp_id(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_layers_paging_substituted_and_json_default(mock_backend):
+    mock_backend.set_response('{"ok":true,"compId":"42","layers":[]}')
+    _, run_fn = HANDLERS["ae.layers"]
+    result = await run_fn(S.AeLayersArgs(comp_id="42", offset=5, limit=10), None)
+    assert isinstance(result, dict)  # default format is json
+    jsx = mock_backend.calls[-1]["code"]
+    assert "var offset = 5;" in jsx
+    assert "var limit = 10;" in jsx
+
+
+@pytest.mark.asyncio
+async def test_layers_text_format_renders_table(mock_backend):
+    mock_backend.set_response(json.dumps({
+        "ok": True, "compId": "42", "compName": "Hero",
+        "total": 1, "offset": 0, "limit": 100, "returned": 1, "hasMore": False,
+        "layers": [{"id": 1, "name": "BG", "type": "solid",
+                    "enabled": True, "isThreeD": False, "parent": None}],
+    }))
+    _, run_fn = HANDLERS["ae.layers"]
+    result = await run_fn(S.AeLayersArgs(comp_id="42", format="text"), None)
+    assert isinstance(result, str)
+    assert 'Comp: "Hero"' in result
+    assert "1 | BG | solid" in result
+
+
+@pytest.mark.asyncio
 async def test_exec_forwards_all_args(mock_backend):
     # With checkpoint_label set, _run_exec first calls backend.exec for the
     # path probe (returns untitled project), then calls backend.exec for
@@ -330,6 +356,33 @@ async def test_create_rig_builds_transform_controller_jsx(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_create_rig_typed_controls_flow_into_jsx(mock_backend):
+    mock_backend.set_response(json.dumps({
+        "ok": True, "rigType": "effect_controls",
+        "controllerLayerId": 2, "targetLayerId": 1,
+        "createdLayers": [2], "wiredProperties": ["Transform/Opacity"],
+    }))
+    from ae_mcp.handlers.rig import _run_create_rig
+
+    args = S.AeCreateRigArgs(
+        rig_type="effect_controls",
+        target_layer_id=1,
+        name="CTRL",
+        controls=[
+            S.RigControl(name="Amount", type="slider", property="Transform/Opacity"),
+            S.RigControl(name="Spin", type="angle", property="Transform/Rotation"),
+        ],
+    )
+    result = await _run_create_rig(args, None)
+    assert result["ok"] is True
+    jsx = mock_backend.calls[-1]["code"]
+    # Typed controls serialized into options['controls'] for the JSX builder.
+    assert "Amount" in jsx
+    assert "Spin" in jsx
+    assert '"property": "Transform/Rotation"' in jsx
+
+
+@pytest.mark.asyncio
 async def test_create_rig_missing_preset_path_returns_backend_error(mock_backend):
     mock_backend.set_response(json.dumps({
         "ok": False,
@@ -510,6 +563,28 @@ async def test_exec_with_label_creates_checkpoint(mock_backend, tmp_path, monkey
     assert result["ok"] is True
     # Meta sidecar should have been written
     assert (d / "exec_id.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_exec_checkpoint_probe_failure_does_not_abort_edit(mock_backend, monkeypatch):
+    # If the project-path probe blows up (hung/broken bridge or unwritable
+    # store), the user's edit must STILL run; the failure degrades to a
+    # checkpointSkipped note. This is the non-blocking auto-checkpoint
+    # invariant (a thrown error mid-checkpoint can corrupt unrelated state).
+    async def _boom(ctx):
+        raise RuntimeError("bridge exploded")
+
+    monkeypatch.setattr("ae_mcp.handlers.core._resolve_project_path", _boom)
+    mock_backend.set_response(json.dumps({"ok": True, "result": 7}))
+
+    from ae_mcp.handlers.core import _run_exec
+    args = S.AeExecArgs(code="7", checkpoint_label="risky")
+    result = await _run_exec(args, ctx=None)
+
+    assert result["ok"] is True
+    assert "checkpoint-failed" in result["checkpointSkipped"]
+    # The user code actually reached the backend despite the checkpoint failure.
+    assert any(c["code"] == "7" for c in mock_backend.calls)
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_handlers_core.py
+++ b/packages/core/tests/test_handlers_core.py
@@ -59,6 +59,21 @@ async def test_layers_paging_substituted_and_json_default(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_layers_default_limit_is_all_no_truncation(mock_backend):
+    # Regression: ae.layers must NOT silently cap the default path. With no
+    # limit arg, the JSX receives limit=0 and the (limit > 0) guard returns
+    # every layer — preserving the historical full-enumeration contract. The
+    # JSX also keeps the additive hasParent field alongside the new parent.
+    mock_backend.set_response('{"ok":true,"compId":"42","layers":[]}')
+    _, run_fn = HANDLERS["ae.layers"]
+    await run_fn(S.AeLayersArgs(comp_id="42"), None)
+    jsx = mock_backend.calls[-1]["code"]
+    assert "var limit = 0;" in jsx
+    assert "(limit > 0)" in jsx
+    assert "hasParent" in jsx and "parent:" in jsx
+
+
+@pytest.mark.asyncio
 async def test_layers_text_format_renders_table(mock_backend):
     mock_backend.set_response(json.dumps({
         "ok": True, "compId": "42", "compName": "Hero",
@@ -383,6 +398,32 @@ async def test_create_rig_typed_controls_flow_into_jsx(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_create_rig_typed_controls_override_raw_options(mock_backend):
+    # Documented precedence: a typed `controls=` replaces any raw
+    # options['controls'] so the two can't silently conflict.
+    mock_backend.set_response(json.dumps({
+        "ok": True, "rigType": "effect_controls",
+        "controllerLayerId": 2, "targetLayerId": 1,
+        "createdLayers": [2], "wiredProperties": [],
+    }))
+    from ae_mcp.handlers.rig import _run_create_rig
+
+    args = S.AeCreateRigArgs(
+        rig_type="effect_controls",
+        target_layer_id=1,
+        name="CTRL",
+        options={"controls": [
+            {"name": "RAW", "type": "slider", "property": "Transform/Opacity"},
+        ]},
+        controls=[S.RigControl(name="TYPED", type="slider", property="Transform/Opacity")],
+    )
+    await _run_create_rig(args, None)
+    jsx = mock_backend.calls[-1]["code"]
+    assert "TYPED" in jsx
+    assert "RAW" not in jsx
+
+
+@pytest.mark.asyncio
 async def test_create_rig_missing_preset_path_returns_backend_error(mock_backend):
     mock_backend.set_response(json.dumps({
         "ok": False,
@@ -585,6 +626,54 @@ async def test_exec_checkpoint_probe_failure_does_not_abort_edit(mock_backend, m
     assert "checkpoint-failed" in result["checkpointSkipped"]
     # The user code actually reached the backend despite the checkpoint failure.
     assert any(c["code"] == "7" for c in mock_backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_exec_checkpoint_timeout_degrades(mock_backend, monkeypatch):
+    # A hung project-path probe must time out and degrade to a
+    # checkpoint-timeout note rather than stalling or aborting the edit.
+    import asyncio
+
+    async def _hang(ctx):
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr("ae_mcp.handlers.core._resolve_project_path", _hang)
+    mock_backend.set_response(json.dumps({"ok": True, "result": 7}))
+
+    from ae_mcp.handlers.core import _run_exec
+    args = S.AeExecArgs(code="7", checkpoint_label="risky")
+    result = await _run_exec(args, ctx=None)
+
+    assert result["ok"] is True
+    assert result["checkpointSkipped"] == "checkpoint-timeout"
+    assert any(c["code"] == "7" for c in mock_backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_exec_checkpoint_bad_result_degrades(mock_backend, tmp_path, monkeypatch):
+    # The snapshot JSX returning a non-ok result must degrade to
+    # 'checkpoint-failed: bad-result' while the user code still runs.
+    from ae_mcp import checkpoint_store
+    store = checkpoint_store.CheckpointStore(root=tmp_path)
+    monkeypatch.setattr("ae_mcp.handlers.core._store", store)
+    monkeypatch.setattr(store, "make_id", lambda: "bad_id")
+
+    def _resp(code="", **kw):
+        if "app.project.file" in code and "path:" in code:
+            return json.dumps({"ok": True, "path": "C:/Foo.aep"})
+        if "checkpoint_create" in code or "File.copy" in code:
+            return json.dumps({"ok": False, "error": "copy failed"})
+        return json.dumps({"ok": True, "result": 9})
+
+    mock_backend.set_response(_resp)
+
+    from ae_mcp.handlers.core import _run_exec
+    args = S.AeExecArgs(code="9", checkpoint_label="risky")
+    result = await _run_exec(args, ctx=None)
+
+    assert result["ok"] is True
+    assert result["checkpointSkipped"] == "checkpoint-failed: bad-result"
+    assert any(c["code"] == "9" for c in mock_backend.calls)
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_render_text.py
+++ b/packages/core/tests/test_render_text.py
@@ -65,3 +65,33 @@ def test_maybe_render_renderer_failure_falls_back_to_dict():
 
     d = {"ok": True}
     assert render_text.maybe_render(d, "text", boom) is d
+
+
+def test_render_layers_limit_all_and_hasmore_yes():
+    # limit=0 (the back-compat "return all" default) renders as limit=all,
+    # and hasMore=True renders as Y.
+    d = {
+        "ok": True, "compName": "Big", "compId": "1",
+        "total": 250, "offset": 0, "limit": 0, "returned": 250, "hasMore": True,
+        "layers": [],
+    }
+    out = render_text.render_layers(d)
+    assert "limit=all" in out
+    assert "hasMore=Y" in out
+
+
+def test_render_layers_name_fallback_when_unnamed():
+    d = {"ok": True, "total": 0, "offset": 0, "limit": 0,
+         "returned": 0, "hasMore": False, "layers": []}
+    out = render_text.render_layers(d)
+    assert 'Comp: "?"' in out
+
+
+def test_render_layers_omits_page_line_when_not_paginated():
+    # No 'offset' key -> the verb wasn't paginated, so no Page: line.
+    d = {"ok": True, "compName": "C", "total": 1,
+         "layers": [{"id": 1, "name": "X", "type": "solid",
+                     "enabled": True, "isThreeD": False, "parent": None}]}
+    out = render_text.render_layers(d)
+    assert "Page:" not in out
+    assert "1 | X | solid" in out

--- a/packages/core/tests/test_render_text.py
+++ b/packages/core/tests/test_render_text.py
@@ -1,0 +1,67 @@
+"""Compact text renderers (format='text') for high-volume read verbs."""
+from __future__ import annotations
+
+from ae_mcp import render_text
+
+
+def test_render_layers_table_and_paging():
+    d = {
+        "ok": True, "compName": "Hero", "compId": "1",
+        "total": 3, "offset": 0, "limit": 100, "returned": 2, "hasMore": False,
+        "layers": [
+            {"id": 1, "name": "BG", "type": "solid",
+             "enabled": True, "isThreeD": False, "parent": None},
+            {"id": 2, "name": "Title", "type": "text",
+             "enabled": False, "isThreeD": True, "parent": "Null 1"},
+        ],
+    }
+    out = render_text.render_layers(d)
+    assert isinstance(out, str)
+    assert 'Comp: "Hero" (3 layers)' in out
+    assert "Page: offset=0 limit=100 returned=2 total=3 hasMore=N" in out
+    assert "id | name | type | state | parent" in out
+    assert "1 | BG | solid | - | -" in out
+    assert "2 | Title | text | off,3D | Null 1" in out
+
+
+def test_render_layers_is_compact_vs_json():
+    import json
+    d = {
+        "ok": True, "compName": "C", "compId": "1", "total": 20,
+        "offset": 0, "limit": 100, "returned": 20, "hasMore": False,
+        "layers": [
+            {"id": i, "name": f"layer{i}", "type": "solid",
+             "enabled": True, "inPoint": 0.0, "outPoint": 5.0,
+             "isThreeD": False, "parent": None}
+            for i in range(1, 21)
+        ],
+    }
+    text_len = len(render_text.render_layers(d))
+    json_len = len(json.dumps(d, ensure_ascii=False))
+    assert text_len < json_len  # compact form is strictly smaller
+
+
+def test_maybe_render_passes_json_through():
+    d = {"ok": True, "layers": []}
+    assert render_text.maybe_render(d, "json", render_text.render_layers) is d
+
+
+def test_maybe_render_text_renders_string():
+    d = {"ok": True, "compName": "C", "total": 0, "offset": 0,
+         "limit": 10, "returned": 0, "hasMore": False, "layers": []}
+    out = render_text.maybe_render(d, "text", render_text.render_layers)
+    assert isinstance(out, str)
+    assert 'Comp: "C"' in out
+
+
+def test_maybe_render_passes_errors_through():
+    err = {"ok": False, "error": "no comp"}
+    assert render_text.maybe_render(err, "text", render_text.render_layers) is err
+
+
+def test_maybe_render_renderer_failure_falls_back_to_dict():
+    def boom(_d):
+        raise ValueError("nope")
+
+    d = {"ok": True}
+    assert render_text.maybe_render(d, "text", boom) is d

--- a/packages/core/tests/test_runtime_jsx.py
+++ b/packages/core/tests/test_runtime_jsx.py
@@ -1,0 +1,86 @@
+"""runtime.jsx ships ES3 polyfills + the AEMCP helper namespace.
+
+These are text/token assertions: runtime.jsx is loaded into AE's persistent
+ExtendScript engine at panel startup, so there is no Python import to exercise.
+We assert the additions are present and (for polyfills) guarded — the guard is
+what keeps them safe on AE 2026's modern engine and on panel re-init.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+RUNTIME = Path(__file__).resolve().parents[3] / "plugin" / "jsx" / "runtime.jsx"
+
+
+@pytest.fixture(scope="module")
+def src() -> str:
+    return RUNTIME.read_text(encoding="utf-8")
+
+
+def test_runtime_file_exists():
+    assert RUNTIME.exists(), f"runtime.jsx missing at {RUNTIME}"
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["indexOf", "forEach", "map", "filter", "reduce", "some", "every", "includes"],
+)
+def test_array_polyfill_present_and_guarded(src, method):
+    assert f"if (!Array.prototype.{method})" in src
+    assert f"Array.prototype.{method} = function" in src
+
+
+def test_array_isarray_guarded(src):
+    assert "if (!Array.isArray)" in src
+    assert "Array.isArray = function" in src
+
+
+@pytest.mark.parametrize("fn", ["keys", "values", "entries"])
+def test_object_polyfill_present_and_guarded(src, fn):
+    assert f"if (!Object.{fn})" in src
+    assert f"Object.{fn} = function" in src
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        "AEMCP.compById",
+        "AEMCP.activeComp",
+        "AEMCP.layerById",
+        "AEMCP.propByPath",
+        "AEMCP.propByMatchPath",
+    ],
+)
+def test_aemcp_namespace_helpers_present(src, helper):
+    assert f"{helper} = function" in src
+
+
+def test_aemcp_namespace_guarded_for_reinit(src):
+    # Re-running runtime.jsx must not clobber an existing namespace.
+    assert "if (typeof AEMCP === 'undefined')" in src
+
+
+def test_json_polyfill_retained(src):
+    assert "if (typeof JSON === 'undefined')" in src
+
+
+def _strip_line_comments(src: str) -> str:
+    # runtime.jsx uses only `//` line comments and no `//` inside string
+    # literals, so cutting at the first `//` per line yields the code.
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line[:idx] if idx != -1 else line)
+    return "\n".join(out)
+
+
+def test_runtime_is_es3_no_modern_syntax(src):
+    # The persistent-engine blast radius means modern syntax is forbidden in
+    # code (comments may use normal punctuation).
+    code = _strip_line_comments(src)
+    assert "=>" not in code, "arrow functions are not ES3-safe"
+    assert "`" not in code, "template literals are not ES3-safe"
+    assert "const " not in code, "const is not ES3-safe"
+    assert "let " not in code, "let is not ES3-safe"

--- a/packages/core/tests/test_server_instructions.py
+++ b/packages/core/tests/test_server_instructions.py
@@ -1,0 +1,30 @@
+"""The MCP server advertises ae-mcp operating guidance at handshake."""
+from __future__ import annotations
+
+from ae_mcp.instructions import SERVER_INSTRUCTIONS
+from ae_mcp.server import build_server
+
+
+def test_instructions_nonempty_and_substantial():
+    assert isinstance(SERVER_INSTRUCTIONS, str)
+    assert len(SERVER_INSTRUCTIONS) > 400
+
+
+def test_instructions_cover_key_discipline():
+    text = SERVER_INSTRUCTIONS
+    # Phased workflow + the verbs an agent must know about.
+    assert "ae.init" in text
+    assert "ae.validateExpressions" in text
+    assert "ae.previewFrame" in text
+    # ES3 discipline + the runtime helpers we ship.
+    assert "ECMAScript 3" in text
+    assert "AEMCP.propByMatchPath" in text
+    # Never-throw safety invariant.
+    assert "NEVER let JSX throw" in text
+
+
+def test_build_server_advertises_instructions():
+    server = build_server()
+    assert server.instructions == SERVER_INSTRUCTIONS
+    opts = server.create_initialization_options()
+    assert opts.instructions == SERVER_INSTRUCTIONS

--- a/plugin/jsx/runtime.jsx
+++ b/plugin/jsx/runtime.jsx
@@ -31,3 +31,222 @@ if (typeof JSON === 'undefined') {
         return 'null';
     };
 }
+
+// ---------------------------------------------------------------------------
+// ES3 Array / Object polyfills.
+//
+// AE's classic ExtendScript engine is ECMAScript 3-era and lacks the Array
+// iteration methods and Object.keys/values/entries that agent-authored JSX
+// (sent through ae.exec / ae.readProps) routinely reaches for. Each polyfill
+// is guarded with an if-not-present check so it is a no-op on AE 2026's modern
+// engine and safe to re-run on panel re-init. Keep everything ES3: var only,
+// function keyword, no arrow/const/let.
+//
+// This file loads ONCE into the persistent engine (manifest ScriptPath), so a
+// syntax error here breaks EVERY verb. Edit with care.
+// ---------------------------------------------------------------------------
+if (!Array.prototype.indexOf) {
+    Array.prototype.indexOf = function (needle, from) {
+        var len = this.length >>> 0;
+        var i = from ? Number(from) : 0;
+        if (i < 0) i = Math.max(0, len + i);
+        for (; i < len; i++) {
+            if (i in this && this[i] === needle) return i;
+        }
+        return -1;
+    };
+}
+if (!Array.prototype.forEach) {
+    Array.prototype.forEach = function (fn, thisArg) {
+        var len = this.length >>> 0;
+        for (var i = 0; i < len; i++) {
+            if (i in this) fn.call(thisArg, this[i], i, this);
+        }
+    };
+}
+if (!Array.prototype.map) {
+    Array.prototype.map = function (fn, thisArg) {
+        var len = this.length >>> 0;
+        var out = new Array(len);
+        for (var i = 0; i < len; i++) {
+            if (i in this) out[i] = fn.call(thisArg, this[i], i, this);
+        }
+        return out;
+    };
+}
+if (!Array.prototype.filter) {
+    Array.prototype.filter = function (fn, thisArg) {
+        var len = this.length >>> 0;
+        var out = [];
+        for (var i = 0; i < len; i++) {
+            if (i in this && fn.call(thisArg, this[i], i, this)) out.push(this[i]);
+        }
+        return out;
+    };
+}
+if (!Array.prototype.reduce) {
+    Array.prototype.reduce = function (fn, init) {
+        var len = this.length >>> 0;
+        var i = 0, acc;
+        if (arguments.length >= 2) {
+            acc = init;
+        } else {
+            while (i < len && !(i in this)) i++;
+            acc = this[i++];
+        }
+        for (; i < len; i++) {
+            if (i in this) acc = fn(acc, this[i], i, this);
+        }
+        return acc;
+    };
+}
+if (!Array.prototype.some) {
+    Array.prototype.some = function (fn, thisArg) {
+        var len = this.length >>> 0;
+        for (var i = 0; i < len; i++) {
+            if (i in this && fn.call(thisArg, this[i], i, this)) return true;
+        }
+        return false;
+    };
+}
+if (!Array.prototype.every) {
+    Array.prototype.every = function (fn, thisArg) {
+        var len = this.length >>> 0;
+        for (var i = 0; i < len; i++) {
+            if (i in this && !fn.call(thisArg, this[i], i, this)) return false;
+        }
+        return true;
+    };
+}
+if (!Array.prototype.includes) {
+    Array.prototype.includes = function (needle) {
+        return this.indexOf(needle) !== -1;
+    };
+}
+if (!Array.isArray) {
+    Array.isArray = function (o) {
+        return Object.prototype.toString.call(o) === '[object Array]';
+    };
+}
+if (!Object.keys) {
+    Object.keys = function (obj) {
+        var keys = [];
+        for (var k in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, k)) keys.push(k);
+        }
+        return keys;
+    };
+}
+if (!Object.values) {
+    Object.values = function (obj) {
+        var vals = [];
+        for (var k in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, k)) vals.push(obj[k]);
+        }
+        return vals;
+    };
+}
+if (!Object.entries) {
+    Object.entries = function (obj) {
+        var ents = [];
+        for (var k in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, k)) ents.push([k, obj[k]]);
+        }
+        return ents;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// AEMCP helper namespace.
+//
+// A single source of truth for the targeting + property-resolution idioms
+// every JSX template would otherwise re-implement. Loaded once into the
+// persistent engine, so agent-authored ae.exec / ae.readProps scripts can
+// call these directly. All helpers are defensive: they return null (never
+// throw) on bad input, honouring the "JSX must never throw" invariant.
+// ---------------------------------------------------------------------------
+if (typeof AEMCP === 'undefined') { AEMCP = {}; }
+
+AEMCP.version = '0.1.0';
+
+// Count of a node's child properties, or -1 when `node` is a leaf Property /
+// not a group. try/catch shields against leaf nodes that lack numProperties.
+AEMCP._numProps = function (node) {
+    var n;
+    try { n = node.numProperties; } catch (e) { return -1; }
+    return (typeof n === 'number') ? n : -1;
+};
+
+// Resolve a CompItem by AE item id, or null when the id isn't a comp.
+// itemByID throws "Item Not Found" on an unknown id (AE 26.2+) rather than
+// returning null, so guard it to honour the never-throw invariant.
+AEMCP.compById = function (id) {
+    var it;
+    try { it = app.project.itemByID(id); } catch (e) { return null; }
+    return (it && it instanceof CompItem) ? it : null;
+};
+
+// The active comp, or null when the foreground item isn't a comp.
+AEMCP.activeComp = function () {
+    var it = app.project.activeItem;
+    return (it && it instanceof CompItem) ? it : null;
+};
+
+// A layer by 1-based index within a comp, or null.
+AEMCP.layerById = function (comp, idx) {
+    if (!comp) return null;
+    try { return comp.layer(idx); } catch (e) { return null; }
+};
+
+// Resolve a property by display-name path, e.g. "Transform/Position" or
+// "Effects/Gaussian Blur/Blurriness". Returns the Property/PropertyGroup or
+// null. .property() accepts names, matchNames, or indices.
+AEMCP.propByPath = function (root, path) {
+    if (!root || !path) return null;
+    var segs = String(path).split('/');
+    var cur = root;
+    for (var i = 0; i < segs.length; i++) {
+        if (segs[i] === '') continue;
+        var next = null;
+        try { next = cur.property(segs[i]); } catch (e) { return null; }
+        if (!next) return null;
+        cur = next;
+    }
+    return cur;
+};
+
+// Resolve a property by matchName path with optional #ordinals, e.g.
+// "ADBE Transform Group#1/ADBE Position#1". Ordinals count siblings sharing a
+// matchName (default 1) so duplicate-matchName effects stay addressable.
+// Returns the Property/PropertyGroup or null.
+AEMCP.propByMatchPath = function (root, path) {
+    if (!root || !path) return null;
+    var segs = String(path).split('/');
+    var cur = root;
+    for (var i = 0; i < segs.length; i++) {
+        var seg = segs[i];
+        if (seg === '') continue;
+        var mn = seg, ord = 1;
+        var h = seg.lastIndexOf('#');
+        if (h > 0) {
+            var parsed = parseInt(seg.substring(h + 1), 10);
+            if (!isNaN(parsed) && parsed >= 1) {
+                mn = seg.substring(0, h);
+                ord = parsed;
+            }
+        }
+        var n = AEMCP._numProps(cur);
+        if (n < 0) return null;
+        var found = null, count = 0;
+        for (var j = 1; j <= n; j++) {
+            var child = cur.property(j);
+            if (child && child.matchName === mn) {
+                count++;
+                if (count === ord) { found = child; break; }
+            }
+        }
+        if (!found) return null;
+        cur = found;
+    }
+    return cur;
+};


### PR DESCRIPTION
## 概要 / Summary
面向 Atom（`atom-ae` MCP）能力对齐的一轮优化。完整对比路线图见 `docs/ATOM_PARITY_ROADMAP.md`（25 项）。**每项改动默认保持原有行为，对机器消费方无破坏性影响。**

A round of optimization toward parity with Atom. Every change defaults to prior behavior — no breaking impact for machine consumers.

## 改动 / Changes
**Added**
- `AEMCP` runtime helper namespace (`compById`/`activeComp`/`layerById`/`propByPath`/`propByMatchPath`) + ES3 Array/Object polyfills in `plugin/jsx/runtime.jsx`, loaded once into the persistent engine.
- Static agent guidance at the MCP handshake (`instructions.py` + `Server(instructions=...)`).
- `ae.layers`: `offset`/`limit` pagination, `type`/`parent` columns, and `format='json'|'text'` compact output (`render_text.py`) — text ≈ 1/3 the tokens of json.
- `schemas.RigControl` typed model for `createRig` controls.
- `docs/ATOM_PARITY_ROADMAP.md`, `CHANGELOG.md`.

**Changed**
- `ae.exec` auto-checkpoint made truly non-blocking — degrades to `checkpointSkipped` instead of aborting the edit when the checkpoint store is broken/hangs.

**Fixed**
- `AEMCP.compById` threw `{Item Not Found}` on an unknown item id (AE 26.2 `itemByID` throws, not null) — now guarded. **Caught only by live testing.**

## 验证 / Verification
- ✅ Unit suite: **196 passed**
- ✅ Live suite on AE 26.2.1: **24/24 passed** (incl. new `test_runtime_helpers.py` regression)

## 备注 / Notes
Builds on #1 (already merged). All new params are additive; defaults unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)