### PR TITLE
fix(security): authenticate /exec, serialize JSX calls, stop shipping .debug (#11)

### DIFF
--- a/packages/bridge/ae_mcp_bridge/__init__.py
+++ b/packages/bridge/ae_mcp_bridge/__init__.py
@@ -2,11 +2,22 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Optional
 
 import httpx
 
 from ae_mcp.backends.base import Backend, BackendError
+
+# Header carrying the shared-secret token on /exec requests. Must match the
+# header the Node host (plugin/host/server.js) checks.
+_TOKEN_HEADER = "X-AE-MCP-Token"
+
+
+def _token_path() -> Path:
+    """Per-user token file shared with the Node host. Must match the path the
+    panel writes (~/.ae-mcp/auth-token)."""
+    return Path.home() / ".ae-mcp" / "auth-token"
 
 
 class HttpBridge(Backend):
@@ -16,13 +27,44 @@ class HttpBridge(Backend):
 
     def __init__(self, url: str) -> None:
         self.url = url.rstrip("/")
+        # Cache the token after the first successful read so we don't hit the
+        # filesystem on every exec.
+        self._token: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> "HttpBridge":
         url = os.environ.get("AE_MCP_PLUGIN_URL", "http://127.0.0.1:11488")
         return cls(url=url)
 
+    def _read_token(self) -> str:
+        """Read (and cache) the shared-secret token. Fail closed with a clear
+        message if the file is missing — the panel generates it on startup, so a
+        missing file means the panel hasn't been started/installed."""
+        if self._token is not None:
+            return self._token
+        path = _token_path()
+        try:
+            token = path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            raise BackendError(
+                "HttpBridge: auth token not found at "
+                f"{path}. Start (or reinstall) the ae-mcp panel in After "
+                "Effects so it can generate the token, then retry."
+            ) from None
+        except OSError as e:
+            raise BackendError(
+                f"HttpBridge: could not read auth token at {path}: {e}"
+            ) from e
+        if not token:
+            raise BackendError(
+                f"HttpBridge: auth token at {path} is empty. Restart the "
+                "ae-mcp panel to regenerate it."
+            )
+        self._token = token
+        return token
+
     async def health_check(self, timeout_sec: float = 5.0) -> bool:
+        # /health is unauthenticated (it executes no code), so no token needed.
         try:
             async with httpx.AsyncClient(timeout=timeout_sec) as http:
                 r = await http.get(f"{self.url}/health")
@@ -38,15 +80,20 @@ class HttpBridge(Backend):
         checkpoint_label: Optional[str] = None,
         timeout_sec: float = 30.0,
     ) -> str:
+        # Fail closed: if the token can't be read, raise before making the call.
+        token = self._read_token()
         payload = {
             "code": code,
             "undoGroup": undo_group,
             "checkpointLabel": checkpoint_label,
             "timeoutMs": int(timeout_sec * 1000),
         }
+        headers = {_TOKEN_HEADER: token}
         try:
             async with httpx.AsyncClient(timeout=timeout_sec + 5.0) as http:
-                r = await http.post(f"{self.url}/exec", json=payload)
+                r = await http.post(
+                    f"{self.url}/exec", json=payload, headers=headers
+                )
         except httpx.HTTPError as e:
             raise BackendError(f"HttpBridge: HTTP error: {e}") from e
 

--- a/packages/bridge/tests/test_http_bridge.py
+++ b/packages/bridge/tests/test_http_bridge.py
@@ -3,7 +3,17 @@ import pytest
 import respx
 from httpx import Response
 
+import ae_mcp_bridge
 from ae_mcp_bridge import HttpBridge
+
+
+@pytest.fixture
+def token_file(tmp_path, monkeypatch):
+    """Point the bridge at a temp token file with a known value."""
+    tok = tmp_path / "auth-token"
+    tok.write_text("testtoken123", encoding="utf-8")
+    monkeypatch.setattr(ae_mcp_bridge, "_token_path", lambda: tok)
+    return tok
 
 
 def test_from_env_default_url(monkeypatch):
