### PR TITLE
fix: finish issue #8 remediation + ae_status diagnostics (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.3.1] — 2026-06-11
+
+继 0.3.0 之后，这一批补齐了 issue #8(“失败伪装成功”)修复方案的剩余部分。全部为兼容的健壮性改进，**不影响已有调用方**。
+
+#### 🐛 修复
+- **针对已删除 / 失效 comp、越界图层 id 的操作返回明确的“找不到”**（#8）——此前在 AE 26.2+ 上会抛出不透明的 `EvalScript error.`；现在 comp / 图层查找统一走防御式 helper，稳定返回 `{ok:false}`。
+- **只升级 Python 端、面板没重启也不再整批失效**（#8）——脚本现在自带所需的 helper 定义，不再依赖面板那一侧是否已加载新版命名空间，消除升级时的版本错配。
+- **坏掉 / 半卸载的截图插件不再拖垮整个工具列表**——快照器发现过程逐个隔离，单个损坏的扩展只会被跳过并记一条警告。
+- **后端缺失时给出可操作的提示，而不是空白工具列表**——新增 `ae_status` 诊断工具：没有可用后端时返回带安装指引的说明；其它 AE 工具异常时可先调它排查。
+- **更多失败被如实上报**（#8）——属性路径写错、传入无效图层 id、脚本输出损坏 / 被截断，现在都返回明确错误，而不是一个具有欺骗性的“成功”。
+- **插件 `/health` 报告真实版本号**，不再硬编码为 `0.1.0`。
+
 ### [0.3.0] — 2026-06-10
 
 > ⚠️ **升级须知（破坏性变更）**：本次为插件的 `/exec` 接口加上了本地鉴权，**面板（CEP 插件）和 Python 端必须一起升级**。只升级一边会导致调用被拒（401）。请按文档重新安装 / 同步面板后再使用。
