### PR TITLE
fix(jsx): matchName addressing, JSON.parse polyfill, traversal budgets, skill $ escaping (#12)

### DIFF
--- a/packages/core/ae_mcp/handlers/typed.py
+++ b/packages/core/ae_mcp/handlers/typed.py
@@ -34,6 +34,13 @@ def _backend():
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "jsx_templates"
 
+# Wall-clock budget (ms) spliced into the search/scan traversal templates so a
+# large project returns partial results with truncated:true instead of running
+# past AE's 30s evalScript timeout (yielding zero output and a blocked UI).
+# Kept as a rendered constant rather than user-facing schema surface; ~20s sits
+# comfortably under the 30s exec timeout. #12
+_TRAVERSAL_BUDGET_MS = 20000
+
 
 @lru_cache(maxsize=16)
 def _load_template(name: str) -> Template:
@@ -357,6 +364,7 @@ def render_scan_property_tree(args: schemas.AeScanPropertyTreeArgs) -> str:
         layer_id=int(args.layer_id),
         max_depth=int(args.max_depth),
         include_values="true" if args.include_values else "false",
+        time_budget_ms=_TRAVERSAL_BUDGET_MS,
     )
 
 
@@ -514,6 +522,7 @@ def render_search_project(args: schemas.AeSearchProjectArgs) -> str:
         query_js=_json_literal(args.query),
         scope_js=_json_literal(list(args.scope)),
         limit=int(args.limit),
+        time_budget_ms=_TRAVERSAL_BUDGET_MS,
     )
 
 

--- a/packages/core/ae_mcp/jsx_templates/create_layer.jsx
+++ b/packages/core/ae_mcp/jsx_templates/create_layer.jsx
@@ -58,7 +58,13 @@
 
     if (position) {
         try {
-            layer.property("Transform").property("Position").setValue(position);
+            // Address Transform/Position by matchName so it resolves on
+            // non-English AE (display-name "Transform"/"Position" is null on
+            // JP/DE/etc., which would silently drop the position). #12
+            var posProp = AEMCP.propByMatchPath(
+                layer, "ADBE Transform Group#1/ADBE Position#1"
+            );
+            if (posProp) posProp.setValue(position);
         } catch (e) { /* shape layers may lack Transform.Position; ignore */ }
     }
 

--- a/packages/core/ae_mcp/jsx_templates/create_rig.jsx
+++ b/packages/core/ae_mcp/jsx_templates/create_rig.jsx
@@ -206,7 +206,7 @@
     if (!comp || !(comp instanceof CompItem)) {
       return fail("No active comp, or comp_id did not resolve to a CompItem.");
     }
-    var target = comp.layer($target_layer_id);
+    var target = AEMCP.layerById(comp, $target_layer_id);
     if (!target) {
       return fail("target layer not found: " + $target_layer_id);
     }

--- a/packages/core/ae_mcp/jsx_templates/scan_property_tree.jsx
+++ b/packages/core/ae_mcp/jsx_templates/scan_property_tree.jsx
@@ -9,6 +9,13 @@
     var includeValues = ${include_values};
     var truncated = null;
 
+    // Wall-clock budget so deep/wide trees return partial results instead of
+    // blowing the 30s evalScript timeout with zero output. #12
+    var BUDGET_MS = ${time_budget_ms};
+    var START_MS = new Date().getTime();
+    var budgetHit = false;
+    function overBudget() { return (new Date().getTime() - START_MS) >= BUDGET_MS; }
+
     function nodeFor(prop, depth) {
         var n = {
             name: prop.name,
@@ -33,6 +40,7 @@
                 return n;
             }
             for (var i = 1; i <= prop.numProperties; i++) {
+                if (budgetHit || overBudget()) { budgetHit = true; break; }
                 var child = prop.property(i);
                 if (!child) continue;
                 n.children.push(nodeFor(child, depth + 1));
@@ -43,6 +51,7 @@
 
     var rootChildren = [];
     for (var pi = 1; pi <= layer.numProperties; pi++) {
+        if (budgetHit || overBudget()) { budgetHit = true; break; }
         var top = layer.property(pi);
         if (!top) continue;
         rootChildren.push(nodeFor(top, 1));
@@ -55,6 +64,8 @@
         tree: { name: "(root)", matchName: "", kind: "PropertyGroup",
                 propType: null, value: null, hasExpression: false,
                 numKeyframes: 0, children: rootChildren },
-        truncatedAt: truncated
+        truncatedAt: truncated,
+        truncated: budgetHit,
+        reason: budgetHit ? "time budget exceeded" : null
     });
 })()

