### PR TITLE
fix: close out the 3 deferred v0.3.1 findings - protocol isError, EvalScript sentinel, at_time null (#22 #23 #24)

### DIFF
--- a/packages/core/ae_mcp/handlers/typed.py
+++ b/packages/core/ae_mcp/handlers/typed.py
@@ -115,14 +115,7 @@ register("ae.createLayer", schemas.AeCreateLayerArgs, _run_create_layer)
 
 
 async def _run_set_property(args: schemas.AeSetPropertyArgs, ctx: Any) -> Any:
-    tmpl = _load_template("set_property.jsx")
-    jsx = with_prelude(tmpl.substitute(
-        comp_expr=_comp_expr(args.comp_id),
-        layer_id=int(args.layer_id),
-        path=_json_literal(args.path),
-        value=_json_literal(args.value),
-        at_time=float(args.at_time) if args.at_time is not None else -1.0,
-    ))
+    jsx = render_set_property(args)
 
     async def _call() -> Any:
         out = await _backend().exec(
@@ -279,7 +272,7 @@ def render_set_property(args: schemas.AeSetPropertyArgs) -> str:
         layer_id=int(args.layer_id),
         path=_json_literal(args.path),
         value=_json_literal(args.value),
-        at_time=float(args.at_time) if args.at_time is not None else -1.0,
+        at_time=_json_literal(float(args.at_time) if args.at_time is not None else None),
     ))
 
 

--- a/packages/core/ae_mcp/jsx_result.py
+++ b/packages/core/ae_mcp/jsx_result.py
@@ -7,9 +7,11 @@ weak JSON contract:
 - Empty string or the literal "undefined" / "null" — surfaces as
   `{ok:false, error, raw}`. This catches silent failure modes where the
   wrapping bug or a half-broken template produced no value at all.
