### PR TITLE
chore(release): v0.3.0 — bump versions + reconcile CHANGELOG (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,32 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
-### [0.2.1] — 2026-06-08
+### [0.3.0] — 2026-06-10
+
+> ⚠️ **升级须知（破坏性变更）**：本次为插件的 `/exec` 接口加上了本地鉴权，**面板（CEP 插件）和 Python 端必须一起升级**。只升级一边会导致调用被拒（401）。请按文档重新安装 / 同步面板后再使用。
+
+本次发布合并了 6 个修复 PR（#14–#19），覆盖数据安全、连接安全、跨语言与大型工程的健壮性，以及一批安装与字段一致性问题。
+
+#### 🔒 安全
+- **`/exec` 现在需要本地令牌鉴权**（#11）——此前任何本地进程都能向插件发送任意脚本并以你的身份执行。面板启动时会在 `~/.ae-mcp/auth-token` 生成密钥，只有持有它的本机调用方才能执行。
+- **不再向用户分发远程调试端口**（#11）——打包的面板会剔除 `.debug`，避免在每台机器上开放可被本地进程附加的调试端口。签名也改为必填证书密码并加入时间戳服务。
+- **脚本调用串行化**（#11）——并发请求不再交错执行、互相污染。
 
 #### 🐛 修复
-- **部分客户端（如 Claude 桌面版扩展）连接时报错、无法新建对话**——工具名此前带 `.`（如 `ae.ping`），不符合 MCP 工具名规范 `^[a-zA-Z0-9_-]{1,64}$`，严格客户端会拒绝并报 `FrontendRemoteMcpToolDefinition.name`。现在对外统一改用下划线名（`ae.ping` → `ae_ping`），调用时自动映射回去。**仍兼容原有带点名调用，已有调用方不受影响。**
+- **回滚不再把工程偷偷搬进临时目录**（#10）——`ae_revert` 现在把存档原子地还原到原工程路径再打开原文件；此前会直接打开 `%TEMP%` 里的副本，导致之后的保存写进临时目录、并可能被清理删除。未保存（无路径）的工程会被明确拒绝而非冒险打开。同名工程的存档也不再互相串台。
+- **失败不再伪装成成功**（#8）——ExtendScript 抛错会作为错误上报；无效 / 越界图层 id 返回明确的“找不到图层”而非崩溃；后端选择失败会给出可诊断提示。
+- **从零克隆即可安装**（#9）——锁文件已纳入版本管理，文档里的 `npm ci` 在干净克隆上不再失败。
+- **非英文版 AE 下新建图层不再丢失位置**（#12）——改用与语言无关的属性寻址。
+- **大型工程的搜索 / 扫描不再卡死**（#12）——超出时间预算会返回已找到的部分结果并标记 `truncated`，而不是耗尽超时、零结果、还卡住界面。
+- **进度心跳真正发出**（#13）——长任务不再因“看似无响应”被客户端中途断开。
+- **截图抓的是 After Effects 窗口**（#13）——按进程识别 AE 窗口，不再误抓同名网页标签页或整块屏幕；找不到时明确报错。
+- **部分客户端（如 Claude 桌面版扩展）连接报错**（#3 / #4 / #7）——工具名统一为下划线形式（`ae.ping` → `ae_ping`），严格客户端可正常连接；**仍兼容原有带点名调用**。
+- **含 `$` 的技能脚本不再保存后无法使用**（#12）——`$.writeln` 等 ExtendScript 写法可正常渲染。
+- **预览的 `scale` 参数现在真的生效**（#13）。
+
+#### 🔧 改进
+- **面板端口会被记住**（#13）——重启后不再重置为默认值，`AE_MCP_PLUGIN_URL` 不会被悄悄打断。
+- **文档**（#13）——补充“三件套需一起安装”、`AE_MCP_SKILL_DIR` / `AE_MCP_CHECKPOINT_KEEP` 环境变量说明，以及 PyPI 占名风险提示。
 
 ### [0.2.0] — 2026-06-05
 
@@ -43,10 +65,32 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ## English
 
-### [0.2.1] — 2026-06-08
+### [0.3.0] — 2026-06-10
+
+> ⚠️ **Upgrade note (breaking change):** local authentication was added to the plugin's `/exec` endpoint, so **the panel (CEP plugin) and the Python side must be upgraded together**. Upgrading only one side will get calls rejected (401). Reinstall / re-sync the panel per the docs before use.
+
+This release merges 6 fix PRs (#14–#19) covering data safety, connection security, cross-language & large-project robustness, and a batch of install / field-consistency issues.
+
+#### 🔒 Security
+- **`/exec` now requires a local token** (#11) — previously any local process could send arbitrary script to the plugin and run it as you. The panel generates a secret at `~/.ae-mcp/auth-token` on startup; only callers holding it can execute.
+- **The remote-debug port no longer ships to users** (#11) — the packaged panel strips `.debug`, so no machine exposes a debug port a local process could attach to. Signing now also requires the cert password and adds a timestamp server.
+- **JSX calls are serialized** (#11) — concurrent requests no longer interleave and corrupt each other.
 
 #### 🐛 Fixed
-- **Some clients (e.g. Claude Desktop extensions) errored on connect and couldn't start a conversation** — tool names were dotted (`ae.ping`), which violates the MCP tool-name pattern `^[a-zA-Z0-9_-]{1,64}$`, so strict clients rejected them with `FrontendRemoteMcpToolDefinition.name`. Exposed names are now underscore-form (`ae.ping` → `ae_ping`), mapped back on call. **The original dotted names are still accepted, so existing callers are unaffected.**
+- **Revert no longer hijacks your project into a temp folder** (#10) — `ae_revert` now atomically restores the checkpoint over the original project path and reopens the original; it used to open the copy inside `%TEMP%`, so later saves went to temp and could be wiped by cleanup. Unsaved (path-less) projects are refused rather than risked. Same-named projects no longer mix checkpoints.
+- **Failures no longer masquerade as success** (#8) — ExtendScript throws surface as errors; an invalid/out-of-range layer id returns a clear "no layer" instead of crashing; backend-selection failure emits a diagnostic.
+- **Fresh clones install cleanly** (#9) — the lockfile is tracked, so the documented `npm ci` no longer fails on a clean clone.
+- **New layers keep their position on non-English AE** (#12) — property addressing is now locale-independent.
+- **Search / scan no longer hang on large projects** (#12) — exceeding the time budget returns partial results flagged `truncated` instead of blowing the timeout with zero output and a frozen UI.
+- **Progress heartbeats actually emit** (#13) — long operations are no longer dropped by clients that think the server stalled.
+- **Snapshots capture the After Effects window** (#13) — the AE window is found by process, not a title substring, so it no longer grabs a same-named browser tab or the whole desktop; a clear error is returned when none is found.
+- **Some clients (e.g. Claude Desktop extensions) errored on connect** (#3 / #4 / #7) — tool names are unified to underscore form (`ae.ping` → `ae_ping`) so strict clients connect; **dotted names are still accepted**.
+- **Skills containing `$` are no longer unusable after saving** (#12) — ExtendScript like `$.writeln` renders correctly.
+- **The preview `scale` argument now actually works** (#13).
+
+#### 🔧 Improved
+- **The panel port is remembered** (#13) — it no longer resets to the default on restart, so `AE_MCP_PLUGIN_URL` isn't silently broken.
+- **Docs** (#13) — added "install all three packages together", the `AE_MCP_SKILL_DIR` / `AE_MCP_CHECKPOINT_KEEP` env vars, and a PyPI name-squatting note.
 
 ### [0.2.0] — 2026-06-05
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -75,7 +75,7 @@ pip install ./packages/core ./packages/bridge ./packages/snapshot-mss
 - `ae.previewFrame` 需要的 snapshotter
 
 > **三个包必须一起安装。** `ae-mcp-bridge` 和 `ae-mcp-snapshot-mss` 在各自的
-> `pyproject.toml` 里按名字依赖 `ae-mcp>=0.2.0`，而这个名字在 PyPI 上并不存在
+> `pyproject.toml` 里按名字依赖 `ae-mcp>=0.3.0`，而这个名字在 PyPI 上并不存在
 > （仓库尚未发布到 PyPI）。所以不要单独跑 `pip install ./packages/bridge`，
 > 那会因为找不到 `ae-mcp` 而失败。请把三个路径放在同一条 `pip install` 命令里
 > （core 在最前，让 bridge/snapshot 的依赖在同一次解析中就地命中），或者用
@@ -244,7 +244,7 @@ This provides:
 - the snapshotter required by `ae.previewFrame`
 
 > **The three packages must be installed together.** `ae-mcp-bridge` and
-> `ae-mcp-snapshot-mss` declare a by-name dependency on `ae-mcp>=0.2.0` in their
+> `ae-mcp-snapshot-mss` declare a by-name dependency on `ae-mcp>=0.3.0` in their
 > `pyproject.toml`, but that name is not published on PyPI (this repo is not on
 > PyPI yet). A standalone `pip install ./packages/bridge` therefore fails — pip
 > cannot resolve `ae-mcp`. Pass all three paths in a single `pip install`

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.2.0"
+version = "0.3.0"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "ae-mcp>=0.2.0",
+    "ae-mcp>=0.3.0",
     "httpx>=0.27",
 ]
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cross-platform mss-based screen capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "ae-mcp>=0.2.0",
+    "ae-mcp>=0.3.0",
     "mss>=10.0",
     "pillow>=10.0.0",
 ]

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.2.0"
+                   ExtensionBundleVersion="0.3.0"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.2.0" />
+        <Extension Id="com.aemcp.panel" Version="0.3.0" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "mcp" },
@@ -44,7 +44,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -70,7 +70,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
## Summary

Cuts **v0.3.0** and fixes the version/CHANGELOG drift from [#6](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/6) (PR #3 had added a `[0.2.1]` changelog entry but bumped no version file).

**Why 0.3.0, not 0.2.1:** #11's `/exec` authentication is a **breaking change** — the panel and the Python bridge must now upgrade together (an old bridge against a new panel gets 401). Under SemVer that's more than a patch. The never-released `[0.2.1]` tool-name entry is folded into the new `[0.3.0]`.

### Version files bumped 0.2.0 → 0.3.0
- `packages/core/pyproject.toml`, `packages/bridge/pyproject.toml`, `packages/snapshot-mss/pyproject.toml` (+ inter-package `ae-mcp>=0.3.0` pins)
- `plugin/CSXS/manifest.xml` (ExtensionBundleVersion + Extension Version)
- `plugin/host/package.json` + `package-lock.json` (host package only; dependency entries untouched)
- `uv.lock` (regenerated via `uv lock` — the three editable packages now resolve at 0.3.0)
- `docs/INSTALL.md` dependency-pin references synced to `>=0.3.0`

### CHANGELOG [0.3.0] (zh + en)
Covers everything shipped since 0.2.0: #8/#9 (PR #14), #10 (#15), #11 (#16), #12 (#17), #13 (#18), #4/#5/#7 (#19) — grouped Security / Fixed / Improved, led by a **breaking-change upgrade note** about the panel+bridge coupling.

## Test Plan
- `uv run pytest -q` → **261 passed, 24 deselected** (version bumps touch no asserted strings).
- `uv lock` resolved cleanly; the three local packages report 0.3.0.

## ⚠️ Manual release step (not in this PR)
The **signed ZXP must be rebuilt by a maintainer** — `scripts/package-zxp.ps1` needs `ZXPSignCmd.exe`, a cert, the now-**mandatory** `-CertPassword`, and TSA network access, none available in CI. Run it after merge to produce the 0.3.0 panel. **Release notes must tell users to reinstall the panel** so they get the #11 bridge-layer auth fix (the installed panel is a standalone copy).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)