### PR TITLE
fix: real progress notifications, AE-window snapshot, honest scale field, accurate install docs (#13)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -74,6 +74,17 @@ pip install ./packages/core ./packages/bridge ./packages/snapshot-mss
 - `ae-mcp` backend entry point
 - `ae.previewFrame` 需要的 snapshotter
 
+> **三个包必须一起安装。** `ae-mcp-bridge` 和 `ae-mcp-snapshot-mss` 在各自的
+> `pyproject.toml` 里按名字依赖 `ae-mcp>=0.2.0`，而这个名字在 PyPI 上并不存在
+> （仓库尚未发布到 PyPI）。所以不要单独跑 `pip install ./packages/bridge`，
+> 那会因为找不到 `ae-mcp` 而失败。请把三个路径放在同一条 `pip install` 命令里
+> （core 在最前，让 bridge/snapshot 的依赖在同一次解析中就地命中），或者用
+> `uv sync --all-packages`（见上方开发安装）。
+>
+> **供应链提示：** 一旦 `ae-mcp` 这个名字以后被发布到公共 PyPI，第三方就可能抢注
+> 同名包。在该名字由本项目正式发布前，请始终从本仓库的本地路径安装这三个包，
+> 不要让 pip 去公共索引拉取名为 `ae-mcp` 的包。
+
 2. 安装并打开 AE 面板：
 
 ```powershell
@@ -153,7 +164,7 @@ uv run pytest packages/core/tests/live -o addopts='' -vv
 - 面板红灯：查看面板里的 `Last error` 和日志区域。
 - `ae-mcp` 命令找不到：把 `command` 改成安装环境里的 launcher 绝对路径；Windows 通常是 `ae-mcp.exe`，macOS/Linux 通常是 `ae-mcp`。
 - 报 `AE_MCP_BACKEND='ae-mcp' but no such backend installed`：说明当前 Python 环境缺 `ae-mcp-bridge`。
-- 端口冲突：在面板中修改端口，并同步更新 `AE_MCP_PLUGIN_URL`。
+- 端口冲突：在面板中修改端口，并同步更新 `AE_MCP_PLUGIN_URL`。面板会把改过的端口记到 `localStorage`，重启后仍然保留（不会再被重置回 11488）。
 - `evalScript` 超时：先关闭 AE 模态弹窗；如果仍然卡住，重启 AE。
 - `ae.snapshot` 是诊断截图；`ae.previewFrame` 是快速 viewer capture，不是真实渲染。
 - macOS 试跑问题：请提 GitHub issue，并附上 AE 版本、macOS 版本、Python 版本和面板日志。
@@ -231,6 +242,21 @@ This provides:
 - the `ae-mcp` launcher
 - the `ae-mcp` backend entry point
 - the snapshotter required by `ae.previewFrame`
+
+> **The three packages must be installed together.** `ae-mcp-bridge` and
+> `ae-mcp-snapshot-mss` declare a by-name dependency on `ae-mcp>=0.2.0` in their
+> `pyproject.toml`, but that name is not published on PyPI (this repo is not on
+> PyPI yet). A standalone `pip install ./packages/bridge` therefore fails — pip
+> cannot resolve `ae-mcp`. Pass all three paths in a single `pip install`
+> command (core first, so the bridge/snapshot dependency resolves against the
+> local copy in the same run), or use `uv sync --all-packages` (see Developer
+> Install above).
+>
+> **Supply-chain note:** if the name `ae-mcp` is ever published to the public
+> PyPI by someone else, a third party could squat that name. Until this project
+> formally publishes the name, always install the three packages from this
+> repo's local paths and do not let pip pull an `ae-mcp` package from the public
+> index.
 
 2. Install and open the AE panel:
 
@@ -311,7 +337,7 @@ Current expected result: `24 passed`.
 - Panel red: read the panel `Last error` line and log area.
 - `ae-mcp` command not found: change `command` to the absolute path of the installed launcher; on Windows this is usually `ae-mcp.exe`, while on macOS/Linux it is usually `ae-mcp`.
 - `AE_MCP_BACKEND='ae-mcp' but no such backend installed`: the current Python environment is missing `ae-mcp-bridge`.
-- Port conflict: edit the port in the panel and update `AE_MCP_PLUGIN_URL`.
+- Port conflict: edit the port in the panel and update `AE_MCP_PLUGIN_URL`. The panel persists the changed port in `localStorage`, so it survives a restart (it no longer resets to 11488).
 - `evalScript` timeouts: close AE modal dialogs first; restart AE if calls still hang.
 - `ae.snapshot` is diagnostic capture. `ae.previewFrame` is fast viewer capture, not a true render.
 - macOS trial issues: please open a GitHub issue with your AE version, macOS version, Python version, and panel logs.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -18,6 +18,15 @@
 | 非 live 验证 | `203 passed, 24 deselected` |
 | live 验证 | AE 打开且面板绿灯时 `24 passed` |
 
+### 环境变量
+
+| 变量 | 作用 | 默认值 |
+|---|---|---|
+| `AE_MCP_BACKEND` | 选择后端 entry point 名称（bridge 注册为 `ae-mcp`） | 无（单后端时自动选用） |
+| `AE_MCP_PLUGIN_URL` | bridge 后端连接 AE 面板 HTTP RPC 的地址 | `http://127.0.0.1:11488` |
+| `AE_MCP_SKILL_DIR` | skill 存储目录（`ae.skill*` 读写的 `<name>.json`） | `~/.ae-mcp/skills` |
+| `AE_MCP_CHECKPOINT_KEEP` | 每个工程保留的 checkpoint 数量上限（旧的自动清理，最小 1） | `50` |
+
 ### 架构
 
 ```text
@@ -203,6 +212,15 @@ ae-mcp 是独立实现，参考了 Atom 风格 AE 操作面和 FX Console 风格
 | Checkpoint store | `%TEMP%/ae_mcp_checkpoints/<basename>/<id>.aep + .json` |
 | Current non-live verification | `203 passed, 24 deselected` |
 | Current live verification | `24 passed` with AE open and panel green |
+
+### Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `AE_MCP_BACKEND` | Selects the backend entry-point name (the bridge registers as `ae-mcp`) | unset (auto-selected when exactly one backend is installed) |
+| `AE_MCP_PLUGIN_URL` | Address the bridge backend uses to reach the AE panel's HTTP RPC | `http://127.0.0.1:11488` |
+| `AE_MCP_SKILL_DIR` | Directory where skills are stored (the `<name>.json` files read/written by `ae.skill*`) | `~/.ae-mcp/skills` |
+| `AE_MCP_CHECKPOINT_KEEP` | Max checkpoints retained per project (older ones are pruned; minimum 1) | `50` |
 
 ### Architecture
 

--- a/packages/core/ae_mcp/backends/discovery.py
+++ b/packages/core/ae_mcp/backends/discovery.py
@@ -10,6 +10,31 @@ from ae_mcp.backends.base import Backend
 
 ENTRY_POINT_GROUP = "ae_mcp.backends"
 
+# Known backend entry-point name -> the PyPI/distribution package that provides
+# it. The entry-point name and the package name differ (e.g. the "ae-mcp"
+# backend lives in the "ae-mcp-bridge" package), so a naive
+# "pip install ae-mcp-backend-<name>" hint points at a package that does not
+# exist. Keep this in sync with the entry_points declared by the backend
+# packages' pyprojects.
+_KNOWN_BACKEND_PACKAGES = {
+    "ae-mcp": "ae-mcp-bridge",
+}
+
+
+def _install_hint(requested: str) -> str:
+    """Return an accurate `pip install` hint for a requested backend name.
+
+    Uses the known entry-point -> package mapping when available; otherwise
+    falls back to advising the user to consult their plugin's docs (we cannot
+    guess an arbitrary third-party package name)."""
+    pkg = _KNOWN_BACKEND_PACKAGES.get(requested)
+    if pkg:
+        return f"Try: pip install {pkg}"
+    return (
+        "Install the backend package that provides this name "
+        "(see your AE plugin's docs for the package name)."
+    )
+
 
 class BackendSelectionError(RuntimeError):
     """Raised when no usable backend can be chosen."""
@@ -37,7 +62,7 @@ def select_backend() -> Backend:
             raise BackendSelectionError(
                 f"AE_MCP_BACKEND={requested!r} but no such backend installed.\n"
                 f"  Installed backends: {installed_names}\n"
-                f"  Try: pip install ae-mcp-backend-{requested}\n"
+                f"  {_install_hint(requested)}\n"
                 f"  Or fix AE_MCP_BACKEND to one of the installed names."
             )
         return installed[requested].from_env()

--- a/packages/core/ae_mcp/handlers/core.py
+++ b/packages/core/ae_mcp/handlers/core.py
@@ -553,6 +553,32 @@ def _attach_preview_file_data(parsed: dict[str, Any], include_base64: bool) -> d
     return parsed
 
 
+def _downscale_png(path: Path, scale: float) -> Optional[tuple[int, int]]:
+    """Resample the PNG at `path` in place by `scale` (0<scale, !=1.0).
+
+    Returns the new (width, height), or None if no resize was applied (scale
+    ~1.0 or the result would be degenerate). Uses Pillow, a declared core
+    dependency. Never raises into the caller — on failure the original file is
+    left untouched and None is returned.
+    """
+    if scale <= 0 or abs(scale - 1.0) < 1e-9:
+        return None
+    try:
+        from PIL import Image
+
+        with Image.open(path) as im:
+            new_w = max(1, int(round(im.width * scale)))
+            new_h = max(1, int(round(im.height * scale)))
+            if (new_w, new_h) == (im.width, im.height):
+                return None
+            resized = im.resize((new_w, new_h), Image.LANCZOS)
+        resized.save(path, "PNG")
+        return (new_w, new_h)
+    except Exception:  # noqa: BLE001
+        log.debug("preview downscale failed for %s", path, exc_info=True)
+        return None
+
+
 async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
     from ae_mcp.handlers.typed import _comp_expr  # type: ignore
     from ae_mcp.snapshot import discovery as _snap_discovery
@@ -597,12 +623,24 @@ async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
 
             comp_id = str(prepared.get("compId"))
             comp_name = prepared.get("compName")
+            # Apply the requested output scale to the captured PNG (in place).
+            frame_w = snap.get("width")
+            frame_h = snap.get("height")
+            snap_path = snap.get("path")
+            if snap_path:
+                new_dims = _downscale_png(Path(str(snap_path)), args.scale)
+                if new_dims is not None:
+                    frame_w, frame_h = new_dims
             frame = {
                 "time": prepared.get("time"),
-                "path": snap.get("path"),
-                "width": snap.get("width"),
-                "height": snap.get("height"),
-                "sizeBytes": snap.get("bytes"),
+                "path": snap_path,
+                "width": frame_w,
+                "height": frame_h,
+                "sizeBytes": (
+                    Path(str(snap_path)).stat().st_size
+                    if snap_path and Path(str(snap_path)).exists()
+                    else snap.get("bytes")
+                ),
                 "source": "viewer",
                 "method": snap.get("method"),
                 "compId": comp_id,

--- a/packages/core/ae_mcp/progress.py
+++ b/packages/core/ae_mcp/progress.py
@@ -4,7 +4,15 @@ Why: long-running AE ops (`ae.exec` with heavy JSX, 6 typed verbs that build
 JSX and round-trip through the file bridge) can take tens of seconds. Without
 periodic progress notifications the MCP client sees a silent stall and may
 time out the request. `with_heartbeat` pairs the real work with a background
-task that emits `ctx.report_progress` every `interval` seconds.
+task that emits a progress notification every `interval` seconds.
+
+The handlers receive the low-level ``mcp.shared.context.RequestContext`` (this
+server is built on ``mcp.server.Server``, not FastMCP). That object has NO
+``report_progress`` method — only FastMCP's ``Context`` does. The real
+out-of-band progress channel is ``ctx.session.send_progress_notification``,
+and it only does anything when the inbound request carried a
+``_meta.progressToken`` (exposed as ``ctx.meta.progressToken``). When no token
+is present there is nobody to notify, so we no-op cleanly.
 
 Usage:
     result = await with_heartbeat(ctx, do_work_coro, interval=2.0,
@@ -21,21 +29,55 @@ from typing import Any, Awaitable, Optional
 log = logging.getLogger("ae_mcp.progress")
 
 
+def _progress_token(ctx: Any) -> Any:
+    """Extract the inbound request's progressToken, or None if absent."""
+    meta = getattr(ctx, "meta", None)
+    if meta is None:
+        return None
+    return getattr(meta, "progressToken", None)
+
+
 async def _safe_report_progress(
     ctx: Any, progress: float, total: Optional[float], message: Optional[str]
 ) -> None:
     """Best-effort progress notification. Swallow errors — heartbeat must
     never break the actual work path.
 
-    Accepts ctx=None (useful for tests that drive handlers without FastMCP).
+    Resolution order:
+      1. Low-level path (the real server): emit a notifications/progress via
+         ``ctx.session.send_progress_notification`` when the request carried a
+         progressToken. No token -> nothing to notify -> clean no-op.
+      2. FastMCP path: if the ctx exposes ``report_progress`` (e.g. tests using
+         a FastMCP-style fake), use it.
+      3. Otherwise no-op.
+
+    Accepts ctx=None (useful for tests that drive handlers without a ctx).
+    Never raises into the caller.
     """
     if ctx is None:
         return
     try:
+        session = getattr(ctx, "session", None)
+        send = getattr(session, "send_progress_notification", None)
+        if send is not None:
+            token = _progress_token(ctx)
+            if token is None:
+                # No progressToken on the request: the client didn't ask for
+                # progress, so there's nothing to send. Clean no-op.
+                return
+            await send(
+                progress_token=token,
+                progress=progress,
+                total=total,
+                message=message,
+            )
+            return
         # FastMCP Context exposes async report_progress(progress, total, message).
-        await ctx.report_progress(progress=progress, total=total, message=message)
+        report = getattr(ctx, "report_progress", None)
+        if report is not None:
+            await report(progress=progress, total=total, message=message)
     except Exception:  # noqa: BLE001
-        log.debug("report_progress failed", exc_info=True)
+        log.debug("progress notification failed", exc_info=True)
 
 
 async def with_heartbeat(

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -150,7 +150,12 @@ class AePreviewFrameArgs(_StrictModel):
         False, description="Attach base64 PNG bytes to each returned frame."
     )
     scale: float = Field(
-        1.0, gt=0, le=4, description="Requested preview scale. MVP renders native comp size."
+        1.0, gt=0, le=4,
+        description=(
+            "Output scale factor applied to the captured PNG (0<scale<=4). "
+            "1.0 = native size; e.g. 0.5 returns a half-size image. The frame "
+            "is captured at native size then resampled to scale before return."
+        ),
     )
     repaint_delay_ms: int = Field(
         300, ge=0, le=5000,

--- a/packages/core/tests/test_discovery.py
+++ b/packages/core/tests/test_discovery.py
@@ -68,7 +68,23 @@ def test_env_var_unknown_raises_with_install_hint(monkeypatch):
             select_backend()
         msg = str(ei.value)
         assert "ghost" in msg
-        assert "pip install" in msg
+        # Unknown backend names have no known package, so we fall back to a
+        # generic (but accurate) hint rather than inventing a package name.
+        assert "ae-mcp-backend-ghost" not in msg
+        assert "plugin's docs" in msg
+
+
+def test_env_var_known_backend_hint_names_real_package(monkeypatch):
+    """The 'ae-mcp' backend lives in the 'ae-mcp-bridge' package; the hint
+    must name the real package, not the bogus 'ae-mcp-backend-ae-mcp'."""
+    monkeypatch.setenv("AE_MCP_BACKEND", "ae-mcp")
+    with _patch_installed({"a": FakeBackendA}):
+        with pytest.raises(BackendSelectionError) as ei:
+            select_backend()
+        msg = str(ei.value)
+        assert "pip install ae-mcp-bridge" in msg
+        assert "ae-mcp-backend-ae-mcp" not in msg
+
 
 
 def test_list_installed_backends_returns_dict():

--- a/packages/core/tests/test_handlers_core.py
+++ b/packages/core/tests/test_handlers_core.py
@@ -231,6 +231,100 @@ async def test_preview_frame_errors_without_snapshotter(monkeypatch, mock_backen
     assert "snapshotter" in result["error"]
 
 
+class _RealPngSnapshotter:
+    """Writes an actual decodable PNG so the scale/downscale path runs."""
+
+    def __init__(self, w=800, h=600):
+        self.w, self.h = w, h
+
+    async def capture(self, out_path, *, hwnd=None, main_window=False, method="auto"):
+        from PIL import Image
+
+        Image.new("RGB", (self.w, self.h), (10, 20, 30)).save(out_path, "PNG")
+        return {
+            "ok": True,
+            "path": str(out_path),
+            "bytes": out_path.stat().st_size,
+            "width": self.w,
+            "height": self.h,
+            "hwnd": hwnd,
+            "method": method,
+        }
+
+
+def test_downscale_png_halves_dimensions(tmp_path):
+    from PIL import Image
+
+    from ae_mcp.handlers.core import _downscale_png
+
+    p = tmp_path / "f.png"
+    Image.new("RGB", (800, 600), (1, 2, 3)).save(p, "PNG")
+    dims = _downscale_png(p, 0.5)
+    assert dims == (400, 300)
+    with Image.open(p) as im:
+        assert (im.width, im.height) == (400, 300)
+
+
+def test_downscale_png_noop_at_unit_scale(tmp_path):
+    from PIL import Image
+
+    from ae_mcp.handlers.core import _downscale_png
+
+    p = tmp_path / "f.png"
+    Image.new("RGB", (640, 480), (1, 2, 3)).save(p, "PNG")
+    assert _downscale_png(p, 1.0) is None
+    with Image.open(p) as im:
+        assert (im.width, im.height) == (640, 480)
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_honors_scale(monkeypatch, mock_backend, tmp_path):
+    """scale=0.5 must return a frame whose reported and on-disk dimensions are
+    half the native capture size (Item 3: scale was previously ignored)."""
+    monkeypatch.setattr(
+        "ae_mcp.snapshot.discovery.select_snapshotter",
+        lambda: _RealPngSnapshotter(800, 600),
+    )
+    mock_backend.set_response(json.dumps({
+        "ok": True, "compId": "7", "compName": "Preview", "time": 0.0,
+    }))
+
+    _, run_fn = HANDLERS["ae.previewFrame"]
+    result = await run_fn(
+        S.AePreviewFrameArgs(comp_id="7", time=0.0, out_dir=str(tmp_path), scale=0.5),
+        None,
+    )
+
+    assert result["ok"] is True
+    frame = result["frames"][0]
+    assert frame["width"] == 400
+    assert frame["height"] == 300
+    from PIL import Image
+    with Image.open(frame["path"]) as im:
+        assert (im.width, im.height) == (400, 300)
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_native_size_when_scale_default(monkeypatch, mock_backend, tmp_path):
+    monkeypatch.setattr(
+        "ae_mcp.snapshot.discovery.select_snapshotter",
+        lambda: _RealPngSnapshotter(800, 600),
+    )
+    mock_backend.set_response(json.dumps({
+        "ok": True, "compId": "7", "compName": "Preview", "time": 0.0,
+    }))
+
+    _, run_fn = HANDLERS["ae.previewFrame"]
+    result = await run_fn(
+        S.AePreviewFrameArgs(comp_id="7", time=0.0, out_dir=str(tmp_path)),
+        None,
+    )
+    frame = result["frames"][0]
+    assert frame["width"] == 800
+    assert frame["height"] == 600
+
+
+
 @pytest.mark.asyncio
 async def test_skill_crud_and_render(monkeypatch, tmp_path):
     monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path))

--- a/packages/core/tests/test_progress.py
+++ b/packages/core/tests/test_progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,13 +12,40 @@ from ae_mcp import progress
 
 
 class FakeCtx:
-    """Records report_progress calls."""
+    """Records report_progress calls (FastMCP-style ctx)."""
 
     def __init__(self) -> None:
         self.reports: list = []
 
     async def report_progress(self, progress: float, total, message):
         self.reports.append((progress, total, message))
+
+
+class FakeSession:
+    """Records low-level send_progress_notification calls."""
+
+    def __init__(self) -> None:
+        self.notifications: list = []
+
+    async def send_progress_notification(
+        self, progress_token, progress, total=None, message=None
+    ):
+        self.notifications.append(
+            {
+                "progress_token": progress_token,
+                "progress": progress,
+                "total": total,
+                "message": message,
+            }
+        )
+
+
+def _lowlevel_ctx(token):
+    """Build a RequestContext-shaped fake: .session + .meta.progressToken."""
+    return SimpleNamespace(
+        session=FakeSession(),
+        meta=SimpleNamespace(progressToken=token),
+    )
 
 
 @pytest.mark.asyncio
@@ -102,3 +130,70 @@ async def test_heartbeat_safe_with_none_ctx():
 
     result = await progress.with_heartbeat(None, work(), interval=0.05)
     assert result == "ok"
+
+
+# --- low-level RequestContext path (mcp.server.Server, not FastMCP) ---------
+
+
+@pytest.mark.asyncio
+async def test_lowlevel_sends_notification_when_token_present():
+    """When the request carried a progressToken, a real
+    notifications/progress is emitted via session.send_progress_notification."""
+    ctx = _lowlevel_ctx(token="tok-123")
+
+    async def work():
+        return "done"
+
+    result = await progress.with_heartbeat(ctx, work(), interval=0.05)
+    assert result == "done"
+    # The initial 0-progress report should have been sent on the session.
+    assert len(ctx.session.notifications) >= 1
+    first = ctx.session.notifications[0]
+    assert first["progress_token"] == "tok-123"
+    assert first["progress"] == 0
+
+
+@pytest.mark.asyncio
+async def test_lowlevel_noop_when_token_absent():
+    """No progressToken -> nobody asked for progress -> no send, no raise."""
+    ctx = _lowlevel_ctx(token=None)
+
+    async def work():
+        await asyncio.sleep(0.15)
+        return "done"
+
+    result = await progress.with_heartbeat(ctx, work(), interval=0.05)
+    assert result == "done"
+    # Nothing should have been sent (clean no-op).
+    assert ctx.session.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_lowlevel_swallows_send_errors():
+    """A raising send_progress_notification must not break the work path."""
+
+    class BoomSession:
+        async def send_progress_notification(self, **kw):
+            raise RuntimeError("network down")
+
+    ctx = SimpleNamespace(
+        session=BoomSession(),
+        meta=SimpleNamespace(progressToken="tok"),
+    )
+
+    async def work():
+        return "ok"
+
+    # Should not raise despite the failing send.
+    result = await progress.with_heartbeat(ctx, work(), interval=0.05)
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_safe_report_progress_no_meta_attr_no_raise():
+    """A ctx with a session but no .meta attribute must no-op, not raise."""
+    ctx = SimpleNamespace(session=FakeSession())  # no .meta
+
+    await progress._safe_report_progress(ctx, 0.0, None, "x")
+    assert ctx.session.notifications == []
+

--- a/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
+++ b/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
@@ -33,26 +33,35 @@ class MssSnapshotter(Snapshotter):
         out_path = Path(out_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Resolve target rect
+        # Resolve target rect. An explicit hwnd wins; otherwise we always
+        # locate the real After Effects window (by owning AfterFX.exe process)
+        # rather than silently grabbing the whole desktop — which previously
+        # could return the primary monitor while AE sat on a second one.
         target_hwnd: Optional[int] = None
         if hwnd:
             target_hwnd = int(hwnd, 16) if hwnd.lower().startswith("0x") else int(hwnd)
-        elif main_window:
+        else:
             target_hwnd = find_ae_main_hwnd()
+            if target_hwnd is None:
+                return {
+                    "ok": False,
+                    "error": "After Effects window not found",
+                }
 
-        rect = hwnd_to_rect(target_hwnd) if target_hwnd else None
+        rect = hwnd_to_rect(target_hwnd)
+        if rect is None:
+            return {
+                "ok": False,
+                "error": f"could not resolve screen rect for hwnd {target_hwnd:#x}",
+            }
 
         with mss.mss() as sct:
-            if rect is None:
-                # fallback: capture primary monitor
-                monitor = sct.monitors[1]
-            else:
-                left, top, right, bottom = rect
-                width, height = right - left, bottom - top
-                if width <= 0 or height <= 0:
-                    return {"ok": False, "error":
-                            f"target hwnd {target_hwnd:#x} has zero size ({width}x{height})"}
-                monitor = {"left": left, "top": top, "width": width, "height": height}
+            left, top, right, bottom = rect
+            width, height = right - left, bottom - top
+            if width <= 0 or height <= 0:
+                return {"ok": False, "error":
+                        f"target hwnd {target_hwnd:#x} has zero size ({width}x{height})"}
+            monitor = {"left": left, "top": top, "width": width, "height": height}
             shot = sct.grab(monitor)
             img = Image.frombytes("RGB", shot.size, shot.rgb)
             img.save(out_path, "PNG")

--- a/packages/snapshot-mss/ae_mcp_snapshot_mss/_hwnd_rect.py
+++ b/packages/snapshot-mss/ae_mcp_snapshot_mss/_hwnd_rect.py
@@ -1,8 +1,15 @@
 """Translate a window handle to a screen rect across OSes."""
 from __future__ import annotations
 
+import os
 import sys
 from typing import Optional, Tuple
+
+# Executable that owns genuine After Effects windows. Matching on the owning
+# process (rather than a title substring like "After Effects") avoids grabbing
+# unrelated windows such as a browser tab titled
+# "After Effects tutorial - YouTube".
+AE_PROCESS_NAME = "AfterFX.exe"
 
 
 def hwnd_to_rect(hwnd: Optional[int]) -> Optional[Tuple[int, int, int, int]]:
@@ -10,11 +17,11 @@ def hwnd_to_rect(hwnd: Optional[int]) -> Optional[Tuple[int, int, int, int]]:
 
     On Windows: uses ctypes user32.GetWindowRect.
     On macOS:   not yet implemented for arbitrary windowID; returns None.
-                (Most common case — main_window=True — handled by caller via
-                 mss's full-monitor grab fallback.)
     On Linux:   not yet implemented; returns None.
 
-    Caller falls back to monitor-0 capture when this returns None.
+    Returns None when the rect cannot be resolved; the caller decides how to
+    handle that (the mss snapshotter surfaces an error rather than silently
+    grabbing the desktop).
     """
     if hwnd is None:
         return None
@@ -29,15 +36,97 @@ def hwnd_to_rect(hwnd: Optional[int]) -> Optional[Tuple[int, int, int, int]]:
     return None
 
 
+def _process_name_for_pid(pid: int) -> Optional[str]:
+    """Best-effort executable basename for a Windows process id, or None."""
+    import ctypes
+    from ctypes import wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    handle = kernel32.OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+    )
+    if not handle:
+        return None
+    try:
+        buf = ctypes.create_unicode_buffer(32768)
+        size = wintypes.DWORD(len(buf))
+        # QueryFullProcessImageNameW(hProcess, dwFlags=0, lpExeName, lpdwSize)
+        ok = kernel32.QueryFullProcessImageNameW(
+            handle, 0, buf, ctypes.byref(size)
+        )
+        if not ok:
+            return None
+        return os.path.basename(buf.value)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _hwnd_process_name(user32, hwnd) -> Optional[str]:
+    """Executable basename of the process that owns `hwnd`, or None."""
+    import ctypes
+    from ctypes import wintypes
+
+    pid = wintypes.DWORD(0)
+    user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    if not pid.value:
+        return None
+    return _process_name_for_pid(pid.value)
+
+
+def _is_ae_window(exe: Optional[str]) -> bool:
+    """True when `exe` (a process executable basename) is After Effects."""
+    return bool(exe) and exe.lower() == AE_PROCESS_NAME.lower()
+
+
+def _select_largest_ae_window(windows) -> Optional[int]:
+    """Pure selection: pick the largest-area AfterFX.exe window.
+
+    `windows` is an iterable of dicts with keys:
+      hwnd (int), visible (bool), exe (str|None), rect (l,t,r,b)|None
+    Returns the chosen hwnd, or None when no qualifying window exists.
+
+    Kept free of win32 calls so the matching policy is unit-testable: the
+    real enumeration in find_ae_main_hwnd builds these records from ctypes.
+    """
+    found: list[tuple[int, int]] = []
+    for w in windows:
+        if not w.get("visible"):
+            continue
+        if not _is_ae_window(w.get("exe")):
+            continue
+        rect = w.get("rect")
+        if not rect:
+            continue
+        left, top, right, bottom = rect
+        width = max(0, right - left)
+        height = max(0, bottom - top)
+        area = width * height
+        if area > 0 and left > -30000 and top > -30000:
+            found.append((area, int(w["hwnd"])))
+    if not found:
+        return None
+    found.sort(reverse=True)
+    return found[0][1]
+
+
 def find_ae_main_hwnd() -> Optional[int]:
-    """Best-effort find AE main window. Windows-only; returns None elsewhere."""
+    """Best-effort find the AfterFX.exe main window. Windows-only; returns
+    None elsewhere or when no After Effects window is present.
+
+    Selection is by owning PROCESS (executable ``AfterFX.exe``), not by window
+    title, so unrelated windows (e.g. a browser tab named "After Effects
+    tutorial") are never matched. Of the qualifying visible top-level windows
+    the largest by area is chosen and brought to the foreground.
+    """
     if sys.platform != "win32":
         return None
     import ctypes
     from ctypes import wintypes
     user32 = ctypes.WinDLL("user32", use_last_error=True)
 
-    found: list[tuple[int, int]] = []
+    records: list[dict] = []
     EnumWindowsProc = ctypes.WINFUNCTYPE(
         wintypes.BOOL, wintypes.HWND, wintypes.LPARAM,
     )
@@ -45,27 +134,22 @@ def find_ae_main_hwnd() -> Optional[int]:
     def callback(hwnd, lparam):
         if not user32.IsWindowVisible(hwnd):
             return True
-        length = user32.GetWindowTextLengthW(hwnd)
-        if length == 0:
+        exe = _hwnd_process_name(user32, hwnd)
+        if not _is_ae_window(exe):
             return True
-        buf = ctypes.create_unicode_buffer(length + 1)
-        user32.GetWindowTextW(hwnd, buf, length + 1)
-        title = buf.value
-        if "After Effects" in title:
-            if user32.IsIconic(hwnd):
-                user32.ShowWindow(hwnd, 9)  # SW_RESTORE
-            user32.SetForegroundWindow(hwnd)
-            rect = wintypes.RECT()
-            if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
-                width = max(0, rect.right - rect.left)
-                height = max(0, rect.bottom - rect.top)
-                area = width * height
-                if area > 0 and rect.left > -30000 and rect.top > -30000:
-                    found.append((area, int(hwnd)))
+        # Bring the genuine AE window forward before measuring/capturing.
+        if user32.IsIconic(hwnd):
+            user32.ShowWindow(hwnd, 9)  # SW_RESTORE
+        user32.SetForegroundWindow(hwnd)
+        rect = wintypes.RECT()
+        if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            records.append({
+                "hwnd": int(hwnd),
+                "visible": True,
+                "exe": exe,
+                "rect": (rect.left, rect.top, rect.right, rect.bottom),
+            })
         return True
 
     user32.EnumWindows(EnumWindowsProc(callback), 0)
-    if not found:
-        return None
-    found.sort(reverse=True)
-    return found[0][1]
+    return _select_largest_ae_window(records)

--- a/packages/snapshot-mss/tests/test_mss_snapshot.py
+++ b/packages/snapshot-mss/tests/test_mss_snapshot.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ae_mcp_snapshot_mss import MssSnapshotter
+from ae_mcp_snapshot_mss._hwnd_rect import _select_largest_ae_window, _is_ae_window
 
 
 def test_supports_platform_always_true():
@@ -24,7 +25,9 @@ async def test_capture_writes_png(tmp_path):
     fake_shot.size = (10, 10)
     fake_shot.rgb = b"\xff" * (10 * 10 * 3)
 
-    with patch("mss.mss") as mss_factory:
+    with patch("ae_mcp_snapshot_mss.find_ae_main_hwnd", return_value=0x1234), \
+         patch("ae_mcp_snapshot_mss.hwnd_to_rect", return_value=(0, 0, 10, 10)), \
+         patch("mss.mss") as mss_factory:
         mss_inst = MagicMock()
         mss_inst.__enter__ = MagicMock(return_value=mss_inst)
         mss_inst.__exit__ = MagicMock(return_value=False)
@@ -48,3 +51,68 @@ async def test_capture_zero_size_returns_error():
         r = await s.capture(Path("/tmp/x.png"), hwnd="0x1234")
     assert r["ok"] is False
     assert "zero size" in r["error"]
+
+
+@pytest.mark.asyncio
+async def test_capture_no_ae_window_returns_error_not_desktop(tmp_path):
+    """When no AfterFX.exe window is found, capture must surface a clear error
+    instead of silently grabbing the whole primary monitor."""
+    out = tmp_path / "should_not_exist.png"
+    s = MssSnapshotter()
+
+    with patch("ae_mcp_snapshot_mss.find_ae_main_hwnd", return_value=None), \
+         patch("mss.mss") as mss_factory:
+        result = await s.capture(out)
+
+    assert result["ok"] is False
+    assert "After Effects window not found" in result["error"]
+    # The desktop must NOT have been captured.
+    mss_factory.assert_not_called()
+    assert not out.exists()
+
+
+# --- window selection policy (process-name based, title-independent) --------
+
+
+def test_is_ae_window_matches_only_afterfx_exe():
+    assert _is_ae_window("AfterFX.exe") is True
+    assert _is_ae_window("afterfx.exe") is True  # case-insensitive
+    assert _is_ae_window("chrome.exe") is False
+    assert _is_ae_window(None) is False
+    assert _is_ae_window("") is False
+
+
+def test_select_picks_afterfx_not_browser_tab():
+    """A browser tab titled 'After Effects tutorial' (chrome.exe) must be
+    ignored; the real AfterFX.exe window is chosen even when smaller."""
+    windows = [
+        # Big chrome window with an "After Effects" title — must be skipped.
+        {"hwnd": 1, "visible": True, "exe": "chrome.exe",
+         "rect": (0, 0, 1920, 1080)},
+        # Smaller genuine AE window on a second monitor.
+        {"hwnd": 2, "visible": True, "exe": "AfterFX.exe",
+         "rect": (1920, 0, 1920 + 1280, 720)},
+    ]
+    assert _select_largest_ae_window(windows) == 2
+
+
+def test_select_picks_largest_when_multiple_ae_windows():
+    windows = [
+        {"hwnd": 10, "visible": True, "exe": "AfterFX.exe",
+         "rect": (0, 0, 400, 300)},          # area 120000
+        {"hwnd": 11, "visible": True, "exe": "AfterFX.exe",
+         "rect": (0, 0, 1280, 720)},         # area 921600 -> winner
+    ]
+    assert _select_largest_ae_window(windows) == 11
+
+
+def test_select_returns_none_when_no_ae_window():
+    windows = [
+        {"hwnd": 1, "visible": True, "exe": "chrome.exe",
+         "rect": (0, 0, 800, 600)},
+        {"hwnd": 2, "visible": False, "exe": "AfterFX.exe",
+         "rect": (0, 0, 800, 600)},   # AE but not visible
+    ]
+    assert _select_largest_ae_window(windows) is None
+
+

--- a/plugin/client/client.js
+++ b/plugin/client/client.js
@@ -40,6 +40,43 @@
         mcpConfigEl.textContent = JSON.stringify(config, null, 2);
     }
 
+    // Persist the chosen port across panel restarts. Without this the input
+    // resets to the index.html default (11488) every launch, silently breaking
+    // AE_MCP_PLUGIN_URL for users who changed it to dodge a port conflict.
+    var PORT_STORAGE_KEY = 'ae_mcp_panel_port';
+
+    function isValidPort(p) {
+        return isFinite(p) && p >= 1024 && p <= 65535;
+    }
+
+    function loadSavedPort() {
+        try {
+            var raw = window.localStorage.getItem(PORT_STORAGE_KEY);
+            var p = parseInt(raw, 10);
+            if (isValidPort(p)) {
+                return p;
+            }
+        } catch (e) {
+            // localStorage may be unavailable in some CEP hosts; ignore.
+        }
+        return null;
+    }
+
+    function savePort(port) {
+        try {
+            window.localStorage.setItem(PORT_STORAGE_KEY, String(port));
+        } catch (e) {
+            // Non-fatal: persistence is best-effort.
+        }
+    }
+
+    // Restore the saved port (overrides the index.html default) before any
+    // code reads portInput.value below.
+    var savedPort = loadSavedPort();
+    if (savedPort !== null) {
+        portInput.value = savedPort;
+    }
+
     function normalizeCepPath(value) {
         var normalized = String(value || '');
         normalized = normalized.replace(/^file:\\+/i, '');
@@ -80,6 +117,7 @@
                 setStatus('ok', 'Listening on 127.0.0.1:' + port);
                 setError('');
                 updateMcpConfig(port);
+                savePort(port);
                 log('Host ready.');
             }
         });
@@ -91,7 +129,7 @@
 
     applyBtn.addEventListener('click', function () {
         var newPort = parseInt(portInput.value, 10);
-        if (!Number.isFinite(newPort) || newPort < 1024 || newPort > 65535) {
+        if (!isValidPort(newPort)) {
             log('Invalid port');
             setError('Invalid port');
             return;
@@ -106,6 +144,7 @@
                 } else {
                     setStatus('ok', 'Listening on 127.0.0.1:' + newPort);
                     setError('');
+                    savePort(newPort);
                     log('Restarted on ' + newPort);
                 }
             });


### PR DESCRIPTION
## Summary

Fixes the setup-friction / misleading-field papercuts in [#13](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/13). Each item was verified against the current code first.

- **Progress heartbeat raised AttributeError (verified).** Handlers get the low-level `mcp.shared.context.RequestContext` (mcp 1.27.0), which has no `report_progress` — every heartbeat raised and was swallowed at debug, so keep-alive notifications never emitted. Now emits a real `ctx.session.send_progress_notification(progress_token=ctx.meta.progressToken, ...)` when the request carried a progressToken, cleanly no-ops when absent, and keeps a FastMCP fallback. (Signature confirmed against the installed mcp.)
- **Snapshot grabbed the wrong window / whole monitor (verified).** `find_ae_main_hwnd` matched any title containing "After Effects" (e.g. a browser tab) and `capture` fell back to the whole primary monitor when nothing resolved. Now the AE window is identified by its owning **`AfterFX.exe`** process (GetWindowThreadProcessId → QueryFullProcessImageNameW), and the silent desktop fallback is removed — no AE window returns `{ok:false,"After Effects window not found"}`.
- **`scale` was a dead/lying schema field (verified).** `previewFrame` advertised `scale` but `_run_preview_frame` never read it. **Implemented** (Pillow is already a declared core dep): the captured PNG is downscaled in place (LANCZOS) and width/height/sizeBytes recomputed.
- **discovery hint named a nonexistent package (verified).** `pip install ae-mcp-backend-{name}` → accurate mapping (`ae-mcp` → `ae-mcp-bridge`) with a sane generic fallback for unknown backends.
- **Panel port wasn't persisted (verified).** `client.js` now persists the port in `localStorage` (ES5), restores on load, saves on start/restart success — so `AE_MCP_PLUGIN_URL` no longer silently breaks on restart.
- **Docs.** INSTALL.md now states the three packages (core first) must be installed together + a PyPI `ae-mcp` supply-chain note; REFERENCE.md documents `AE_MCP_SKILL_DIR` and `AE_MCP_CHECKPOINT_KEEP` (zh/en).

## Test Plan
- `uv run pytest -q` → **241 passed, 24 deselected** (+14 tests: progress token-present/absent paths, AE-window selection + no-match error, scale downscaling, corrected discovery hint).
- **Behavior change (intended):** on macOS/Linux `find_ae_main_hwnd` returns None, so a default `ae.snapshot` there now returns an honest `ok:false` instead of a desktop grab.
- **Deferred (needs live AE/panel):** real multi-monitor AE capture; panel localStorage round-trip in a live CEP host.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)