### PR TITLE
refactor(server): underscore tool names in model-facing text; reverse map + collision guard; wire tests (#4, #5, #7)

### DIFF
--- a/packages/core/ae_mcp/instructions.py
+++ b/packages/core/ae_mcp/instructions.py
@@ -6,7 +6,7 @@ at zero per-call cost. It mirrors the single biggest differentiator of mature
 AE MCPs: front-loaded operating discipline (phased workflow, ExtendScript ES3
 rules, matchName-path discipline, verification, and safety).
 
-Dynamic, per-project state stays in `ae.init` / `ae.overview`; only durable
+Dynamic, per-project state stays in `ae_init` / `ae_overview`; only durable
 operating rules live here.
 """
 
@@ -17,21 +17,21 @@ You are driving Adobe After Effects through the ae-mcp tools. Think like a
 motion designer: explore the project, make a change, then prove it landed.
 
 WORKFLOW — every task follows this loop:
-  1. Explore  — ae.init (once per session), then ae.overview / ae.layers.
-                Discover properties with ae.scanPropertyTree (structure /
-                matchName paths) and ae.getProperties (values). Never guess
+  1. Explore  — ae_init (once per session), then ae_overview / ae_layers.
+                Discover properties with ae_scanPropertyTree (structure /
+                matchName paths) and ae_getProperties (values). Never guess
                 comp or layer ids — read them first.
-  2. Act      — Prefer the typed verbs (ae.createLayer, ae.setProperty,
-                ae.applyEffect, ae.moveLayer, ae.createRig). Drop to ae.exec
+  2. Act      — Prefer the typed verbs (ae_createLayer, ae_setProperty,
+                ae_applyEffect, ae_moveLayer, ae_createRig). Drop to ae_exec
                 only for logic the typed verbs can't express.
-  3. Verify   — After writing expressions, run ae.validateExpressions BEFORE
+  3. Verify   — After writing expressions, run ae_validateExpressions BEFORE
                 visual review; it force-evaluates and reports errors. Then use
-                ae.previewFrame to confirm the change visually. Directional
+                ae_previewFrame to confirm the change visually. Directional
                 changes (move/rotate/scale) need >=2 sampled times to prove
                 progression; static changes (color/opacity) need one.
   4. Iterate  — If it's wrong, adjust and re-run. Keep going until it's right.
 
-WRITING ExtendScript (ae.exec / ae.readProps):
+WRITING ExtendScript (ae_exec / ae_readProps):
   AE's classic engine is ECMAScript 3. Use `var`, the `function` keyword,
   traditional for-loops, and string concatenation. Avoid let/const, arrow
   functions, template literals, destructuring, and classes.
@@ -50,7 +50,7 @@ WRITING ExtendScript (ae.exec / ae.readProps):
   state. Guard fallible calls and return structured {ok:false, error:...}.
 
 PROPERTY PATHS:
-  ae.scanPropertyTree and ae.getProperties emit both display-name paths and
+  ae_scanPropertyTree and ae_getProperties emit both display-name paths and
   matchName paths (matchPath). matchName paths with #ordinals
   ("ADBE Gaussian Blur 2#2") disambiguate duplicate-matchName siblings.
 
@@ -59,7 +59,7 @@ LOCALIZATION:
   e.g. effect("Value")(1) instead of effect("Value")("Slider").
 
 SAFETY & RECOVERY:
-  ae.checkpoint snapshots the whole .aep; ae.revert restores a whole-project
+  ae_checkpoint snapshots the whole .aep; ae_revert restores a whole-project
   snapshot (a full file swap — it cannot partially delete layers). Auto-
   checkpointing is best-effort: if it is skipped the response says so via
   `checkpointSkipped`, and your edit still runs.

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, List
 
 from mcp.server import Server
@@ -23,6 +24,11 @@ from ae_mcp.handlers import HANDLERS, load_all
 from ae_mcp.instructions import SERVER_INSTRUCTIONS
 
 log = logging.getLogger("ae_mcp.server")
+
+# Matches a leading dotted verb token at the very start of a docstring, e.g.
+# "ae.init — bootstrap …". Only the leading token is rewritten so the rest of
+# the description (which may legitimately mention dotted names) is untouched.
+_LEADING_VERB = re.compile(r"^(ae\.[A-Za-z][A-Za-z0-9]*)")
 
 
 def _filtered_tool_names() -> set:
@@ -68,15 +74,53 @@ def expose_tool_name(verb: str) -> str:
     return verb.replace(".", "_")
 
 
-def resolve_tool_name(name: str, handlers) -> "str | None":
+def build_reverse_map(handlers) -> "dict[str, str]":
+    """Build an ``exposed name -> canonical verb`` map for O(1) resolution.
+
+    ``resolve_tool_name`` otherwise falls back to a linear scan for the common
+    (underscore-name) call path. Precomputing this map once — after
+    ``load_all()`` has populated HANDLERS — keeps the hot path O(1) while
+    preserving identical fallback semantics.
+    """
+    return {expose_tool_name(verb): verb for verb in handlers}
+
+
+def tool_description(schema_cls, verb: str) -> str:
+    """Build a Tool description that LEADS with the exposed underscore name.
+
+    The description is sourced from the pydantic schema docstring, which opens
+    with the dotted verb ("ae.init — …"). Strict clients can only call the
+    advertised (underscore) name, so we rewrite *only* the leading dotted-verb
+    token to its exposed form; the remainder of the docstring is untouched.
+    """
+    doc = (schema_cls.__doc__ or "").strip()
+    exposed = expose_tool_name(verb)
+    if not doc:
+        return f"ae-mcp verb {exposed}"
+    m = _LEADING_VERB.match(doc)
+    if m and m.group(1) == verb:
+        return exposed + doc[m.end():]
+    # Docstring doesn't open with this verb token (defensive): prepend the
+    # exposed name so the description still leads with the callable name.
+    return f"{exposed} — {doc}"
+
+
+def resolve_tool_name(name: str, handlers, reverse_map=None) -> "str | None":
     """Map an exposed tool name back to its canonical verb.
 
     Accepts both the exposed dot-free name ("ae_ping") and, for backward
     compatibility, the original dotted verb ("ae.ping"). Returns ``None`` if
     the name matches no registered verb.
+
+    ``reverse_map`` (from :func:`build_reverse_map`) makes the underscore-name
+    path O(1); when omitted, a linear scan is used so direct/programmatic
+    callers still resolve correctly.
     """
+    # Dotted-name fast path (back-compat for direct callers).
     if name in handlers:
         return name
+    if reverse_map is not None:
+        return reverse_map.get(name)
     for verb in handlers:
         if expose_tool_name(verb) == name:
             return verb
@@ -84,8 +128,29 @@ def resolve_tool_name(name: str, handlers) -> "str | None":
 
 
 def build_server() -> Server:
-    """Construct the low-level MCP Server with all 15 verbs registered."""
+    """Construct the low-level MCP Server with all registered verbs."""
     load_all()
+
+    # Reverse map (exposed name -> canonical verb) for O(1) resolution on the
+    # common underscore-name call path. Built once, after load_all() has
+    # populated HANDLERS.
+    reverse_map = build_reverse_map(HANDLERS)
+
+    # Collision guard: expose_tool_name() is lossy (dots -> underscores), so a
+    # future verb could collapse onto another's exposed name and make
+    # _list_tools emit duplicate Tool names. Fail loudly if that ever happens.
+    if len(reverse_map) != len(HANDLERS):
+        seen: dict[str, str] = {}
+        collisions: list[str] = []
+        for verb in HANDLERS:
+            exposed = expose_tool_name(verb)
+            if exposed in seen:
+                collisions.append(f"{seen[exposed]!r} and {verb!r} -> {exposed!r}")
+            else:
+                seen[exposed] = verb
+        raise RuntimeError(
+            "exposed tool-name collision(s): " + "; ".join(collisions)
+        )
 
     server: Server = Server("ae", instructions=SERVER_INSTRUCTIONS)
 
@@ -102,12 +167,12 @@ def build_server() -> Server:
             except Exception as e:  # noqa: BLE001
                 log.warning("schema for %s failed: %s", verb_name, e)
                 input_schema = {"type": "object", "properties": {}}
-            # Description pulled from the pydantic class docstring.
-            desc = (schema_cls.__doc__ or f"ae-mcp verb {verb_name}").strip()
+            # Description leads with the EXPOSED (underscore) name so strict
+            # clients see the name they can actually call.
             tools.append(
                 Tool(
                     name=expose_tool_name(verb_name),
-                    description=desc,
+                    description=tool_description(schema_cls, verb_name),
                     inputSchema=input_schema,
                 )
             )
@@ -117,7 +182,7 @@ def build_server() -> Server:
     async def _call_tool(name: str, arguments: dict | None) -> List[TextContent]:
         # Tools are exposed with dots replaced by underscores; map the exposed
         # name back to the canonical verb (the dotted name is accepted too).
-        canonical = resolve_tool_name(name, HANDLERS)
+        canonical = resolve_tool_name(name, HANDLERS, reverse_map)
         if canonical is None:
             payload = _format_result({"ok": False, "error": f"unknown tool: {name}"})
             return [TextContent(type="text", text=payload)]
@@ -146,6 +211,14 @@ def build_server() -> Server:
             return [TextContent(type="text", text=payload)]
 
         return [TextContent(type="text", text=_format_result(result))]
+
+    # Expose the dispatch closures + reverse map for testing. The decorators
+    # above already registered them via the MCP request_handlers registry;
+    # these handles let tests drive dispatch directly without changing any
+    # runtime behaviour.
+    server._ae_list_tools = _list_tools  # type: ignore[attr-defined]
+    server._ae_call_tool = _call_tool  # type: ignore[attr-defined]
+    server._ae_reverse_map = reverse_map  # type: ignore[attr-defined]
 
     return server
 

--- a/packages/core/tests/test_server_instructions.py
+++ b/packages/core/tests/test_server_instructions.py
@@ -14,15 +14,27 @@ def test_instructions_nonempty_and_substantial():
 
 def test_instructions_cover_key_discipline():
     text = SERVER_INSTRUCTIONS
-    # Phased workflow + the verbs an agent must know about.
-    assert "ae.init" in text
-    assert "ae.validateExpressions" in text
-    assert "ae.previewFrame" in text
+    # Phased workflow + the verbs an agent must know about. The instructions
+    # name verbs by their EXPOSED (underscore) form — strict clients can only
+    # call the advertised names (issue #4).
+    assert "ae_init" in text
+    assert "ae_validateExpressions" in text
+    assert "ae_previewFrame" in text
     # ES3 discipline + the runtime helpers we ship.
     assert "ECMAScript 3" in text
     assert "AEMCP.propByMatchPath" in text
     # Never-throw safety invariant.
     assert "NEVER let JSX throw" in text
+
+
+def test_instructions_use_underscore_verb_names_not_dotted():
+    """Issue #4: model-facing guidance must not feed the model dotted verb
+    names it can't call on strict clients. No dotted ``ae.<verb>`` token may
+    appear in the instructions (AEMCP.* helper calls are not verbs)."""
+    import re
+
+    dotted = re.findall(r"\bae\.[a-zA-Z]\w*", SERVER_INSTRUCTIONS)
+    assert dotted == [], f"instructions still name dotted verbs: {sorted(set(dotted))}"
 
 
 def test_build_server_advertises_instructions():

--- a/packages/core/tests/test_tool_names.py
+++ b/packages/core/tests/test_tool_names.py
@@ -7,10 +7,18 @@ back on call.
 """
 from __future__ import annotations
 
+import json
 import re
 
+import pytest
+
 from ae_mcp.handlers import HANDLERS, load_all
-from ae_mcp.server import expose_tool_name, resolve_tool_name
+from ae_mcp.server import (
+    build_reverse_map,
+    build_server,
+    expose_tool_name,
+    resolve_tool_name,
+)
 
 _MCP_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
@@ -44,3 +52,149 @@ def test_resolve_unknown_returns_none():
     load_all()
     assert resolve_tool_name("does_not_exist", HANDLERS) is None
     assert resolve_tool_name("ae.unknownVerb", HANDLERS) is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #7 — reverse map (O(1) hot path) + collision guard / uniqueness.
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_map_resolves_same_as_linear_scan():
+    """The reverse map must give identical results to the linear-scan fallback,
+    and still honour the dotted-name back-compat fast path."""
+    load_all()
+    rmap = build_reverse_map(HANDLERS)
+    for verb in HANDLERS:
+        exposed = expose_tool_name(verb)
+        # O(1) path matches the linear scan.
+        assert resolve_tool_name(exposed, HANDLERS, rmap) == verb
+        assert resolve_tool_name(exposed, HANDLERS, rmap) == resolve_tool_name(exposed, HANDLERS)
+        # Dotted name still resolves with a reverse map present.
+        assert resolve_tool_name(verb, HANDLERS, rmap) == verb
+    # Unknown names return None on both paths.
+    assert resolve_tool_name("nope", HANDLERS, rmap) is None
+
+
+def test_exposed_names_are_globally_unique():
+    """expose_tool_name() is lossy; a future collision would make _list_tools
+    emit duplicate Tool names. Assert the mapping is injective today."""
+    load_all()
+    exposed = [expose_tool_name(v) for v in HANDLERS]
+    assert len(exposed) == len(set(exposed)), "exposed tool names collide"
+    # The reverse map being the same length as HANDLERS is the guard's check.
+    assert len(build_reverse_map(HANDLERS)) == len(HANDLERS)
+
+
+def test_build_server_raises_on_exposed_name_collision(monkeypatch):
+    """The collision guard in build_server() must fail loudly if two verbs ever
+    collapse onto the same exposed name."""
+    from ae_mcp import server as srv
+
+    load_all()
+    # Two distinct dotted verbs that collapse to the same underscore name.
+    fake = {"ae.fo_o": ("schema_a", "run_a"), "ae.fo.o": ("schema_b", "run_b")}
+    monkeypatch.setattr(srv, "HANDLERS", fake)
+    with pytest.raises(RuntimeError, match="collision"):
+        build_server()
+
+
+# ---------------------------------------------------------------------------
+# Issue #5 — wire/dispatch-level regression tests.
+#
+# These exercise the integration points PR #3 changed: _list_tools must emit
+# underscore-form names, and _call_tool must reassign to the canonical verb
+# before dispatch. Both stayed green under the old helper-only tests even when
+# the regressions were reintroduced.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _full_tool_listing(monkeypatch):
+    """build_server() with _filtered_tool_names stubbed to the full verb set so
+    _list_tools actually emits tools (it returns empty without a live backend)."""
+    from ae_mcp import server as srv
+
+    load_all()
+    monkeypatch.setattr(srv, "_filtered_tool_names", lambda: set(HANDLERS.keys()))
+    return build_server()
+
+
+async def test_list_tools_emits_only_mcp_compliant_names(_full_tool_listing):
+    """Drive the registered list_tools handler and assert every emitted
+    Tool.name is underscore-form (no dots). Fails if _list_tools reverts to
+    emitting dotted names."""
+    tools = await _full_tool_listing._ae_list_tools()
+    assert tools, "expected tools to be emitted with the full verb set stubbed"
+    assert len(tools) == len(HANDLERS)
+    for tool in tools:
+        assert _MCP_TOOL_NAME.fullmatch(tool.name), f"{tool.name!r} is not MCP-compliant"
+        assert "." not in tool.name
+
+
+async def test_list_tools_descriptions_lead_with_exposed_name(_full_tool_listing):
+    """Issue #4 at the wire level: each Tool.description must lead with the
+    EXPOSED (underscore) name, not the dotted verb."""
+    tools = await _full_tool_listing._ae_list_tools()
+    for tool in tools:
+        assert tool.description.startswith(tool.name), (
+            f"{tool.name!r} description should lead with the exposed name, "
+            f"got {tool.description[:40]!r}"
+        )
+        assert not tool.description.startswith("ae."), (
+            f"{tool.name!r} description still leads with a dotted verb"
+        )
+
+
+async def test_call_tool_dispatches_to_canonical_verb(monkeypatch):
+    """Drive the registered call_tool handler with the EXPOSED name and assert
+    dispatch reaches the canonical (dotted) verb. Fails if _call_tool drops the
+    canonical reassignment (which would KeyError on HANDLERS[name])."""
+    from ae_mcp import server as srv
+
+    load_all()
+    seen = {}
+
+    async def _fake_run(validated, ctx):
+        # If dispatch didn't reassign to the canonical verb, the handler keyed
+        # by "ae.ping" would never be reached.
+        seen["dispatched"] = True
+        return {"ok": True, "pong": validated.expect}
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    result = await server._ae_call_tool("ae_ping", {"expect": "hi"})
+
+    assert seen.get("dispatched") is True, "dispatch never reached the canonical ae.ping handler"
+    payload = json.loads(result[0].text)
+    assert payload == {"ok": True, "pong": "hi"}
+
+
+async def test_call_tool_accepts_dotted_name_for_backcompat(monkeypatch):
+    """Direct/programmatic callers using the dotted name must still dispatch."""
+    from ae_mcp import server as srv  # noqa: F401
+
+    load_all()
+
+    async def _fake_run(validated, ctx):
+        return {"ok": True, "pong": validated.expect}
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    result = await server._ae_call_tool("ae.ping", {"expect": "yo"})
+    payload = json.loads(result[0].text)
+    assert payload == {"ok": True, "pong": "yo"}
+
+
+async def test_call_tool_unknown_returns_structured_error():
+    """An unknown tool name must return the {ok:false, 'unknown tool'} payload
+    rather than raising."""
+    load_all()
+    server = build_server()
+    result = await server._ae_call_tool("totally_unknown", {})
+    payload = json.loads(result[0].text)
+    assert payload["ok"] is False
+    assert "unknown tool" in payload["error"]


### PR DESCRIPTION
## Summary

Closes the three tool-name follow-ups to #3 in one PR. All verified against current code.

### #4 — finish dotted→underscore rename in model-facing text
Strict clients can only call the **advertised** (underscore) names, but two channels still fed the model dotted names:
- `SERVER_INSTRUCTIONS` now names every model-callable verb in underscore form (`ae_init`, `ae_exec`, …). `AEMCP.*` helper calls and non-verb prose left intact.
- Tool `description` now leads with the exposed name: a new `tool_description()` rewrites **only** the leading dotted-verb token of the schema docstring (strict `^ae\.<verb>` match, verified equal to the verb, defensive prepend fallback) — no hand-editing 30 docstrings.
- `resolve_tool_name`'s dotted fallback is **kept** for direct callers.
- **User docs sweep deferred:** ~198 dotted hits span zh prose, verb tables, wildcard tokens (`ae.skill*`), and historical CHANGELOG/RELEASE/ROADMAP entries where dotted is correct — not a clean mechanical replace. Flagged as remaining follow-up.

### #5 — wire/dispatch regression tests
Added tests that exercise the integration points #3 changed (the pure-helper tests didn't): every emitted `Tool.name` matches `^[a-zA-Z0-9_-]{1,64}$` (with `_filtered_tool_names` monkeypatched to the full set), descriptions lead with the exposed name, `ae_ping` dispatches to canonical `ae.ping`, dotted back-compat dispatch works, and an unknown name returns `{ok:false,"unknown tool"}`. **Verified not hollow:** reverting `_list_tools` to dotted names and dropping the `_call_tool` canonical reassignment each make the new tests fail (the latter with the exact `KeyError` #5 describes).

### #7 — harden the mapping (no current bugs)
- `build_reverse_map()` precomputes `{exposed → verb}`; `_call_tool` uses it for O(1) resolution (dotted fast-path + fallback semantics unchanged).
- **Collision guard** in `build_server` raises `RuntimeError` if two verbs ever collapse to one exposed name (today all 30 are collision-free).
- Fixed the stale `build_server` docstring ("all 15 verbs" → 30 registered).

## Test Plan
- `uv run pytest -q` → **261 passed, 24 deselected** (+9 tests; no regressions).

## Notes
- `schemas.py` module docstring still says "22 ae-mcp verbs" (stale, should be 30) — left as out-of-scope follow-up.
- Dispatch closures exposed as `server._ae_*` purely for testability; no runtime behavior change.

Closes #4
Closes #5
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)