--- a/packages/core/ae_mcp/jsx_templates/search_project.jsx
+++ b/packages/core/ae_mcp/jsx_templates/search_project.jsx
@@ -5,6 +5,12 @@
     var scope = ${scope_js};
     var limit = ${limit};
 
+    // Wall-clock budget so large projects return partial results instead of
+    // blowing the 30s evalScript timeout with zero output. #12
+    var BUDGET_MS = ${time_budget_ms};
+    var START_MS = new Date().getTime();
+    function overBudget() { return (new Date().getTime() - START_MS) >= BUDGET_MS; }
+
     var orGroups = query.toLowerCase().split("|");
     for (var oi = 0; oi < orGroups.length; oi++) {
         var raw = orGroups[oi].split(/\s+/);
@@ -34,6 +40,7 @@
 
     var hits = [];
     var truncated = false;
+    var budgetHit = false;
     function add(h) {
         if (truncated) return;
         if (hits.length >= limit) { truncated = true; return; }
@@ -43,6 +50,7 @@
     var n = app.project.numItems;
     for (var i = 1; i <= n; i++) {
         if (truncated) break;
+        if (overBudget()) { truncated = true; budgetHit = true; break; }
         var it = app.project.item(i);
         if (!it) continue;
 
@@ -54,6 +62,7 @@
             if (inScope("layers") || inScope("expressions") || inScope("effects")) {
                 for (var li = 1; li <= it.numLayers; li++) {
                     if (truncated) break;
+                    if (overBudget()) { truncated = true; budgetHit = true; break; }
                     var layer = it.layer(li);
                     if (inScope("layers") && matches(layer.name)) {
                         add({kind:"layer", compId:String(it.id), layerId:li,
@@ -101,5 +110,6 @@
     }
 
     hits.sort(function(a,b){return b.score - a.score;});
-    return JSON.stringify({ok:true, hits:hits, truncated:truncated});
+    return JSON.stringify({ok:true, hits:hits, truncated:truncated,
+        reason: budgetHit ? "time budget exceeded" : (truncated ? "limit reached" : null)});
 })()

--- a/packages/core/ae_mcp/skill_store.py
+++ b/packages/core/ae_mcp/skill_store.py
@@ -135,4 +135,8 @@ def render_skill(skill: Skill, provided_args: dict[str, Any]) -> str:
         name: _value_for_template(skill, values[name])
         for name in placeholders
     }
-    return Template(skill.template).substitute(rendered_values)
+    # safe_substitute (not substitute) so idiomatic ExtendScript `$` sequences
+    # like `$.writeln` / `$.global` pass through untouched instead of raising
+    # "Invalid placeholder in string". Declared ${name} placeholders are still
+    # substituted; only unknown bare-$ runs are left verbatim. #12
+    return Template(skill.template).safe_substitute(rendered_values)

--- a/packages/core/tests/test_handlers_typed.py
+++ b/packages/core/tests/test_handlers_typed.py
@@ -274,6 +274,57 @@ def test_render_search_project():
     assert "var limit = 10;" in jsx
 
 
+def test_render_create_layer_position_uses_matchname():
+    # #12: position must be addressed by matchName, not the localized display
+    # names "Transform"/"Position" (null on JP/DE AE -> position silently lost).
+    from ae_mcp.handlers.typed import render_create_layer
+    args = S.AeCreateLayerArgs(type="solid", name="P", position=(10, 20, 0))
+    jsx = render_create_layer(args)
+    assert "AEMCP.propByMatchPath(" in jsx
+    assert "ADBE Transform Group#1/ADBE Position#1" in jsx
+    # The brittle display-name chain is gone.
+    assert 'property("Transform").property("Position")' not in jsx
+
+
+def test_render_search_project_has_time_budget():
+    # #12: traversal must be wall-clock bounded so big projects return partial
+    # results instead of blowing the 30s timeout with zero output.
+    from ae_mcp.handlers.typed import render_search_project, _TRAVERSAL_BUDGET_MS
+    jsx = render_search_project(schemas.AeSearchProjectArgs(query="x"))
+    assert f"var BUDGET_MS = {_TRAVERSAL_BUDGET_MS};" in jsx
+    assert "new Date().getTime()" in jsx
+    assert "overBudget()" in jsx
+    assert "budgetHit" in jsx
+    assert _TRAVERSAL_BUDGET_MS < 30000  # comfortably under the exec timeout
+
+
+def test_render_scan_property_tree_has_time_budget():
+    from ae_mcp.handlers.typed import render_scan_property_tree, _TRAVERSAL_BUDGET_MS
+    jsx = render_scan_property_tree(schemas.AeScanPropertyTreeArgs(layer_id=1))
+    assert f"var BUDGET_MS = {_TRAVERSAL_BUDGET_MS};" in jsx
+    assert "overBudget()" in jsx
+    assert "budgetHit" in jsx
+
+
+def test_render_create_rig_uses_layerById():
+    # #12 (carried from PR #14 review): resolve the target via AEMCP.layerById
+    # so the `if (!target)` guard is reachable and returns the friendly
+    # "target layer not found" message instead of AE's raw exception.
+    from ae_mcp.handlers.rig import _load_jsx
+    import json as _json
+    jsx = _load_jsx("create_rig.jsx").substitute(
+        comp_expr="null",
+        target_layer_id=_json.dumps(99),
+        rig_type=_json.dumps("transform_controller"),
+        name=_json.dumps("Ctrl"),
+        options=_json.dumps({}),
+    )
+    assert "AEMCP.layerById(comp, 99)" in jsx
+    assert "comp.layer(99)" not in jsx
+    assert "target layer not found" in jsx
+
+
+
 @pytest.mark.asyncio
 async def test_run_search_project(mock_backend):
     mock_backend.set_response(

--- a/packages/core/tests/test_runtime_jsx.py
+++ b/packages/core/tests/test_runtime_jsx.py
@@ -29,7 +29,9 @@ def test_runtime_file_exists():
 )
 def test_array_polyfill_present_and_guarded(src, method):
     assert f"if (!Array.prototype.{method})" in src
-    assert f"Array.prototype.{method} = function" in src
+    # Installed via the non-enumerable _definePoly helper (#12), no longer a
+    # bare `Array.prototype.X = function` assignment.
+    assert f"_definePoly(Array.prototype, '{method}', function" in src
 
 
 def test_array_isarray_guarded(src):
@@ -64,6 +66,39 @@ def test_aemcp_namespace_guarded_for_reinit(src):
 
 def test_json_polyfill_retained(src):
     assert "if (typeof JSON === 'undefined')" in src
+
+
+def test_json_stringify_guarded_by_function_check(src):
+    # stringify is now also defended for the "JSON exists but lacks stringify"
+    # case, not just "JSON undefined".
+    assert "typeof JSON.stringify !== 'function'" in src
+    assert "JSON.stringify = function" in src
+
+
+def test_json_parse_polyfill_present_and_guarded(src):
+    # #12: classic-engine ae.exec code calling JSON.parse must not throw.
+    assert "typeof JSON.parse !== 'function'" in src
+    assert "JSON.parse = function" in src
+    # eval-with-validation must include Crockford's security regex so it can
+    # never eval arbitrary code.
+    assert r"/^[\],:{}\s]*$/" in src
+    assert "throw new SyntaxError" in src
+
+
+def test_array_polyfills_are_non_enumerable(src):
+    # #12: prototype additions install via a non-enumerable defineProperty
+    # helper so `for (var k in arr)` doesn't surface polyfill names.
+    assert "function _definePoly(proto, name, fn)" in src
+    assert "Object.defineProperty(proto, name, {" in src
+    assert "enumerable: false" in src
+    # try/catch fallback to plain assignment on engines where defineProperty
+    # throws on native prototypes.
+    assert "proto[name] = fn;" in src
+    # Every Array.prototype method routes through the helper, not a bare assign.
+    for method in ["indexOf", "forEach", "map", "filter", "reduce",
+                   "some", "every", "includes"]:
+        assert f"_definePoly(Array.prototype, '{method}'," in src
+        assert f"Array.prototype.{method} = function" not in src
 
 
 def _strip_line_comments(src: str) -> str:

--- a/packages/core/tests/test_skill_store.py
+++ b/packages/core/tests/test_skill_store.py
@@ -1,0 +1,62 @@
+"""Unit tests for skill_store rendering (no live AE).
+
+render_skill drives ae.skillUse; it must substitute declared ${name}
+placeholders while leaving idiomatic ExtendScript `$` sequences ($.writeln,
+$.global, ...) untouched. Before #12 it used Template.substitute, which throws
+"Invalid placeholder in string" on a bare `$.` — so a skill could save via
+skillCreate yet fail on every skillUse.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ae_mcp.skill_store import Skill, render_skill
+
+
+def _skill(template: str, args_schema=None, template_type: str = "jsx") -> Skill:
+    return Skill(
+        name="probe",
+        description="",
+        template_type=template_type,
+        template=template,
+        args_schema=args_schema or {},
+    )
+
+
+def test_render_passes_through_extendscript_dollar_and_substitutes_arg():
+    skill = _skill(
+        '$.writeln("x"); var c = app.project.itemByID(${comp_id});',
+        args_schema={"comp_id": {"type": "number"}},
+    )
+    out = render_skill(skill, {"comp_id": 42})
+    # ExtendScript `$.writeln` survives verbatim.
+    assert '$.writeln("x")' in out
+    # Declared placeholder is still substituted (jsx => JSON literal).
+    assert "itemByID(42)" in out
+
+
+def test_render_handles_multiple_bare_dollar_idioms():
+    skill = _skill('$.global; $.engineName; var n = ${name};',
+                   args_schema={"name": {"type": "string"}})
+    out = render_skill(skill, {"name": "hero"})
+    assert "$.global" in out
+    assert "$.engineName" in out
+    assert '"hero"' in out
+
+
+def test_render_prompt_type_substitutes_plainly():
+    skill = _skill("Use $.writeln then set ${val}",
+                   args_schema={"val": {"type": "string"}},
+                   template_type="prompt")
+    out = render_skill(skill, {"val": "go"})
+    assert "$.writeln" in out
+    # prompt type substitutes the raw string, not a JSON literal.
+    assert "set go" in out
+
+
+def test_render_missing_arg_still_raises():
+    skill = _skill("$.writeln(${needed});",
+                   args_schema={"needed": {"type": "string"}})
+    with pytest.raises(Exception) as exc:
+        render_skill(skill, {})
+    assert "missing skill args" in str(exc.value)

--- a/plugin/jsx/runtime.jsx
+++ b/plugin/jsx/runtime.jsx
@@ -4,6 +4,8 @@
 // may run script in classic mode in some contexts.
 if (typeof JSON === 'undefined') {
     JSON = {};
+}
+if (typeof JSON === 'undefined' || typeof JSON.stringify !== 'function') {
     JSON.stringify = function (v) {
         if (v === null) return 'null';
         if (typeof v === 'undefined') return 'null';
@@ -31,6 +33,32 @@ if (typeof JSON === 'undefined') {
         return 'null';
     };
 }
+// JSON.parse polyfill for the classic engine. AE 2026's modern engine has a
+// native JSON.parse, so this is guarded to a no-op there. Agent ae.exec code
+// that calls JSON.parse would otherwise throw on the classic engine. #12
+//
+// eval-with-validation approach: the source is first vetted against the
+// security regex from Crockford's json2.js (which rejects anything that isn't
+// well-formed JSON) so eval can only ever produce a JSON value, never run
+// arbitrary code. ES3-safe: var/function only.
+if (typeof JSON === 'undefined' || typeof JSON.parse !== 'function') {
+    JSON.parse = function (text) {
+        var src = String(text);
+        // The four-stage check is the standard json2.js guard:
+        //   1. replace JSON escapes with '@'
+        //   2. replace literals/numbers with ']'
+        //   3. delete commas/brackets between those tokens
+        //   4. what remains must be empty for the text to be valid JSON
+        var cleaned = src
+            .replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+            .replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+            .replace(/(?:^|:|,)(?:\s*\[)+/g, '');
+        if (!(/^[\],:{}\s]*$/.test(cleaned))) {
+            throw new SyntaxError('JSON.parse: invalid JSON');
+        }
+        return eval('(' + src + ')');
+    };
+}
 
 // ---------------------------------------------------------------------------
 // ES3 Array / Object polyfills.
@@ -42,11 +70,33 @@ if (typeof JSON === 'undefined') {
 // engine and safe to re-run on panel re-init. Keep everything ES3: var only,
 // function keyword, no arrow/const/let.
 //
+// Additions are installed NON-ENUMERABLE via Object.defineProperty so that
+// third-party scripts doing `for (var k in arr)` don't suddenly see the
+// polyfilled method names as keys (prototype-pollution hazard). Some ancient
+// engines throw when defineProperty is used on native prototypes, so the
+// helper wraps it in try/catch and falls back to a plain (enumerable)
+// assignment only when defineProperty is unavailable or fails. #12
+//
 // This file loads ONCE into the persistent engine (manifest ScriptPath), so a
 // syntax error here breaks EVERY verb. Edit with care.
 // ---------------------------------------------------------------------------
+
+// Define `name` on `proto` non-enumerably when possible; plain-assign otherwise.
+function _definePoly(proto, name, fn) {
+    var defined = false;
+    if (typeof Object.defineProperty === 'function') {
+        try {
+            Object.defineProperty(proto, name, {
+                value: fn, enumerable: false, writable: true, configurable: true
+            });
+            defined = true;
+        } catch (e) { defined = false; }
+    }
+    if (!defined) { proto[name] = fn; }
+}
+
 if (!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function (needle, from) {
+    _definePoly(Array.prototype, 'indexOf', function (needle, from) {
         var len = this.length >>> 0;
         var i = from ? Number(from) : 0;
         if (i < 0) i = Math.max(0, len + i);
@@ -54,38 +104,38 @@ if (!Array.prototype.indexOf) {
             if (i in this && this[i] === needle) return i;
         }
         return -1;
-    };
+    });
 }
 if (!Array.prototype.forEach) {
-    Array.prototype.forEach = function (fn, thisArg) {
+    _definePoly(Array.prototype, 'forEach', function (fn, thisArg) {
         var len = this.length >>> 0;
         for (var i = 0; i < len; i++) {
             if (i in this) fn.call(thisArg, this[i], i, this);
         }
-    };
+    });
 }
 if (!Array.prototype.map) {
-    Array.prototype.map = function (fn, thisArg) {
+    _definePoly(Array.prototype, 'map', function (fn, thisArg) {
         var len = this.length >>> 0;
         var out = new Array(len);
         for (var i = 0; i < len; i++) {
             if (i in this) out[i] = fn.call(thisArg, this[i], i, this);
         }
         return out;
-    };
+    });
 }
 if (!Array.prototype.filter) {
-    Array.prototype.filter = function (fn, thisArg) {
+    _definePoly(Array.prototype, 'filter', function (fn, thisArg) {
         var len = this.length >>> 0;
         var out = [];
         for (var i = 0; i < len; i++) {
             if (i in this && fn.call(thisArg, this[i], i, this)) out.push(this[i]);
         }
         return out;
-    };
+    });
 }
 if (!Array.prototype.reduce) {
-    Array.prototype.reduce = function (fn, init) {
+    _definePoly(Array.prototype, 'reduce', function (fn, init) {
         var len = this.length >>> 0;
         var i = 0, acc;
         if (arguments.length >= 2) {
@@ -98,30 +148,30 @@ if (!Array.prototype.reduce) {
             if (i in this) acc = fn(acc, this[i], i, this);
         }
         return acc;
-    };
+    });
 }
 if (!Array.prototype.some) {
-    Array.prototype.some = function (fn, thisArg) {
+    _definePoly(Array.prototype, 'some', function (fn, thisArg) {
         var len = this.length >>> 0;
         for (var i = 0; i < len; i++) {
             if (i in this && fn.call(thisArg, this[i], i, this)) return true;
         }
         return false;
-    };
+    });
 }
 if (!Array.prototype.every) {
-    Array.prototype.every = function (fn, thisArg) {
+    _definePoly(Array.prototype, 'every', function (fn, thisArg) {
         var len = this.length >>> 0;
         for (var i = 0; i < len; i++) {
             if (i in this && !fn.call(thisArg, this[i], i, this)) return false;
         }
         return true;
-    };
+    });
 }
 if (!Array.prototype.includes) {
-    Array.prototype.includes = function (needle) {
+    _definePoly(Array.prototype, 'includes', function (needle) {
         return this.indexOf(needle) !== -1;
-    };
+    });
 }
 if (!Array.isArray) {
     Array.isArray = function (o) {


### PR DESCRIPTION
## Summary

Fixes the ExtendScript robustness / i18n gaps in [#12](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/12). All five items were verified to still reproduce before fixing.

- **create_layer dropped position on non-English AE.** `create_layer.jsx` set position via localized display names (`property("Transform").property("Position")`), which are null on JP/DE/etc. — silently dropping position while reporting ok:true. Now resolved via `AEMCP.propByMatchPath(layer, "ADBE Transform Group#1/ADBE Position#1")`. Audited every template: this was the **only** display-name-addressed standard property; all others already use ADBE matchNames or walk user-supplied path segments (correctly left alone).
- **runtime.jsx: missing JSON.parse + enumerable prototype pollution.** Added a guarded `JSON.parse` polyfill (eval-with-validation using Crockford's json2.js security regex — injection payloads verified rejected; no-op on AE 2026's native JSON). The 8 `Array.prototype` polyfills now install **non-enumerable** via `Object.defineProperty` (try/catch → plain-assign fallback on engines that reject it), so `for (var k in arr)` no longer enumerates them.
- **search_project / scan_property_tree had no time budget.** Both now carry a wall-clock budget (`_TRAVERSAL_BUDGET_MS = 20000`, rendered constant, ~20s under the 30s exec timeout) and return partial results with `truncated:true` + `reason` instead of blowing the timeout with zero output.
- **skill_store crashed on ExtendScript `$`.** `render_skill` used `Template.substitute`, which throws on `$.writeln`/`$.global`. Switched to `safe_substitute` — declared `${name}` placeholders still resolve; bare-$ passes through.
- **create_rig dead guard (carried from #14 review).** `create_rig.jsx:209` used `comp.layer($target_layer_id)` (raw AE exception); now `AEMCP.layerById(...)` so the friendly "target layer not found" guard is reachable.

## Test Plan
- `uv run pytest -q` → **238 passed, 24 deselected** (no regressions; added skill_store `$` pass-through, runtime.jsx JSON.parse + non-enumerable assertions, and render-string assertions for matchName/budget/layerById).
- **Deferred (needs live AE):** position-setting on a localized AE install; JSON.parse / non-enumerability on the real classic engine; large-project traversal actually hitting the budget.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)