### PR TITLE
fix: MCP-compliant tool names (replace . with _) for strict clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.2.1] — 2026-06-08
+
+#### 🐛 修复
+- **部分客户端（如 Claude 桌面版扩展）连接时报错、无法新建对话**——工具名此前带 `.`（如 `ae.ping`），不符合 MCP 工具名规范 `^[a-zA-Z0-9_-]{1,64}$`，严格客户端会拒绝并报 `FrontendRemoteMcpToolDefinition.name`。现在对外统一改用下划线名（`ae.ping` → `ae_ping`），调用时自动映射回去。**仍兼容原有带点名调用，已有调用方不受影响。**
+
 ### [0.2.0] — 2026-06-05
 
 本次发布合并了两个 PR：**#1**（多步操作可靠性）和 **#2**（向 Atom 能力对齐的一轮优化）。
@@ -37,6 +42,11 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.2.1] — 2026-06-08
+
+#### 🐛 Fixed
+- **Some clients (e.g. Claude Desktop extensions) errored on connect and couldn't start a conversation** — tool names were dotted (`ae.ping`), which violates the MCP tool-name pattern `^[a-zA-Z0-9_-]{1,64}$`, so strict clients rejected them with `FrontendRemoteMcpToolDefinition.name`. Exposed names are now underscore-form (`ae.ping` → `ae_ping`), mapped back on call. **The original dotted names are still accepted, so existing callers are unaffected.**
 
 ### [0.2.0] — 2026-06-05
 

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -56,6 +56,32 @@ def _format_result(result: Any) -> str:
     return repr(result)
 
 
+def expose_tool_name(verb: str) -> str:
+    """Map a canonical verb to its MCP-exposed tool name.
+
+    Verbs are dotted internally ("ae.ping"), but the MCP spec requires tool
+    names to match ``^[a-zA-Z0-9_-]{1,64}$``. Dots are illegal, and strict
+    clients (e.g. Claude Desktop extensions) reject them at handshake time, so
+    we expose dot-free names ("ae.ping" -> "ae_ping").
+    """
+    return verb.replace(".", "_")
+
+
+def resolve_tool_name(name: str, handlers) -> "str | None":
+    """Map an exposed tool name back to its canonical verb.
+
+    Accepts both the exposed dot-free name ("ae_ping") and, for backward
+    compatibility, the original dotted verb ("ae.ping"). Returns ``None`` if
+    the name matches no registered verb.
+    """
+    if name in handlers:
+        return name
+    for verb in handlers:
+        if expose_tool_name(verb) == name:
+            return verb
+    return None
+
+
 def build_server() -> Server:
     """Construct the low-level MCP Server with all 15 verbs registered."""
     load_all()
@@ -79,7 +105,7 @@ def build_server() -> Server:
             desc = (schema_cls.__doc__ or f"ae-mcp verb {verb_name}").strip()
             tools.append(
                 Tool(
-                    name=verb_name,
+                    name=expose_tool_name(verb_name),
                     description=desc,
                     inputSchema=input_schema,
                 )
@@ -88,9 +114,13 @@ def build_server() -> Server:
 
     @server.call_tool()
     async def _call_tool(name: str, arguments: dict | None) -> List[TextContent]:
-        if name not in HANDLERS:
+        # Tools are exposed with dots replaced by underscores; map the exposed
+        # name back to the canonical verb (the dotted name is accepted too).
+        canonical = resolve_tool_name(name, HANDLERS)
+        if canonical is None:
             payload = _format_result({"ok": False, "error": f"unknown tool: {name}"})
             return [TextContent(type="text", text=payload)]
+        name = canonical
 
         schema_cls, run_fn = HANDLERS[name]
 

--- a/packages/core/tests/test_tool_names.py
+++ b/packages/core/tests/test_tool_names.py
@@ -1,0 +1,46 @@
+"""Exposed MCP tool names must satisfy the spec's name pattern.
+
+The MCP spec (and strict clients such as Claude Desktop extensions) require
+tool names to match ``^[a-zA-Z0-9_-]{1,64}$``. Verbs are dotted internally
+("ae.ping"), so the server must expose dot-free names ("ae_ping") and map them
+back on call.
+"""
+from __future__ import annotations
+
+import re
+
+from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.server import expose_tool_name, resolve_tool_name
+
+_MCP_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def test_expose_tool_name_strips_dots():
+    assert expose_tool_name("ae.ping") == "ae_ping"
+    assert expose_tool_name("ae.scanPropertyTree") == "ae_scanPropertyTree"
+    # Already dot-free names are unchanged.
+    assert expose_tool_name("ae_ping") == "ae_ping"
+
+
+def test_every_exposed_verb_matches_mcp_pattern():
+    load_all()
+    assert HANDLERS, "handlers registry should be populated"
+    for verb in HANDLERS:
+        exposed = expose_tool_name(verb)
+        assert _MCP_TOOL_NAME.fullmatch(exposed), f"{verb!r} -> {exposed!r} is not MCP-compliant"
+
+
+def test_resolve_round_trips_for_every_verb():
+    load_all()
+    for verb in HANDLERS:
+        exposed = expose_tool_name(verb)
+        # Exposed (dot-free) name resolves back to the canonical verb...
+        assert resolve_tool_name(exposed, HANDLERS) == verb
+        # ...and the original dotted name is still accepted (backward compat).
+        assert resolve_tool_name(verb, HANDLERS) == verb
+
+
+def test_resolve_unknown_returns_none():
+    load_all()
+    assert resolve_tool_name("does_not_exist", HANDLERS) is None
+    assert resolve_tool_name("ae.unknownVerb", HANDLERS) is None


### PR DESCRIPTION
## Summary

Verbs are dotted internally (`ae.ping`, `ae.scanPropertyTree`). The MCP spec
requires tool names to match `^[a-zA-Z0-9_-]{1,64}$`, in which `.` is illegal.
Lenient clients tolerate it, but strict ones — notably **Claude Desktop
extensions (`.mcpb`)** — reject the whole tool list at handshake and the user
cannot even start a conversation:

```
tools.<n>.FrontendRemoteMcpToolDefinition.name: String should match pattern '^[a-zA-Z0-9_-]{1,64}$'
```

(The same server works when wired via `claude_desktop_config.json` `mcpServers`,
because that path is lenient; only the stricter Extension/Frontend path rejects
the dots — which is why this is easy to miss.)

## Change

- `list_tools` now exposes dot-free names via a small `expose_tool_name()`
  helper (`ae.ping` → `ae_ping`).
- `call_tool` maps the exposed name back to the canonical verb via
  `resolve_tool_name()`, which **also still accepts the original dotted name**.
- New unit tests assert that every registered verb's exposed name matches the
  MCP pattern and round-trips back to its canonical form.

## Compatibility

- **Backward compatible**: dotted names remain callable, so existing callers and
  configs are unaffected.
- `SERVER_INSTRUCTIONS` / docs still reference `ae.*`; those calls resolve fine
  through the dotted-name fallback, so no doc churn is required.

## Testing

- `uv run pytest packages/core/tests` → **191 passed** (24 live deselected).
- Verified end-to-end against live After Effects through a Claude Desktop `.mcpb`
  extension: new conversations now load, and `ae_init` / `ae_ping` return `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