@@ -64,7 +74,7 @@ async def test_health_check_connection_error():
 
 
 @pytest.mark.asyncio
-async def test_exec_returns_result():
+async def test_exec_returns_result(token_file):
     async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
         mock.post("/exec").mock(
             return_value=Response(200, json={"ok": True, "result": "42"})
@@ -78,7 +88,7 @@ async def test_exec_returns_result():
 
 
 @pytest.mark.asyncio
-async def test_exec_propagates_plugin_error():
+async def test_exec_propagates_plugin_error(token_file):
     from ae_mcp.backends.base import BackendError
     async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
         mock.post("/exec").mock(
@@ -94,7 +104,7 @@ async def test_exec_propagates_plugin_error():
 
 
 @pytest.mark.asyncio
-async def test_exec_propagates_http_error():
+async def test_exec_propagates_http_error(token_file):
     from ae_mcp.backends.base import BackendError
     async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
         mock.post("/exec").mock(return_value=Response(500, text="boom"))
@@ -107,7 +117,7 @@ async def test_exec_propagates_http_error():
 
 
 @pytest.mark.asyncio
-async def test_exec_passes_undo_and_checkpoint_label():
+async def test_exec_passes_undo_and_checkpoint_label(token_file):
     captured = {}
     async def _resp(request):
         import json
@@ -126,3 +136,76 @@ async def test_exec_passes_undo_and_checkpoint_label():
     assert captured["body"]["undoGroup"] == "g"
     assert captured["body"]["checkpointLabel"] == "lab"
     assert captured["body"]["timeoutMs"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_exec_sends_auth_token_header(token_file):
+    captured = {}
+    async def _resp(request):
+        captured["token"] = request.headers.get("X-AE-MCP-Token")
+        return Response(200, json={"ok": True, "result": "ok"})
+
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/exec").mock(side_effect=_resp)
+        b = HttpBridge("http://127.0.0.1:11488")
+        try:
+            await b.exec("1")
+        finally:
+            await b.shutdown()
+
+    assert captured["token"] == "testtoken123"
+
+
+@pytest.mark.asyncio
+async def test_exec_missing_token_raises(tmp_path, monkeypatch):
+    from ae_mcp.backends.base import BackendError
+
+    missing = tmp_path / "nope" / "auth-token"
+    monkeypatch.setattr(ae_mcp_bridge, "_token_path", lambda: missing)
+
+    b = HttpBridge("http://127.0.0.1:11488")
+    try:
+        with pytest.raises(BackendError) as ei:
+            await b.exec("1")
+        msg = str(ei.value)
+        assert "token not found" in msg
+        assert "panel" in msg
+    finally:
+        await b.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_empty_token_raises(tmp_path, monkeypatch):
+    from ae_mcp.backends.base import BackendError
+
+    tok = tmp_path / "auth-token"
+    tok.write_text("   ", encoding="utf-8")
+    monkeypatch.setattr(ae_mcp_bridge, "_token_path", lambda: tok)
+
+    b = HttpBridge("http://127.0.0.1:11488")
+    try:
+        with pytest.raises(BackendError) as ei:
+            await b.exec("1")
+        assert "empty" in str(ei.value)
+    finally:
+        await b.shutdown()
+
+
+def test_token_path_uses_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(ae_mcp_bridge.Path, "home", classmethod(lambda cls: tmp_path))
+    assert ae_mcp_bridge._token_path() == tmp_path / ".ae-mcp" / "auth-token"
+
+
+@pytest.mark.asyncio
+async def test_health_check_needs_no_token(tmp_path, monkeypatch):
+    # /health must work even when the token file is absent so the bridge can
+    # still probe readiness before the panel has generated a token.
+    missing = tmp_path / "nope" / "auth-token"
+    monkeypatch.setattr(ae_mcp_bridge, "_token_path", lambda: missing)
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.get("/health").mock(return_value=Response(200, json={"ok": True}))
+        b = HttpBridge("http://127.0.0.1:11488")
+        try:
+            assert await b.health_check() is True
+        finally:
+            await b.shutdown()

--- a/plugin/host/auth-token.js
+++ b/plugin/host/auth-token.js
@@ -1,0 +1,66 @@
+// Shared-secret auth for /exec. The token lives at a per-user, cross-platform
+// path (~/.ae-mcp/auth-token) so the Node host (panel) and the Python bridge
+// agree without any handshake. Loopback binding limits reach to local
+// processes; the token defeats the "any local process can call /exec" threat.
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// ~/.ae-mcp/auth-token — must match the path used by the Python bridge.
+function tokenDir() {
+    return path.join(os.homedir(), '.ae-mcp');
+}
+
+function tokenPath() {
+    return path.join(tokenDir(), 'auth-token');
+}
+
+// Ensure the token file exists, generating a fresh 32-byte hex secret if not.
+// Best-effort 0600 perms on POSIX; on Windows the chmod is a no-op so we just
+// write the file. Returns the token string.
+function ensureToken() {
+    var dir = tokenDir();
+    var file = tokenPath();
+    if (fs.existsSync(file)) {
+        var existing = fs.readFileSync(file, 'utf8').trim();
+        if (existing.length > 0) {
+            return existing;
+        }
+        // Empty/corrupt file: fall through and regenerate.
+    }
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+    var token = crypto.randomBytes(32).toString('hex');
+    fs.writeFileSync(file, token, 'utf8');
+    try {
+        // POSIX: restrict to owner read/write. No-op effect on Windows.
+        fs.chmodSync(file, 0o600);
+    } catch (e) {
+        // chmod can fail on some filesystems; the token is still written.
+    }
+    return token;
+}
+
+// Constant-time comparison that first guards against length mismatch (which
+// timingSafeEqual would otherwise throw on for unequal-length buffers).
+function tokenMatches(provided, expected) {
+    if (typeof provided !== 'string' || typeof expected !== 'string') {
+        return false;
+    }
+    var a = Buffer.from(provided, 'utf8');
+    var b = Buffer.from(expected, 'utf8');
+    if (a.length !== b.length) {
+        return false;
+    }
+    return crypto.timingSafeEqual(a, b);
+}
+
+module.exports = {
+    HEADER: 'x-ae-mcp-token',
+    tokenDir: tokenDir,
+    tokenPath: tokenPath,
+    ensureToken: ensureToken,
+    tokenMatches: tokenMatches,
+};

--- a/plugin/host/jsx-bridge.js
+++ b/plugin/host/jsx-bridge.js
@@ -6,29 +6,56 @@ function setCSInterface(cs) {
     csInterface = cs;
 }
 
-function evalScript(jsx, timeoutMs) {
+// There is a single persistent ExtendScript engine with shared globals behind
+// csInterface.evalScript. Two overlapping evalScript calls would interleave and
+// half-apply edits, so we serialize: each call chains off the previous one and
+// only runs once its predecessor has resolved/rejected/timed out. The tail of
+// the chain is `queue`; we deliberately swallow its rejection in the chain so a
+// failed call never poisons the queue for the next caller.
+let queue = Promise.resolve();
+
+function evalScriptInner(jsx, timeoutMs) {
     return new Promise((resolve, reject) => {
         if (!csInterface) {
             reject(new Error('CSInterface not initialized'));
             return;
         }
+        let settled = false;
+        const finish = (fn, arg) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            fn(arg);
+        };
         const timer = setTimeout(() => {
-            reject(new Error('JSX timeout after ' + timeoutMs + 'ms'));
+            finish(reject, new Error('JSX timeout after ' + timeoutMs + 'ms'));
         }, timeoutMs);
         try {
             csInterface.evalScript(jsx, (result) => {
-                clearTimeout(timer);
                 if (typeof result === 'string' && result.indexOf('EvalScript error') === 0) {
-                    reject(new Error(result));
+                    finish(reject, new Error(result));
                 } else {
-                    resolve(result);
+                    finish(resolve, result);
                 }
             });
         } catch (e) {
-            clearTimeout(timer);
-            reject(e);
+            finish(reject, e);
         }
     });
+}
+
+function evalScript(jsx, timeoutMs) {
+    // Chain this call after whatever is currently in flight. Whether the prior
+    // call resolved or rejected, we proceed (the `.catch` keeps the chain
+    // alive) so a timed-out/rejected call still releases the lock.
+    const run = queue.then(
+        () => evalScriptInner(jsx, timeoutMs),
+        () => evalScriptInner(jsx, timeoutMs)
+    );
+    // Advance the queue tail to this call's completion, swallowing its result so
+    // the next caller's `.then` always fires regardless of success/failure.
+    queue = run.then(function () {}, function () {});
+    return run;
 }
 
 module.exports = { setCSInterface, evalScript };

--- a/plugin/host/jsx-bridge.test.js
+++ b/plugin/host/jsx-bridge.test.js
@@ -1,0 +1,113 @@
+// Tests for the JSX bridge: sentinel rejection, normal resolve, serialization
+// (mutex), and that a timeout releases the lock. Uses Node's built-in test
+// runner (node --test) with a fake csInterface — no external deps.
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Fresh module per test so the internal queue state doesn't leak between cases.
+function freshBridge() {
+    delete require.cache[require.resolve('./jsx-bridge')];
+    return require('./jsx-bridge');
+}
+
+test('normal result resolves', async () => {
+    const bridge = freshBridge();
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) { cb('hello'); },
+    });
+    const r = await bridge.evalScript('1', 1000);
+    assert.strictEqual(r, 'hello');
+});
+
+test('"EvalScript error." sentinel (with period) rejects', async () => {
+    const bridge = freshBridge();
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) { cb('EvalScript error.'); },
+    });
+    await assert.rejects(
+        () => bridge.evalScript('boom', 1000),
+        /EvalScript error\./
+    );
+});
+
+test('missing CSInterface rejects', async () => {
+    const bridge = freshBridge();
+    await assert.rejects(
+        () => bridge.evalScript('1', 1000),
+        /CSInterface not initialized/
+    );
+});
+
+test('timeout rejects and releases the lock for the next call', async () => {
+    const bridge = freshBridge();
+    let firstCb = null;
+    let secondCalled = false;
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) {
+            if (firstCb === null) {
+                // Never invoke the callback for the first call -> it times out.
+                firstCb = cb;
+            } else {
+                secondCalled = true;
+                cb('second-ok');
+            }
+        },
+    });
+
+    const first = bridge.evalScript('slow', 20);
+    const second = bridge.evalScript('fast', 1000);
+
+    await assert.rejects(() => first, /JSX timeout after 20ms/);
+    // The lock must have been released so the second call can run and resolve.
+    const r = await second;
+    assert.strictEqual(r, 'second-ok');
+    assert.strictEqual(secondCalled, true);
+});
+
+test('mutex serializes: two concurrent calls do not overlap', async () => {
+    const bridge = freshBridge();
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const order = [];
+
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) {
+            inFlight++;
+            maxConcurrent = Math.max(maxConcurrent, inFlight);
+            order.push('start:' + jsx);
+            // Simulate async AE work; the second call must not start until this
+            // callback fires.
+            setTimeout(function () {
+                order.push('end:' + jsx);
+                inFlight--;
+                cb('done:' + jsx);
+            }, 15);
+        },
+    });
+
+    const a = bridge.evalScript('A', 1000);
+    const b = bridge.evalScript('B', 1000);
+    const [ra, rb] = await Promise.all([a, b]);
+
+    assert.strictEqual(ra, 'done:A');
+    assert.strictEqual(rb, 'done:B');
+    // The critical invariant: never two evalScript bodies in flight at once.
+    assert.strictEqual(maxConcurrent, 1, 'evalScript calls overlapped');
+    // And they ran strictly in submission order, fully serialized.
+    assert.deepStrictEqual(order, ['start:A', 'end:A', 'start:B', 'end:B']);
+});
+
+test('a rejected call does not poison the queue', async () => {
+    const bridge = freshBridge();
+    let n = 0;
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) {
+            n++;
+            if (n === 1) { cb('EvalScript error.'); }
+            else { cb('ok'); }
+        },
+    });
+    await assert.rejects(() => bridge.evalScript('bad', 1000));
+    const r = await bridge.evalScript('good', 1000);
+    assert.strictEqual(r, 'ok');
+});

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "private": true,
   "main": "server.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "express": "^4.18.0"
   }

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -1,10 +1,14 @@
 // HTTP server for the ae-mcp CEP plugin. Exposes /health and /exec.
 const express = require('express');
 const jsxBridge = require('./jsx-bridge');