-- A string beginning with "EvalScript error" (CSInterface's uncaught-error
+- A string exactly equal to "EvalScript error." (CSInterface's uncaught-error
   sentinel) — surfaces as `{ok:false, error, raw}`. Backstop for the
-  jsx-bridge.js sentinel check (see GitHub issue #8).
+  jsx-bridge.js sentinel check (see GitHub issues #8 and #23). A legitimate
+  string exactly equal to that in-band sentinel cannot be distinguished from
+  CEP's uncaught-error signal; CEP provides only that one in-band value.
 - JSON-shaped text that fails `json.loads` — surfaces as `{ok:false, error,
   raw}` rather than falling through to silent success.
 - Other non-JSON text — returned as `{ok:true, content:text}` because some
@@ -29,6 +31,10 @@ from typing import Any
 
 
 _NO_VALUE_SENTINELS = frozenset({"undefined", "null"})
+
+# Must equal EvalScript_ErrMessage in plugin/client/CSInterface.js:33 (vendored
+# Adobe constant) and EVALSCRIPT_ERR_SENTINEL in plugin/host/jsx-bridge.js.
+_EVALSCRIPT_ERR_SENTINEL = "EvalScript error."
 
 
 def _fail(error: str, raw: str) -> dict[str, str | bool]:
@@ -56,10 +62,11 @@ def parse_jsx_result(text: str) -> Any:
         )
 
     # CSInterface returns the literal "EvalScript error." (the constant
-    # EvalScript_ErrMessage) when ExtendScript threw uncaught. jsx-bridge.js
-    # rejects it, but this is the Python backstop: surface it as a failure
-    # rather than wrapping the error message as ok:true content.
-    if stripped.startswith("EvalScript error"):
+    # EvalScript_ErrMessage in plugin/client/CSInterface.js:33) when ExtendScript
+    # threw uncaught. plugin/host/jsx-bridge.js rejects EVALSCRIPT_ERR_SENTINEL,
+    # but this is the Python backstop: surface the exact sentinel as a failure
+    # rather than wrapping it as ok:true content.
+    if stripped == _EVALSCRIPT_ERR_SENTINEL:
         return _fail(stripped, text)
 
     if stripped[:1] in ("{", "["):

--- a/packages/core/ae_mcp/jsx_templates/set_property.jsx
+++ b/packages/core/ae_mcp/jsx_templates/set_property.jsx
@@ -1,5 +1,7 @@
 // Template for ae.setProperty. Substitution: Python string.Template.
 // Placeholders: comp_expr, layer_id, path, value, at_time.
+// at_time null means write a constant value; any number, including negative AE
+// times, means write a keyframe with setValueAtTime.
 // Returns JSON: ok, previous, current (or ok:false + error).
 (function() {
     var comp = ${comp_expr};
@@ -25,7 +27,7 @@
     try { prev = prop.value; } catch (e) { /* may lack .value */ }
 
     try {
-        if (atTime >= 0) {
+        if (atTime !== null) {
             prop.setValueAtTime(atTime, value);
         } else {
             prop.setValue(value);

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -219,7 +219,11 @@ class AeSetPropertyArgs(_StrictModel):
         description="Scalar or array. Numeric arrays are passed as-is to setValue.",
     )
     at_time: Optional[float] = Field(
-        None, description="If set, writes a keyframe at this time instead of the constant value."
+        None,
+        description=(
+            "If set, writes a keyframe at this time (seconds; negative times "
+            "are legal in AE). Omit to write the constant value."
+        ),
     )
 
 

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -18,7 +18,7 @@ from typing import Any, List
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import CallToolResult, TextContent, Tool
 
 from ae_mcp.handlers import HANDLERS, load_all
 from ae_mcp.instructions import SERVER_INSTRUCTIONS
@@ -192,13 +192,19 @@ def build_server() -> Server:
         return tools
 
     @server.call_tool()
-    async def _call_tool(name: str, arguments: dict | None) -> List[TextContent]:
+    async def _call_tool(name: str, arguments: dict | None) -> CallToolResult:
+        # Return CallToolResult explicitly so MCP clients can branch on the
+        # protocol-level isError flag. The JSON payload still carries ok:false
+        # for human/model-readable details and remains byte-for-byte stable.
         # Tools are exposed with dots replaced by underscores; map the exposed
         # name back to the canonical verb (the dotted name is accepted too).
         canonical = resolve_tool_name(name, HANDLERS, reverse_map)
         if canonical is None:
             payload = _format_result({"ok": False, "error": f"unknown tool: {name}"})
-            return [TextContent(type="text", text=payload)]
+            return CallToolResult(
+                content=[TextContent(type="text", text=payload)],
+                isError=True,
+            )
         name = canonical
 
         schema_cls, run_fn = HANDLERS[name]
@@ -207,7 +213,10 @@ def build_server() -> Server:
             validated = schema_cls(**(arguments or {}))
         except Exception as e:  # noqa: BLE001
             payload = _format_result({"ok": False, "error": f"schema: {e}"})
-            return [TextContent(type="text", text=payload)]
+            return CallToolResult(
+                content=[TextContent(type="text", text=payload)],
+                isError=True,
+            )
 
         # Pull ctx from request context so handlers can emit progress.
         ctx = None
@@ -221,9 +230,15 @@ def build_server() -> Server:
         except Exception as e:  # noqa: BLE001
             log.exception("handler %s raised", name)
             payload = _format_result({"ok": False, "error": str(e)})
-            return [TextContent(type="text", text=payload)]
+            return CallToolResult(
+                content=[TextContent(type="text", text=payload)],
+                isError=True,
+            )
 
-        return [TextContent(type="text", text=_format_result(result))]
+        return CallToolResult(
+            content=[TextContent(type="text", text=_format_result(result))],
+            isError=isinstance(result, dict) and result.get("ok") is False,
+        )
 
     # Expose the dispatch closures + reverse map for testing. The decorators
     # above already registered them via the MCP request_handlers registry;

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "ae-mcp contributors" }]
 dependencies = [
-    "mcp>=1.0.0",
+    # CallToolResult direct return needs >=1.19.0 (python-sdk #1459);
+    # older SDKs silently mangle it (pydantic models are iterable).
+    "mcp>=1.19.0",
     "pydantic>=2.5.0",
     "pillow>=10.0.0",
 ]

--- a/packages/core/tests/test_handlers_typed.py
+++ b/packages/core/tests/test_handlers_typed.py
@@ -56,7 +56,16 @@ def test_render_set_property_with_keyframe():
 def test_render_set_property_without_keyframe():
     args = S.AeSetPropertyArgs(layer_id=1, path="Opacity", value=50)
     jsx = T.render_set_property(args)
-    assert "-1.0" in jsx  # at_time sentinel
+    assert "var atTime = null;" in jsx
+
+
+@pytest.mark.parametrize("at_time", [-0.5, -1.0, 0.0, 1.5])
+def test_render_set_property_at_time_allows_negative_times(at_time):
+    args = S.AeSetPropertyArgs(
+        layer_id=1, path="Opacity", value=50, at_time=at_time,
+    )
+    jsx = T.render_set_property(args)
+    assert f"var atTime = {at_time};" in jsx
 
 
 def test_render_move_layer_clamps_in_js_not_py():

--- a/packages/core/tests/test_jsx_result.py
+++ b/packages/core/tests/test_jsx_result.py
@@ -80,16 +80,22 @@ def test_parsed_ok_false_is_preserved():
 def test_evalscript_error_sentinel_is_failure_not_silent_success():
     # CSInterface surfaces an uncaught ExtendScript error as the literal
     # "EvalScript error." (note the PERIOD). jsx-bridge.js should reject it,
-    # but this is the Python backstop: a result that begins with
-    # "EvalScript error" must flip to ok:false, not be wrapped as content.
+    # but this is the Python backstop: that exact sentinel must flip to
+    # ok:false, not be wrapped as content.
     result = parse_jsx_result("EvalScript error.")
     assert result["ok"] is False
     assert result["raw"] == "EvalScript error."
     assert "EvalScript error" in result["error"]
 
 
-def test_evalscript_error_colon_variant_is_failure():
-    # Defensive: also catch a colon/trailing-detail variant.
-    result = parse_jsx_result("EvalScript error: ReferenceError foo is undefined")
-    assert result["ok"] is False
-    assert result["raw"] == "EvalScript error: ReferenceError foo is undefined"
+def test_evalscript_error_colon_variant_is_content():
+    # Exact matching is intentional: the colon variant is not CEP's sentinel.
+    # Issue #8 taught us that ':' vs '.' mismatch can miss the real sentinel;
+    # issue #23 taught us that a bare prefix check false-positives valid text.
+    content = "EvalScript error: ReferenceError foo is undefined"
+    assert parse_jsx_result(content) == {"ok": True, "content": content}
+
+
+def test_evalscript_errors_diagnostic_prefix_is_content():
+    content = "EvalScript errors found: 0"
+    assert parse_jsx_result(content) == {"ok": True, "content": content}

--- a/packages/core/tests/test_tool_names.py
+++ b/packages/core/tests/test_tool_names.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import re
 
+import mcp.types as types
 import pytest
 
 from ae_mcp.handlers import HANDLERS, load_all
@@ -167,7 +168,8 @@ async def test_call_tool_dispatches_to_canonical_verb(monkeypatch):
     result = await server._ae_call_tool("ae_ping", {"expect": "hi"})
 
     assert seen.get("dispatched") is True, "dispatch never reached the canonical ae.ping handler"
-    payload = json.loads(result[0].text)
+    assert result.isError is False
+    payload = json.loads(result.content[0].text)
     assert payload == {"ok": True, "pong": "hi"}
 
 
@@ -185,7 +187,8 @@ async def test_call_tool_accepts_dotted_name_for_backcompat(monkeypatch):
 
     server = build_server()
     result = await server._ae_call_tool("ae.ping", {"expect": "yo"})
-    payload = json.loads(result[0].text)
+    assert result.isError is False
+    payload = json.loads(result.content[0].text)
     assert payload == {"ok": True, "pong": "yo"}
 
 
@@ -195,6 +198,120 @@ async def test_call_tool_unknown_returns_structured_error():
     load_all()
     server = build_server()
     result = await server._ae_call_tool("totally_unknown", {})
-    payload = json.loads(result[0].text)
+    assert result.isError is True
+    payload = json.loads(result.content[0].text)
     assert payload["ok"] is False
     assert "unknown tool" in payload["error"]
+
+
+async def test_call_tool_schema_error_sets_iserror_true():
+    """The direct dispatch path still marks pydantic validation failures."""
+    load_all()
+    server = build_server()
+    result = await server._ae_call_tool("ae_ping", {"junk": 1})
+    assert result.isError is True
+    payload = json.loads(result.content[0].text)
+    assert payload["ok"] is False
+    assert payload["error"].startswith("schema:")
+
+
+async def test_call_tool_handler_raise_sets_iserror_true(monkeypatch):
+    """Handler exceptions keep the structured JSON payload and set isError."""
+    load_all()
+
+    async def _fake_run(validated, ctx):
+        raise RuntimeError("boom")
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    result = await server._ae_call_tool("ae_ping", {"expect": "hi"})
+    assert result.isError is True
+    payload = json.loads(result.content[0].text)
+    assert payload == {"ok": False, "error": "boom"}
+
+
+async def test_call_tool_ok_false_payload_sets_iserror_true(monkeypatch):
+    """A non-raising handler can still report a semantic failure via ok:false."""
+    load_all()
+    expected = {"ok": False, "error": "AE rejected operation", "code": "AE_FAIL"}
+
+    async def _fake_run(validated, ctx):
+        return expected
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    result = await server._ae_call_tool("ae_ping", {"expect": "hi"})
+    assert result.isError is True
+    assert json.loads(result.content[0].text) == expected
+
+
+@pytest.mark.parametrize("handler_result", [{"pong": "hi"}, "plain text"])
+async def test_call_tool_without_ok_false_sets_iserror_false(monkeypatch, handler_result):
+    """Only a top-level dict with ok:false is treated as a protocol error."""
+    load_all()
+
+    async def _fake_run(validated, ctx):
+        return handler_result
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    result = await server._ae_call_tool("ae_ping", {"expect": "hi"})
+    assert result.isError is False
+    assert result.content[0].text == (
+        json.dumps(handler_result, ensure_ascii=False)
+        if isinstance(handler_result, dict)
+        else handler_result
+    )
+
+
+async def test_sdk_call_tool_handler_preserves_call_tool_result_iserror(monkeypatch):
+    """Drive the SDK request handler to prove CallToolResult is passed through."""
+    from ae_mcp import server as srv
+
+    load_all()
+    monkeypatch.setattr(srv, "_filtered_tool_names", lambda: set(HANDLERS.keys()))
+    attempts = 0
+
+    async def _fake_run(validated, ctx):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {"ok": True, "pong": validated.expect}
+        return {"ok": False, "error": "semantic failure"}
+
+    schema_cls, _ = HANDLERS["ae.ping"]
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema_cls, _fake_run))
+
+    server = build_server()
+    request_handler = server.request_handlers[types.CallToolRequest]
+
+    ok_response = await request_handler(
+        types.CallToolRequest(
+            params=types.CallToolRequestParams(
+                name="ae_ping",
+                arguments={"expect": "hi"},
+            )
+        )
+    )
+    assert ok_response.root.isError is False
+    assert json.loads(ok_response.root.content[0].text) == {"ok": True, "pong": "hi"}
+
+    error_response = await request_handler(
+        types.CallToolRequest(
+            params=types.CallToolRequestParams(
+                name="ae_ping",
+                arguments={"expect": "hi"},
+            )
+        )
+    )
+    assert error_response.root.isError is True
+    assert json.loads(error_response.root.content[0].text) == {
+        "ok": False,
+        "error": "semantic failure",
+    }

--- a/plugin/host/jsx-bridge.js
+++ b/plugin/host/jsx-bridge.js
@@ -1,5 +1,12 @@
 // Bridge between Node.js (CEP host process) and AE ExtendScript via CSInterface.
 // CSInterface is loaded in the parent (panel) process; we accept it via setCSInterface.
+// Must equal EvalScript_ErrMessage in plugin/client/CSInterface.js:33 (vendored
+// Adobe constant). CEP returns it VERBATIM on uncaught ExtendScript errors -
+// no detail suffix - so exact equality is the correct check (a bare prefix
+// match false-positives legitimate strings like "EvalScript errors found: 0").
+// Python backstop with the same constant: packages/core/ae_mcp/jsx_result.py.
+const EVALSCRIPT_ERR_SENTINEL = 'EvalScript error.';
+
 let csInterface = null;
 
 function setCSInterface(cs) {
@@ -32,7 +39,7 @@ function evalScriptInner(jsx, timeoutMs) {
         }, timeoutMs);
         try {
             csInterface.evalScript(jsx, (result) => {
-                if (typeof result === 'string' && result.indexOf('EvalScript error') === 0) {
+                if (typeof result === 'string' && result === EVALSCRIPT_ERR_SENTINEL) {
                     finish(reject, new Error(result));
                 } else {
                     finish(resolve, result);

--- a/plugin/host/jsx-bridge.test.js
+++ b/plugin/host/jsx-bridge.test.js
@@ -30,6 +30,24 @@ test('"EvalScript error." sentinel (with period) rejects', async () => {
     );
 });
 
+test('legitimate string beginning with EvalScript errors resolves', async () => {
+    const bridge = freshBridge();
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) { cb('EvalScript errors found: 0'); },
+    });
+    const r = await bridge.evalScript('diagnostics', 1000);
+    assert.strictEqual(r, 'EvalScript errors found: 0');
+});
+
+test('EvalScript error colon variant resolves because only the exact sentinel rejects', async () => {
+    const bridge = freshBridge();
+    bridge.setCSInterface({
+        evalScript: function (jsx, cb) { cb('EvalScript error: ReferenceError x is undefined'); },
+    });
+    const r = await bridge.evalScript('diagnostics', 1000);
+    assert.strictEqual(r, 'EvalScript error: ReferenceError x is undefined');
+});
+
 test('missing CSInterface rejects', async () => {
     const bridge = freshBridge();
     await assert.rejects(

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.19.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },


### PR DESCRIPTION
关闭 v0.3.1 收尾时有意保留待议的 3 条 finding（均为 2026-06 review 系列的"静默成功"主题残留）。三个修复相互独立，经 codex-fanout 三个并行 worktree 实现，orchestrator（Fable 5）逐 diff 审查后合并。

Closes #22
Closes #23
Closes #24

## #22 (P1) — 协议层 isError

`_call_tool` 对所有结果都返回裸 `TextContent` list，SDK 固定生成 `isError=False`，按 isError 分支的客户端会把失败的 AE 操作记成成功。

- `_call_tool` 改为显式返回 `CallToolResult`：未知工具 / pydantic 校验失败 / handler 抛异常 / handler 返回顶层 `{ok:false}` 四类路径均置 `isError=True`；payload JSON 文本逐字节不变（isError 给机器分支，ok:false 照旧给人/模型读）。
- 不用 `raise` 方案：SDK 会把异常坍缩成裸 `str(e)`，丢失结构化 payload。
- **`mcp` 依赖下限 `>=1.0.0` → `>=1.19.0`**：`CallToolResult` 直接返回是 python-sdk#1459（v1.19.0）引入的；更老版本会把它当 iterable 静默搅碎（pydantic model 有 `__iter__`）。lock 实际仍是 1.27.0，无行为变化。
- 新增覆盖：四类失败态 + 成功态 + 经 `request_handlers[CallToolRequest]` 的 SDK 全链路透传验证。

## #23 (P2) — EvalScript 哨兵精确匹配

裸前缀 `indexOf/startswith "EvalScript error"` 会把 `"EvalScript errors found: 0"` 这类合法字符串误判为失败。CEP 对未捕获 ExtendScript 异常返回的是常量 `EvalScript_ErrMessage = "EvalScript error."` 整串（无附加信息），故收紧为精确相等。

- `jsx-bridge.js` 与 `jsx_result.py` 各自引入命名常量，注释互链并指向 `CSInterface.js:33`（vendored Adobe 常量，唯一事实来源）——#8 的教训是冒号/句号失配漏报，#23 是前缀误报，互链防止三副本再漂移。
- 冒号变体测试语义有意翻转为 `ok:true`（它不是 CEP 哨兵）；新增前缀合法串两侧回归。

## #24 (P2) — at_time 改用 null 哨兵

AE 图层可早于 t=0，`setValueAtTime` 接受负时间，但 `-1.0` 哨兵把 `at_time=-0.5` 静默路由到 `setValue`（写常量不建关键帧）还报 ok:true。

- 哨兵改为 JSON `null` 贯穿：schema 不加 `ge=0`（负时间合法），`typed.py` 渲染 `None → null`，模板判 `atTime !== null`。
- 顺手收敛重复：`_run_set_property` 改为调用 `render_set_property`，替换逻辑单一来源。
- 回归：`-1.0` 现在按真实关键帧时间处理；`null/-0.5/-1.0/0.0/1.5` 全覆盖。

## 验证

- Python：`pytest packages/core/tests` — **263 passed, 0 failed**（24 deselected 为需真实 AE 的集成用例，与 main 一致）
- JS：`plugin/host` `node --test` — **16/16 passed**（含 2 条新哨兵回归）
- 八方 merge 无冲突（三任务文件域不相交）；uv.lock 已同步 mcp 下限记录。

合并后可另出 v0.3.2（版本号 + 双语 CHANGELOG 沿用 v0.3.1 的 release commit 模式）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)