@@ -64,6 +76,18 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.3.1] — 2026-06-11
+
+A follow-up to 0.3.0 that finishes the remaining half of the issue #8 ("failures masquerading as success") remediation. All changes are compatible robustness fixes; **existing callers are unaffected.**
+
+#### 🐛 Fixed
+- **Operations on a deleted/stale comp or an out-of-range layer id return a clear "not found"** (#8) — on AE 26.2+ these used to throw an opaque `EvalScript error.`; comp/layer lookups now go through defensive helpers that reliably return `{ok:false}`.
+- **Upgrading only the Python side no longer breaks every verb until the panel is reloaded** (#8) — scripts now carry their own helper definitions instead of depending on whether the panel loaded the newer namespace, eliminating upgrade-time version skew.
+- **A broken / half-uninstalled snapshot plugin no longer takes down the whole tool list** — snapshotter discovery isolates each entry point; one bad extension is skipped with a warning.
+- **A missing backend now gives an actionable hint instead of a blank tool list** — a new `ae_status` diagnostic verb returns the backend-selection result with install hints; call it first when other AE tools are missing or failing.
+- **More failures are reported honestly** (#8) — a mistyped property path, invalid layer ids, or corrupt/truncated script output now return an explicit error instead of a deceptive "success".
+- **The plugin's `/health` reports its real version** instead of a hardcoded `0.1.0`.
 
 ### [0.3.0] — 2026-06-10
 

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.3.0"
+version = "0.3.1"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/core/ae_mcp/handlers/__init__.py
+++ b/packages/core/ae_mcp/handlers/__init__.py
@@ -23,6 +23,7 @@ def load_all() -> None:
     """Import core + typed modules so they register their handlers."""
     # Imported for side effects (registration via @register or explicit register() calls).
     from ae_mcp.handlers import core  # noqa: F401
+    from ae_mcp.handlers import status  # noqa: F401
     from ae_mcp.handlers import typed  # noqa: F401
     from ae_mcp.handlers import skills  # noqa: F401
     from ae_mcp.handlers import rig  # noqa: F401

--- a/packages/core/ae_mcp/handlers/core.py
+++ b/packages/core/ae_mcp/handlers/core.py
@@ -27,6 +27,7 @@ from typing import Any, Optional
 from ae_mcp import checkpoint_store, progress, render_text, schemas
 from ae_mcp.backends import discovery as _discovery
 from ae_mcp.handlers import register
+from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.jsx_result import parse_jsx_result as _try_json
 
 log = logging.getLogger("ae_mcp.handlers.core")
@@ -113,7 +114,9 @@ def _atomic_replace(src_aep: Path, dst_path: str) -> None:
 
 async def _run_init(args: schemas.AeInitArgs, ctx: Any) -> Any:
     tmpl = _load_jsx("init.jsx")
-    jsx = tmpl.substitute(refresh_only="true" if args.refresh_only else "false")
+    jsx = with_prelude(
+        tmpl.substitute(refresh_only="true" if args.refresh_only else "false")
+    )
 
     async def _call() -> Any:
         out = await _backend().exec(jsx, timeout_sec=20.0)
@@ -134,7 +137,7 @@ register("ae.init", schemas.AeInitArgs, _run_init)
 
 async def _run_overview(args: schemas.AeOverviewArgs, ctx: Any) -> Any:
     tmpl = _load_jsx("overview.jsx")
-    jsx = tmpl.substitute()
+    jsx = with_prelude(tmpl.substitute())
 
     async def _call() -> Any:
         out = await _backend().exec(jsx, timeout_sec=15.0)
@@ -156,11 +159,11 @@ register("ae.overview", schemas.AeOverviewArgs, _run_overview)
 async def _run_layers(args: schemas.AeLayersArgs, ctx: Any) -> Any:
     from ae_mcp.handlers.typed import _comp_expr  # type: ignore
     tmpl = _load_jsx("get_layers.jsx")
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         offset=int(args.offset),
         limit=int(args.limit),
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(jsx, timeout_sec=15.0)
@@ -220,7 +223,9 @@ async def _run_exec(args: schemas.AeExecArgs, ctx: Any) -> Any:
                     dst = _store.aep_path(project_path, cid)
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     tmpl = _load_jsx("checkpoint_create.jsx")
-                    jsx_cp = tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+                    jsx_cp = with_prelude(
+                        tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+                    )
                     cp_out = await backend.exec(code=jsx_cp, timeout_sec=60.0)
                     cp_parsed = _try_json(cp_out)
                     if isinstance(cp_parsed, dict) and cp_parsed.get("ok"):
@@ -299,7 +304,9 @@ async def _run_checkpoint(args: schemas.AeCheckpointArgs, ctx: Any) -> Any:
         dst = _store.aep_path(project_path, cid)
         dst.parent.mkdir(parents=True, exist_ok=True)
         tmpl = _load_jsx("checkpoint_create.jsx")
-        jsx = tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+        jsx = with_prelude(
+            tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+        )
         out = await _backend().exec(
             code=jsx,
             undo_group=f"MCP checkpoint: {args.label or cid}",
@@ -452,7 +459,9 @@ async def _branch_snapshot(project_path: str, checkpoint_id: str) -> Optional[st
         dst = _store.aep_path(project_path, cid)
         dst.parent.mkdir(parents=True, exist_ok=True)
         tmpl = _load_jsx("checkpoint_create.jsx")
-        jsx = tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+        jsx = with_prelude(
+            tmpl.substitute(dst_path=json.dumps(str(dst), ensure_ascii=False))
+        )
         out = await _backend().exec(code=jsx, timeout_sec=60.0)
         parsed = _try_json(out)
         if isinstance(parsed, dict) and parsed.get("ok") and not parsed.get("skipped"):
@@ -598,10 +607,10 @@ async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
         comp_name: str | None = None
 
         for frame_request in frame_requests:
-            jsx = tmpl.substitute(
+            jsx = with_prelude(tmpl.substitute(
                 comp_expr=_comp_expr(args.comp_id),
                 time=json.dumps(frame_request["time"]),
-            )
+            ))
             out = await _backend().exec(code=jsx, timeout_sec=15.0)
             prepared = _try_json(out)
             if not isinstance(prepared, dict) or not prepared.get("ok"):
@@ -679,17 +688,15 @@ def _apply_effect_jsx(comp_id: str | None, layer_id: int, match_name: str) -> st
     # JSON-escape the match name so embedded quotes are safe inside JSX.
     escaped_name = json.dumps(match_name)
     comp_expr = (
-        f"(function(){{ var it = app.project.itemByID({int(comp_id)}); "
-        f"return (it && it instanceof CompItem) ? it : null; }})()"
+        f"AEMCP.compById({int(comp_id)})"
         if comp_id else
-        "(function(){ var it = app.project.activeItem; "
-        "return (it && it instanceof CompItem) ? it : null; })()"
+        "AEMCP.activeComp()"
     )
-    return (
+    return with_prelude(
         "(function(){\n"
         f"  var comp = {comp_expr};\n"
         "  if (!comp) return JSON.stringify({ok:false,error:'no comp'});\n"
-        f"  var layer = comp.layer({int(layer_id)});\n"
+        f"  var layer = AEMCP.layerById(comp, {int(layer_id)});\n"
         "  if (!layer) return JSON.stringify({ok:false,error:'no layer'});\n"
         "  var effects = layer.property('ADBE Effect Parade');\n"
         "  if (!effects) return JSON.stringify({ok:false,error:'no effect parade'});\n"
@@ -728,7 +735,9 @@ def _ping_template() -> Template:
 
 
 async def _run_ping(args: schemas.AePingArgs, ctx: Any) -> Any:
-    jsx = _ping_template().substitute(expect=json.dumps(args.expect, ensure_ascii=False))
+    jsx = with_prelude(
+        _ping_template().substitute(expect=json.dumps(args.expect, ensure_ascii=False))
+    )
 
     async def _call() -> Any:
         out = await _backend().exec(code=jsx, timeout_sec=10.0)

--- a/packages/core/ae_mcp/handlers/rig.py
+++ b/packages/core/ae_mcp/handlers/rig.py
@@ -9,6 +9,7 @@ from typing import Any
 from ae_mcp import progress, schemas
 from ae_mcp.backends import discovery as _discovery
 from ae_mcp.handlers import register
+from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.jsx_result import parse_jsx_result as _try_json
 
 
@@ -32,13 +33,13 @@ async def _run_create_rig(args: schemas.AeCreateRigArgs, ctx: Any) -> Any:
     if args.controls is not None:
         options["controls"] = [c.model_dump() for c in args.controls]
 
-    jsx = _load_jsx("create_rig.jsx").substitute(
+    jsx = with_prelude(_load_jsx("create_rig.jsx").substitute(
         comp_expr=_comp_expr(args.comp_id),
         target_layer_id=json.dumps(args.target_layer_id),
         rig_type=json.dumps(args.rig_type),
         name=json.dumps(args.name, ensure_ascii=False),
         options=json.dumps(options, ensure_ascii=False),
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(

--- a/packages/core/ae_mcp/handlers/status.py
+++ b/packages/core/ae_mcp/handlers/status.py
@@ -1,0 +1,54 @@
+"""Diagnostic status handler exposed even when no backend can be selected."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ae_mcp.backends import discovery as _backend_discovery
+from ae_mcp.handlers import register
+from ae_mcp.schemas import AeStatusArgs
+from ae_mcp.snapshot import discovery as _snapshot_discovery
+
+log = logging.getLogger("ae_mcp.handlers.status")
+
+
+async def _run_status(args: AeStatusArgs, ctx: Any) -> dict[str, Any]:
+    del args, ctx
+
+    result: dict[str, Any] = {
+        "ok": False,
+        "backend": None,
+        "backendError": None,
+        "installedBackends": [],
+        "snapshotter": None,
+    }
+
+    try:
+        installed = _backend_discovery.list_installed_backends()
+    except Exception as e:  # noqa: BLE001
+        log.warning("backend install scan failed: %s", e)
+        result["installScanError"] = str(e)
+    else:
+        result["installedBackends"] = sorted(installed.keys())
+
+    try:
+        backend = _backend_discovery.select_backend()
+    except Exception as e:  # noqa: BLE001
+        result["backendError"] = str(e)
+    else:
+        result["ok"] = True
+        result["backend"] = backend.__class__.__name__
+
+    try:
+        snapshotter = _snapshot_discovery.select_snapshotter()
+    except Exception as e:  # noqa: BLE001
+        log.warning("snapshotter status probe failed: %s", e)
+    else:
+        if snapshotter is not None:
+            result["snapshotter"] = snapshotter.__class__.__name__
+
+    return result
+
+
+register("ae.status", AeStatusArgs, _run_status)

--- a/packages/core/ae_mcp/handlers/typed.py
+++ b/packages/core/ae_mcp/handlers/typed.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from ae_mcp import progress, schemas
 from ae_mcp.backends import discovery as _discovery
 from ae_mcp.handlers import register
+from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.jsx_result import parse_jsx_result as _try_json_or_raw
 
 log = logging.getLogger("ae_mcp.handlers.typed")
@@ -58,15 +59,8 @@ def _load_template(name: str) -> Template:
 def _comp_expr(comp_id: Optional[str]) -> str:
     """Build a JSX expression that evaluates to a CompItem or null."""
     if comp_id:
-        return (
-            "(function(){ var it = app.project.itemByID("
-            + str(int(comp_id))
-            + "); return (it && it instanceof CompItem) ? it : null; })()"
-        )
-    return (
-        "(function(){ var it = app.project.activeItem; "
-        "return (it && it instanceof CompItem) ? it : null; })()"
-    )
+        return f"AEMCP.compById({int(comp_id)})"
+    return "AEMCP.activeComp()"
 
 
 def _json_literal(value: Any) -> str:
@@ -87,7 +81,7 @@ async def _run_create_layer(args: schemas.AeCreateLayerArgs, ctx: Any) -> Any:
     duration = float(args.duration) if args.duration is not None else -1.0
     position_js = _json_literal(list(args.position) if args.position else None)
 
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         type=args.type,           # retained for parity; unused in template body
         type_str=_json_literal(args.type),
@@ -97,7 +91,7 @@ async def _run_create_layer(args: schemas.AeCreateLayerArgs, ctx: Any) -> Any:
         size_h=size_h,
         duration=duration,
         position=position_js,
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -122,13 +116,13 @@ register("ae.createLayer", schemas.AeCreateLayerArgs, _run_create_layer)
 
 async def _run_set_property(args: schemas.AeSetPropertyArgs, ctx: Any) -> Any:
     tmpl = _load_template("set_property.jsx")
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         path=_json_literal(args.path),
         value=_json_literal(args.value),
         at_time=float(args.at_time) if args.at_time is not None else -1.0,
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -153,11 +147,11 @@ register("ae.setProperty", schemas.AeSetPropertyArgs, _run_set_property)
 
 async def _run_move_layer(args: schemas.AeMoveLayerArgs, ctx: Any) -> Any:
     tmpl = _load_template("move_layer.jsx")
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         to_index=int(args.to_index),
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -187,10 +181,10 @@ async def _run_select_layers(args: schemas.AeSelectLayersArgs, ctx: Any) -> Any:
     else:
         selector_js = _json_literal(sel)  # "all" | "none"
 
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         selector_js=selector_js,
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -213,10 +207,10 @@ register("ae.selectLayers", schemas.AeSelectLayersArgs, _run_select_layers)
 
 async def _run_set_time(args: schemas.AeSetTimeArgs, ctx: Any) -> Any:
     tmpl = _load_template("set_time.jsx")
-    jsx = tmpl.substitute(
+    jsx = with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         time=float(args.time),
-    )
+    ))
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -239,7 +233,7 @@ register("ae.setTime", schemas.AeSetTimeArgs, _run_set_time)
 
 async def _run_get_time(args: schemas.AeGetTimeArgs, ctx: Any) -> Any:
     tmpl = _load_template("get_time.jsx")
-    jsx = tmpl.substitute(comp_expr=_comp_expr(args.comp_id))
+    jsx = with_prelude(tmpl.substitute(comp_expr=_comp_expr(args.comp_id)))
 
     async def _call() -> Any:
         out = await _backend().exec(code=jsx, timeout_sec=20.0)
@@ -265,7 +259,7 @@ def render_create_layer(args: schemas.AeCreateLayerArgs) -> str:
     size_h = float(args.size[1]) if args.size else -1.0
     duration = float(args.duration) if args.duration is not None else -1.0
     position_js = _json_literal(list(args.position) if args.position else None)
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         type=args.type,
         type_str=_json_literal(args.type),
@@ -275,27 +269,27 @@ def render_create_layer(args: schemas.AeCreateLayerArgs) -> str:
         size_h=size_h,
         duration=duration,
         position=position_js,
-    )
+    ))
 
 
 def render_set_property(args: schemas.AeSetPropertyArgs) -> str:
     tmpl = _load_template("set_property.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         path=_json_literal(args.path),
         value=_json_literal(args.value),
         at_time=float(args.at_time) if args.at_time is not None else -1.0,
-    )
+    ))
 
 
 def render_move_layer(args: schemas.AeMoveLayerArgs) -> str:
     tmpl = _load_template("move_layer.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         to_index=int(args.to_index),
-    )
+    ))
 
 
 def render_select_layers(args: schemas.AeSelectLayersArgs) -> str:
@@ -305,20 +299,22 @@ def render_select_layers(args: schemas.AeSelectLayersArgs) -> str:
         selector_js = _json_literal([int(i) for i in sel])
     else:
         selector_js = _json_literal(sel)
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         selector_js=selector_js,
-    )
+    ))
 
 
 def render_set_time(args: schemas.AeSetTimeArgs) -> str:
     tmpl = _load_template("set_time.jsx")
-    return tmpl.substitute(comp_expr=_comp_expr(args.comp_id), time=float(args.time))
+    return with_prelude(
+        tmpl.substitute(comp_expr=_comp_expr(args.comp_id), time=float(args.time))
+    )
 
 
 def render_get_time(args: schemas.AeGetTimeArgs) -> str:
     tmpl = _load_template("get_time.jsx")
-    return tmpl.substitute(comp_expr=_comp_expr(args.comp_id))
+    return with_prelude(tmpl.substitute(comp_expr=_comp_expr(args.comp_id)))
 
 
 # ---------------------------------------------------------------------------
@@ -328,13 +324,13 @@ def render_get_time(args: schemas.AeGetTimeArgs) -> str:
 
 def render_get_properties(args: schemas.AeGetPropertiesArgs) -> str:
     tmpl = _load_template("get_properties.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_ids_js=_json_literal([int(i) for i in args.layer_ids]),
         query_js=_json_literal(args.query),
         offset=int(args.offset),
         limit=int(args.limit),
-    )
+    ))
 
 
 async def _run_get_properties(args: schemas.AeGetPropertiesArgs, ctx: Any) -> Any:
@@ -359,13 +355,13 @@ register("ae.getProperties", schemas.AeGetPropertiesArgs, _run_get_properties)
 
 def render_scan_property_tree(args: schemas.AeScanPropertyTreeArgs) -> str:
     tmpl = _load_template("scan_property_tree.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         max_depth=int(args.max_depth),
         include_values="true" if args.include_values else "false",
         time_budget_ms=_TRAVERSAL_BUDGET_MS,
-    )
+    ))
 
 
 async def _run_scan_property_tree(args: schemas.AeScanPropertyTreeArgs, ctx: Any) -> Any:
@@ -390,11 +386,11 @@ register("ae.scanPropertyTree", schemas.AeScanPropertyTreeArgs, _run_scan_proper
 
 def render_inspect_property_capabilities(args: schemas.AeInspectPropertyCapabilitiesArgs) -> str:
     tmpl = _load_template("inspect_property_capabilities.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         path=_json_literal(args.path),
-    )
+    ))
 
 
 async def _run_inspect_property_capabilities(
@@ -423,12 +419,12 @@ register("ae.inspectPropertyCapabilities",
 
 def render_get_expressions(args: schemas.AeGetExpressionsArgs) -> str:
     tmpl = _load_template("get_expressions.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_ids_js=_json_literal(list(args.layer_ids)) if args.layer_ids else "null",
         prop_filter_js=_json_literal(args.prop) if args.prop else "null",
         max_results=int(args.max_results),
-    )
+    ))
 
 
 async def _run_get_expressions(args: schemas.AeGetExpressionsArgs, ctx: Any) -> Any:
@@ -453,7 +449,7 @@ register("ae.getExpressions", schemas.AeGetExpressionsArgs, _run_get_expressions
 
 def render_validate_expressions(args: schemas.AeValidateExpressionsArgs) -> str:
     tmpl = _load_template("validate_expressions.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_ids_js=_json_literal(list(args.layer_ids)) if args.layer_ids else "null",
         prop_filter_js=_json_literal(args.prop) if args.prop else "null",
@@ -462,7 +458,7 @@ def render_validate_expressions(args: schemas.AeValidateExpressionsArgs) -> str:
             if args.sample_times is not None else "null"
         ),
         max_results=int(args.max_results),
-    )
+    ))
 
 
 async def _run_validate_expressions(
@@ -489,11 +485,11 @@ register("ae.validateExpressions", schemas.AeValidateExpressionsArgs, _run_valid
 
 def render_get_keyframes(args: schemas.AeGetKeyframesArgs) -> str:
     tmpl = _load_template("get_keyframes.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         comp_expr=_comp_expr(args.comp_id),
         layer_id=int(args.layer_id),
         path=_json_literal(args.path),
-    )
+    ))
 
 
 async def _run_get_keyframes(args: schemas.AeGetKeyframesArgs, ctx: Any) -> Any:
@@ -518,12 +514,12 @@ register("ae.getKeyframes", schemas.AeGetKeyframesArgs, _run_get_keyframes)
 
 def render_search_project(args: schemas.AeSearchProjectArgs) -> str:
     tmpl = _load_template("search_project.jsx")
-    return tmpl.substitute(
+    return with_prelude(tmpl.substitute(
         query_js=_json_literal(args.query),
         scope_js=_json_literal(list(args.scope)),
         limit=int(args.limit),
         time_budget_ms=_TRAVERSAL_BUDGET_MS,
-    )
+    ))
 
 
 async def _run_search_project(args: schemas.AeSearchProjectArgs, ctx: Any) -> Any:

--- a/packages/core/ae_mcp/jsx_prelude.py
+++ b/packages/core/ae_mcp/jsx_prelude.py
@@ -1,0 +1,26 @@
+"""Helpers for prefixing rendered JSX with the AEMCP runtime prelude."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent / "jsx_templates"
+
+
+@lru_cache(maxsize=1)
+def _aemcp_prelude() -> str:
+    return (_TEMPLATES_DIR / "_aemcp_prelude.jsx").read_text(encoding="utf-8")
+
+
+def with_prelude(jsx: str) -> str:
+    """Prefix rendered JSX with AEMCP helpers.
+
+    The prelude is appended only after string.Template substitution: it must
+    never pass through Template because a future verbatim copy could contain
+    dollar signs that Template would treat as placeholders. Bundling the
+    helpers into each script also keeps old panels that lack AEMCP compatible
+    with newer Python templates, and vice versa.
+    """
+    return _aemcp_prelude() + "\n" + jsx

--- a/packages/core/ae_mcp/jsx_result.py
+++ b/packages/core/ae_mcp/jsx_result.py
@@ -10,6 +10,8 @@ weak JSON contract:
 - A string beginning with "EvalScript error" (CSInterface's uncaught-error
   sentinel) — surfaces as `{ok:false, error, raw}`. Backstop for the
   jsx-bridge.js sentinel check (see GitHub issue #8).
+- JSON-shaped text that fails `json.loads` — surfaces as `{ok:false, error,
+  raw}` rather than falling through to silent success.
 - Other non-JSON text — returned as `{ok:true, content:text}` because some
   callers intentionally use ae.exec to fetch a string.
 
@@ -29,46 +31,41 @@ from typing import Any
 _NO_VALUE_SENTINELS = frozenset({"undefined", "null"})
 
 
+def _fail(error: str, raw: str) -> dict[str, str | bool]:
+    return {"ok": False, "error": error, "raw": raw}
+
+
 def parse_jsx_result(text: str) -> Any:
     """Parse raw JSX output text into a uniform result dict.
 
     Returns:
         - dict/list from json.loads when text looks like JSON
         - {ok:false, error, raw} for empty or "undefined"/"null" outputs
+        - {ok:false, error, raw} for JSON-shaped text that fails to parse
         - {ok:true, content:text} for other non-JSON strings (back-compat
           for ae.exec users who return raw strings)
     """
     if not text or text.strip() == "":
-        return {
-            "ok": False,
-            "error": "jsx returned no value (empty output)",
-            "raw": text,
-        }
+        return _fail("jsx returned no value (empty output)", text)
 
     stripped = text.strip()
     if stripped in _NO_VALUE_SENTINELS:
-        return {
-            "ok": False,
-            "error": f"jsx evaluated to {stripped}; ensure your code "
-                     "returns JSON.stringify(...) or a value",
-            "raw": text,
-        }
+        return _fail(
+            f"jsx evaluated to {stripped}; ensure your code returns JSON.stringify(...) or a value",
+            text,
+        )
 
     # CSInterface returns the literal "EvalScript error." (the constant
     # EvalScript_ErrMessage) when ExtendScript threw uncaught. jsx-bridge.js
     # rejects it, but this is the Python backstop: surface it as a failure
     # rather than wrapping the error message as ok:true content.
     if stripped.startswith("EvalScript error"):
-        return {
-            "ok": False,
-            "error": stripped,
-            "raw": text,
-        }
+        return _fail(stripped, text)
 
     if stripped[:1] in ("{", "["):
         try:
             return json.loads(stripped)
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as e:
+            return _fail(f"jsx returned JSON-like text that failed to parse: {e}", text)
 
     return {"ok": True, "content": text}

--- a/packages/core/ae_mcp/jsx_templates/_aemcp_prelude.jsx
+++ b/packages/core/ae_mcp/jsx_templates/_aemcp_prelude.jsx
@@ -1,0 +1,96 @@
+// AEMCP-HELPERS-BEGIN — source of truth lives in plugin/jsx/runtime.jsx; keep both in sync (enforced by test_jsx_prelude.py)
+// ---------------------------------------------------------------------------
+// AEMCP helper namespace.
+//
+// A single source of truth for the targeting + property-resolution idioms
+// every JSX template would otherwise re-implement. Loaded once into the
+// persistent engine, so agent-authored ae.exec / ae.readProps scripts can
+// call these directly. All helpers are defensive: they return null (never
+// throw) on bad input, honouring the "JSX must never throw" invariant.
+// ---------------------------------------------------------------------------
+if (typeof AEMCP === 'undefined') { AEMCP = {}; }
+
+AEMCP.version = '0.1.0';
+
+// Count of a node's child properties, or -1 when `node` is a leaf Property /
+// not a group. try/catch shields against leaf nodes that lack numProperties.
+AEMCP._numProps = function (node) {
+    var n;
+    try { n = node.numProperties; } catch (e) { return -1; }
+    return (typeof n === 'number') ? n : -1;
+};
+
+// Resolve a CompItem by AE item id, or null when the id isn't a comp.
+// itemByID throws "Item Not Found" on an unknown id (AE 26.2+) rather than
+// returning null, so guard it to honour the never-throw invariant.
+AEMCP.compById = function (id) {
+    var it;
+    try { it = app.project.itemByID(id); } catch (e) { return null; }
+    return (it && it instanceof CompItem) ? it : null;
+};
+
+// The active comp, or null when the foreground item isn't a comp.
+AEMCP.activeComp = function () {
+    var it = app.project.activeItem;
+    return (it && it instanceof CompItem) ? it : null;
+};
+
+// A layer by 1-based index within a comp, or null.
+AEMCP.layerById = function (comp, idx) {
+    if (!comp) return null;
+    try { return comp.layer(idx); } catch (e) { return null; }
+};
+
+// Resolve a property by display-name path, e.g. "Transform/Position" or
+// "Effects/Gaussian Blur/Blurriness". Returns the Property/PropertyGroup or
+// null. .property() accepts names, matchNames, or indices.
+AEMCP.propByPath = function (root, path) {
+    if (!root || !path) return null;
+    var segs = String(path).split('/');
+    var cur = root;
+    for (var i = 0; i < segs.length; i++) {
+        if (segs[i] === '') continue;
+        var next = null;
+        try { next = cur.property(segs[i]); } catch (e) { return null; }
+        if (!next) return null;
+        cur = next;
+    }
+    return cur;
+};
+
+// Resolve a property by matchName path with optional #ordinals, e.g.
+// "ADBE Transform Group#1/ADBE Position#1". Ordinals count siblings sharing a
+// matchName (default 1) so duplicate-matchName effects stay addressable.
+// Returns the Property/PropertyGroup or null.
+AEMCP.propByMatchPath = function (root, path) {
+    if (!root || !path) return null;
+    var segs = String(path).split('/');
+    var cur = root;
+    for (var i = 0; i < segs.length; i++) {
+        var seg = segs[i];
+        if (seg === '') continue;
+        var mn = seg, ord = 1;
+        var h = seg.lastIndexOf('#');
+        if (h > 0) {
+            var parsed = parseInt(seg.substring(h + 1), 10);
+            if (!isNaN(parsed) && parsed >= 1) {
+                mn = seg.substring(0, h);
+                ord = parsed;
+            }
+        }
+        var n = AEMCP._numProps(cur);
+        if (n < 0) return null;
+        var found = null, count = 0;
+        for (var j = 1; j <= n; j++) {
+            var child = cur.property(j);
+            if (child && child.matchName === mn) {
+                count++;
+                if (count === ord) { found = child; break; }
+            }
+        }
+        if (!found) return null;
+        cur = found;
+    }
+    return cur;
+};
+// AEMCP-HELPERS-END

--- a/packages/core/ae_mcp/jsx_templates/get_properties.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_properties.jsx
@@ -34,6 +34,7 @@
     }
 
     var hits = [];
+    var missing = [];
 
     function visit(prop, layerId, pathSegs, matchSegs, depth) {
         if (depth > 6) return;
@@ -73,7 +74,7 @@
 
     for (var li = 0; li < layerIds.length; li++) {
         var layer = AEMCP.layerById(comp, layerIds[li]);
-        if (!layer) continue;
+        if (!layer) { missing.push(layerIds[li]); continue; }
         for (var pi = 1; pi <= layer.numProperties; pi++) {
             var top = layer.property(pi);
             if (!top) continue;
@@ -81,10 +82,16 @@
         }
     }
 
+    // Silent partial results are indistinguishable from "this layer had no matches"
+    // unless missing layer ids are surfaced explicitly to the caller.
+    if (missing.length === layerIds.length) {
+        return JSON.stringify({ok:false, error:"no valid layers in layer_ids", missingLayerIds:missing});
+    }
+
     hits.sort(function(a, b) { return b._score - a._score; });
     var total = hits.length;
     var paged = hits.slice(offset, offset + limit);
     for (var pi2 = 0; pi2 < paged.length; pi2++) delete paged[pi2]._score;
 
-    return JSON.stringify({ok:true, total: total, results: paged});
+    return JSON.stringify({ok:true, total: total, results: paged, missingLayerIds:missing});
 })()

--- a/packages/core/ae_mcp/jsx_templates/inspect_property_capabilities.jsx
+++ b/packages/core/ae_mcp/jsx_templates/inspect_property_capabilities.jsx
@@ -11,10 +11,7 @@
     for (var i = 0; i < segs.length; i++) {
         try {
             prop = prop.property(segs[i]);
-            if (!prop) return JSON.stringify({
-                ok: true, exists: false,
-                error: "path segment not found: " + segs[i]
-            });
+            if (!prop) return JSON.stringify({ok:false, exists: false, error:"path segment not found: " + segs[i]});
         } catch (e) {
             return JSON.stringify({ok:false, exists: false,
                 error: "property() threw: " + String(e)});

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -252,7 +252,7 @@ class AeGetTimeArgs(_StrictModel):
 class AeGetPropertiesArgs(_StrictModel):
     """ae.getProperties — search properties by name across selected layers."""
     comp_id: Optional[str] = Field(None, description="AE comp id. Omit for active.")
-    layer_ids: List[int] = Field(..., description="1-based layer indices to scan.")
+    layer_ids: List[Annotated[int, Field(ge=1)]] = Field(..., min_length=1, description="1-based layer indices to scan.")
     query: str = Field(..., description="Multi-word AND; '|' separates OR groups.")
     offset: int = Field(0, ge=0, description="Pagination offset.")
     limit: int = Field(50, ge=1, le=500, description="Pagination size.")

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -394,6 +394,11 @@ class AeCreateRigArgs(_StrictModel):
     options: Dict[str, Any] = Field(default_factory=dict, description="Rig-type-specific options.")
 
 
+class AeStatusArgs(_StrictModel):
+    """ae.status — diagnose the ae-mcp install: backend selection result (with install hints when missing), installed backends, snapshotter availability. Call this first when other AE tools are missing or failing."""
+    pass
+
+
 # ---------------------------------------------------------------------------
 # Registry of verb -> schema (handlers.core / handlers.typed reference this)
 # ---------------------------------------------------------------------------
@@ -411,6 +416,7 @@ SCHEMAS = {
     "ae.previewFrame": AePreviewFrameArgs,
     "ae.applyEffect": AeApplyEffectArgs,
     "ae.ping": AePingArgs,
+    "ae.status": AeStatusArgs,
     "ae.createLayer": AeCreateLayerArgs,
     "ae.setProperty": AeSetPropertyArgs,
     "ae.moveLayer": AeMoveLayerArgs,
@@ -432,4 +438,4 @@ SCHEMAS = {
     "ae.createRig": AeCreateRigArgs,
 }
 
-assert len(SCHEMAS) == 30, f"expected 30 verbs, got {len(SCHEMAS)}"
+assert len(SCHEMAS) == 31, f"expected 31 verbs, got {len(SCHEMAS)}"

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -32,19 +32,32 @@ _LEADING_VERB = re.compile(r"^(ae\.[A-Za-z][A-Za-z0-9]*)")
 
 
 def _filtered_tool_names() -> set:
-    """Return verb names this server should expose, given active backend
-    capabilities + whether a snapshotter is installed."""
+    """Return verb names this server should expose.
+
+    Always includes ae.status so clients have a diagnostic entry point even
+    when backend selection fails. Other verbs depend on backend capabilities
+    and whether a snapshotter is available.
+    """
     from ae_mcp.backends import discovery as _discovery
     from ae_mcp.snapshot import discovery as _snap_discovery
     try:
         backend = _discovery.select_backend()
         supported = backend.supported_verbs()
     except Exception as e:  # noqa: BLE001
-        log.warning("backend selection failed; exposing no tools: %s", e)
-        return set()
-    if _snap_discovery.select_snapshotter() is None:
+        log.warning(
+            "backend selection failed; exposing only ae.status "
+            "(tool name ae_status) for diagnostics: %s",
+            e,
+        )
+        return {"ae.status"}
+    try:
+        snapshotter = _snap_discovery.select_snapshotter()
+    except Exception as e:  # noqa: BLE001
+        log.warning("snapshotter selection failed; hiding ae.snapshot: %s", e)
+        snapshotter = None
+    if snapshotter is None:
         supported = supported - {"ae.snapshot"}
-    return supported
+    return supported | {"ae.status"}
 
 
 def _format_result(result: Any) -> str:

--- a/packages/core/ae_mcp/snapshot/discovery.py
+++ b/packages/core/ae_mcp/snapshot/discovery.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import importlib.metadata
+import logging
 from typing import Dict, Optional, Type
 
 from ae_mcp.snapshot.base import Snapshotter
 
 
 ENTRY_POINT_GROUP = "ae_mcp.snapshotters"
+log = logging.getLogger("ae_mcp.snapshot.discovery")
 
 
 class SnapshotSelectionError(RuntimeError):
@@ -16,7 +18,13 @@ class SnapshotSelectionError(RuntimeError):
 
 def _scan_entry_points() -> Dict[str, Type[Snapshotter]]:
     eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
-    return {ep.name: ep.load() for ep in eps}
+    installed: Dict[str, Type[Snapshotter]] = {}
+    for ep in eps:
+        try:
+            installed[ep.name] = ep.load()
+        except Exception as e:  # noqa: BLE001
+            log.warning("failed to load snapshotter entry point %s: %s", ep.name, e)
+    return installed
 
 
 def list_installed_snapshotters() -> Dict[str, Type[Snapshotter]]:
@@ -24,14 +32,24 @@ def list_installed_snapshotters() -> Dict[str, Type[Snapshotter]]:
 
 
 def select_snapshotter() -> Optional[Snapshotter]:
-    """Return the first snapshotter whose supports_platform() is True.
+    """Return the first usable snapshotter whose supports_platform() is True.
 
-    Returns None if no usable snapshotter is installed; core uses this
-    to hide ae.snapshot from tools/list.
+    Returns None if no usable snapshotter is installed or every candidate
+    fails to initialize/platform-probe; core uses this to hide ae.snapshot
+    from tools/list.
     """
     installed = _scan_entry_points()
     for name, cls in sorted(installed.items()):
-        inst = cls()
-        if inst.supports_platform():
+        try:
+            inst = cls()
+        except Exception as e:  # noqa: BLE001
+            log.warning("failed to initialize snapshotter %s: %s", name, e)
+            continue
+        try:
+            supported = inst.supports_platform()
+        except Exception as e:  # noqa: BLE001
+            log.warning("snapshotter %s platform probe failed: %s", name, e)
+            continue
+        if supported:
             return inst
     return None

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/core/tests/test_handlers_core.py
+++ b/packages/core/tests/test_handlers_core.py
@@ -140,7 +140,7 @@ async def test_apply_effect_builds_jsx(mock_backend):
     assert len(mock_backend.calls) >= 1
     jsx = mock_backend.calls[-1]["code"]
     assert "ADBE Gaussian Blur 2" in jsx
-    assert "comp.layer(3)" in jsx
+    assert "AEMCP.layerById(comp, 3)" in jsx
 
 
 @pytest.mark.asyncio
@@ -196,7 +196,7 @@ async def test_preview_frame_uses_viewer_snapshot_not_render(monkeypatch, mock_b
     jsx = mock_backend.calls[-1]["code"]
     assert "saveFrameToPng" not in jsx
     assert "openInViewer" in jsx
-    assert "itemByID(7)" in jsx
+    assert "AEMCP.compById(7)" in jsx
 
 
 @pytest.mark.asyncio
@@ -431,7 +431,7 @@ async def test_validate_expressions_builds_jsx_and_reports_invalid(mock_backend)
     assert result["valid"] is False
     assert result["errors"][0]["expressionError"] == "bad slider reference"
     jsx = mock_backend.calls[-1]["code"]
-    assert "itemByID(12)" in jsx
+    assert "AEMCP.compById(12)" in jsx
     assert "[0.0, 1.0]" in jsx
 
 
@@ -461,7 +461,7 @@ async def test_create_rig_builds_transform_controller_jsx(mock_backend):
     jsx = mock_backend.calls[-1]["code"]
     assert "Main CTRL" in jsx
     assert "transform_controller" in jsx
-    assert "itemByID(12)" in jsx
+    assert "AEMCP.compById(12)" in jsx
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_handlers_typed.py
+++ b/packages/core/tests/test_handlers_typed.py
@@ -47,7 +47,7 @@ def test_render_set_property_with_keyframe():
     # Single-layer resolution must route through AEMCP.layerById so a stale
     # /out-of-range id returns null (caught by the `if (!layer)` guard) instead
     # of throwing (issue #8).
-    assert "AEMCP.layerById(comp," in jsx
+    assert "AEMCP.layerById(comp, 2)" in jsx
     assert '"Transform/Position"' in jsx
     assert "[100, 200]" in jsx
     assert "1.5" in jsx
@@ -65,7 +65,7 @@ def test_render_move_layer_clamps_in_js_not_py():
     # The source layer is resolved via AEMCP.layerById (issue #8). The
     # destination `comp.layer(to)` stays as-is — `to` is clamped to a valid
     # 1-based index in JS, so it never throws.
-    assert "AEMCP.layerById(comp," in jsx
+    assert "AEMCP.layerById(comp, 3)" in jsx
     assert "var to = 10;" in jsx
 
 
@@ -88,12 +88,12 @@ def test_render_set_time():
 
 def test_render_get_time_uses_active_comp_by_default():
     jsx = T.render_get_time(S.AeGetTimeArgs())
-    assert "activeItem" in jsx
+    assert "AEMCP.activeComp()" in jsx
 
 
 def test_render_get_time_with_comp_id():
     jsx = T.render_get_time(S.AeGetTimeArgs(comp_id="42"))
-    assert "itemByID(42)" in jsx
+    assert "AEMCP.compById(42)" in jsx
 
 
 # -------- Dispatch round-trips (using mock_backend) --------
@@ -167,7 +167,7 @@ def test_render_get_properties_substitutes_query():
     assert '[1, 2]' in jsx or '[1,2]' in jsx
     # Per-layer resolution in the loop routes through AEMCP.layerById so a
     # stale id is skipped via `continue` instead of throwing (issue #8).
-    assert "AEMCP.layerById(comp," in jsx
+    assert "AEMCP.layerById(comp, layerIds[li])" in jsx
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ def test_render_scan_property_tree():
     from ae_mcp.handlers.typed import render_scan_property_tree
     args = schemas.AeScanPropertyTreeArgs(layer_id=3, max_depth=2, include_values=False)
     jsx = render_scan_property_tree(args)
-    assert "AEMCP.layerById(comp," in jsx  # issue #8
+    assert "AEMCP.layerById(comp, 3)" in jsx  # issue #8
     assert "var maxDepth = 2;" in jsx
     assert "var includeValues = false;" in jsx
 
@@ -212,7 +212,7 @@ def test_render_inspect_property_capabilities():
     args = schemas.AeInspectPropertyCapabilitiesArgs(layer_id=1, path="Transform/Position")
     jsx = render_inspect_property_capabilities(args)
     assert '"Transform/Position"' in jsx
-    assert "AEMCP.layerById(comp," in jsx  # issue #8
+    assert "AEMCP.layerById(comp, 1)" in jsx  # issue #8
 
 
 @pytest.mark.asyncio
@@ -251,7 +251,7 @@ def test_render_get_keyframes():
     args = schemas.AeGetKeyframesArgs(layer_id=1, path="Transform/Position")
     jsx = render_get_keyframes(args)
     assert '"Transform/Position"' in jsx
-    assert "AEMCP.layerById(comp," in jsx  # issue #8
+    assert "AEMCP.layerById(comp, 1)" in jsx  # issue #8
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_jsx_prelude.py
+++ b/packages/core/tests/test_jsx_prelude.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from ae_mcp import schemas as S
+from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.handlers import core as C
+from ae_mcp.handlers import typed as T
+from ae_mcp.handlers.rig import _run_create_rig
+
+
+BEGIN = "AEMCP-HELPERS-BEGIN"
+END = "AEMCP-HELPERS-END"
+
+
+def _helper_body(path):
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    begin = next((i for i, line in enumerate(lines) if BEGIN in line), None)
+    end = next((i for i, line in enumerate(lines) if END in line), None)
+    assert begin is not None and end is not None and begin < end, (
+        f"{path} must contain {BEGIN}/{END} markers; "
+        "the runtime helper block and Python prelude copy must stay in sync."
+    )
+    return "".join(lines[begin + 1:end])
+
+
+def _body_after_prelude(jsx: str) -> str:
+    assert BEGIN in jsx
+    assert END in jsx
+    return jsx.split(END, 1)[1]
+
+
+def test_aemcp_prelude_is_verbatim_runtime_helper_copy():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    runtime = root / "plugin" / "jsx" / "runtime.jsx"
+    prelude = (
+        root
+        / "packages"
+        / "core"
+        / "ae_mcp"
+        / "jsx_templates"
+        / "_aemcp_prelude.jsx"
+    )
+
+    assert _helper_body(prelude) == _helper_body(runtime)
+
+
+def test_rendered_templates_are_prefixed_with_aemcp_prelude():
+    set_property = T.render_set_property(
+        S.AeSetPropertyArgs(layer_id=2, path="Transform/Position", value=[1, 2])
+    )
+    apply_effect = C._apply_effect_jsx("12", 3, "ADBE Gaussian Blur 2")
+
+    assert BEGIN in set_property
+    assert "AEMCP.activeComp()" in _body_after_prelude(set_property)
+    assert "AEMCP.layerById(comp, 2)" in _body_after_prelude(set_property)
+
+    assert BEGIN in apply_effect
+    assert "AEMCP.compById(12)" in _body_after_prelude(apply_effect)
+    assert "AEMCP.layerById(comp, 3)" in _body_after_prelude(apply_effect)
+
+
+@pytest.mark.asyncio
+async def test_create_rig_and_init_are_prefixed_with_aemcp_prelude(mock_backend):
+    load_all()
+
+    mock_backend.set_response('{"ok":true}')
+    await _run_create_rig(
+        S.AeCreateRigArgs(
+            target_layer_id=4,
+            rig_type="effect_controls",
+            name="Controls",
+        ),
+        ctx=None,
+    )
+    create_rig = mock_backend.calls[-1]["code"]
+    assert BEGIN in create_rig
+    assert "AEMCP.activeComp()" in _body_after_prelude(create_rig)
+    assert "AEMCP.layerById(comp, 4)" in _body_after_prelude(create_rig)
+
+    mock_backend.set_response('{"pluginVersion":"test-stub"}')
+    _, run_fn = HANDLERS["ae.init"]
+    await run_fn(S.AeInitArgs(refresh_only=True), None)
+    init_jsx = mock_backend.calls[-1]["code"]
+    assert BEGIN in init_jsx
+
+
+@pytest.mark.asyncio
+async def test_exec_user_code_is_not_prefixed_with_aemcp_prelude(mock_backend):
+    load_all()
+
+    mock_backend.set_response('{"ok":true}')
+    _, run_fn = HANDLERS["ae.exec"]
+    await run_fn(S.AeExecArgs(code="JSON.stringify({ok:true})"), None)
+
+    assert mock_backend.calls[-1]["code"] == "JSON.stringify({ok:true})"
+    assert BEGIN not in mock_backend.calls[-1]["code"]

--- a/packages/core/tests/test_jsx_result.py
+++ b/packages/core/tests/test_jsx_result.py
@@ -62,10 +62,12 @@ def test_non_json_text_returned_as_content_for_back_compat():
     assert result == {"ok": True, "content": "hello world"}
 
 
-def test_invalid_json_falls_back_to_content_wrap():
-    # JSX returned something that LOOKS JSON-ish but isn't parseable.
-    result = parse_jsx_result('{not really json')
-    assert result == {"ok": True, "content": "{not really json"}
+@pytest.mark.parametrize("payload", ['{"ok":false,"error":"x\x0b"}', '{"a":1'])
+def test_json_shaped_but_invalid_text_is_failure(payload: str):
+    result = parse_jsx_result(payload)
+    assert result["ok"] is False
+    assert "failed to parse" in result["error"]
+    assert result["raw"] == payload
 
 
 def test_parsed_ok_false_is_preserved():

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -8,12 +8,12 @@ from pydantic import ValidationError
 from ae_mcp import schemas as S
 
 
-def test_registry_has_30_verbs():
-    assert len(S.SCHEMAS) == 30, f"expected 30 verbs, got {len(S.SCHEMAS)}"
+def test_registry_has_all_verbs():
+    assert len(S.SCHEMAS) == 31, f"expected 31 verbs, got {len(S.SCHEMAS)}"
     assert set(S.SCHEMAS) == {
         "ae.init", "ae.overview", "ae.layers", "ae.readProps", "ae.exec",
         "ae.checkpoint", "ae.revert", "ae.snapshot", "ae.previewFrame",
-        "ae.applyEffect", "ae.ping",
+        "ae.applyEffect", "ae.ping", "ae.status",
         "ae.createLayer", "ae.setProperty", "ae.moveLayer", "ae.selectLayers",
         "ae.setTime", "ae.getTime",
         "ae.getProperties", "ae.scanPropertyTree",

--- a/packages/core/tests/test_server_instructions.py
+++ b/packages/core/tests/test_server_instructions.py
@@ -45,9 +45,7 @@ def test_build_server_advertises_instructions():
 
 
 def test_filtered_tool_names_logs_when_backend_selection_fails(monkeypatch, caplog):
-    """A failing backend must yield an empty tool list AND a WARNING log —
-    not a silent empty set (issue #8). Previously the bare `except` swallowed
-    the error with zero diagnostic."""
+    """A failing backend must still expose ae.status and log where to look."""
     from ae_mcp.backends import discovery as _discovery
     from ae_mcp import server as _server
 
@@ -59,8 +57,9 @@ def test_filtered_tool_names_logs_when_backend_selection_fails(monkeypatch, capl
     with caplog.at_level(logging.WARNING, logger="ae_mcp.server"):
         result = _server._filtered_tool_names()
 
-    assert result == set()
+    assert result == {"ae.status"}
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert any("backend selection failed" in r.getMessage() for r in warnings), (
         f"expected a backend-selection WARNING, got: {[r.getMessage() for r in warnings]}"
     )
+    assert any("ae_status" in r.getMessage() for r in warnings)

--- a/packages/core/tests/test_silent_success_residuals.py
+++ b/packages/core/tests/test_silent_success_residuals.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from string import Template
+
+import pytest
+from pydantic import ValidationError
+
+from ae_mcp.schemas import AeGetPropertiesArgs
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _render_template(name: str, **substitutions: str) -> str:
+    path = ROOT / "ae_mcp" / "jsx_templates" / name
+    return Template(path.read_text(encoding="utf-8")).substitute(**substitutions)
+
+
+def test_inspect_property_capabilities_reports_missing_segment_as_failure():
+    rendered = _render_template(
+        "inspect_property_capabilities.jsx",
+        comp_expr="app.project.activeItem",
+        layer_id="1",
+        path='"Transform/Position"',
+    )
+    assert "ok:false, exists: false" in rendered
+    assert "ok: true, exists: false" not in rendered
+
+
+def test_get_properties_template_reports_missing_layers_explicitly():
+    rendered = _render_template(
+        "get_properties.jsx",
+        comp_expr="app.project.activeItem",
+        layer_ids_js="[1,2]",
+        query_js='"position"',
+        offset="0",
+        limit="50",
+    )
+    assert "missingLayerIds" in rendered
+    assert "no valid layers" in rendered
+
+
+@pytest.mark.parametrize("layer_ids", ([0], [-1], []))
+def test_get_properties_schema_rejects_invalid_layer_ids(layer_ids: list[int]):
+    with pytest.raises(ValidationError):
+        AeGetPropertiesArgs(layer_ids=layer_ids, query="position")
+
+
+def test_get_properties_schema_accepts_positive_layer_ids():
+    args = AeGetPropertiesArgs(layer_ids=[1, 2], query="position")
+    assert args.layer_ids == [1, 2]

--- a/packages/core/tests/test_snapshot_discovery.py
+++ b/packages/core/tests/test_snapshot_discovery.py
@@ -46,3 +46,63 @@ def test_multiple_installed_picks_first_supported():
     with _patch_installed({"bados": FakeSnapBadOS, "fake": FakeSnap}):
         s = select_snapshotter()
         assert isinstance(s, FakeSnap)
+
+
+def test_entry_point_load_error_is_skipped(monkeypatch):
+    class _BrokenEP:
+        name = "broken"
+
+        def load(self):
+            raise ImportError("half-uninstalled")
+
+    class _GoodEP:
+        name = "good"
+
+        def load(self):
+            return FakeSnap
+
+    monkeypatch.setattr(
+        "ae_mcp.snapshot.discovery.importlib.metadata.entry_points",
+        lambda group: [_BrokenEP(), _GoodEP()],
+    )
+
+    installed = list_installed_snapshotters()
+    assert installed == {"good": FakeSnap}
+
+    selected = select_snapshotter()
+    assert isinstance(selected, FakeSnap)
+
+
+def test_snapshotter_init_error_is_skipped():
+    class BrokenInitSnap(Snapshotter):
+        name = "broken-init"
+
+        def __init__(self):
+            raise RuntimeError("ctor exploded")
+
+        async def capture(self, out_path, **kw):
+            return {"ok": True}
+
+        def supports_platform(self):
+            return True
+
+    with _patch_installed({"broken": BrokenInitSnap, "good": FakeSnap}):
+        selected = select_snapshotter()
+
+    assert isinstance(selected, FakeSnap)
+
+
+def test_snapshotter_supports_platform_error_is_skipped():
+    class BrokenSupportsSnap(Snapshotter):
+        name = "broken-supports"
+
+        async def capture(self, out_path, **kw):
+            return {"ok": True}
+
+        def supports_platform(self):
+            raise RuntimeError("platform probe exploded")
+
+    with _patch_installed({"broken": BrokenSupportsSnap, "good": FakeSnap}):
+        selected = select_snapshotter()
+
+    assert isinstance(selected, FakeSnap)

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from ae_mcp.backends.discovery import BackendSelectionError
+from ae_mcp.backends.mock import MockBackend
+from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.server import _filtered_tool_names
+
+
+def _load_status_handler():
+    load_all()
+    schema_cls, run_fn = HANDLERS["ae.status"]
+    return schema_cls, run_fn
+
+
+@pytest.mark.asyncio
+async def test_status_tool_is_only_exposed_when_backend_selection_fails(monkeypatch):
+    def _boom():
+        raise BackendSelectionError("no backend configured\nTry: pip install ae-mcp-backend-demo")
+
+    monkeypatch.setattr("ae_mcp.backends.discovery.select_backend", _boom)
+    monkeypatch.setattr("ae_mcp.backends.discovery.list_installed_backends", lambda: {})
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+
+    assert _filtered_tool_names() == {"ae.status"}
+
+    schema_cls, run_fn = _load_status_handler()
+    result = await run_fn(schema_cls(), None)
+
+    assert result["ok"] is False
+    assert "pip install" in result["backendError"]
+    assert result["backend"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_tool_reports_backend_and_supported_verbs(monkeypatch):
+    backend = MockBackend()
+    monkeypatch.setattr(backend, "supported_verbs", lambda: {"ae.ping", "ae.snapshot"})
+    monkeypatch.setattr("ae_mcp.backends.discovery.select_backend", lambda: backend)
+    monkeypatch.setattr("ae_mcp.backends.discovery.list_installed_backends", lambda: {"mock": MockBackend})
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+
+    filtered = _filtered_tool_names()
+    assert filtered == {"ae.ping", "ae.status"}
+
+    schema_cls, run_fn = _load_status_handler()
+    result = await run_fn(schema_cls(), None)
+
+    assert result["ok"] is True
+    assert result["backend"] == "MockBackend"
+    assert result["backendError"] is None
+    assert result["installedBackends"] == ["mock"]
+
+
+def test_filtered_tool_names_ignores_snapshotter_selection_exceptions(monkeypatch):
+    backend = MockBackend()
+    monkeypatch.setattr(backend, "supported_verbs", lambda: {"ae.ping", "ae.snapshot"})
+    monkeypatch.setattr("ae_mcp.backends.discovery.select_backend", lambda: backend)
+
+    def _snap_boom():
+        raise RuntimeError("snapshotter probe exploded")
+
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", _snap_boom)
+
+    assert _filtered_tool_names() == {"ae.ping", "ae.status"}

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.3.0"
+version = "0.3.1"
 description = "Cross-platform mss-based screen capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.3.0"
+                   ExtensionBundleVersion="0.3.1"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.3.0" />
+        <Extension Id="com.aemcp.panel" Version="0.3.1" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const jsxBridge = require('./jsx-bridge');
 const authToken = require('./auth-token');
+const PKG_VERSION = require('./package.json').version;
 
 let app = null;
 let httpServer = null;
@@ -40,7 +41,7 @@ function buildApp() {
         // readiness proxy. /exec is what actually probes AE.
         res.json({
             ok: true,
-            pluginVersion: '0.1.0',
+            pluginVersion: PKG_VERSION,
             port: currentPort,
         });
     });

--- a/plugin/jsx/runtime.jsx
+++ b/plugin/jsx/runtime.jsx
@@ -206,6 +206,7 @@ if (!Object.entries) {
     };
 }
 
+// AEMCP-HELPERS-BEGIN — verbatim copy lives in packages/core/ae_mcp/jsx_templates/_aemcp_prelude.jsx; keep both in sync (enforced by test_jsx_prelude.py)
 // ---------------------------------------------------------------------------
 // AEMCP helper namespace.
 //
@@ -300,3 +301,4 @@ AEMCP.propByMatchPath = function (root, path) {
     }
     return cur;
 };
+// AEMCP-HELPERS-END

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "mcp" },
@@ -44,7 +44,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -70,7 +70,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
继 PR #14 之后,这是对 issue #8(“失败伪装成功”)修复方案剩余部分的补齐 —— 来自一次对 `b1a0ada..ec8af3f` 的 15 条 max-effort review。本批 rebase 到当前 `main`(v0.3.0)。

This finishes the issue #8 ("failures masquerading as success") remediation that PR #14 started, from a 15-finding review of `b1a0ada..ec8af3f`. Rebased onto current `main` (v0.3.0).

## 改了什么 / What's in it

- **`6307564` 路由 comp/layer 查找走打包进脚本的 AEMCP prelude (#8)** — `_comp_expr` / `_apply_effect_jsx` 改用 `AEMCP.compById` / `activeComp`(AE 26.2+ 上 `itemByID` 对失效 id 会抛错,使 `if(!comp)` 守卫成死代码);剩余两处裸 `comp.layer()` 输入查找改走 `AEMCP.layerById`。每个 Python 渲染的脚本现在前置一份与 `runtime.jsx` **逐字节一致**(测试钉死)的 AEMCP helper 拷贝,消除“只升级一边”的版本错配 —— v0.1.0 面板根本没有 AEMCP。`ae.exec` 用户代码不包。
- **`47a8d5b` `/health` 报告真实版本** — 不再硬编码 `0.1.0`(原 finding 的 lockfile 部分已过时,main 的 lock 早已是 0.3.0)。
- **`664f1b1` 消除残留的静默成功 (#8 follow-up)** — `inspect_property_capabilities` 路径段缺失返回 `ok:false`;`get_properties` 失效图层 id 收进 `missingLayerIds`,全失效返回 `ok:false`,schema 加逐元素 `ge=1` + 非空;`jsx_result` 中 JSON 形状但解析失败的文本返回失败信封而非 `ok:true content`。
- **`589f6f4` 容忍坏掉的 snapshotter 入口点 + `ae_status` 诊断 (#8)** — 快照器发现逐个隔离(load/构造/平台探测各自 warn-and-skip);新增常驻 `ae_status`(暴露名 `ae_status`),后端缺失时把带安装指引的 `BackendSelectionError` 经 MCP 通道送达,而不是给客户端一个无解释的空 tools/list。
- **`722c13c` chore(release): v0.3.1** — bump 全部版本文件,补 [0.3.1] CHANGELOG(CN/EN)。跨包 floor pin 保持 `>=0.3.0`(core 公共 API 未变)。

## 验证 / Verification

- `uv run pytest packages/core/tests packages/bridge/tests packages/snapshot-mss/tests -q` → **278 passed, 24 deselected**(新增约 29 条:prelude 字节一致性 + 注入、ae_status、snapshotter 隔离、静默成功回归)。
- `node --check plugin/host/server.js` 通过;host lock 与 package.json 同步在 0.3.1。

## 冲突解决要点 / Conflict notes (rebase onto v0.3.0)

- `core.py`:保留 main 对 #10 的 revert 重写(关闭→原子替换→重开),丢弃我对**旧** revert 代码的 prelude 包装;`_branch_snapshot` 里的 `checkpoint_create` 渲染补上 prelude 以保持一致。
- `typed.py`:`with_prelude` 包装与 main #12 的 `time_budget_ms` 遍历预算两者都保留。
- `server.js`:`PKG_VERSION` require 与 main #11 的 `authToken` require 两者都保留。

## 仍未处理(本批有意不做)/ Knowingly deferred

review 15 条里的 finding 5(MCP 协议层 `isError` 在失败时仍为 false —— 需要先定协议语义)、12(`EvalScript error` 前缀哨兵对合法字符串的低概率误判)、13(`at_time` 的 -1.0 哨兵 vs 合法负时间)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)