+const authToken = require('./auth-token');
 
 let app = null;
 let httpServer = null;
 let currentPort = null;
+// The shared secret /exec requires. Populated in start() so the file is read
+// (and generated if missing) exactly once per host lifetime.
+let execToken = null;
 
 // Wrap user JSX in app.beginUndoGroup / app.endUndoGroup.
 //
@@ -42,6 +46,14 @@ function buildApp() {
     });
 
     a.post('/exec', async (req, res) => {
+        // Require the shared-secret token. /exec runs arbitrary ExtendScript, so
+        // every caller must prove it can read ~/.ae-mcp/auth-token. Constant-time
+        // compare to avoid leaking the token via timing.
+        const provided = req.get(authToken.HEADER);
+        if (!authToken.tokenMatches(provided, execToken)) {
+            return res.status(401).json({ ok: false, error: 'unauthorized' });
+        }
+
         const { code, undoGroup, checkpointLabel, timeoutMs } = req.body || {};
         if (typeof code !== 'string' || code.length === 0) {
             return res.status(400).json({ ok: false, error: 'missing or empty `code`' });
@@ -67,6 +79,13 @@ function buildApp() {
 function start(port, callback) {
     if (httpServer) {
         return callback(new Error('already started; call restart() to change port'));
+    }
+    // Ensure the shared-secret token exists (generate on first run) before we
+    // accept any /exec request. The Python bridge reads the same file.
+    try {
+        execToken = authToken.ensureToken();
+    } catch (e) {
+        return callback(new Error('failed to initialize auth token: ' + e.message));
     }
     app = buildApp();
     httpServer = app.listen(port, '127.0.0.1', (err) => {
@@ -99,4 +118,8 @@ module.exports = {
     setCSInterface: jsxBridge.setCSInterface,
     // Exported for unit-testing the wrap shape without spinning up Express.
     wrapWithUndoGroup,
+    // Exported so tests can build the app and inject a known token without
+    // touching the real token file.
+    buildApp,
+    _setExecToken: function (t) { execToken = t; },
 };

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -1,0 +1,125 @@
+// Tests for auth-token helpers and that the server wires the token header into
+// /exec (401 without, 200 with). Uses node --test plus Node's built-in http to
+// drive the real Express app on an ephemeral loopback port — no supertest.
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const authToken = require('./auth-token');
+
+// ---- tokenMatches (pure helper) ----
+
+test('tokenMatches: equal strings match', () => {
+    assert.strictEqual(authToken.tokenMatches('abc123', 'abc123'), true);
+});
+
+test('tokenMatches: different same-length strings do not match', () => {
+    assert.strictEqual(authToken.tokenMatches('abc123', 'abc124'), false);
+});
+
+test('tokenMatches: different-length strings do not match (no throw)', () => {
+    assert.strictEqual(authToken.tokenMatches('short', 'longertoken'), false);
+});
+
+test('tokenMatches: non-string inputs do not match', () => {
+    assert.strictEqual(authToken.tokenMatches(undefined, 'x'), false);
+    assert.strictEqual(authToken.tokenMatches('x', undefined), false);
+    assert.strictEqual(authToken.tokenMatches(null, null), false);
+});
+
+// ---- ensureToken (filesystem) ----
+
+test('ensureToken generates a 64-char hex token and is idempotent', (t) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-tok-'));
+    t.mock.method(os, 'homedir', () => tmp);
+
+    const tok1 = authToken.ensureToken();
+    assert.match(tok1, /^[0-9a-f]{64}$/);
+    assert.ok(fs.existsSync(path.join(tmp, '.ae-mcp', 'auth-token')));
+
+    // Second call returns the same token (does not regenerate).
+    const tok2 = authToken.ensureToken();
+    assert.strictEqual(tok2, tok1);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// ---- /exec auth wiring via the real Express app ----
+
+function startApp() {
+    delete require.cache[require.resolve('./server')];
+    delete require.cache[require.resolve('./jsx-bridge')];
+    const server = require('./server');
+    // Inject a known token and a stub CSInterface so /exec can "run".
+    server._setExecToken('known-secret-token');
+    server.setCSInterface({
+        evalScript: function (jsx, cb) { cb('stub-result'); },
+    });
+    const app = server.buildApp();
+    return new Promise((resolve) => {
+        const srv = app.listen(0, '127.0.0.1', () => {
+            resolve({ srv: srv, port: srv.address().port });
+        });
+    });
+}
+
+function post(port, pathname, headers, body) {
+    return new Promise((resolve, reject) => {
+        const data = JSON.stringify(body);
+        const req = http.request({
+            host: '127.0.0.1',
+            port: port,
+            path: pathname,
+            method: 'POST',
+            headers: Object.assign(
+                { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) },
+                headers || {}
+            ),
+        }, (res) => {
+            let chunks = '';
+            res.on('data', (c) => { chunks += c; });
+            res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(chunks || '{}') }));
+        });
+        req.on('error', reject);
+        req.write(data);
+        req.end();
+    });
+}
+
+test('/exec returns 401 without a token', async () => {
+    const { srv, port } = await startApp();
+    try {
+        const r = await post(port, '/exec', {}, { code: '1' });
+        assert.strictEqual(r.status, 401);
+        assert.strictEqual(r.body.ok, false);
+        assert.strictEqual(r.body.error, 'unauthorized');
+    } finally {
+        srv.close();
+    }
+});
+
+test('/exec returns 401 with a wrong token', async () => {
+    const { srv, port } = await startApp();
+    try {
+        const r = await post(port, '/exec', { 'X-AE-MCP-Token': 'wrong' }, { code: '1' });
+        assert.strictEqual(r.status, 401);
+        assert.strictEqual(r.body.error, 'unauthorized');
+    } finally {
+        srv.close();
+    }
+});
+
+test('/exec returns 200 with the correct token', async () => {
+    const { srv, port } = await startApp();
+    try {
+        const r = await post(port, '/exec', { 'X-AE-MCP-Token': 'known-secret-token' }, { code: '1' });
+        assert.strictEqual(r.status, 200);
+        assert.strictEqual(r.body.ok, true);
+        assert.strictEqual(r.body.result, 'stub-result');
+    } finally {
+        srv.close();
+    }
+});

--- a/scripts/install-plugin-dev.ps1
+++ b/scripts/install-plugin-dev.ps1
@@ -22,6 +22,9 @@ if (Test-Path $cepDir) { Remove-Item -Recurse -Force $cepDir }
 Write-Host "  Done."
 
 Write-Host "[3/3] Copying plugin/ -> $cepDir ..."
+# Dev install intentionally KEEPS plugin/.debug so developers get the CEF
+# remote-debugging port. The packaged ZXP (scripts/package-zxp.ps1) strips it
+# so it never reaches end users.
 Copy-Item -Recurse -Force $pluginSrc $cepDir
 Write-Host "  Done."
 

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -1,17 +1,25 @@
 # Build a signed ZXP package for the ae-mcp CEP panel.
 #
 # Usage:
-#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe
+#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw>
 # Optional:
-#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPath release\ae-mcp.p12 -CertPassword changeit
+#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw> -CertPath release\ae-mcp.p12
+#
+# -CertPassword is REQUIRED (no baked-in default secret). The same password is
+# used to create the self-signed cert (if none exists) and to sign.
 
 param(
     [Parameter(Mandatory=$true)]
     [string]$ZxpSignCmd,
 
+    [Parameter(Mandatory=$true)]
+    [string]$CertPassword,
+
     [string]$CertPath = "",
-    [string]$CertPassword = "ae-mcp-dev",
-    [string]$OutputPath = ""
+    [string]$OutputPath = "",
+    # Timestamp server: an untimestamped self-signed ZXP fails validation once
+    # the cert expires. Timestamping pins the signature to signing time.
+    [string]$Tsa = "http://timestamp.digicert.com"
 )
 
 $ErrorActionPreference = 'Stop'
@@ -42,6 +50,10 @@ Copy-Item -Recurse -Force $pluginSrc $stageDir
 if (Test-Path (Join-Path $stageDir 'host\node_modules')) {
     Remove-Item -Recurse -Force (Join-Path $stageDir 'host\node_modules')
 }
+# Never ship the CEF remote-debug port file to end users: it opens a
+# remote-debugging port (the CEF context runs with node enabled), letting any
+# local process attach a DevTools/Node client. Strip it before signing.
+Remove-Item -Force (Join-Path $stageDir '.debug') -ErrorAction SilentlyContinue
 
 Write-Host "[2/4] Installing host production dependencies..."
 Push-Location (Join-Path $stageDir 'host')
@@ -62,7 +74,9 @@ Write-Host "[4/4] Signing package..."
 if (Test-Path $OutputPath) {
     Remove-Item -Force $OutputPath
 }
-& $ZxpSignCmd -sign $stageDir $OutputPath $CertPath $CertPassword
+# -tsa adds a trusted timestamp so the signature stays valid after the cert
+# expires.
+& $ZxpSignCmd -sign $stageDir $OutputPath $CertPath $CertPassword -tsa $Tsa
 
 Write-Host ""
 Write-Host "Wrote $OutputPath"


### PR DESCRIPTION
## Summary

Fixes the security issues in [#11](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/11).

### 1. /exec now requires a shared-secret token
`/exec` runs arbitrary ExtendScript (incl. `system.callSystem` and file IO) and had **no auth** — any local process could POST and get code execution. Added a shared token at `~/.ae-mcp/auth-token` (cross-platform: Node `os.homedir()` ↔ Python `Path.home()`):
- **Panel** (`auth-token.js`/`server.js`): `start()` generates a 32-byte hex token if absent (best-effort `0600`); `/exec` requires header `X-AE-MCP-Token` and 401s on mismatch via length-guarded `crypto.timingSafeEqual`. `/health` stays open (executes no code).
- **Bridge** (`HttpBridge`): reads + caches the same token, sends the header, and **fails closed** with an actionable `BackendError` if the file is missing.

### 2. JSX calls are serialized
The single persistent ExtendScript engine has shared globals; two overlapping `/exec` calls could interleave/half-apply edits. `jsx-bridge.js` now chains every `evalScript` through an in-flight queue (one at a time). A `settled` guard + queue tail that swallows results means a timeout/rejection always releases the lock — no deadlock, no queue poisoning.

### 3. .debug no longer ships to end users
`plugin/.debug` opens a CEF remote-debug port (CEF context runs with node enabled). `package-zxp.ps1` now strips the staged `.debug` before signing. The dev installer keeps it intentionally (commented).

### 4. Signing hygiene
`package-zxp.ps1`: removed the baked-in default cert password (`-CertPassword` is now mandatory) and added `-Tsa` (default `http://timestamp.digicert.com`) so signatures stay valid after the cert expires.

## Test Plan
- `node --test` in `plugin/host` → **14/14** (new `node:test` runner — no new deps): sentinel reject, normal resolve, missing CSInterface, timeout-releases-lock, **mutex no-overlap (`maxConcurrent===1` + strict order)**, no queue poisoning; `tokenMatches`/`ensureToken` idempotency; `/exec` 401(none)/401(wrong)/200(correct) over real Express.
- `uv run pytest -q` → **215 passed, 24 deselected** (bridge tests assert the header is sent and missing/empty token errors).
- `node --check` on all changed JS: clean.
- **Deferred (needs live panel/AE):** `ensureToken()` firing in the CEP Node host, the real engine honoring the mutex, and `ZXPSignCmd -tsa` reaching the TSA.

## Notes
- **Panel and bridge are now coupled** — both must ship together in v0.2.1 (old bridge ↔ new panel → 401 until updated). This is the intended fail-closed behavior; flag it in release notes.
- Adds a Node test runner to `plugin/host`, paying down the testing gap noted in #14.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)