### PR TITLE
P5: embedded panel chat - Claude subscription backend + BYOK fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,32 @@ jobs:
         env:
           UV_LINK_MODE: copy
         run: python -m uv run pytest -v
+
+  js-tests:
+    name: JS tests (panel / sidecar / host)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run host tests
+        working-directory: plugin/host
+        run: |
+          npm ci
+          npm test
+
+      - name: Run panel tests
+        working-directory: plugin/panel
+        run: |
+          npm ci
+          npm test
+
+      - name: Run sidecar tests
+        working-directory: plugin/sidecar
+        run: |
+          npm ci
+          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node 20
+      - name: Setup Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run host tests
         working-directory: plugin/host

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 build/
 release/
 plugin/host/node_modules/
+plugin/sidecar/node_modules/
 
 # OS
 .DS_Store

--- a/packages/core/ae_mcp/jsx_templates/_aemcp_prelude.jsx
+++ b/packages/core/ae_mcp/jsx_templates/_aemcp_prelude.jsx
@@ -10,7 +10,41 @@
 // ---------------------------------------------------------------------------
 if (typeof AEMCP === 'undefined') { AEMCP = {}; }
 
-AEMCP.version = '0.1.0';
+AEMCP.version = '0.2.0';
+
+// Map a property value to something JSON.stringify can serialize, never
+// throwing. TextDocument flattens to its .text string BEFORE the generic
+// object path (stringifying a TextDocument touches box-text-only getters that
+// throw on point text, and point/box text should yield the same shape).
+// Primitives pass through; arrays recurse; other host objects (Shape,
+// KeyframeEase, ...) are kept as-is when a stringify probe succeeds, else
+// degrade to String(v), else null. Uncaught throws must never escape a
+// template: AE 2026 surfaces them as EMPTY evalScript output (not the
+// "EvalScript error." sentinel), which callers see as "returned no value".
+AEMCP.safeValue = function (v) {
+    if (v === null || typeof v === 'undefined') return null;
+    var t = typeof v;
+    if (t === 'number' || t === 'boolean' || t === 'string') return v;
+    try {
+        if (typeof TextDocument !== 'undefined' && v instanceof TextDocument) {
+            return String(v.text);
+        }
+    } catch (eTd) {}
+    if (v instanceof Array) {
+        var out = [];
+        for (var i = 0; i < v.length; i++) {
+            try { out.push(AEMCP.safeValue(v[i])); } catch (eEl) { out.push(null); }
+        }
+        return out;
+    }
+    if (t === 'object') {
+        try { JSON.stringify(v); return v; } catch (eProbe) {}
+        try { return String(v); } catch (eStr) {}
+        return null;
+    }
+    try { return String(v); } catch (eOther) {}
+    return null;
+};
 
 // Count of a node's child properties, or -1 when `node` is a leaf Property /
 // not a group. try/catch shields against leaf nodes that lack numProperties.

--- a/packages/core/ae_mcp/jsx_templates/get_keyframes.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_keyframes.jsx
@@ -31,14 +31,14 @@
         var entry = {
             index: k,
             time: prop.keyTime(k),
-            value: prop.keyValue(k),
             interpIn: interpName(prop.keyInInterpolationType(k)),
             interpOut: interpName(prop.keyOutInterpolationType(k))
         };
-        try { entry.easeIn = prop.keyInTemporalEase(k); } catch (e) { entry.easeIn = null; }
-        try { entry.easeOut = prop.keyOutTemporalEase(k); } catch (e) { entry.easeOut = null; }
-        try { entry.spatialIn = prop.keyInSpatialTangent(k); } catch (e) { entry.spatialIn = null; }
-        try { entry.spatialOut = prop.keyOutSpatialTangent(k); } catch (e) { entry.spatialOut = null; }
+        try { entry.value = AEMCP.safeValue(prop.keyValue(k)); } catch (e) { entry.value = null; }
+        try { entry.easeIn = AEMCP.safeValue(prop.keyInTemporalEase(k)); } catch (e) { entry.easeIn = null; }
+        try { entry.easeOut = AEMCP.safeValue(prop.keyOutTemporalEase(k)); } catch (e) { entry.easeOut = null; }
+        try { entry.spatialIn = AEMCP.safeValue(prop.keyInSpatialTangent(k)); } catch (e) { entry.spatialIn = null; }
+        try { entry.spatialOut = AEMCP.safeValue(prop.keyOutSpatialTangent(k)); } catch (e) { entry.spatialOut = null; }
         keyframes.push(entry);
     }
     return JSON.stringify({ok:true, numKeyframes:n, keyframes:keyframes});

--- a/packages/core/ae_mcp/jsx_templates/get_properties.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_properties.jsx
@@ -41,7 +41,7 @@
         if (prop.propertyType === PropertyType.PROPERTY) {
             if (matches(prop.name, prop.matchName)) {
                 var val = null;
-                try { val = prop.value; } catch (e) { }
+                try { val = AEMCP.safeValue(prop.value); } catch (e) { }
                 var score = 0;
                 if (matchSegs[0] === "ADBE Transform Group") score += 10;
                 if (prop.name.toLowerCase().indexOf(orGroups[0][0] || "") !== -1) score += 5;

--- a/packages/core/ae_mcp/jsx_templates/scan_property_tree.jsx
+++ b/packages/core/ae_mcp/jsx_templates/scan_property_tree.jsx
@@ -32,7 +32,7 @@
             n.numKeyframes = prop.numKeys || 0;
             n.hasExpression = prop.canSetExpression && (prop.expression !== "");
             if (includeValues) {
-                try { n.value = prop.value; } catch (e) { }
+                try { n.value = AEMCP.safeValue(prop.value); } catch (e) { }
             }
         } else {
             if (depth >= maxDepth) {

--- a/packages/core/ae_mcp/jsx_templates/set_property.jsx
+++ b/packages/core/ae_mcp/jsx_templates/set_property.jsx
@@ -24,7 +24,7 @@
     var value = ${value};
     var atTime = ${at_time};
     var prev = null;
-    try { prev = prop.value; } catch (e) { /* may lack .value */ }
+    try { prev = AEMCP.safeValue(prop.value); } catch (e) { /* may lack .value */ }
 
     try {
         if (atTime !== null) {
@@ -37,7 +37,11 @@
     }
 
     var cur = null;
-    try { cur = prop.value; } catch (e) { }
+    try { cur = AEMCP.safeValue(prop.value); } catch (e) { }
 
-    return JSON.stringify({ok:true, previous:prev, current:cur});
+    try {
+        return JSON.stringify({ok:true, previous:prev, current:cur});
+    } catch (e) {
+        return '{"ok":true,"previous":null,"current":null,"note":"value set; previous/current not serializable"}';
+    }
 })()

--- a/packages/core/tests/live/test_set_property_text.py
+++ b/packages/core/tests/live/test_set_property_text.py
@@ -1,0 +1,52 @@
+"""Live regression test for ae.setProperty on text Source Text."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from ae_mcp import schemas
+from ae_mcp.handlers.typed import _run_set_property
+
+
+pytestmark = pytest.mark.live
+
+
+SETUP_JSX = """
+(function(){
+  try {
+    var comp = app.project.items.addComp("SetTextProbe", 320, 240, 1, 2.0, 24);
+    var textLayer = comp.layers.addText("before");
+    comp.openInViewer();
+    return JSON.stringify({ok:true, compId: String(comp.id), layerId: textLayer.index});
+  } catch (e) {
+    return JSON.stringify({ok:false, error:String(e), line:e.line});
+  }
+})()
+"""
+
+
+@pytest.fixture
+def text_scene(clean_project):
+    out = asyncio.run(clean_project.exec(code=SETUP_JSX, timeout_sec=20.0))
+    parsed = json.loads(out)
+    assert parsed["ok"] is True, parsed
+    return parsed
+
+
+@pytest.mark.asyncio
+async def test_set_property_source_text_returns_serializable_values(text_scene):
+    result = await _run_set_property(
+        schemas.AeSetPropertyArgs(
+            comp_id=text_scene["compId"],
+            layer_id=text_scene["layerId"],
+            path="Text/Source Text",
+            value="after",
+        ),
+        None,
+    )
+
+    assert result["ok"] is True, result
+    assert result["previous"] == "before"
+    assert result["current"] == "after"

--- a/packages/core/tests/test_handlers_typed.py
+++ b/packages/core/tests/test_handlers_typed.py
@@ -51,6 +51,10 @@ def test_render_set_property_with_keyframe():
     assert '"Transform/Position"' in jsx
     assert "[100, 200]" in jsx
     assert "1.5" in jsx
+    assert "AEMCP.safeValue(prop.value)" in jsx
+    assert "prev = prop.value" not in jsx
+    assert "cur = prop.value" not in jsx
+    assert "value set; previous/current not serializable" in jsx
 
 
 def test_render_set_property_without_keyframe():
@@ -177,6 +181,7 @@ def test_render_get_properties_substitutes_query():
     # Per-layer resolution in the loop routes through AEMCP.layerById so a
     # stale id is skipped via `continue` instead of throwing (issue #8).
     assert "AEMCP.layerById(comp, layerIds[li])" in jsx
+    assert "AEMCP.safeValue(" in jsx
 
 
 @pytest.mark.asyncio
@@ -202,6 +207,7 @@ def test_render_scan_property_tree():
     assert "AEMCP.layerById(comp, 3)" in jsx  # issue #8
     assert "var maxDepth = 2;" in jsx
     assert "var includeValues = false;" in jsx
+    assert "AEMCP.safeValue(" in jsx
 
 
 @pytest.mark.asyncio
@@ -261,6 +267,7 @@ def test_render_get_keyframes():
     jsx = render_get_keyframes(args)
     assert '"Transform/Position"' in jsx
     assert "AEMCP.layerById(comp, 1)" in jsx  # issue #8
+    assert "AEMCP.safeValue(" in jsx
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_jsx_prelude.py
+++ b/packages/core/tests/test_jsx_prelude.py
@@ -63,6 +63,22 @@ def test_rendered_templates_are_prefixed_with_aemcp_prelude():
     assert "AEMCP.layerById(comp, 3)" in _body_after_prelude(apply_effect)
 
 
+def test_aemcp_prelude_defines_safe_value():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    prelude = (
+        root
+        / "packages"
+        / "core"
+        / "ae_mcp"
+        / "jsx_templates"
+        / "_aemcp_prelude.jsx"
+    )
+
+    assert "AEMCP.safeValue = function" in _helper_body(prelude)
+
+
 @pytest.mark.asyncio
 async def test_create_rig_and_init_are_prefixed_with_aemcp_prelude(mock_backend):
     load_all()

--- a/packages/core/tests/test_runtime_jsx.py
+++ b/packages/core/tests/test_runtime_jsx.py
@@ -53,6 +53,7 @@ def test_object_polyfill_present_and_guarded(src, fn):
         "AEMCP.layerById",
         "AEMCP.propByPath",
         "AEMCP.propByMatchPath",
+        "AEMCP.safeValue",
     ],
 )
 def test_aemcp_namespace_helpers_present(src, helper):

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -52,7 +52,7 @@
       }, enqueueReplaceState: function() {
       }, enqueueSetState: function() {
       } };
-      var C = Object.assign;
+      var C2 = Object.assign;
       var D2 = {};
       function E(a, b, e) {
         this.props = a;
@@ -79,15 +79,15 @@
       }
       var H = G.prototype = new F();
       H.constructor = G;
-      C(H, E.prototype);
+      C2(H, E.prototype);
       H.isPureReactComponent = true;
       var I = Array.isArray;
       var J = Object.prototype.hasOwnProperty;
       var K = { current: null };
-      var L = { key: true, ref: true, __self: true, __source: true };
+      var L2 = { key: true, ref: true, __self: true, __source: true };
       function M(a, b, e) {
         var d, c = {}, k = null, h = null;
-        if (null != b) for (d in void 0 !== b.ref && (h = b.ref), void 0 !== b.key && (k = "" + b.key), b) J.call(b, d) && !L.hasOwnProperty(d) && (c[d] = b[d]);
+        if (null != b) for (d in void 0 !== b.ref && (h = b.ref), void 0 !== b.key && (k = "" + b.key), b) J.call(b, d) && !L2.hasOwnProperty(d) && (c[d] = b[d]);
         var g = arguments.length - 2;
         if (1 === g) c.children = e;
         else if (1 < g) {
@@ -200,12 +200,12 @@
       exports.act = X2;
       exports.cloneElement = function(a, b, e) {
         if (null === a || void 0 === a) throw Error("React.cloneElement(...): The argument must be a React element, but you passed " + a + ".");
-        var d = C({}, a.props), c = a.key, k = a.ref, h = a._owner;
+        var d = C2({}, a.props), c = a.key, k = a.ref, h = a._owner;
         if (null != b) {
           void 0 !== b.ref && (k = b.ref, h = K.current);
           void 0 !== b.key && (c = "" + b.key);
           if (a.type && a.type.defaultProps) var g = a.type.defaultProps;
-          for (f in b) J.call(b, f) && !L.hasOwnProperty(f) && (d[f] = void 0 === b[f] && void 0 !== g ? g[f] : b[f]);
+          for (f in b) J.call(b, f) && !L2.hasOwnProperty(f) && (d[f] = void 0 === b[f] && void 0 !== g ? g[f] : b[f]);
         }
         var f = arguments.length - 2;
         if (1 === f) d.children = e;
@@ -332,8 +332,8 @@
         if (c !== b) {
           a[0] = c;
           a: for (var d = 0, e = a.length, w = e >>> 1; d < w; ) {
-            var m = 2 * (d + 1) - 1, C = a[m], n = m + 1, x = a[n];
-            if (0 > g(C, c)) n < e && 0 > g(x, C) ? (a[d] = x, a[n] = c, d = n) : (a[d] = C, a[m] = c, d = m);
+            var m = 2 * (d + 1) - 1, C2 = a[m], n = m + 1, x = a[n];
+            if (0 > g(C2, c)) n < e && 0 > g(x, C2) ? (a[d] = x, a[n] = c, d = n) : (a[d] = C2, a[m] = c, d = m);
             else if (n < e && 0 > g(x, c)) a[d] = x, a[n] = c, d = n;
             else break a;
           }
@@ -389,7 +389,7 @@
       }
       function J(a, b) {
         A2 = false;
-        B && (B = false, E(L), L = -1);
+        B && (B = false, E(L2), L2 = -1);
         z = true;
         var c = y;
         try {
@@ -419,7 +419,7 @@
       }
       var N = false;
       var O = null;
-      var L = -1;
+      var L2 = -1;
       var P = 5;
       var Q = -1;
       function M() {
@@ -457,7 +457,7 @@
         N || (N = true, S2());
       }
       function K(a, b) {
-        L = D2(function() {
+        L2 = D2(function() {
           a(exports.unstable_now());
         }, b);
       }
@@ -544,7 +544,7 @@
         }
         e = c + e;
         a = { id: u++, callback: b, priorityLevel: a, startTime: c, expirationTime: e, sortIndex: -1 };
-        c > d ? (a.sortIndex = c, f(t, a), null === h(r) && a === h(t) && (B ? (E(L), L = -1) : B = true, K(H, c - d))) : (a.sortIndex = e, f(r, a), A2 || z || (A2 = true, I(J)));
+        c > d ? (a.sortIndex = c, f(t, a), null === h(r) && a === h(t) && (B ? (E(L2), L2 = -1) : B = true, K(H, c - d))) : (a.sortIndex = e, f(r, a), A2 || z || (A2 = true, I(J)));
         return a;
       };
       exports.unstable_shouldYield = M;
@@ -1598,7 +1598,7 @@
           c &= ~e;
         }
       }
-      var C = 0;
+      var C2 = 0;
       function Dc(a) {
         a &= -a;
         return 1 < a ? 4 < a ? 0 !== (a & 268435455) ? 16 : 536870912 : 4 : 1;
@@ -1736,21 +1736,21 @@
       var cd = ua.ReactCurrentBatchConfig;
       var dd = true;
       function ed(a, b, c, d) {
-        var e = C, f = cd.transition;
+        var e = C2, f = cd.transition;
         cd.transition = null;
         try {
-          C = 1, fd(a, b, c, d);
+          C2 = 1, fd(a, b, c, d);
         } finally {
-          C = e, cd.transition = f;
+          C2 = e, cd.transition = f;
         }
       }
       function gd(a, b, c, d) {
-        var e = C, f = cd.transition;
+        var e = C2, f = cd.transition;
         cd.transition = null;
         try {
-          C = 4, fd(a, b, c, d);
+          C2 = 4, fd(a, b, c, d);
         } finally {
-          C = e, cd.transition = f;
+          C2 = e, cd.transition = f;
         }
       }
       function fd(a, b, c, d) {
@@ -2823,10 +2823,10 @@
       function jg() {
         if (!gg && null !== eg) {
           gg = true;
-          var a = 0, b = C;
+          var a = 0, b = C2;
           try {
             var c = eg;
-            for (C = 1; a < c.length; a++) {
+            for (C2 = 1; a < c.length; a++) {
               var d = c[a];
               do
                 d = d(true);
@@ -2837,7 +2837,7 @@
           } catch (e) {
             throw null !== eg && (eg = eg.slice(a + 1)), ac(fc, jg), e;
           } finally {
-            C = b, gg = false;
+            C2 = b, gg = false;
           }
         }
         return null;
@@ -3495,7 +3495,7 @@
       function Bh(a) {
         vh.current === a && (E(uh), E(vh));
       }
-      var L = Uf(0);
+      var L2 = Uf(0);
       function Ch(a) {
         for (var b = a; null !== b; ) {
           if (13 === b.tag) {
@@ -3799,15 +3799,15 @@
         return b;
       }
       function vi(a, b) {
-        var c = C;
-        C = 0 !== c && 4 > c ? c : 4;
+        var c = C2;
+        C2 = 0 !== c && 4 > c ? c : 4;
         a(true);
         var d = Gh.transition;
         Gh.transition = {};
         try {
           a(false), b();
         } finally {
-          C = c, Gh.transition = d;
+          C2 = c, Gh.transition = d;
         }
       }
       function wi() {
@@ -4285,11 +4285,11 @@
         return { baseLanes: a, cachePool: null, transitions: null };
       }
       function oj(a, b, c) {
-        var d = b.pendingProps, e = L.current, f = false, g = 0 !== (b.flags & 128), h;
+        var d = b.pendingProps, e = L2.current, f = false, g = 0 !== (b.flags & 128), h;
         (h = g) || (h = null !== a && null === a.memoizedState ? false : 0 !== (e & 2));
         if (h) f = true, b.flags &= -129;
         else if (null === a || null !== a.memoizedState) e |= 1;
-        G(L, e & 1);
+        G(L2, e & 1);
         if (null === a) {
           Eg(b);
           a = b.memoizedState;
@@ -4443,7 +4443,7 @@
       function xj(a, b, c) {
         var d = b.pendingProps, e = d.revealOrder, f = d.tail;
         Xi(a, b, d.children, c);
-        d = L.current;
+        d = L2.current;
         if (0 !== (d & 2)) d = d & 1 | 2, b.flags |= 128;
         else {
           if (null !== a && 0 !== (a.flags & 128)) a: for (a = b.child; null !== a; ) {
@@ -4464,7 +4464,7 @@
           }
           d &= 1;
         }
-        G(L, d);
+        G(L2, d);
         if (0 === (b.mode & 1)) b.memoizedState = null;
         else switch (e) {
           case "forwards":
@@ -4538,13 +4538,13 @@
           case 13:
             d = b.memoizedState;
             if (null !== d) {
-              if (null !== d.dehydrated) return G(L, L.current & 1), b.flags |= 128, null;
+              if (null !== d.dehydrated) return G(L2, L2.current & 1), b.flags |= 128, null;
               if (0 !== (c & b.child.childLanes)) return oj(a, b, c);
-              G(L, L.current & 1);
+              G(L2, L2.current & 1);
               a = Zi(a, b, c);
               return null !== a ? a.sibling : null;
             }
-            G(L, L.current & 1);
+            G(L2, L2.current & 1);
             break;
           case 19:
             d = 0 !== (c & b.childLanes);
@@ -4554,7 +4554,7 @@
             }
             e = b.memoizedState;
             null !== e && (e.rendering = null, e.tail = null, e.lastEffect = null);
-            G(L, L.current);
+            G(L2, L2.current);
             if (d) break;
             else return null;
           case 22:
@@ -4916,7 +4916,7 @@
             S2(b);
             return null;
           case 13:
-            E(L);
+            E(L2);
             d = b.memoizedState;
             if (null === a || null !== a.memoizedState && null !== a.memoizedState.dehydrated) {
               if (I && null !== yg && 0 !== (b.mode & 1) && 0 === (b.flags & 128)) Hg(), Ig(), b.flags |= 98560, f = false;
@@ -4935,7 +4935,7 @@
             }
             if (0 !== (b.flags & 128)) return b.lanes = c, b;
             d = null !== d;
-            d !== (null !== a && null !== a.memoizedState) && d && (b.child.flags |= 8192, 0 !== (b.mode & 1) && (null === a || 0 !== (L.current & 1) ? 0 === T2 && (T2 = 3) : tj()));
+            d !== (null !== a && null !== a.memoizedState) && d && (b.child.flags |= 8192, 0 !== (b.mode & 1) && (null === a || 0 !== (L2.current & 1) ? 0 === T2 && (T2 = 3) : tj()));
             null !== b.updateQueue && (b.flags |= 4);
             S2(b);
             return null;
@@ -4946,7 +4946,7 @@
           case 17:
             return Zf(b.type) && $f(), S2(b), null;
           case 19:
-            E(L);
+            E(L2);
             f = b.memoizedState;
             if (null === f) return S2(b), null;
             d = 0 !== (b.flags & 128);
@@ -4963,7 +4963,7 @@
                   b.subtreeFlags = 0;
                   d = c;
                   for (c = b.child; null !== c; ) f = c, a = d, f.flags &= 14680066, g = f.alternate, null === g ? (f.childLanes = 0, f.lanes = a, f.child = null, f.subtreeFlags = 0, f.memoizedProps = null, f.memoizedState = null, f.updateQueue = null, f.dependencies = null, f.stateNode = null) : (f.childLanes = g.childLanes, f.lanes = g.lanes, f.child = g.child, f.subtreeFlags = 0, f.deletions = null, f.memoizedProps = g.memoizedProps, f.memoizedState = g.memoizedState, f.updateQueue = g.updateQueue, f.type = g.type, a = g.dependencies, f.dependencies = null === a ? null : { lanes: a.lanes, firstContext: a.firstContext }), c = c.sibling;
-                  G(L, L.current & 1 | 2);
+                  G(L2, L2.current & 1 | 2);
                   return b.child;
                 }
                 a = a.sibling;
@@ -4976,7 +4976,7 @@
               } else 2 * B() - f.renderingStartTime > Gj && 1073741824 !== c && (b.flags |= 128, d = true, Dj(f, false), b.lanes = 4194304);
               f.isBackwards ? (g.sibling = b.child, b.child = g) : (c = f.last, null !== c ? c.sibling = g : b.child = g, f.last = g);
             }
-            if (null !== f.tail) return b = f.tail, f.rendering = b, f.tail = b.sibling, f.renderingStartTime = B(), b.sibling = null, c = L.current, G(L, d ? c & 1 | 2 : c & 1), b;
+            if (null !== f.tail) return b = f.tail, f.rendering = b, f.tail = b.sibling, f.renderingStartTime = B(), b.sibling = null, c = L2.current, G(L2, d ? c & 1 | 2 : c & 1), b;
             S2(b);
             return null;
           case 22:
@@ -4999,7 +4999,7 @@
           case 5:
             return Bh(b), null;
           case 13:
-            E(L);
+            E(L2);
             a = b.memoizedState;
             if (null !== a && null !== a.dehydrated) {
               if (null === b.alternate) throw Error(p(340));
@@ -5008,7 +5008,7 @@
             a = b.flags;
             return a & 65536 ? (b.flags = a & -65537 | 128, b) : null;
           case 19:
-            return E(L), null;
+            return E(L2), null;
           case 4:
             return zh(), null;
           case 10:
@@ -5798,7 +5798,7 @@
         if (0 === (a.mode & 1)) return 1;
         if (0 !== (K & 2) && 0 !== Z) return Z & -Z;
         if (null !== Kg.transition) return 0 === Bk && (Bk = yc()), Bk;
-        a = C;
+        a = C2;
         if (0 !== a) return a;
         a = window.event;
         a = void 0 === a ? 16 : jd(a.type);
@@ -6012,11 +6012,11 @@
         null !== wk && 0 === wk.tag && 0 === (K & 6) && Hk();
         var b = K;
         K |= 1;
-        var c = ok.transition, d = C;
+        var c = ok.transition, d = C2;
         try {
-          if (ok.transition = null, C = 1, a) return a();
+          if (ok.transition = null, C2 = 1, a) return a();
         } finally {
-          C = d, ok.transition = c, K = b, 0 === (K & 6) && jg();
+          C2 = d, ok.transition = c, K = b, 0 === (K & 6) && jg();
         }
       }
       function Hj() {
@@ -6049,10 +6049,10 @@
               zh();
               break;
             case 13:
-              E(L);
+              E(L2);
               break;
             case 19:
-              E(L);
+              E(L2);
               break;
             case 10:
               ah(d.type._context);
@@ -6264,11 +6264,11 @@
         0 === T2 && (T2 = 5);
       }
       function Pk(a, b, c) {
-        var d = C, e = ok.transition;
+        var d = C2, e = ok.transition;
         try {
-          ok.transition = null, C = 1, Wk(a, b, c, d);
+          ok.transition = null, C2 = 1, Wk(a, b, c, d);
         } finally {
-          ok.transition = e, C = d;
+          ok.transition = e, C2 = d;
         }
         return null;
       }
@@ -6296,8 +6296,8 @@
         if (0 !== (c.subtreeFlags & 15990) || f) {
           f = ok.transition;
           ok.transition = null;
-          var g = C;
-          C = 1;
+          var g = C2;
+          C2 = 1;
           var h = K;
           K |= 4;
           nk.current = null;
@@ -6310,7 +6310,7 @@
           hk(c, a, e);
           dc();
           K = h;
-          C = g;
+          C2 = g;
           ok.transition = f;
         } else a.current = c;
         vk && (vk = false, wk = a, xk = e);
@@ -6328,10 +6328,10 @@
       }
       function Hk() {
         if (null !== wk) {
-          var a = Dc(xk), b = ok.transition, c = C;
+          var a = Dc(xk), b = ok.transition, c = C2;
           try {
             ok.transition = null;
-            C = 16 > a ? 16 : a;
+            C2 = 16 > a ? 16 : a;
             if (null === wk) var d = false;
             else {
               a = wk;
@@ -6447,7 +6447,7 @@
             }
             return d;
           } finally {
-            C = c, ok.transition = b;
+            C2 = c, ok.transition = b;
           }
         }
         return false;
@@ -7062,14 +7062,14 @@
         }
       };
       Hc = function() {
-        return C;
+        return C2;
       };
       Ic = function(a, b) {
-        var c = C;
+        var c = C2;
         try {
-          return C = a, b();
+          return C2 = a, b();
         } finally {
-          C = c;
+          C2 = c;
         }
       };
       yb = function(a, b, c) {
@@ -7280,11 +7280,11 @@
   });
 
   // src/main.jsx
-  var import_react31 = __toESM(require_react(), 1);
+  var import_react38 = __toESM(require_react(), 1);
   var import_client = __toESM(require_client(), 1);
 
   // src/app/App.jsx
-  var import_react30 = __toESM(require_react(), 1);
+  var import_react37 = __toESM(require_react(), 1);
 
   // src/app/i18n.jsx
   var import_react = __toESM(require_react(), 1);
@@ -7747,9 +7747,9 @@
     circle: Circle
   };
   function Icon2({ name, size = 14, strokeWidth = 1.75, color = "currentColor", style }) {
-    const C = MAP[name];
-    if (!C) return null;
-    return /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(C, { size, strokeWidth, color, style, "aria-hidden": "true" });
+    const C2 = MAP[name];
+    if (!C2) return null;
+    return /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(C2, { size, strokeWidth, color, style, "aria-hidden": "true" });
   }
 
   // src/components/core/StatusDot.jsx
@@ -8209,7 +8209,7 @@
   }
 
   // src/screens/SettingsScreen.jsx
-  var import_react18 = __toESM(require_react(), 1);
+  var import_react19 = __toESM(require_react(), 1);
 
   // package.json
   var package_default = {
@@ -8542,6 +8542,81 @@
     ] });
   }
 
+  // src/components/shell/Toast.jsx
+  var import_react18 = __toESM(require_react(), 1);
+  var import_jsx_runtime16 = __toESM(require_jsx_runtime(), 1);
+  var TOAST_ICONS = {
+    ok: { icon: "check", color: "var(--ok)" },
+    error: { icon: "circle-alert", color: "var(--error)" },
+    warn: { icon: "triangle-alert", color: "var(--warn)" },
+    info: { icon: "info", color: "var(--text-secondary)" }
+  };
+  function Toast({ type = "info", message, actionLabel, onAction, onClose, style }) {
+    const t = TOAST_ICONS[type] || TOAST_ICONS.info;
+    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(
+      "div",
+      {
+        role: "status",
+        style: {
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-2)",
+          maxWidth: "100%",
+          padding: "5px 6px 5px 10px",
+          background: "var(--bg-overlay)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-md)",
+          boxShadow: "var(--shadow-toast)",
+          animation: "ds-fade-up var(--dur-slow) var(--ease-out)",
+          ...style
+        },
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Icon2, { name: t.icon, size: 13, strokeWidth: 2.25, color: t.color }),
+          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(
+            "span",
+            {
+              style: {
+                flex: 1,
+                minWidth: 0,
+                font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`,
+                color: "var(--text-primary)"
+              },
+              children: message
+            }
+          ),
+          actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(ToastAction, { label: actionLabel, onClick: onAction }) : null,
+          onClose ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(IconButton, { icon: "x", title: "\u5173\u95ED Dismiss", onClick: onClose, style: { width: 20, height: 20 } }) : null
+        ]
+      }
+    );
+  }
+  function ToastAction({ label, onClick }) {
+    const [hover, setHover] = import_react18.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(
+      "button",
+      {
+        type: "button",
+        className: "ds-focusable",
+        onClick,
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        style: {
+          flex: "none",
+          height: 20,
+          padding: "0 6px",
+          background: hover ? "var(--bg-active)" : "var(--bg-hover)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-sm)",
+          color: "var(--text-primary)",
+          font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`,
+          cursor: "pointer",
+          whiteSpace: "nowrap"
+        },
+        children: label
+      }
+    );
+  }
+
   // src/lib/clipboard.js
   function copyTextLegacy(text) {
     const ta = document.createElement("textarea");
@@ -8567,17 +8642,23 @@
   }
 
   // src/screens/SettingsScreen.jsx
-  var import_jsx_runtime16 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime17 = __toESM(require_jsx_runtime(), 1);
   var S = {
     zh: {
       ai: "AI \u670D\u52A1",
-      aiDisabled: "P5 \u63A5\u901A\u5185\u5D4C\u5BF9\u8BDD\u540E\u542F\u7528\u3002",
       conn: "\u8FDE\u63A5",
       sec: "\u5B89\u5168",
       gen: "\u901A\u7528",
       about: "\u5173\u4E8E",
       apiKey: "API Key",
       apiKeyCap: "\u4EC5\u4FDD\u5B58\u5728\u672C\u673A\uFF0C\u4E0D\u4F1A\u4E0A\u4F20",
+      saveVerify: "\u4FDD\u5B58\u5E76\u9A8C\u8BC1",
+      validating: "\u6B63\u5728\u9A8C\u8BC1\u2026",
+      saved: "API Key \u5DF2\u4FDD\u5B58\u5E76\u9A8C\u8BC1",
+      invalidKey: "\u65E0\u6548 key",
+      verifyFailed: "\u9A8C\u8BC1\u5931\u8D25\uFF0C\u8BF7\u7A0D\u540E\u91CD\u8BD5",
+      clear: "\u6E05\u9664",
+      cleared: "API Key \u5DF2\u6E05\u9664",
       model: "\u6A21\u578B",
       port: "\u7AEF\u53E3",
       portHint: "\u9ED8\u8BA4 11488",
@@ -8616,13 +8697,19 @@
     },
     en: {
       ai: "AI service",
-      aiDisabled: "Enabled in P5 when built-in chat is wired.",
       conn: "Connection",
       sec: "Security",
       gen: "General",
       about: "About",
       apiKey: "API Key",
       apiKeyCap: "Stored locally, never uploaded",
+      saveVerify: "Save and verify",
+      validating: "Validating\u2026",
+      saved: "API Key saved and verified",
+      invalidKey: "Invalid key",
+      verifyFailed: "Verification failed. Try again later.",
+      clear: "Clear",
+      cleared: "API Key cleared",
       model: "Model",
       port: "Port",
       portHint: "Default 11488",
@@ -8661,27 +8748,27 @@
     }
   };
   function Section({ title, children, disabled, caption }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)", opacity: disabled ? 0.45 : 1 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: "600 11px/1 var(--font-ui)", letterSpacing: "0.04em", color: "var(--text-tertiary)", textTransform: "uppercase", paddingBottom: 2, borderBottom: "1px solid var(--border-subtle)" }, children: title }),
-      caption ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: caption }) : null,
+    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)", opacity: disabled ? 0.45 : 1 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: "600 11px/1 var(--font-ui)", letterSpacing: "0.04em", color: "var(--text-tertiary)", textTransform: "uppercase", paddingBottom: 2, borderBottom: "1px solid var(--border-subtle)" }, children: title }),
+      caption ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: caption }) : null,
       children
     ] });
   }
   function ClientRow({ name, lastActive, blocked, onBlock, blockLabel }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 32, padding: "2px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: blocked ? 0.55 : 1 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: blocked ? "line-through" : "none" }, children: name }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: lastActive })
+    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 32, padding: "2px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: blocked ? 0.55 : 1 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: blocked ? "line-through" : "none" }, children: name }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: lastActive })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { font: "400 10px/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: blockLabel }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Switch, { checked: blocked, onChange: onBlock })
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { font: "400 10px/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: blockLabel }),
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Switch, { checked: blocked, onChange: onBlock })
     ] });
   }
   function VersionRow({ label, value, badge }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { flex: 1, font: "400 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
+    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { flex: 1, font: "400 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
       badge,
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { font: "400 11px/1 var(--font-mono)", color: "var(--text-secondary)" }, children: value })
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { font: "400 11px/1 var(--font-mono)", color: "var(--text-secondary)" }, children: value })
     ] });
   }
   function maskToken(value) {
@@ -8726,19 +8813,28 @@
     onBlockClient,
     onRegenToken,
     hostVersion = "-",
-    pythonVersion = "-"
+    pythonVersion = "-",
+    apiKey = "",
+    onSaveApiKey,
+    onClearApiKey,
+    validateKey,
+    model = "claude-sonnet-4-6",
+    onModelChange,
+    permissionMode = "manual",
+    onPermissionMode
   }) {
     const t = S[lang] || S.zh;
-    const [key, setKey] = import_react18.default.useState("");
-    const [model, setModel] = import_react18.default.useState("sonnet");
-    const [draftPort, setDraftPort] = import_react18.default.useState(String(port));
-    const [tokenRaw, setTokenRaw] = import_react18.default.useState("");
-    const [autostart, setAutostart] = import_react18.default.useState(true);
-    const [perm, setPerm] = import_react18.default.useState("manual");
-    const [logLevel, setLogLevel] = import_react18.default.useState("info");
-    const [copied, setCopied] = import_react18.default.useState("");
-    import_react18.default.useEffect(() => setDraftPort(String(port)), [port]);
-    import_react18.default.useEffect(() => setTokenRaw(readTokenValue()), []);
+    const [key, setKey] = import_react19.default.useState(apiKey);
+    const [aiBusy, setAiBusy] = import_react19.default.useState(false);
+    const [aiToast, setAiToast] = import_react19.default.useState(null);
+    const [draftPort, setDraftPort] = import_react19.default.useState(String(port));
+    const [tokenRaw, setTokenRaw] = import_react19.default.useState("");
+    const [autostart, setAutostart] = import_react19.default.useState(true);
+    const [logLevel, setLogLevel] = import_react19.default.useState("info");
+    const [copied, setCopied] = import_react19.default.useState("");
+    import_react19.default.useEffect(() => setDraftPort(String(port)), [port]);
+    import_react19.default.useEffect(() => setTokenRaw(readTokenValue()), []);
+    import_react19.default.useEffect(() => setKey(apiKey), [apiKey]);
     const copy = (label, text) => {
       copyText(text).then(() => {
         setCopied(label);
@@ -8746,8 +8842,35 @@
       }).catch(() => {
       });
     };
-    const permCap = perm === "manual" ? t.permCap1 : perm === "auto" ? t.permCap2 : t.permCap3;
+    const permCap = permissionMode === "manual" ? t.permCap1 : permissionMode === "auto" ? t.permCap2 : t.permCap3;
     const tokenDisplay = tokenRaw ? maskToken(tokenRaw) : t.tokenMissing;
+    const saveApiKey = () => {
+      if (aiBusy) return;
+      setAiBusy(true);
+      setAiToast(null);
+      Promise.resolve(validateKey ? validateKey(key) : true).then((result) => {
+        const ok = result === true || result && result.ok === true || result && result.status === 200;
+        const status = result && typeof result === "object" ? result.status : null;
+        if (!ok) {
+          setAiToast({ type: "error", message: status === 401 ? t.invalidKey : t.verifyFailed });
+          return null;
+        }
+        return Promise.resolve(onSaveApiKey ? onSaveApiKey(key) : null).then(() => {
+          setAiToast({ type: "ok", message: t.saved });
+        });
+      }).catch((e) => {
+        const status = e && (e.status || e.response && e.response.status);
+        setAiToast({ type: "error", message: status === 401 ? t.invalidKey : t.verifyFailed });
+      }).finally(() => setAiBusy(false));
+    };
+    const clearApiKey = () => {
+      setKey("");
+      Promise.resolve(onClearApiKey ? onClearApiKey() : null).then(() => {
+        setAiToast({ type: "info", message: t.cleared });
+      }).catch(() => {
+        setAiToast({ type: "error", message: t.verifyFailed });
+      });
+    };
     const regenerate = () => {
       if (!onRegenToken) return;
       const result = onRegenToken();
@@ -8758,37 +8881,42 @@
         setTokenRaw(result || readTokenValue());
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-5)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(Section, { title: t.ai, disabled: true, caption: t.aiDisabled, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.apiKey, caption: t.apiKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Input, { secret: true, disabled: true, value: key, onChange: setKey, placeholder: "sk-ant-..." }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Select, { disabled: true, value: model, onChange: setModel, options: [
-          { value: "sonnet", label: "Claude Sonnet" },
-          { value: "haiku", label: "Claude Haiku" }
+    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-5)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.ai, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.apiKey, caption: t.apiKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Input, { secret: true, value: key, onChange: setKey, placeholder: "sk-ant-...", style: { flex: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "primary", disabled: aiBusy || !key.trim(), onClick: saveApiKey, children: aiBusy ? t.validating : t.saveVerify }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", disabled: aiBusy, onClick: clearApiKey, children: t.clear })
+        ] }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Select, { value: model, onChange: onModelChange, options: [
+          { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+          { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" }
+        ] }) }),
+        aiToast ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Toast, { type: aiToast.type, message: aiToast.message, onClose: () => setAiToast(null) }) : null
+      ] }),
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.conn, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.port, hint: t.portHint, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Input, { mono: true, value: draftPort, onChange: setDraftPort, style: { flex: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", onClick: () => onApplyPort && onApplyPort(draftPort), children: t.apply })
+        ] }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.token, caption: t.tokenCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Input, { mono: true, value: tokenDisplay, style: { flex: 1 }, suffix: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(IconButton, { icon: "copy", title: t.copy, disabled: !tokenRaw, onClick: () => copy("token", tokenRaw), style: { width: 20, height: 20 } }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", icon: "rotate-cw", onClick: regenerate, children: t.regen })
+        ] }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { layout: "row", label: t.autostart, caption: t.autostartCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Switch, { checked: autostart, onChange: setAutostart }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.mcp, caption: copied === "mcp" ? t.copied : null, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("pre", { style: { margin: 0, maxHeight: 160, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-secondary)", font: "400 10px/1.4 var(--font-mono)" }, children: mcpConfig }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", icon: "copy", onClick: () => copy("mcp", mcpConfig), children: t.copy })
         ] }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(Section, { title: t.conn, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.port, hint: t.portHint, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Input, { mono: true, value: draftPort, onChange: setDraftPort, style: { flex: 1 } }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "secondary", onClick: () => onApplyPort && onApplyPort(draftPort), children: t.apply })
-        ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.token, caption: t.tokenCap, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Input, { mono: true, value: tokenDisplay, style: { flex: 1 }, suffix: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(IconButton, { icon: "copy", title: t.copy, disabled: !tokenRaw, onClick: () => copy("token", tokenRaw), style: { width: 20, height: 20 } }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "secondary", icon: "rotate-cw", onClick: regenerate, children: t.regen })
-        ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { layout: "row", label: t.autostart, caption: t.autostartCap, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Switch, { checked: autostart, onChange: setAutostart }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.mcp, caption: copied === "mcp" ? t.copied : null, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("pre", { style: { margin: 0, maxHeight: 160, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-secondary)", font: "400 10px/1.4 var(--font-mono)" }, children: mcpConfig }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "secondary", icon: "copy", onClick: () => copy("mcp", mcpConfig), children: t.copy })
-        ] }) })
-      ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(Section, { title: t.sec, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.permTitle, caption: permCap, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Segmented, { full: true, value: perm, onChange: setPerm, options: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.sec, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.permTitle, caption: permCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Segmented, { full: true, value: permissionMode, onChange: onPermissionMode, options: [
           { value: "manual", label: t.perm1 },
           { value: "auto", label: t.perm2 },
           { value: "none", label: t.perm3 }
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.clients }),
-        clients.map((client) => /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.clients }),
+        clients.map((client) => /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
           ClientRow,
           {
             name: client.label,
@@ -8800,39 +8928,39 @@
           client.label
         ))
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(Section, { title: t.gen, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.language, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.logLevel, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Select, { value: logLevel, onChange: setLogLevel, style: { flex: 1 }, options: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.gen, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.language, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.logLevel, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Select, { value: logLevel, onChange: setLogLevel, style: { flex: 1 }, options: [
             { value: "error", label: "Error" },
             { value: "info", label: "Info" },
             { value: "debug", label: "Debug" }
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "secondary", icon: "download", disabled: true, children: t.exportLog })
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", icon: "download", disabled: true, children: t.exportLog })
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Field, { label: t.logs, children: /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("details", { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("summary", { style: { cursor: "pointer", color: "var(--text-secondary)", font: "500 11px/1.35 var(--font-ui)" }, children: t.logs }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("pre", { style: { margin: "6px 0 0", maxHeight: 128, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-tertiary)", font: "400 10px/1.4 var(--font-mono)" }, children: logs.join("\n") })
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.logs, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("details", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("summary", { style: { cursor: "pointer", color: "var(--text-secondary)", font: "500 11px/1.35 var(--font-ui)" }, children: t.logs }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("pre", { style: { margin: "6px 0 0", maxHeight: 128, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-tertiary)", font: "400 10px/1.4 var(--font-mono)" }, children: logs.join("\n") })
         ] }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(Section, { title: t.about, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(VersionRow, { label: t.verPanel, value: `v${package_default.version}` }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(VersionRow, { label: t.verHost, value: hostVersion, badge: hostVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(VersionRow, { label: t.verPy, value: pythonVersion, badge: pythonVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "ghost", size: "sm", icon: "book-open", children: t.docs }),
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(Button, { variant: "ghost", size: "sm", icon: "github", children: t.github })
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.about, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(VersionRow, { label: t.verPanel, value: `v${package_default.version}` }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(VersionRow, { label: t.verHost, value: hostVersion, badge: hostVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(VersionRow, { label: t.verPy, value: pythonVersion, badge: pythonVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "ghost", size: "sm", icon: "book-open", children: t.docs }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "ghost", size: "sm", icon: "github", children: t.github })
         ] })
       ] })
     ] });
   }
 
   // src/screens/ActivityScreen.jsx
-  var import_react21 = __toESM(require_react(), 1);
+  var import_react22 = __toESM(require_react(), 1);
 
   // src/components/activity/FilterBar.jsx
-  var import_react19 = __toESM(require_react(), 1);
-  var import_jsx_runtime17 = __toESM(require_jsx_runtime(), 1);
+  var import_react20 = __toESM(require_react(), 1);
+  var import_jsx_runtime18 = __toESM(require_jsx_runtime(), 1);
   function FilterBar({
     query = "",
     onQuery,
@@ -8840,8 +8968,8 @@
     filters = [],
     style
   }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", padding: "var(--space-2)", borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", padding: "var(--space-2)", borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
         Input,
         {
           value: query,
@@ -8851,13 +8979,13 @@
           suffix: null
         }
       ),
-      filters.map((f, i) => /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Select, { full: false, value: f.value, onChange: f.onChange, options: f.options, style: { flex: "none", width: f.width || 96 } }, i))
+      filters.map((f, i) => /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Select, { full: false, value: f.value, onChange: f.onChange, options: f.options, style: { flex: "none", width: f.width || 96 } }, i))
     ] });
   }
 
   // src/components/activity/ActivityRow.jsx
-  var import_react20 = __toESM(require_react(), 1);
-  var import_jsx_runtime18 = __toESM(require_jsx_runtime(), 1);
+  var import_react21 = __toESM(require_react(), 1);
+  var import_jsx_runtime19 = __toESM(require_jsx_runtime(), 1);
   var RESULT = {
     success: { icon: "check", color: "var(--ok)" },
     error: { icon: "x", color: "var(--error)" },
@@ -8875,11 +9003,11 @@
     expandable = true,
     style
   }) {
-    const [expanded, setExpanded] = import_react20.default.useState(false);
-    const [hover, setHover] = import_react20.default.useState(false);
+    const [expanded, setExpanded] = import_react21.default.useState(false);
+    const [hover, setHover] = import_react21.default.useState(false);
     const r = RESULT[result] || RESULT.success;
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(
         "div",
         {
           role: expandable ? "button" : void 0,
@@ -8897,11 +9025,11 @@
             transition: "background var(--dur-fast) var(--ease-out)"
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Icon2, { name: r.icon, size: 12, strokeWidth: 2.5, color: r.color }),
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { flex: "none", font: `var(--weight-regular) var(--text-micro)/1 var(--font-mono)`, color: "var(--text-tertiary)" }, children: time }),
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Badge, { status: "neutral", style: { flex: "none", maxWidth: 84, overflow: "hidden" }, children: source }),
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { flex: "none", font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Icon2, { name: r.icon, size: 12, strokeWidth: 2.5, color: r.color }),
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { flex: "none", font: `var(--weight-regular) var(--text-micro)/1 var(--font-mono)`, color: "var(--text-tertiary)" }, children: time }),
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Badge, { status: "neutral", style: { flex: "none", maxWidth: 84, overflow: "hidden" }, children: source }),
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { flex: "none", font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
               "span",
               {
                 style: {
@@ -8916,7 +9044,7 @@
                 children: target
               }
             ),
-            expandable ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+            expandable ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
               Icon2,
               {
                 name: "chevron-down",
@@ -8928,8 +9056,8 @@
           ]
         }
       ),
-      expanded ? /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2) 26px", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
-        params != null ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+      expanded ? /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2) 26px", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+        params != null ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           "pre",
           {
             style: {
@@ -8948,7 +9076,7 @@
             children: typeof params === "string" ? params : JSON.stringify(params, null, 2)
           }
         ) : null,
-        onUndo ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: onUndo, style: { alignSelf: "flex-start" }, children: undoLabel }) : null
+        onUndo ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: onUndo, style: { alignSelf: "flex-start" }, children: undoLabel }) : null
       ] }) : null
     ] });
   }
@@ -8978,7 +9106,7 @@
   }
 
   // src/screens/ActivityScreen.jsx
-  var import_jsx_runtime19 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime20 = __toESM(require_jsx_runtime(), 1);
   var A = {
     zh: {
       search: "\u641C\u7D22\u64CD\u4F5C\u2026",
@@ -9019,13 +9147,13 @@
     emptyCaption
   }) {
     const t = A[lang] || A.zh;
-    const [q, setQ] = import_react21.default.useState("");
-    const [res, setRes] = import_react21.default.useState("all");
+    const [q, setQ] = import_react22.default.useState("");
+    const [res, setRes] = import_react22.default.useState("all");
     const rows = filterEvents(events, { mode: res, query: q });
     const empty = events.length === 0;
-    return /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: empty ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(import_react21.default.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", borderBottom: "1px solid var(--border-subtle)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: empty ? /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)(import_react22.default.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)("div", { style: { display: "flex", borderBottom: "1px solid var(--border-subtle)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
           FilterBar,
           {
             query: q,
@@ -9045,9 +9173,9 @@
             ]
           }
         ),
-        onClear ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { display: "flex", alignItems: "center", padding: "var(--space-2) var(--space-2) var(--space-2) 0" }, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { size: "sm", variant: "ghost", icon: "trash-2", onClick: onClear, title: t.clear, children: t.clear }) }) : null
+        onClear ? /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("div", { style: { display: "flex", alignItems: "center", padding: "var(--space-2) var(--space-2) var(--space-2) 0" }, children: /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(Button, { size: "sm", variant: "ghost", icon: "trash-2", onClick: onClear, title: t.clear, children: t.clear }) }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { flex: 1, minHeight: 0, overflow: "auto" }, children: rows.length ? rows.map((evt) => /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("div", { style: { flex: 1, minHeight: 0, overflow: "auto" }, children: rows.length ? rows.map((evt) => /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
         ActivityRow,
         {
           time: new Date(evt.ts).toLocaleTimeString(),
@@ -9058,18 +9186,18 @@
           params: eventDetails(evt)
         },
         evt.id
-      )) : /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) })
+      )) : /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) })
     ] }) });
   }
 
   // src/screens/WizardScreen.jsx
-  var import_react24 = __toESM(require_react(), 1);
+  var import_react25 = __toESM(require_react(), 1);
 
   // src/components/core/Spinner.jsx
-  var import_react22 = __toESM(require_react(), 1);
-  var import_jsx_runtime20 = __toESM(require_jsx_runtime(), 1);
+  var import_react23 = __toESM(require_react(), 1);
+  var import_jsx_runtime21 = __toESM(require_jsx_runtime(), 1);
   function Spinner({ size = 12, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
       "span",
       {
         role: "progressbar",
@@ -9090,10 +9218,10 @@
   }
 
   // src/components/chat/AIAvatar.jsx
-  var import_react23 = __toESM(require_react(), 1);
-  var import_jsx_runtime21 = __toESM(require_jsx_runtime(), 1);
+  var import_react24 = __toESM(require_react(), 1);
+  var import_jsx_runtime22 = __toESM(require_jsx_runtime(), 1);
   function AIAvatar({ size = 20, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(
       "span",
       {
         "aria-label": "AI",
@@ -9109,13 +9237,13 @@
           borderRadius: "var(--radius-md)",
           ...style
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Icon2, { name: "sparkles", size: Math.round(size * 0.6), color: "var(--accent)", strokeWidth: 2 })
+        children: /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Icon2, { name: "sparkles", size: Math.round(size * 0.6), color: "var(--accent)", strokeWidth: 2 })
       }
     );
   }
 
   // src/screens/WizardScreen.jsx
-  var import_jsx_runtime22 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime23 = __toESM(require_jsx_runtime(), 1);
   var W = {
     zh: {
       stepOf: (n) => `\u7B2C ${n} \u6B65 / \u5171 4 \u6B65`,
@@ -9175,14 +9303,14 @@
     { id: "cursor", name: "Cursor" }
   ];
   function CodeBlock({ code, copyLabel, onCopy, maxHeight }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { position: "relative", background: "var(--gray-0)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("pre", { style: { margin: 0, padding: "10px 36px 10px 12px", font: "400 11px/1.7 var(--font-mono)", color: "var(--text-primary)", overflow: "auto", maxHeight: maxHeight || 180, whiteSpace: "pre" }, children: code }),
-      /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(IconButton, { icon: "copy", title: copyLabel, variant: "secondary", onClick: onCopy, style: { position: "absolute", top: 6, right: 6, background: "var(--bg-panel)" } })
+    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { position: "relative", background: "var(--gray-0)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("pre", { style: { margin: 0, padding: "10px 36px 10px 12px", font: "400 11px/1.7 var(--font-mono)", color: "var(--text-primary)", overflow: "auto", maxHeight: maxHeight || 180, whiteSpace: "pre" }, children: code }),
+      /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(IconButton, { icon: "copy", title: copyLabel, variant: "secondary", onClick: onCopy, style: { position: "absolute", top: 6, right: 6, background: "var(--bg-panel)" } })
     ] });
   }
   function ClientRow2({ name, note, selected, onSelect }) {
-    const [hover, setHover] = import_react24.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(
+    const [hover, setHover] = import_react25.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
       "button",
       {
         type: "button",
@@ -9205,11 +9333,11 @@
           transition: "background var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: name }),
-            note ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: note }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: name }),
+            note ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: note }) : null
           ] }),
-          selected ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Icon2, { name: "check", size: 13, strokeWidth: 2.5, color: "var(--text-primary)" }) : null
+          selected ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Icon2, { name: "check", size: 13, strokeWidth: 2.5, color: "var(--text-primary)" }) : null
         ]
       }
     );
@@ -9231,32 +9359,32 @@
     onSkip
   }) {
     const t = W[lang] || W.zh;
-    return /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "var(--space-6) var(--space-5) var(--space-5)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { display: "flex", gap: 5 }, children: [1, 2, 3, 4].map((n) => /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { width: n === step ? 14 : 5, height: 5, borderRadius: 3, background: n === step ? "var(--gray-11)" : n < step ? "var(--gray-9)" : "var(--gray-6)", transition: "width var(--dur-base) var(--ease-out)" } }, n)) }),
-        /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { font: "400 10px/1 var(--font-mono)", color: "var(--text-tertiary)" }, children: t.stepOf(step) }),
-        /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { flex: 1 } }),
-        onSkip && step < 4 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "ghost", size: "sm", onClick: onSkip, style: { color: "var(--text-tertiary)" }, children: t.skip }) : null
+    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", padding: "var(--space-6) var(--space-5) var(--space-5)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { display: "flex", gap: 5 }, children: [1, 2, 3, 4].map((n) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { width: n === step ? 14 : 5, height: 5, borderRadius: 3, background: n === step ? "var(--gray-11)" : n < step ? "var(--gray-9)" : "var(--gray-6)", transition: "width var(--dur-base) var(--ease-out)" } }, n)) }),
+        /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { font: "400 10px/1 var(--font-mono)", color: "var(--text-tertiary)" }, children: t.stepOf(step) }),
+        /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1 } }),
+        onSkip && step < 4 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "ghost", size: "sm", onClick: onSkip, style: { color: "var(--text-tertiary)" }, children: t.skip }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", display: "flex", flexDirection: "column", gap: "var(--space-3)", paddingTop: "var(--space-6)" }, children: [
-        step === 1 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(AIAvatar, { size: 44 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t1 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b1 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { marginTop: "var(--space-2)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginBottom: 6 }, children: t.langLabel }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] })
+      /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", display: "flex", flexDirection: "column", gap: "var(--space-3)", paddingTop: "var(--space-6)" }, children: [
+        step === 1 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(AIAvatar, { size: 44 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t1 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b1 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { marginTop: "var(--space-2)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginBottom: 6 }, children: t.langLabel }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] })
           ] })
         ] }) : null,
-        step === 2 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t2 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b2 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(CodeBlock, { code: "pip install ae-mcp", copyLabel: t.copy, onCopy })
+        step === 2 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t2 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b2 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(CodeBlock, { code: "pip install ae-mcp", copyLabel: t.copy, onCopy })
         ] }) : null,
-        step === 3 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t3 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b3 }),
-          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: CLIENTS.map((c) => /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(
+        step === 3 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.t3 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b3 }),
+          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: CLIENTS.map((c) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
             ClientRow2,
             {
               name: c.id === "builtin" ? t.builtin : c.name,
@@ -9266,41 +9394,41 @@
             },
             c.id
           )) }),
-          client !== "builtin" ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(CodeBlock, { code: mcpConfig, copyLabel: t.copy, onCopy, maxHeight: 150 }) : null
+          client !== "builtin" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(CodeBlock, { code: mcpConfig, copyLabel: t.copy, onCopy, maxHeight: 150 }) : null
         ] }) : null,
-        step === 4 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "var(--space-2)", textAlign: "center" }, children: [
-          handshake === "waiting" ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Spinner, { size: 28 }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4w }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 230 }, children: t.b4w })
+        step === 4 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "var(--space-2)", textAlign: "center" }, children: [
+          handshake === "waiting" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Spinner, { size: 28 }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4w }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 230 }, children: t.b4w })
           ] }) : null,
-          handshake === "success" ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { width: 48, height: 48, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "var(--ok-bg)", border: "1px solid var(--ok-border)", borderRadius: "50%" }, children: /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Icon2, { name: "check", size: 22, strokeWidth: 2.5, color: "var(--ok)" }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4s }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 230 }, children: t.b4s(clientName) })
+          handshake === "success" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { width: 48, height: 48, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "var(--ok-bg)", border: "1px solid var(--ok-border)", borderRadius: "50%" }, children: /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Icon2, { name: "check", size: 22, strokeWidth: 2.5, color: "var(--ok)" }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4s }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 230 }, children: t.b4s(clientName) })
           ] }) : null,
-          handshake === "timeout" ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { width: 48, height: 48, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "var(--warn-bg)", border: "1px solid var(--warn-border)", borderRadius: "50%" }, children: /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Icon2, { name: "triangle-alert", size: 20, strokeWidth: 2, color: "var(--warn)" }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4t }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.b4t }),
-            /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "secondary", icon: "stethoscope", onClick: onDiagnose, style: { marginTop: 4 }, children: t.diagnose })
+          handshake === "timeout" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { width: 48, height: 48, display: "inline-flex", alignItems: "center", justifyContent: "center", background: "var(--warn-bg)", border: "1px solid var(--warn-border)", borderRadius: "50%" }, children: /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Icon2, { name: "triangle-alert", size: 20, strokeWidth: 2, color: "var(--warn)" }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 15px/1.35 var(--font-ui)", color: "var(--text-primary)", marginTop: 8 }, children: t.t4t }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 11px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.b4t }),
+            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "secondary", icon: "stethoscope", onClick: onDiagnose, style: { marginTop: 4 }, children: t.diagnose })
           ] }) : null
         ] }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", paddingTop: "var(--space-3)" }, children: [
-        step > 1 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "ghost", size: "lg", onClick: onBack, children: t.back }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("span", { style: { flex: 1 } }),
-        step < 4 ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "primary", size: "lg", onClick: onNext, children: t.next }) : handshake === "success" ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "primary", size: "lg", onClick: onDone, children: t.start }) : null
+      /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", paddingTop: "var(--space-3)" }, children: [
+        step > 1 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "ghost", size: "lg", onClick: onBack, children: t.back }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1 } }),
+        step < 4 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "primary", size: "lg", onClick: onNext, children: t.next }) : handshake === "success" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "primary", size: "lg", onClick: onDone, children: t.start }) : null
       ] })
     ] });
   }
 
   // src/screens/ConnectionDrawer.jsx
-  var import_react27 = __toESM(require_react(), 1);
+  var import_react28 = __toESM(require_react(), 1);
 
   // src/components/shell/DiagnosticItem.jsx
-  var import_react25 = __toESM(require_react(), 1);
-  var import_jsx_runtime23 = __toESM(require_jsx_runtime(), 1);
+  var import_react26 = __toESM(require_react(), 1);
+  var import_jsx_runtime24 = __toESM(require_jsx_runtime(), 1);
   var GLYPHS = {
     pass: { icon: "check", color: "var(--ok)" },
     fail: { icon: "x", color: "var(--error)" },
@@ -9308,10 +9436,10 @@
   };
   function DiagnosticItem({ label, status = "pending", detail, actionLabel, onAction, style }) {
     const g = GLYPHS[status];
-    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { padding: "var(--space-1) 0", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: 22 }, children: [
-        status === "running" ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Spinner, { size: 12 }) : /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Icon2, { name: g.icon, size: 12, strokeWidth: 2.5, color: g.color }),
-        /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { padding: "var(--space-1) 0", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: 22 }, children: [
+        status === "running" ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Spinner, { size: 12 }) : /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Icon2, { name: g.icon, size: 12, strokeWidth: 2.5, color: g.color }),
+        /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
           "span",
           {
             style: {
@@ -9324,7 +9452,7 @@
           }
         )
       ] }),
-      status === "fail" && detail ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
+      status === "fail" && detail ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
         "div",
         {
           style: {
@@ -9338,8 +9466,8 @@
             borderRadius: "var(--radius-sm)"
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: detail }),
-            actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, style: { flex: "none" }, children: actionLabel }) : null
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: detail }),
+            actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, style: { flex: "none" }, children: actionLabel }) : null
           ]
         }
       ) : null
@@ -9347,19 +9475,19 @@
   }
 
   // src/components/shell/Drawer.jsx
-  var import_react26 = __toESM(require_react(), 1);
-  var import_jsx_runtime24 = __toESM(require_jsx_runtime(), 1);
+  var import_react27 = __toESM(require_react(), 1);
+  var import_jsx_runtime25 = __toESM(require_jsx_runtime(), 1);
   function Drawer({ open = false, title, onClose, children, closeTitle = "\u5173\u95ED Close", style }) {
     if (!open) return null;
-    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { position: "absolute", inset: 0, zIndex: 30 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { position: "absolute", inset: 0, zIndex: 30 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(
         "div",
         {
           onClick: onClose,
           style: { position: "absolute", inset: 0, background: "var(--scrim)", animation: "ds-fade var(--dur-slow) var(--ease-out)" }
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
+      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(
         "div",
         {
           role: "dialog",
@@ -9380,7 +9508,7 @@
             ...style
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
+            /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(
               "div",
               {
                 style: {
@@ -9391,12 +9519,12 @@
                   borderBottom: "1px solid var(--border-subtle)"
                 },
                 children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-semibold) var(--text-heading)/1 var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
-                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(IconButton, { icon: "x", title: closeTitle, onClick: onClose })
+                  /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-semibold) var(--text-heading)/1 var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+                  /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(IconButton, { icon: "x", title: closeTitle, onClick: onClose })
                 ]
               }
             ),
-            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { overflow: "auto", padding: "var(--space-3)" }, children })
+            /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("div", { style: { overflow: "auto", padding: "var(--space-3)" }, children })
           ]
         }
       )
@@ -9404,7 +9532,7 @@
   }
 
   // src/screens/ConnectionDrawer.jsx
-  var import_jsx_runtime25 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime26 = __toESM(require_jsx_runtime(), 1);
   var D = {
     zh: {
       title: "\u8FDE\u63A5",
@@ -9462,9 +9590,9 @@
     }
   };
   function KV({ k, children }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { width: 72, flex: "none", font: "400 11px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: k }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.35 var(--font-mono)", color: "var(--text-primary)" }, children })
+    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { width: 72, flex: "none", font: "400 11px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: k }),
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.35 var(--font-mono)", color: "var(--text-primary)" }, children })
     ] });
   }
   function formatTime(ts) {
@@ -9490,42 +9618,42 @@
     const hostVersion = info.hostVersion || "-";
     const mismatch = info.pythonVersion && info.pythonVersion !== panelVersion;
     const recent = info.lastClientSeenAt ? [{ time: formatTime(info.lastClientSeenAt), text: lang === "zh" ? "\u5916\u90E8 MCP \u5BA2\u6237\u7AEF" : "External MCP client" }] : [];
-    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(KV, { k: t.status, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(StatusDot, { status: connected ? "connected" : "waiting", size: 7 }),
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { fontFamily: "var(--font-ui)" }, children: statusLabel || (connected ? t.connected : t.waiting) })
+    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.status, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(StatusDot, { status: connected ? "connected" : "waiting", size: 7 }),
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { fontFamily: "var(--font-ui)" }, children: statusLabel || (connected ? t.connected : t.waiting) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(KV, { k: t.port, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.port, children: [
         info.port || "-",
         " ",
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(IconButton, { icon: "copy", title: t.copyConfig, onClick: () => callCopy(onCopyConfig), style: { width: 20, height: 20 } })
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(IconButton, { icon: "copy", title: t.copyConfig, onClick: () => callCopy(onCopyConfig), style: { width: 20, height: 20 } })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(KV, { k: t.token, children: info.tokenLabel || t.tokenLocal }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(KV, { k: t.ver, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(KV, { k: t.token, children: info.tokenLabel || t.tokenLocal }),
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.ver, children: [
         "v",
         panelVersion,
         " \xB7 host ",
         hostVersion,
         " \xB7 py ",
         pythonVersion,
-        mismatch ? /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Badge, { status: "warn", children: t.mismatch }) : null
+        mismatch ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Badge, { status: "warn", children: t.mismatch }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 4 }, children: t.recent }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("div", { style: { background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", padding: "2px 8px" }, children: (recent.length ? recent : [{ time: "-", text: t.noRecent }]).map((r, i) => /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", gap: 8, alignItems: "center", minHeight: 22, font: "400 10px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { fontFamily: "var(--font-mono)", color: "var(--text-tertiary)" }, children: r.time }),
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: r.text })
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 4 }, children: t.recent }),
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", padding: "2px 8px" }, children: (recent.length ? recent : [{ time: "-", text: t.noRecent }]).map((r, i) => /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", gap: 8, alignItems: "center", minHeight: 22, font: "400 10px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { fontFamily: "var(--font-mono)", color: "var(--text-tertiary)" }, children: r.time }),
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: r.text })
       ] }, i)) }),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", gap: 6, marginTop: 4, flexWrap: "wrap" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => callCopy(onCopyConfig), children: t.copyConfig }),
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRestart, children: t.restart }),
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { variant: "secondary", size: "sm", icon: "stethoscope", onClick: onDiagnose, children: t.diagnose })
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", gap: 6, marginTop: 4, flexWrap: "wrap" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => callCopy(onCopyConfig), children: t.copyConfig }),
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRestart, children: t.restart }),
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "stethoscope", onClick: onDiagnose, children: t.diagnose })
       ] })
     ] });
   }
   function DiagnosticsBody({ lang = "zh", diagnostics = [], onRerun }) {
     const t = D[lang] || D.zh;
-    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", flexDirection: "column" }, children: [
-      diagnostics.map((c) => /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", flexDirection: "column" }, children: [
+      diagnostics.map((c) => /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
         DiagnosticItem,
         {
           label: t.checks[c.id] || c.id,
@@ -9534,10 +9662,10 @@
         },
         c.id
       )),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 6, paddingTop: "var(--space-2)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyText(JSON.stringify(diagnostics, null, 2)).catch(() => {
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 6, paddingTop: "var(--space-2)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyText(JSON.stringify(diagnostics, null, 2)).catch(() => {
         }), children: t.copyReport }),
-        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRerun, children: t.rerun })
+        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRerun, children: t.rerun })
       ] })
     ] });
   }
@@ -9545,8 +9673,8 @@
     const diagList = Array.isArray(diagnostics) ? diagnostics : [];
     const t = D[lang] || D.zh;
     const panelVersion = info.panelVersion || package_default.version;
-    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
         ConnectionDrawerBody,
         {
           lang,
@@ -9557,15 +9685,1493 @@
           onDiagnose
         }
       ),
-      diagList.length ? /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("div", { style: { marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(DiagnosticsBody, { lang, diagnostics: diagList, onRerun: onDiagnose }) }) : null
+      diagList.length ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(DiagnosticsBody, { lang, diagnostics: diagList, onRerun: onDiagnose }) }) : null
     ] });
   }
 
+  // src/screens/ChatScreen.jsx
+  var import_react34 = __toESM(require_react(), 1);
+
+  // src/components/chat/ChatBubble.jsx
+  var import_react29 = __toESM(require_react(), 1);
+  var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
+  function ChatBubble({ role = "ai", children, streaming = false, avatar = true, style }) {
+    if (role === "user") {
+      return /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { display: "flex", justifyContent: "flex-end", ...style }, children: /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+        "div",
+        {
+          style: {
+            maxWidth: "85%",
+            padding: "5px 10px",
+            background: "var(--bg-raised)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius-lg)",
+            borderBottomRightRadius: "var(--radius-sm)",
+            font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`,
+            color: "var(--text-primary)",
+            overflowWrap: "break-word"
+          },
+          children
+        }
+      ) });
+    }
+    return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", gap: "var(--space-2)", alignItems: "flex-start", ...style }, children: [
+      avatar ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(AIAvatar, { style: { marginTop: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { width: 20, flex: "none" } }),
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(
+        "div",
+        {
+          style: {
+            flex: 1,
+            minWidth: 0,
+            font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`,
+            color: "var(--text-primary)",
+            overflowWrap: "break-word"
+          },
+          children: [
+            children,
+            streaming ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+              "span",
+              {
+                style: {
+                  display: "inline-block",
+                  width: 6,
+                  height: 12,
+                  marginLeft: 3,
+                  verticalAlign: "-1px",
+                  background: "var(--accent)",
+                  borderRadius: 1,
+                  animation: "ds-pulse 1s var(--ease-in-out) infinite"
+                }
+              }
+            ) : null
+          ]
+        }
+      )
+    ] });
+  }
+
+  // src/components/chat/ToolCallCard.jsx
+  var import_react30 = __toESM(require_react(), 1);
+  var import_jsx_runtime28 = __toESM(require_jsx_runtime(), 1);
+  function StatusGlyph({ status }) {
+    if (status === "running") return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Spinner, { size: 12 });
+    if (status === "error") return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Icon2, { name: "x", size: 12, strokeWidth: 2.5, color: "var(--error)" });
+    return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.5, color: "var(--ok)" });
+  }
+  function ParamsBlock({ params }) {
+    return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+      "pre",
+      {
+        style: {
+          margin: 0,
+          padding: "var(--space-2)",
+          background: "var(--gray-0)",
+          borderTop: "1px solid var(--border-subtle)",
+          font: `var(--weight-regular) var(--text-micro)/1.6 var(--font-mono)`,
+          color: "var(--text-secondary)",
+          maxHeight: 140,
+          overflow: "auto",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-all"
+        },
+        children: typeof params === "string" ? params : JSON.stringify(params, null, 2)
+      }
+    );
+  }
+  function HeaderRow({ status, verb, target, expandable, expanded, onToggle }) {
+    const [hover, setHover] = import_react30.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
+      "div",
+      {
+        role: expandable ? "button" : void 0,
+        onClick: expandable ? onToggle : void 0,
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        style: {
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-15)",
+          minHeight: "var(--hit-min)",
+          padding: "0 var(--space-2)",
+          cursor: expandable ? "pointer" : "default",
+          background: expandable && hover ? "var(--bg-hover)" : "transparent",
+          transition: "background var(--dur-fast) var(--ease-out)"
+        },
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(StatusGlyph, { status }),
+          /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { font: `var(--weight-medium) var(--text-body)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
+          /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+            "span",
+            {
+              style: {
+                flex: 1,
+                minWidth: 0,
+                font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`,
+                color: "var(--text-tertiary)",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis"
+              },
+              children: target
+            }
+          ),
+          expandable ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+            Icon2,
+            {
+              name: "chevron-down",
+              size: 12,
+              color: "var(--text-tertiary)",
+              style: { transform: expanded ? "rotate(180deg)" : "none", transition: "transform var(--dur-base) var(--ease-out)" }
+            }
+          ) : null
+        ]
+      }
+    );
+  }
+  function ToolCallCard({
+    verb,
+    target,
+    status = "success",
+    params,
+    errorMessage,
+    onRetry,
+    steps,
+    groupLabel,
+    defaultExpanded = false,
+    retryLabel = "\u91CD\u8BD5",
+    style
+  }) {
+    const [expanded, setExpanded] = import_react30.default.useState(defaultExpanded);
+    const isGroup = Array.isArray(steps) && steps.length > 0;
+    const expandable = isGroup || params != null;
+    return /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
+      "div",
+      {
+        style: {
+          background: "var(--bg-well)",
+          border: "1px solid var(--border-default)",
+          borderLeft: "2px solid var(--accent)",
+          borderRadius: "var(--radius-md)",
+          overflow: "hidden",
+          ...style
+        },
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+            HeaderRow,
+            {
+              status,
+              verb,
+              target: isGroup ? groupLabel || `${steps.length} steps` : target,
+              expandable,
+              expanded,
+              onToggle: () => setExpanded(!expanded)
+            }
+          ),
+          expanded && isGroup ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("div", { style: { borderTop: "1px solid var(--border-subtle)", padding: "var(--space-1) 0" }, children: steps.map((s, i) => /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
+            "div",
+            {
+              style: { display: "flex", alignItems: "center", gap: "var(--space-15)", minHeight: 22, padding: "0 var(--space-2) 0 var(--space-5)" },
+              children: [
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(StatusGlyph, { status: s.status || "success" }),
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-secondary)", whiteSpace: "nowrap" }, children: s.verb }),
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+                  "span",
+                  {
+                    style: {
+                      flex: 1,
+                      minWidth: 0,
+                      font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`,
+                      color: "var(--text-tertiary)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis"
+                    },
+                    children: s.target
+                  }
+                )
+              ]
+            },
+            i
+          )) }) : null,
+          expanded && !isGroup && params != null ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(ParamsBlock, { params }) : null,
+          status === "error" && errorMessage ? /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
+            "div",
+            {
+              style: {
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-2)",
+                padding: "var(--space-15) var(--space-2)",
+                borderTop: "1px solid var(--border-subtle)",
+                background: "var(--error-bg)"
+              },
+              children: [
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--error)" }, children: errorMessage }),
+                onRetry ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Button, { size: "sm", variant: "secondary", icon: "rotate-cw", onClick: onRetry, children: retryLabel }) : null
+              ]
+            }
+          ) : null
+        ]
+      }
+    );
+  }
+
+  // src/components/chat/ApprovalCard.jsx
+  var import_react31 = __toESM(require_react(), 1);
+  var import_jsx_runtime29 = __toESM(require_jsx_runtime(), 1);
+  var L = {
+    zh: {
+      needs: "\u9700\u8981\u6279\u51C6",
+      high: "\u9AD8\u98CE\u9669",
+      params: "\u67E5\u770B\u53C2\u6570",
+      allow: "\u5141\u8BB8",
+      deny: "\u62D2\u7EDD",
+      session: "\u672C\u4F1A\u8BDD\u6B64\u7C7B\u64CD\u4F5C\u514D\u6279",
+      allowed: "\u5DF2\u5141\u8BB8",
+      denied: "\u5DF2\u62D2\u7EDD"
+    },
+    en: {
+      needs: "Approval required",
+      high: "High risk",
+      params: "View parameters",
+      allow: "Allow",
+      deny: "Deny",
+      session: "Don't ask again this session",
+      allowed: "Allowed",
+      denied: "Denied"
+    }
+  };
+  function ApprovalCard({
+    risk = "normal",
+    title,
+    description,
+    params,
+    lang = "zh",
+    state = "pending",
+    onAllow,
+    onDeny,
+    onAllowSession,
+    style
+  }) {
+    const [expanded, setExpanded] = import_react31.default.useState(false);
+    const t = L[lang] || L.zh;
+    const high = risk === "high";
+    return /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+      "div",
+      {
+        style: {
+          background: "var(--bg-raised)",
+          border: `1px solid ${high ? "var(--error-border)" : "var(--border-strong)"}`,
+          borderLeft: `2px solid ${high ? "var(--error)" : "var(--accent)"}`,
+          borderRadius: "var(--radius-md)",
+          overflow: "hidden",
+          ...style
+        },
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)("div", { style: { padding: "var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)" }, children: high ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Badge, { status: "error", icon: "shield-alert", children: t.high }) : /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Badge, { status: "warn", icon: "shield", children: t.needs }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { style: { font: `var(--weight-semibold) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+            description ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: description }) : null,
+            params != null ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(ApprovalParams, { t, expanded, onToggle: () => setExpanded(!expanded), params }) : null
+          ] }),
+          state === "pending" ? /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Button, { variant: high ? "danger" : "primary", full: true, onClick: onAllow, children: t.allow }),
+              /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Button, { variant: "secondary", full: true, onClick: onDeny, children: t.deny })
+            ] }),
+            onAllowSession && !high ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Button, { variant: "ghost", size: "sm", onClick: onAllowSession, style: { alignSelf: "flex-start", color: "var(--text-tertiary)" }, children: t.session }) : null
+          ] }) : /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+            "div",
+            {
+              style: {
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-15)",
+                padding: "var(--space-15) var(--space-2)",
+                borderTop: "1px solid var(--border-subtle)",
+                font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`,
+                color: state === "allowed" ? "var(--ok)" : "var(--text-tertiary)"
+              },
+              children: [
+                /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Icon2, { name: state === "allowed" ? "check" : "x", size: 12, strokeWidth: 2.5 }),
+                state === "allowed" ? t.allowed : t.denied
+              ]
+            }
+          )
+        ]
+      }
+    );
+  }
+  function ApprovalParams({ t, expanded, onToggle, params }) {
+    const [hover, setHover] = import_react31.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)("div", { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+        "button",
+        {
+          type: "button",
+          className: "ds-focusable",
+          onClick: onToggle,
+          onMouseEnter: () => setHover(true),
+          onMouseLeave: () => setHover(false),
+          style: {
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            minHeight: 20,
+            padding: 0,
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`,
+            color: hover ? "var(--text-secondary)" : "var(--text-tertiary)"
+          },
+          children: [
+            /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Icon2, { name: "chevron-right", size: 11, style: { transform: expanded ? "rotate(90deg)" : "none", transition: "transform var(--dur-base) var(--ease-out)" } }),
+            t.params
+          ]
+        }
+      ),
+      expanded ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(
+        "pre",
+        {
+          style: {
+            margin: "4px 0 0",
+            padding: "var(--space-2)",
+            background: "var(--gray-0)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius-sm)",
+            font: `var(--weight-regular) var(--text-micro)/1.6 var(--font-mono)`,
+            color: "var(--text-secondary)",
+            maxHeight: 120,
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all"
+          },
+          children: typeof params === "string" ? params : JSON.stringify(params, null, 2)
+        }
+      ) : null
+    ] });
+  }
+
+  // src/components/chat/PromptCard.jsx
+  var import_react32 = __toESM(require_react(), 1);
+  var import_jsx_runtime30 = __toESM(require_jsx_runtime(), 1);
+  function PromptCard({ icon = "wand-2", title, caption, onClick, style }) {
+    const [hover, setHover] = import_react32.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
+      "button",
+      {
+        type: "button",
+        className: "ds-focusable",
+        onClick,
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        style: {
+          display: "flex",
+          alignItems: "flex-start",
+          gap: "var(--space-2)",
+          width: "100%",
+          textAlign: "left",
+          padding: "var(--space-2)",
+          background: hover ? "var(--bg-hover)" : "var(--bg-raised)",
+          border: `1px solid ${hover ? "var(--border-strong)" : "var(--border-default)"}`,
+          borderRadius: "var(--radius-md)",
+          cursor: "pointer",
+          transition: "background var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out)",
+          ...style
+        },
+        children: [
+          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Icon2, { name: icon, size: 14, color: "var(--text-tertiary)", style: { marginTop: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { display: "block", font: `var(--weight-medium) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+            caption ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { display: "block", marginTop: 2, font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)" }, children: caption }) : null
+          ] })
+        ]
+      }
+    );
+  }
+
+  // src/components/chat/Composer.jsx
+  var import_react33 = __toESM(require_react(), 1);
+  var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
+  function Composer({
+    value = "",
+    onChange,
+    onSend,
+    onStop,
+    streaming = false,
+    disabled = false,
+    notice,
+    options,
+    placeholder,
+    style
+  }) {
+    const [focus, setFocus] = import_react33.default.useState(false);
+    const canSend = !disabled && !streaming && value.trim().length > 0;
+    const handleKey = (e) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (canSend && onSend) onSend();
+      }
+    };
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-15)", ...style }, children: [
+      notice,
+      /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+        "div",
+        {
+          style: {
+            display: "flex",
+            flexDirection: options ? "column" : "row",
+            alignItems: options ? "stretch" : "flex-end",
+            gap: options ? 2 : "var(--space-15)",
+            padding: "var(--space-15)",
+            background: "var(--bg-well)",
+            border: `1px solid ${focus && !disabled ? "var(--border-strong)" : "var(--border-default)"}`,
+            boxShadow: focus && !disabled ? "0 0 0 1px var(--focus-ring)" : "none",
+            borderRadius: "var(--radius-lg)",
+            opacity: disabled ? 0.5 : 1,
+            transition: "border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)"
+          },
+          children: [
+            /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+              "textarea",
+              {
+                rows: 1,
+                value,
+                placeholder,
+                disabled,
+                onChange: (e) => onChange && onChange(e.target.value),
+                onFocus: () => setFocus(true),
+                onBlur: () => setFocus(false),
+                onKeyDown: handleKey,
+                style: {
+                  flex: 1,
+                  minWidth: 0,
+                  maxHeight: 72,
+                  resize: "none",
+                  background: "transparent",
+                  border: "none",
+                  outline: "none",
+                  padding: "4px 2px 4px 4px",
+                  color: "var(--text-primary)",
+                  font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`
+                }
+              }
+            ),
+            options ? /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 2, minWidth: 0 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 2, overflow: "hidden" }, children: options }),
+              streaming ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
+            ] }) : streaming ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
+          ]
+        }
+      )
+    ] });
+  }
+  function SendButton({ icon, title, kind, disabled = false, onClick }) {
+    const [hover, setHover] = import_react33.default.useState(false);
+    const active = kind === "send" && !disabled;
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+      "button",
+      {
+        type: "button",
+        className: "ds-focusable",
+        title,
+        "aria-label": title,
+        disabled,
+        onClick,
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        style: {
+          width: 24,
+          height: 24,
+          flex: "none",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 0,
+          background: active ? hover ? "var(--accent-hover)" : "var(--accent)" : kind === "stop" ? hover ? "#ffffff" : "var(--gray-11)" : "var(--gray-6)",
+          color: active || kind === "stop" ? "var(--text-on-solid)" : "var(--gray-8)",
+          border: "none",
+          borderRadius: "var(--radius-md)",
+          cursor: disabled ? "default" : "pointer",
+          transition: "background var(--dur-fast) var(--ease-out)"
+        },
+        children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: icon, size: 13, strokeWidth: 2.25 })
+      }
+    );
+  }
+
+  // src/screens/ChatScreen.jsx
+  var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
+  var C = {
+    zh: {
+      hello: "\u4F60\u597D\uFF01\u6211\u53EF\u4EE5\u76F4\u63A5\u64CD\u4F5C\u5F53\u524D\u6253\u5F00\u7684 AE \u5DE5\u7A0B\u3002\u8BD5\u8BD5\u8FD9\u4E9B\uFF1A",
+      keyTitle: "\u5728\u8BBE\u7F6E\u91CC\u7C98\u8D34 Anthropic API Key",
+      keyCaption: "\u4FDD\u5B58\u5E76\u9A8C\u8BC1\u540E\uFF0C\u5C31\u53EF\u4EE5\u5728\u8FD9\u91CC\u8BA9 AI \u64CD\u4F5C\u4F60\u7684\u5DE5\u7A0B\u3002",
+      newSession: "\u65B0\u4F1A\u8BDD",
+      placeholder: "\u63CF\u8FF0\u4F60\u60F3\u5728 AE \u91CC\u505A\u4EC0\u4E48\u2026",
+      noticeAction: "\u65B0\u4F1A\u8BDD",
+      errorTitle: "\u5BF9\u8BDD\u51FA\u9519",
+      denied: "\u5DF2\u62D2\u7EDD",
+      running: "\u6267\u884C\u4E2D",
+      ok: "\u5B8C\u6210",
+      failed: "\u5931\u8D25",
+      awaiting: "\u7B49\u5F85\u6279\u51C6"
+    },
+    en: {
+      hello: "Hi! I can operate the open AE project directly. Try one of these:",
+      keyTitle: "Paste an Anthropic API Key in Settings",
+      keyCaption: "After saving and validating it, AI can operate your project here.",
+      newSession: "New session",
+      placeholder: "Describe what to do in AE\u2026",
+      noticeAction: "New session",
+      errorTitle: "Chat error",
+      denied: "Denied",
+      running: "Running",
+      ok: "Done",
+      failed: "Failed",
+      awaiting: "Awaiting approval"
+    }
+  };
+  var DEFAULT_PROMPTS = {
+    zh: [
+      { icon: "type", title: "\u521B\u5EFA\u4E00\u4E2A\u6807\u9898\u52A8\u753B", caption: "\u65B0\u5EFA\u6587\u672C\u56FE\u5C42\u5E76\u52A0\u5165\u4F4D\u7F6E\u5173\u952E\u5E27" },
+      { icon: "layers", title: "\u6574\u7406\u5DE5\u7A0B\u7D20\u6750", caption: "\u6309\u7C7B\u578B\u628A\u7D20\u6750\u5F52\u8FDB\u6587\u4EF6\u5939" },
+      { icon: "clapperboard", title: "\u7ED9\u753B\u9762\u52A0\u7535\u5F71\u611F\u8C03\u8272", caption: "\u6DFB\u52A0\u8C03\u6574\u56FE\u5C42\u4E0E Lumetri \u9884\u8BBE" }
+    ],
+    en: [
+      { icon: "type", title: "Create a title animation", caption: "New text layer with position keyframes" },
+      { icon: "layers", title: "Organize project assets", caption: "Sort footage into folders by type" },
+      { icon: "clapperboard", title: "Cinematic color grade", caption: "Adjustment layer + Lumetri preset" }
+    ]
+  };
+  function Notice({ text, actionLabel, onAction }) {
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, padding: "5px 8px", background: "var(--bg-well)", border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: "plug", size: 12, color: "var(--text-tertiary)" }),
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { flex: 1, minWidth: 0, font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: text }),
+      onAction ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, children: actionLabel }) : null
+    ] });
+  }
+  function statusForTool(state) {
+    if (state === "running" || state === "awaiting-approval") return "running";
+    if (state === "error" || state === "denied") return "error";
+    return "success";
+  }
+  function toolTarget(entry, t) {
+    if (entry.state === "awaiting-approval") return t.awaiting;
+    if (entry.state === "running") return t.running;
+    if (entry.state === "denied") return t.denied;
+    if (entry.state === "error") return t.failed;
+    return t.ok;
+  }
+  function titleForTool(entry, lang) {
+    return eventTitle({ undoGroup: `MCP ${entry.name || ""}` }, lang);
+  }
+  function Entry({ entry, lang, onApprove }) {
+    const t = C[lang] || C.zh;
+    if (entry.type === "user-text") {
+      return /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(ChatBubble, { role: "user", children: entry.text });
+    }
+    if (entry.type === "ai-text") {
+      return /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(ChatBubble, { role: "ai", children: entry.text });
+    }
+    if (entry.type === "tool-call") {
+      const highRisk = entry.risk === "destructive";
+      return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", gap: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          ToolCallCard,
+          {
+            verb: titleForTool(entry, lang),
+            target: toolTarget(entry, t),
+            status: statusForTool(entry.state),
+            params: entry.input,
+            errorMessage: entry.state === "error" ? entry.text : null
+          }
+        ),
+        entry.state === "awaiting-approval" ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          ApprovalCard,
+          {
+            risk: highRisk ? "high" : "normal",
+            lang,
+            title: titleForTool(entry, lang),
+            description: entry.name,
+            params: entry.input,
+            onAllow: () => onApprove && onApprove(entry.toolUseId, "allow"),
+            onDeny: () => onApprove && onApprove(entry.toolUseId, "deny"),
+            onAllowSession: highRisk ? null : () => onApprove && onApprove(entry.toolUseId, "allow-session")
+          }
+        ) : null
+      ] });
+    }
+    if (entry.type === "error") {
+      return /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(ToolCallCard, { verb: t.errorTitle, target: entry.kind, status: "error", errorMessage: entry.message }) });
+    }
+    return null;
+  }
+  function ChatScreen({
+    lang = "zh",
+    entries = [],
+    streaming = false,
+    composerDisabled = false,
+    disabledHint = "",
+    onSend,
+    onStop,
+    onApprove,
+    onNewSession,
+    promptCards,
+    noticeActionLabel,
+    onNoticeAction
+  }) {
+    const t = C[lang] || C.zh;
+    const [draft, setDraft] = import_react34.default.useState("");
+    const logRef = import_react34.default.useRef(null);
+    const hasEntries = entries.length > 0;
+    const prompts = promptCards || DEFAULT_PROMPTS[lang] || DEFAULT_PROMPTS.zh;
+    import_react34.default.useEffect(() => {
+      const el = logRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    }, [entries, streaming]);
+    const send = () => {
+      const text = draft.trim();
+      if (!text || composerDisabled || streaming) return;
+      if (onSend) onSend(text);
+      setDraft("");
+    };
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
+        !hasEntries && composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(import_react34.default.Fragment, { children: /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(AIAvatar, { size: 32 }),
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: "600 12px/1.35 var(--font-ui)", color: "var(--text-primary)", maxWidth: 240 }, children: disabledHint || t.keyTitle }),
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: "400 11px/1.45 var(--font-ui)", color: "var(--text-tertiary)", maxWidth: 250 }, children: t.keyCaption })
+        ] }) }) : null,
+        !hasEntries && !composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(import_react34.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(AIAvatar, { size: 32 }),
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.hello })
+          ] }),
+          prompts.map((card) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+            PromptCard,
+            {
+              icon: card.icon,
+              title: card.title,
+              caption: card.caption,
+              onClick: () => {
+                if (card.onClick) card.onClick(card);
+                else if (onSend) onSend(card.prompt || card.title);
+              }
+            },
+            card.id || card.title
+          ))
+        ] }) : null,
+        entries.map((entry) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Entry, { entry, lang, onApprove }, entry.id))
+      ] }),
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+        Composer,
+        {
+          value: draft,
+          onChange: setDraft,
+          onSend: send,
+          onStop,
+          streaming,
+          disabled: composerDisabled,
+          placeholder: t.placeholder,
+          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || onNewSession }) : null
+        }
+      ) })
+    ] });
+  }
+
+  // src/lib/sse.js
+  function createSseParser(onEvent) {
+    let buffer = "";
+    function parseFrame(frame) {
+      let event = "";
+      let data = "";
+      const lines = frame.replace(/\r\n/g, "\n").split("\n");
+      for (const line of lines) {
+        if (line.startsWith("event:")) {
+          event = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
+          data += line.slice(5).trimStart();
+        }
+      }
+      const trimmed = data.trim();
+      if (!trimmed || trimmed === "[DONE]") return;
+      try {
+        onEvent({ event, data: JSON.parse(trimmed) });
+      } catch (e) {
+      }
+    }
+    function feed(chunkText) {
+      buffer += String(chunkText || "");
+      buffer = buffer.replace(/\r\n/g, "\n");
+      let splitAt = buffer.indexOf("\n\n");
+      while (splitAt !== -1) {
+        const frame = buffer.slice(0, splitAt);
+        buffer = buffer.slice(splitAt + 2);
+        parseFrame(frame);
+        splitAt = buffer.indexOf("\n\n");
+      }
+    }
+    return { feed };
+  }
+
+  // src/lib/anthropic.js
+  var DEFAULT_MODEL = "claude-sonnet-4-6";
+  var FALLBACK_MODEL = "claude-haiku-4-5-20251001";
+  function buildSystemPrompt(lang = "zh") {
+    if (lang === "en") {
+      return [
+        "You are a concise After Effects assistant inside the AE MCP panel.",
+        "Understand the user goal, then choose appropriate MCP tools before operating.",
+        "Name target comps, layers, properties, or files in quotes before changing them.",
+        "Prefer read-only inspection before edits when context is missing.",
+        "Summarize tool results plainly and ask only when a required detail is missing."
+      ].join(" ");
+    }
+    return [
+      "\u4F60\u662F AE MCP \u9762\u677F\u5185\u7684\u7B80\u6D01 After Effects \u52A9\u624B\u3002",
+      "\u5148\u7406\u89E3\u7528\u6237\u76EE\u6807\uFF0C\u518D\u9009\u62E9\u5408\u9002\u7684 MCP \u5DE5\u5177\u64CD\u4F5C AE\u3002",
+      "\u4FEE\u6539\u524D\u7528\u5F15\u53F7\u660E\u793A\u76EE\u6807\u5408\u6210\u3001\u56FE\u5C42\u3001\u5C5E\u6027\u6216\u6587\u4EF6\u3002",
+      "\u7F3A\u5C11\u4E0A\u4E0B\u6587\u65F6\u4F18\u5148\u7528\u53EA\u8BFB\u5DE5\u5177\u68C0\u67E5\u3002",
+      "\u7528\u7B80\u660E\u8BED\u8A00\u603B\u7ED3\u5DE5\u5177\u7ED3\u679C\uFF0C\u53EA\u5728\u7F3A\u5C11\u5FC5\u8981\u4FE1\u606F\u65F6\u8FFD\u95EE\u3002"
+    ].join(" ");
+  }
+  function mapMcpToolsToAnthropic(tools = []) {
+    return tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description || "",
+      input_schema: tool.inputSchema || tool.input_schema || {}
+    }));
+  }
+  function classifyHttpError(status, fallbackMessage) {
+    if (status === 401 || status === 403) return { kind: "auth", message: "Anthropic authentication failed." };
+    if (status === 429) return { kind: "rate_limit", message: "Anthropic rate limit reached." };
+    if (status === 529 || status >= 500) return { kind: "overloaded", message: "Anthropic service is overloaded." };
+    return { kind: "network", message: fallbackMessage || "Anthropic request failed." };
+  }
+  function toError(kind, message) {
+    const error = new Error(message);
+    error.kind = kind;
+    return error;
+  }
+  function parseAnthropicEvent(data, state, onTextDelta) {
+    if (data.type === "content_block_start") {
+      const block = data.content_block || {};
+      if (block.type === "text") {
+        state.blocks.set(data.index, { type: "text", text: block.text || "" });
+      } else if (block.type === "tool_use") {
+        state.blocks.set(data.index, {
+          type: "tool_use",
+          id: block.id,
+          name: block.name,
+          inputJson: "",
+          startInput: block.input || {}
+        });
+      }
+    } else if (data.type === "content_block_delta") {
+      const block = state.blocks.get(data.index);
+      if (!block || !data.delta) return;
+      if (data.delta.type === "text_delta") {
+        const text = data.delta.text || "";
+        block.text += text;
+        if (text) onTextDelta(text);
+      } else if (data.delta.type === "input_json_delta") {
+        block.inputJson += data.delta.partial_json || "";
+      }
+    } else if (data.type === "message_delta" && data.delta) {
+      state.stopReason = data.delta.stop_reason || state.stopReason;
+    }
+  }
+  function finishBlocks(blocks) {
+    return Array.from(blocks.values()).map((block) => {
+      if (block.type === "tool_use") {
+        let input = block.startInput || {};
+        if (block.inputJson) input = JSON.parse(block.inputJson);
+        return { type: "tool_use", id: block.id, name: block.name, input };
+      }
+      return block;
+    });
+  }
+  async function sendAnthropicMessage({
+    apiKey,
+    model = DEFAULT_MODEL,
+    system = buildSystemPrompt("zh"),
+    messages,
+    tools,
+    signal,
+    fetchImpl = globalThis.fetch,
+    onTextDelta = () => {
+    }
+  } = {}) {
+    if (!apiKey) throw toError("auth", "Anthropic API key is missing.");
+    if (!fetchImpl) throw toError("network", "fetch is unavailable in this runtime.");
+    let response;
+    try {
+      response = await fetchImpl("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        signal,
+        headers: {
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "anthropic-dangerous-direct-browser-access": "true",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 8192,
+          system,
+          messages,
+          tools: mapMcpToolsToAnthropic(tools),
+          stream: true
+        })
+      });
+    } catch (e) {
+      if (e && e.name === "AbortError") throw e;
+      throw toError("network", e && e.message ? e.message : "Anthropic network request failed.");
+    }
+    if (!response.ok) {
+      let detail = "";
+      try {
+        detail = await response.text();
+      } catch (e) {
+      }
+      const classified = classifyHttpError(response.status, detail);
+      throw toError(classified.kind, classified.message);
+    }
+    const reader = response.body && response.body.getReader ? response.body.getReader() : null;
+    if (!reader) throw toError("network", "Anthropic response body is not streamable.");
+    const decoder = new TextDecoder();
+    const state = { blocks: /* @__PURE__ */ new Map(), stopReason: "end_turn" };
+    const parser = createSseParser(({ data }) => parseAnthropicEvent(data, state, onTextDelta));
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      parser.feed(decoder.decode(chunk.value, { stream: true }));
+    }
+    parser.feed(decoder.decode());
+    return {
+      assistantMessage: { role: "assistant", content: finishBlocks(state.blocks) },
+      stopReason: state.stopReason
+    };
+  }
+
+  // src/lib/agentLoop.js
+  var MAX_TOOL_ROUNDS = 25;
+  function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+  }
+  function toolText(result) {
+    const content = result && Array.isArray(result.content) ? result.content : [];
+    const text = content.filter((item) => item && item.type === "text").map((item) => item.text || "").join("\n");
+    if (text) return text;
+    if (result === void 0) return "";
+    try {
+      return JSON.stringify(result);
+    } catch (e) {
+      return String(result);
+    }
+  }
+  function normalizeErrorKind(error) {
+    if (error && error.name === "AbortError") return "aborted";
+    return error && error.kind || "network";
+  }
+  function shouldBypassApproval({ mode, tool, sessionAllowed }) {
+    if (sessionAllowed) return true;
+    if (mode === "none") return true;
+    const annotations = tool && tool.annotations || {};
+    if (mode === "manual") return annotations.readOnlyHint === true;
+    if (mode === "auto") return annotations.destructiveHint !== true;
+    return false;
+  }
+  function approvalRisk(tool) {
+    const annotations = tool && tool.annotations || {};
+    return annotations.destructiveHint === true ? "destructive" : "write";
+  }
+  function getToolUses(message) {
+    return (message && message.content || []).filter((block) => block && block.type === "tool_use");
+  }
+  function makeToolResult(toolUseId, text, isError) {
+    return { type: "tool_result", tool_use_id: toolUseId, content: text, is_error: Boolean(isError) };
+  }
+  function createAgentLoop({
+    getApiKey,
+    getModel,
+    mcp,
+    getPermissionMode,
+    onEvent,
+    anthropic = sendAnthropicMessage,
+    maxToolRounds = MAX_TOOL_ROUNDS,
+    lang = "zh"
+  }) {
+    let messages = [];
+    let activeController = null;
+    let activeRun = null;
+    const pendingApprovals = /* @__PURE__ */ new Map();
+    const sessionAllowedTools = /* @__PURE__ */ new Set();
+    function emit(evt) {
+      if (onEvent) onEvent(evt);
+    }
+    function resetPendingApprovals() {
+      for (const [id, pending] of pendingApprovals) {
+        pending.resolve({ decision: "abort" });
+        pendingApprovals.delete(id);
+      }
+    }
+    async function waitForApproval(toolUse) {
+      return await new Promise((resolve) => {
+        pendingApprovals.set(toolUse.id, { name: toolUse.name, resolve });
+      });
+    }
+    async function executeTool(toolUse) {
+      const start = Date.now();
+      try {
+        const result = await mcp.callTool(toolUse.name, toolUse.input || {});
+        const text = toolText(result);
+        const isError = Boolean(result && result.isError);
+        emit({ type: "tool-result", toolUseId: toolUse.id, ok: !isError, text, durationMs: Date.now() - start });
+        return makeToolResult(toolUse.id, text, isError);
+      } catch (e) {
+        const text = e && e.message ? e.message : "MCP tool call failed.";
+        emit({ type: "tool-result", toolUseId: toolUse.id, ok: false, text, durationMs: Date.now() - start });
+        return makeToolResult(toolUse.id, text, true);
+      }
+    }
+    async function handleToolUse(toolUse, toolByName) {
+      emit({ type: "tool-start", toolUseId: toolUse.id, name: toolUse.name, input: clone(toolUse.input || {}) });
+      const tool = toolByName.get(toolUse.name) || {};
+      const mode = getPermissionMode && getPermissionMode() || "manual";
+      const sessionAllowed = sessionAllowedTools.has(toolUse.name);
+      if (!shouldBypassApproval({ mode, tool, sessionAllowed })) {
+        emit({
+          type: "approval-required",
+          toolUseId: toolUse.id,
+          name: toolUse.name,
+          input: clone(toolUse.input || {}),
+          risk: approvalRisk(tool)
+        });
+        const approved = await waitForApproval(toolUse);
+        pendingApprovals.delete(toolUse.id);
+        if (approved.decision === "abort") throw Object.assign(new Error("aborted"), { name: "AbortError" });
+        if (approved.decision === "deny") {
+          emit({ type: "tool-denied", toolUseId: toolUse.id });
+          return makeToolResult(toolUse.id, "User denied this action.", true);
+        }
+        if (approved.decision === "allow-session") sessionAllowedTools.add(toolUse.name);
+      }
+      return await executeTool(toolUse);
+    }
+    async function sendUser(text) {
+      if (activeRun) return activeRun;
+      const userMessage = { role: "user", content: String(text || "") };
+      messages.push(userMessage);
+      emit({ type: "turn-start" });
+      const controller = new AbortController();
+      activeController = controller;
+      activeRun = (async () => {
+        try {
+          const tools = await mcp.listTools();
+          const toolByName = new Map((tools || []).map((tool) => [tool.name, tool]));
+          let toolRounds = 0;
+          while (true) {
+            if (toolRounds >= maxToolRounds) {
+              emit({ type: "error", kind: "mcp", message: "Stopped after 25 consecutive tool rounds." });
+              return;
+            }
+            const result = await anthropic({
+              apiKey: getApiKey && getApiKey(),
+              model: getModel && getModel() || DEFAULT_MODEL,
+              system: buildSystemPrompt(lang),
+              messages: clone(messages),
+              tools,
+              signal: controller.signal,
+              onTextDelta: (delta) => emit({ type: "text-delta", text: delta })
+            });
+            const assistantMessage = result.assistantMessage || { role: "assistant", content: [] };
+            messages.push(assistantMessage);
+            const toolUses = getToolUses(assistantMessage);
+            if (result.stopReason !== "tool_use" || toolUses.length === 0) {
+              emit({ type: "turn-end", stopReason: result.stopReason || "end_turn" });
+              return;
+            }
+            toolRounds += 1;
+            const toolResults = [];
+            for (const toolUse of toolUses) {
+              toolResults.push(await handleToolUse(toolUse, toolByName));
+            }
+            messages.push({ role: "user", content: toolResults });
+          }
+        } catch (e) {
+          const kind = normalizeErrorKind(e);
+          repairDanglingToolUses();
+          emit({ type: "error", kind, message: e && e.message ? e.message : "Agent loop failed." });
+        } finally {
+          activeController = null;
+          activeRun = null;
+        }
+      })();
+      return await activeRun;
+    }
+    function repairDanglingToolUses() {
+      const last = messages[messages.length - 1];
+      if (!last || last.role !== "assistant") return;
+      const uses = getToolUses(last);
+      if (!uses.length) return;
+      messages.push({
+        role: "user",
+        content: uses.map((use) => makeToolResult(use.id, "Cancelled by user.", true))
+      });
+    }
+    function approve(toolUseId, decision) {
+      const pending = pendingApprovals.get(toolUseId);
+      if (!pending) return;
+      pending.resolve({ decision });
+    }
+    function stop() {
+      if (activeController) activeController.abort();
+      resetPendingApprovals();
+    }
+    function reset() {
+      stop();
+      messages = [];
+      sessionAllowedTools.clear();
+    }
+    return {
+      sendUser,
+      approve,
+      stop,
+      reset,
+      getMessages: () => clone(messages)
+    };
+  }
+
+  // src/cep/mcpClient.js
+  var DEFAULT_TIMEOUT_MS = 3e4;
+  var MCP_PROTOCOL_VERSION = "2025-06-18";
+  var PANEL_VERSION = "0.3.2";
+  function getCepRequire() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+      return globalThis.window.cep_node.require;
+    }
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    throw new Error("CEP Node require is unavailable");
+  }
+  function getCepEnv() {
+    return globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env || {};
+  }
+  function normalizeFsPath(value) {
+    let text = String(value || "").replace(/\//g, "\\");
+    text = text.replace(/\\+$/, "");
+    return text;
+  }
+  function dirname(value) {
+    const normalized = normalizeFsPath(value);
+    const index = normalized.lastIndexOf("\\");
+    if (index <= 0) return "";
+    return normalized.slice(0, index);
+  }
+  function joinPath(base, leaf) {
+    return normalizeFsPath(base) + "\\" + leaf;
+  }
+  function firstWhereHit(stdout) {
+    return String(stdout || "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) || "";
+  }
+  function defaultWhereImpl() {
+    const childProcess = getCepRequire()("child_process");
+    return new Promise((resolve) => {
+      childProcess.execFile("where", ["ae-mcp"], { windowsHide: true }, (err, stdout) => {
+        resolve(err ? "" : stdout);
+      });
+    });
+  }
+  function defaultFs() {
+    return getCepRequire()("fs");
+  }
+  function findProjectRoot({ extRoot, repoRoot, fsImpl }) {
+    if (repoRoot && fsImpl.existsSync(joinPath(repoRoot, "pyproject.toml"))) return normalizeFsPath(repoRoot);
+    let current = normalizeFsPath(extRoot);
+    while (current) {
+      if (fsImpl.existsSync(joinPath(current, "pyproject.toml"))) return current;
+      const parent = dirname(current);
+      if (!parent || parent === current) break;
+      current = parent;
+    }
+    return "";
+  }
+  async function resolveMcpCommand({
+    explicitPath,
+    whereImpl = defaultWhereImpl,
+    fsImpl,
+    extRoot = "",
+    repoRoot = ""
+  } = {}) {
+    const configured = String(explicitPath || "").trim();
+    if (configured) return { command: configured, args: [], source: "explicit" };
+    const found = firstWhereHit(await whereImpl("ae-mcp"));
+    if (found) return { command: found, args: [], source: "where" };
+    const fs = fsImpl || defaultFs();
+    const projectRoot = findProjectRoot({ extRoot, repoRoot, fsImpl: fs });
+    if (projectRoot) {
+      return { command: "uv", args: ["run", "--project", projectRoot, "ae-mcp"], source: "uv" };
+    }
+    throw new Error("Unable to find ae-mcp. Configure the ae-mcp executable path, add ae-mcp to PATH, or run from a checkout containing pyproject.toml for uv run --project.");
+  }
+  function _createRpc(stdinWrite, onLine, options = {}) {
+    const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+    let nextId2 = 1;
+    let buffer = "";
+    const pending = /* @__PURE__ */ new Map();
+    function rejectPending(id, error) {
+      const entry = pending.get(id);
+      if (!entry) return;
+      pending.delete(id);
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    function handleMessage(message) {
+      if (!message || message.id === void 0 || message.id === null) return;
+      const entry = pending.get(message.id);
+      if (!entry) return;
+      pending.delete(message.id);
+      clearTimeout(entry.timer);
+      if (message.error) {
+        const error = new Error(message.error.message || "JSON-RPC request failed");
+        error.code = message.error.code;
+        error.data = message.error.data;
+        entry.reject(error);
+      } else {
+        entry.resolve(message.result);
+      }
+    }
+    function handleChunk(chunk) {
+      buffer += String(chunk || "");
+      let index = buffer.indexOf("\n");
+      while (index !== -1) {
+        const line = buffer.slice(0, index).trim();
+        buffer = buffer.slice(index + 1);
+        if (line) {
+          try {
+            handleMessage(JSON.parse(line));
+          } catch (e) {
+          }
+        }
+        index = buffer.indexOf("\n");
+      }
+    }
+    if (onLine) onLine(handleChunk);
+    function writeMessage(message) {
+      stdinWrite(JSON.stringify(message) + "\n");
+    }
+    function request(method, params) {
+      const id = nextId2++;
+      const message = { jsonrpc: "2.0", id, method };
+      if (params !== void 0) message.params = params;
+      const promise = new Promise((resolve, reject) => {
+        const timer = setTimeout(() => rejectPending(id, new Error(method + " timed out after " + timeoutMs + "ms")), timeoutMs);
+        pending.set(id, { resolve, reject, timer });
+      });
+      writeMessage(message);
+      return promise;
+    }
+    function notify(method, params) {
+      const message = { jsonrpc: "2.0", method };
+      if (params !== void 0) message.params = params;
+      writeMessage(message);
+    }
+    function close(reason = new Error("MCP process closed")) {
+      for (const id of Array.from(pending.keys())) rejectPending(id, reason);
+    }
+    return { request, notify, handleChunk, close };
+  }
+  function createMcpClient({
+    spawnImpl,
+    resolveCommand = resolveMcpCommand,
+    env,
+    onCrash,
+    extRoot,
+    repoRoot,
+    packageVersion = PANEL_VERSION,
+    retryDelays = [1e3, 2e3, 4e3]
+  } = {}) {
+    let proc = null;
+    let rpc = null;
+    let tools = null;
+    let status = "idle";
+    let startPromise = null;
+    let retryCount = 0;
+    let lastError = null;
+    let stopped = false;
+    let restartTimer = null;
+    function currentState() {
+      return { status, retryCount, error: lastError, tools };
+    }
+    function getSpawn() {
+      if (spawnImpl) return spawnImpl;
+      return getCepRequire()("child_process").spawn;
+    }
+    function attachBeforeUnload() {
+      if (globalThis.window && globalThis.window.addEventListener) {
+        globalThis.window.addEventListener("beforeunload", () => stop());
+      }
+    }
+    async function start() {
+      if (status === "ready") return currentState();
+      if (startPromise) return startPromise;
+      stopped = false;
+      status = "starting";
+      startPromise = (async () => {
+        const commandSpec = await resolveCommand({ extRoot, repoRoot });
+        const spawn = getSpawn();
+        const spawnEnv = Object.assign({}, getCepEnv(), env || {}, { AE_MCP_BACKEND: "ae-mcp" });
+        proc = spawn(commandSpec.command, commandSpec.args || [], {
+          stdio: "pipe",
+          windowsHide: true,
+          env: spawnEnv
+        });
+        rpc = _createRpc(
+          (line) => proc.stdin.write(line),
+          (handler) => proc.stdout.on("data", handler)
+        );
+        proc.on("exit", (code, signal) => handleExit(code, signal));
+        proc.on("error", (err) => handleCrash(err));
+        if (proc.stderr && proc.stderr.on) proc.stderr.on("data", () => {
+        });
+        await rpc.request("initialize", {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          clientInfo: { name: "panel-chat", version: packageVersion },
+          capabilities: {}
+        });
+        rpc.notify("notifications/initialized");
+        const listed = await rpc.request("tools/list", {});
+        tools = listed && Array.isArray(listed.tools) ? listed.tools : [];
+        status = "ready";
+        retryCount = 0;
+        lastError = null;
+        attachBeforeUnload();
+        return currentState();
+      })();
+      try {
+        return await startPromise;
+      } catch (e) {
+        status = "error";
+        lastError = e;
+        throw e;
+      } finally {
+        startPromise = null;
+      }
+    }
+    function handleCrash(error) {
+      if (stopped) return;
+      status = "crashed";
+      lastError = error;
+      if (rpc) rpc.close(error instanceof Error ? error : new Error("MCP process crashed"));
+      if (onCrash) onCrash(error);
+      scheduleRestart();
+    }
+    function handleExit(code, signal) {
+      if (stopped) return;
+      handleCrash(new Error("MCP process exited: " + code + (signal ? " " + signal : "")));
+    }
+    function scheduleRestart() {
+      if (retryCount >= retryDelays.length) {
+        status = "error";
+        return;
+      }
+      const delay = retryDelays[retryCount++];
+      clearTimeout(restartTimer);
+      restartTimer = setTimeout(() => {
+        start().catch((err) => {
+          lastError = err;
+          scheduleRestart();
+        });
+      }, delay);
+    }
+    async function listTools() {
+      await start();
+      return tools || [];
+    }
+    async function callTool(name, args = {}) {
+      await start();
+      return rpc.request("tools/call", { name, arguments: args });
+    }
+    function stop() {
+      stopped = true;
+      clearTimeout(restartTimer);
+      restartTimer = null;
+      status = "stopped";
+      if (rpc) rpc.close(new Error("MCP client stopped"));
+      if (proc) {
+        try {
+          proc.kill();
+        } catch (e) {
+        }
+      }
+      proc = null;
+      rpc = null;
+      startPromise = null;
+    }
+    return { start, listTools, callTool, stop, state: currentState };
+  }
+
+  // src/cep/apiKey.js
+  var KEY_FILE = "anthropic-key";
+  function cepRequire2() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) return globalThis.window.cep_node.require;
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    return null;
+  }
+  function defaultDeps() {
+    const req = cepRequire2();
+    if (!req) throw new Error("CEP Node require is unavailable");
+    return {
+      fs: req("fs"),
+      os: req("os"),
+      path: req("path"),
+      pid: req("process") && req("process").pid
+    };
+  }
+  function createApiKeyStore(deps = defaultDeps()) {
+    const fs = deps.fs;
+    const os = deps.os;
+    const path = deps.path;
+    function keyDir() {
+      return path.join(os.homedir(), ".ae-mcp");
+    }
+    function keyPath() {
+      return path.join(keyDir(), KEY_FILE);
+    }
+    function readKey() {
+      try {
+        return fs.readFileSync(keyPath(), "utf8").trim();
+      } catch (e) {
+        if (e && e.code === "ENOENT") return "";
+        throw e;
+      }
+    }
+    function writeKey(key) {
+      const value = String(key || "").trim();
+      const dir = keyDir();
+      const file = keyPath();
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const pid = deps.pid || 0;
+      const tmp = path.join(dir, `${KEY_FILE}.${pid}.${Date.now()}.tmp`);
+      fs.writeFileSync(tmp, value, "utf8");
+      try {
+        fs.chmodSync(tmp, 384);
+      } catch (e) {
+      }
+      fs.renameSync(tmp, file);
+      return value;
+    }
+    function clearKey() {
+      try {
+        fs.unlinkSync(keyPath());
+      } catch (e) {
+        if (!e || e.code !== "ENOENT") throw e;
+      }
+    }
+    return { keyDir, keyPath, readKey, writeKey, clearKey };
+  }
+
+  // src/lib/chatEntries.js
+  function nextId(entries, prefix) {
+    return `${prefix}-${entries.length + 1}`;
+  }
+  function updateTool(entries, toolUseId, updater) {
+    return entries.map((entry) => {
+      if (entry.type !== "tool-call" || entry.toolUseId !== toolUseId) return entry;
+      return updater(entry);
+    });
+  }
+  function reduceEvent(entries, evt) {
+    const current = Array.isArray(entries) ? entries : [];
+    if (!evt || !evt.type) return current;
+    switch (evt.type) {
+      case "turn-start":
+        return current;
+      case "text-delta": {
+        const text = String(evt.text || "");
+        if (!text) return current;
+        const last = current[current.length - 1];
+        if (last && last.type === "ai-text") {
+          return current.slice(0, -1).concat({ ...last, text: `${last.text || ""}${text}` });
+        }
+        return current.concat({ id: nextId(current, "ai"), type: "ai-text", text });
+      }
+      case "tool-start":
+        return current.concat({
+          id: evt.toolUseId || nextId(current, "tool"),
+          type: "tool-call",
+          toolUseId: evt.toolUseId,
+          name: evt.name || "",
+          input: evt.input,
+          state: "running"
+        });
+      case "approval-required":
+        if (!current.some((entry) => entry.type === "tool-call" && entry.toolUseId === evt.toolUseId)) {
+          return current.concat({
+            id: evt.toolUseId || nextId(current, "tool"),
+            type: "tool-call",
+            toolUseId: evt.toolUseId,
+            name: evt.name || "",
+            input: evt.input,
+            risk: evt.risk,
+            state: "awaiting-approval"
+          });
+        }
+        return updateTool(current, evt.toolUseId, (entry) => ({
+          ...entry,
+          name: evt.name || entry.name,
+          input: evt.input === void 0 ? entry.input : evt.input,
+          risk: evt.risk,
+          state: "awaiting-approval"
+        }));
+      case "tool-result":
+        if (!current.some((entry) => entry.type === "tool-call" && entry.toolUseId === evt.toolUseId)) {
+          return current.concat({
+            id: evt.toolUseId || nextId(current, "tool"),
+            type: "tool-call",
+            toolUseId: evt.toolUseId,
+            name: evt.name || "",
+            state: evt.ok ? "ok" : "error",
+            ok: !!evt.ok,
+            text: evt.text || "",
+            durationMs: evt.durationMs
+          });
+        }
+        return updateTool(current, evt.toolUseId, (entry) => ({
+          ...entry,
+          state: evt.ok ? "ok" : "error",
+          ok: !!evt.ok,
+          text: evt.text || "",
+          durationMs: evt.durationMs
+        }));
+      case "tool-denied":
+        return updateTool(current, evt.toolUseId, (entry) => ({
+          ...entry,
+          state: "denied"
+        }));
+      case "turn-end":
+        return current;
+      case "error":
+        return current.concat({
+          id: nextId(current, "error"),
+          type: "error",
+          kind: evt.kind,
+          message: evt.message || ""
+        });
+      default:
+        return current;
+    }
+  }
+
   // src/cep/useActivity.js
-  var import_react28 = __toESM(require_react(), 1);
+  var import_react35 = __toESM(require_react(), 1);
   function useActivity(getHost) {
-    const [events, setEvents] = import_react28.default.useState([]);
-    import_react28.default.useEffect(() => {
+    const [events, setEvents] = import_react35.default.useState([]);
+    import_react35.default.useEffect(() => {
       let unsub = null;
       let retry = null;
       let disposed = false;
@@ -9587,12 +11193,12 @@
         if (retry) clearTimeout(retry);
       };
     }, [getHost]);
-    const clear = import_react28.default.useCallback(() => setEvents([]), []);
+    const clear = import_react35.default.useCallback(() => setEvents([]), []);
     return { events, clear };
   }
 
   // src/cep/useHandshake.js
-  var import_react29 = __toESM(require_react(), 1);
+  var import_react36 = __toESM(require_react(), 1);
   function handshakeReached(info, since) {
     if (!info) return false;
     if (info.lastHealthAt && info.lastHealthAt > since) return true;
@@ -9600,8 +11206,8 @@
     return false;
   }
   function useHandshake(getHost, active) {
-    const [state, setState] = import_react29.default.useState("waiting");
-    import_react29.default.useEffect(() => {
+    const [state, setState] = import_react36.default.useState("waiting");
+    import_react36.default.useEffect(() => {
       if (!active) return void 0;
       const since = Date.now();
       setState("waiting");
@@ -9801,7 +11407,7 @@
       }
     };
   }
-  function getCepRequire() {
+  function getCepRequire2() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -9814,12 +11420,12 @@
     function start(port) {
       onStatus("starting", port);
       try {
-        const cepRequire3 = getCepRequire();
-        const path = cepRequire3("path");
+        const cepRequire4 = getCepRequire2();
+        const path = cepRequire4("path");
         const extRoot = normalizeCepPath(cs2.getSystemPath("extension"));
         const hostPath = path.join(extRoot, "host", "server.js");
         onLog("host: " + hostPath);
-        host = cepRequire3(hostPath);
+        host = cepRequire4(hostPath);
         host.setCSInterface(cs2);
         window.addEventListener("beforeunload", () => {
           try {
@@ -9842,7 +11448,7 @@
   }
 
   // src/app/App.jsx
-  var import_jsx_runtime26 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
   var T = {
     zh: {
       connected: "\u670D\u52A1\u8FD0\u884C\u4E2D",
@@ -9861,7 +11467,10 @@
       regenTitle: "\u91CD\u65B0\u751F\u6210\u8BBF\u95EE Token\uFF1F",
       regenBody: "\u6240\u6709\u5DF2\u8FDE\u63A5\u7684 AI \u5BA2\u6237\u7AEF\u4F1A\u7ACB\u5373\u5931\u53BB\u8BBF\u95EE\u6743\u9650\uFF0C\u9700\u8981\u91CD\u542F\u5B83\u4EEC\u624D\u80FD\u91CD\u65B0\u8FDE\u63A5\u3002",
       regenConfirm: "\u91CD\u65B0\u751F\u6210",
-      cancel: "\u53D6\u6D88"
+      cancel: "\u53D6\u6D88",
+      noKeyHint: "\u5148\u5728\u8BBE\u7F6E\u91CC\u914D\u7F6E Anthropic API Key",
+      pausedHint: "\u5DF2\u6682\u505C \u2014 \u6062\u590D\u540E\u624D\u80FD\u53D1\u9001",
+      goSettings: "\u53BB\u8BBE\u7F6E"
     },
     en: {
       connected: "Service running",
@@ -9880,16 +11489,51 @@
       regenTitle: "Regenerate access token?",
       regenBody: "Every connected AI client loses access immediately and must be restarted to reconnect.",
       regenConfirm: "Regenerate",
-      cancel: "Cancel"
+      cancel: "Cancel",
+      noKeyHint: "Set your Anthropic API key in Settings first",
+      pausedHint: "Paused \u2014 resume to send",
+      goSettings: "Open Settings"
     }
   };
+  function readPref(key, fallback) {
+    try {
+      const v = window.localStorage.getItem(key);
+      return v || fallback;
+    } catch (e) {
+      return fallback;
+    }
+  }
+  function writePref(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (e) {
+    }
+  }
+  async function validateAnthropicKey(key) {
+    const r = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+        "anthropic-dangerous-direct-browser-access": "true",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        model: FALLBACK_MODEL,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "ping" }]
+      })
+    });
+    const ok = r.ok;
+    return { ok, status: ok ? 200 : r.status === 403 ? 401 : r.status };
+  }
   var CLIENT_NAMES = {
     builtin: { zh: "\u9762\u677F\u5185\u7F6E\u5BF9\u8BDD", en: "Built-in chat" },
     "claude-desktop": { zh: "Claude Desktop", en: "Claude Desktop" },
     "claude-code": { zh: "Claude Code", en: "Claude Code" },
     cursor: { zh: "Cursor", en: "Cursor" }
   };
-  function cepRequire2(mod) {
+  function cepRequire3(mod) {
     if (window.cep_node && window.cep_node.require) return window.cep_node.require(mod);
     if (window.require) return window.require(mod);
     return null;
@@ -9897,27 +11541,73 @@
   function Shell({ cs: cs2 }) {
     const { lang, setLang } = useLang();
     const t = T[lang];
-    const [tab, setTab] = import_react30.default.useState("chat");
-    const [status, setStatus] = import_react30.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
-    const [paused, setPaused] = import_react30.default.useState(false);
-    const [logs, setLogs] = import_react30.default.useState([]);
-    const ctrl = import_react30.default.useRef(null);
-    const getHost = import_react30.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
-    const [wizardDone, setWizardDone] = import_react30.default.useState(() => isWizardDone(window.localStorage));
-    const [wizStep, setWizStep] = import_react30.default.useState(1);
-    const [wizClient, setWizClient] = import_react30.default.useState("claude-desktop");
+    const [tab, setTab] = import_react37.default.useState("chat");
+    const [status, setStatus] = import_react37.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
+    const [paused, setPaused] = import_react37.default.useState(false);
+    const [logs, setLogs] = import_react37.default.useState([]);
+    const ctrl = import_react37.default.useRef(null);
+    const getHost = import_react37.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
+    const [wizardDone, setWizardDone] = import_react37.default.useState(() => isWizardDone(window.localStorage));
+    const [wizStep, setWizStep] = import_react37.default.useState(1);
+    const [wizClient, setWizClient] = import_react37.default.useState("claude-desktop");
     const handshake = useHandshake(getHost, !wizardDone && wizStep === 4);
-    const [drawerOpen, setDrawerOpen] = import_react30.default.useState(false);
-    const [connInfo, setConnInfo] = import_react30.default.useState(null);
-    const [diagnostics, setDiagnostics] = import_react30.default.useState(null);
+    const [drawerOpen, setDrawerOpen] = import_react37.default.useState(false);
+    const [connInfo, setConnInfo] = import_react37.default.useState(null);
+    const [diagnostics, setDiagnostics] = import_react37.default.useState(null);
     const { events, clear } = useActivity(getHost);
-    const [clients, setClients] = import_react30.default.useState([]);
-    const [confirmRegen, setConfirmRegen] = import_react30.default.useState(false);
-    const [tokenEpoch, setTokenEpoch] = import_react30.default.useState(0);
-    const pushLog = import_react30.default.useCallback((m) => {
+    const [clients, setClients] = import_react37.default.useState([]);
+    const [confirmRegen, setConfirmRegen] = import_react37.default.useState(false);
+    const [tokenEpoch, setTokenEpoch] = import_react37.default.useState(0);
+    const keyStore = import_react37.default.useMemo(() => {
+      try {
+        return createApiKeyStore();
+      } catch (e) {
+        return null;
+      }
+    }, []);
+    const [apiKey, setApiKey] = import_react37.default.useState(() => {
+      try {
+        return keyStore ? keyStore.readKey() : "";
+      } catch (e) {
+        return "";
+      }
+    });
+    const [model, setModel] = import_react37.default.useState(() => readPref("ae_mcp_model", DEFAULT_MODEL));
+    const [permissionMode, setPermissionMode] = import_react37.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
+    const [chatEntries, setChatEntries] = import_react37.default.useState([]);
+    const [chatStreaming, setChatStreaming] = import_react37.default.useState(false);
+    const prefsRef = import_react37.default.useRef({ apiKey, model, permissionMode });
+    prefsRef.current = { apiKey, model, permissionMode };
+    const chatLoop = import_react37.default.useMemo(() => {
+      const mcp = createMcpClient({});
+      return createAgentLoop({
+        getApiKey: () => prefsRef.current.apiKey,
+        getModel: () => prefsRef.current.model,
+        getPermissionMode: () => prefsRef.current.permissionMode,
+        mcp,
+        lang,
+        onEvent: (evt) => {
+          if (evt.type === "turn-start") setChatStreaming(true);
+          if (evt.type === "turn-end" || evt.type === "error") setChatStreaming(false);
+          setChatEntries((entries) => reduceEvent(entries, evt));
+        }
+      });
+    }, []);
+    const sendChat = (text) => {
+      const trimmed = String(text || "").trim();
+      if (!trimmed) return;
+      setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: "user-text", text: trimmed }));
+      chatLoop.sendUser(trimmed);
+    };
+    const newChatSession = () => {
+      chatLoop.reset();
+      setChatStreaming(false);
+      setChatEntries([]);
+    };
+    const pushLog = import_react37.default.useCallback((m) => {
       setLogs((xs) => [...xs.slice(-199), `[${(/* @__PURE__ */ new Date()).toLocaleTimeString()}] ${m}`]);
     }, []);
-    import_react30.default.useEffect(() => {
+    import_react37.default.useEffect(() => {
       const port = loadSavedPort(window.localStorage) || DEFAULT_PORT;
       ctrl.current = createHostController({
         cs: cs2,
@@ -9933,7 +11623,7 @@
       });
       ctrl.current.start(port);
     }, [cs2, pushLog]);
-    import_react30.default.useEffect(() => {
+    import_react37.default.useEffect(() => {
       if (!drawerOpen) return void 0;
       const update = () => {
         const h = getHost();
@@ -9943,7 +11633,7 @@
       const i = setInterval(update, 3e3);
       return () => clearInterval(i);
     }, [drawerOpen, getHost]);
-    import_react30.default.useEffect(() => {
+    import_react37.default.useEffect(() => {
       if (tab !== "settings") return void 0;
       const update = () => {
         const h = getHost();
@@ -9954,14 +11644,14 @@
       const i = setInterval(update, 4e3);
       return () => clearInterval(i);
     }, [tab, getHost]);
-    const runDiag = import_react30.default.useCallback(async () => {
+    const runDiag = import_react37.default.useCallback(async () => {
       setDiagnostics("running");
       try {
         const items = await runDiagnostics({
           getHost,
           port: status.port,
-          fs: cepRequire2("fs"),
-          os: cepRequire2("os"),
+          fs: cepRequire3("fs"),
+          os: cepRequire3("os"),
           fetchImpl: window.fetch.bind(window)
         });
         setDiagnostics(items);
@@ -9995,7 +11685,7 @@
     };
     const mcpConfigStr = JSON.stringify(buildMcpConfig(status.port), null, 2);
     if (!wizardDone) {
-      return /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         WizardScreen,
         {
           step: wizStep,
@@ -10025,8 +11715,8 @@
       { id: "activity", icon: "list-checks", label: t.activity },
       { id: "settings", icon: "settings", label: t.settings }
     ];
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(import_react30.default.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(import_react37.default.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         StatusBar,
         {
           status: statusForBar,
@@ -10041,9 +11731,24 @@
           settingsTitle: t.settings
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
-        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(EmptyState, { icon: "message-square", title: t.chatEmptyT, caption: t.chatEmptyB }) : null,
-        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
+        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
+          ChatScreen,
+          {
+            lang,
+            entries: chatEntries,
+            streaming: chatStreaming,
+            composerDisabled: paused || !apiKey,
+            disabledHint: paused ? t.pausedHint : !apiKey ? t.noKeyHint : "",
+            noticeActionLabel: paused ? t.resume : t.goSettings,
+            onNoticeAction: () => paused ? togglePause() : setTab("settings"),
+            onSend: sendChat,
+            onStop: () => chatLoop.stop(),
+            onApprove: (id, decision) => chatLoop.approve(id, decision),
+            onNewSession: newChatSession
+          }
+        ) : null,
+        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
           ActivityScreen,
           {
             events,
@@ -10053,7 +11758,7 @@
             emptyCaption: t.actEmptyB
           }
         ) : null,
-        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
           SettingsScreen,
           {
             lang,
@@ -10073,13 +11778,33 @@
             },
             onRegenToken: () => setConfirmRegen(true),
             hostVersion: connInfo && connInfo.hostVersion || "-",
-            pythonVersion: connInfo && connInfo.pythonVersion || "-"
+            pythonVersion: connInfo && connInfo.pythonVersion || "-",
+            apiKey,
+            onSaveApiKey: (k) => {
+              if (keyStore) keyStore.writeKey(k);
+              setApiKey(k);
+            },
+            onClearApiKey: () => {
+              if (keyStore) keyStore.clearKey();
+              setApiKey("");
+            },
+            validateKey: validateAnthropicKey,
+            model,
+            onModelChange: (m) => {
+              setModel(m);
+              writePref("ae_mcp_model", m);
+            },
+            permissionMode,
+            onPermissionMode: (m) => {
+              setPermissionMode(m);
+              writePref("ae_mcp_perm_mode", m);
+            }
           },
           tokenEpoch
         ) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         ConnectionDrawer,
         {
           open: drawerOpen,
@@ -10092,7 +11817,7 @@
           onRestart: () => applyPort(status.port)
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         ConfirmDialog,
         {
           open: confirmRegen,
@@ -10117,13 +11842,13 @@
     ] });
   }
   function App({ cs: cs2 }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Shell, { cs: cs2 }) });
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Shell, { cs: cs2 }) });
   }
 
   // src/main.jsx
-  var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime34 = __toESM(require_jsx_runtime(), 1);
   var cs = new window.CSInterface();
-  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime27.jsx)(App, { cs }));
+  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime34.jsx)(App, { cs }));
 })();
 /*! Bundled license information:
 

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -8650,6 +8650,15 @@
       sec: "\u5B89\u5168",
       gen: "\u901A\u7528",
       about: "\u5173\u4E8E",
+      backend: "\u540E\u7AEF",
+      backendSub: "\u8BA2\u9605",
+      backendByok: "BYOK",
+      claudeReady: "\u5DF2\u767B\u5F55 \u2713",
+      claudeNotLoggedIn: "\u672A\u767B\u5F55",
+      claudeChecking: "\u68C0\u6D4B\u4E2D\u2026",
+      claudeNoNode: "\u9700\u8981 Node 18+",
+      claudeLoginCap: "\u5728\u7EC8\u7AEF\u8FD0\u884C claude /login \u5B8C\u6210\u767B\u5F55\uFF0C\u7136\u540E\u70B9\u300C\u91CD\u65B0\u68C0\u6D4B\u300D",
+      recheckClaude: "\u91CD\u65B0\u68C0\u6D4B",
       apiKey: "API Key",
       apiKeyCap: "\u4EC5\u4FDD\u5B58\u5728\u672C\u673A\uFF0C\u4E0D\u4F1A\u4E0A\u4F20",
       saveVerify: "\u4FDD\u5B58\u5E76\u9A8C\u8BC1",
@@ -8701,6 +8710,15 @@
       sec: "Security",
       gen: "General",
       about: "About",
+      backend: "Backend",
+      backendSub: "Subscription",
+      backendByok: "BYOK",
+      claudeReady: "Logged in \u2713",
+      claudeNotLoggedIn: "Not logged in",
+      claudeChecking: "Checking\u2026",
+      claudeNoNode: "Needs Node 18+",
+      claudeLoginCap: "Run claude /login in a terminal, then click Re-check",
+      recheckClaude: "Re-check",
       apiKey: "API Key",
       apiKeyCap: "Stored locally, never uploaded",
       saveVerify: "Save and verify",
@@ -8820,6 +8838,10 @@
     validateKey,
     model = "claude-sonnet-4-6",
     onModelChange,
+    backend = "subscription",
+    onBackendChange,
+    claudeStatus = { state: "checking" },
+    onRecheckClaude,
     permissionMode = "manual",
     onPermissionMode
   }) {
@@ -8844,6 +8866,9 @@
     };
     const permCap = permissionMode === "manual" ? t.permCap1 : permissionMode === "auto" ? t.permCap2 : t.permCap3;
     const tokenDisplay = tokenRaw ? maskToken(tokenRaw) : t.tokenMissing;
+    const claudeState = claudeStatus && claudeStatus.state || "checking";
+    const claudeBadgeStatus = claudeState === "ready" ? "ok" : claudeState === "not-logged-in" ? "warn" : claudeState === "no-node" ? "error" : "neutral";
+    const claudeBadgeText = claudeState === "ready" ? t.claudeReady : claudeState === "not-logged-in" ? t.claudeNotLoggedIn : claudeState === "no-node" ? t.claudeNoNode : t.claudeChecking;
     const saveApiKey = () => {
       if (aiBusy) return;
       setAiBusy(true);
@@ -8883,7 +8908,18 @@
     };
     return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-5)" }, children: [
       /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.ai, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.apiKey, caption: t.apiKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.backend, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Segmented, { full: true, value: backend, onChange: onBackendChange, options: [
+          { value: "subscription", label: t.backendSub },
+          { value: "byok", label: t.backendByok }
+        ] }) }),
+        backend === "subscription" ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.backendSub, caption: claudeState === "not-logged-in" ? t.claudeLoginCap : claudeStatus && claudeStatus.detail || null, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Badge, { status: claudeBadgeStatus, children: claudeBadgeText }),
+          claudeState === "ready" && claudeStatus.nodeVersion ? /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("span", { style: { flex: 1, font: "400 11px/1 var(--font-mono)", color: "var(--text-secondary)" }, children: [
+            "Node ",
+            String(claudeStatus.nodeVersion).replace(/^v?/, "v")
+          ] }) : /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { flex: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", icon: "rotate-cw", disabled: claudeState === "checking", onClick: onRecheckClaude, children: t.recheckClaude })
+        ] }) }) : /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.apiKey, caption: t.apiKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Input, { secret: true, value: key, onChange: setKey, placeholder: "sk-ant-...", style: { flex: 1 } }),
           /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "primary", disabled: aiBusy || !key.trim(), onClick: saveApiKey, children: aiBusy ? t.validating : t.saveVerify }),
           /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Button, { variant: "secondary", disabled: aiBusy, onClick: clearApiKey, children: t.clear })
@@ -10745,6 +10781,62 @@
     };
   }
 
+  // src/lib/backendSelect.js
+  function pickBackend({ pref, probe, hasApiKey }) {
+    if (pref === "byok") {
+      return hasApiKey ? { backend: "byok", reason: "ok" } : { backend: "none", reason: "no-key" };
+    }
+    if (probe === null) return { backend: "none", reason: "probing" };
+    if (!probe.nodeOk) return hasApiKey ? { backend: "byok", reason: "no-node" } : { backend: "none", reason: "no-node" };
+    if (!probe.loggedIn) return hasApiKey ? { backend: "byok", reason: "not-logged-in" } : { backend: "none", reason: "not-logged-in" };
+    return { backend: "subscription", reason: "ok" };
+  }
+  function deriveToolMeta(tools) {
+    const allowedTools = [];
+    const annotations = {};
+    for (const tool of tools || []) {
+      const name = "mcp__ae__" + tool.name;
+      const ann = tool && tool.annotations || {};
+      const readOnly = ann.readOnlyHint === true;
+      const destructive = ann.destructiveHint === true;
+      if (readOnly) allowedTools.push(name);
+      annotations[name] = { readOnly, destructive };
+    }
+    return { allowedTools, annotations };
+  }
+  function shouldResetOnBackendChange(prevReal, next) {
+    if (next !== "subscription" && next !== "byok") return { reset: false, nextReal: prevReal || null };
+    if (!prevReal) return { reset: false, nextReal: next };
+    if (prevReal === next) return { reset: false, nextReal: prevReal };
+    return { reset: true, nextReal: next };
+  }
+
+  // src/lib/ndjson.js
+  function createLineSplitter(onLine) {
+    let buffer = "";
+    return function push(chunk) {
+      buffer += String(chunk || "");
+      let index = buffer.indexOf("\n");
+      while (index !== -1) {
+        const line = buffer.slice(0, index).trim();
+        buffer = buffer.slice(index + 1);
+        if (line) onLine(line);
+        index = buffer.indexOf("\n");
+      }
+    };
+  }
+  function createNdjsonReader(onMessage) {
+    return createLineSplitter((line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (e) {
+        return;
+      }
+      onMessage(message);
+    });
+  }
+
   // src/cep/mcpClient.js
   var DEFAULT_TIMEOUT_MS = 3e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
@@ -10820,7 +10912,6 @@
   function _createRpc(stdinWrite, onLine, options = {}) {
     const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
     let nextId2 = 1;
-    let buffer = "";
     const pending = /* @__PURE__ */ new Map();
     function rejectPending(id, error) {
       const entry = pending.get(id);
@@ -10844,21 +10935,7 @@
         entry.resolve(message.result);
       }
     }
-    function handleChunk(chunk) {
-      buffer += String(chunk || "");
-      let index = buffer.indexOf("\n");
-      while (index !== -1) {
-        const line = buffer.slice(0, index).trim();
-        buffer = buffer.slice(index + 1);
-        if (line) {
-          try {
-            handleMessage(JSON.parse(line));
-          } catch (e) {
-          }
-        }
-        index = buffer.indexOf("\n");
-      }
-    }
+    const handleChunk = createNdjsonReader(handleMessage);
     if (onLine) onLine(handleChunk);
     function writeMessage(message) {
       stdinWrite(JSON.stringify(message) + "\n");
@@ -11073,6 +11150,410 @@
       }
     }
     return { keyDir, keyPath, readKey, writeKey, clearKey };
+  }
+
+  // src/cep/claudeAuth.js
+  function getCepRequire2() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+      return globalThis.window.cep_node.require;
+    }
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    throw new Error("CEP Node require is unavailable");
+  }
+  function getCepEnv2() {
+    return globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env || {};
+  }
+  function normalizeFsPath2(value) {
+    let text = String(value || "").replace(/\//g, "\\");
+    text = text.replace(/\\+$/, "");
+    return text;
+  }
+  function defaultFs2() {
+    return getCepRequire2()("fs");
+  }
+  function defaultSpawn() {
+    return getCepRequire2()("child_process").spawn;
+  }
+  function joinPath2(base, leaf) {
+    return normalizeFsPath2(base) + "\\" + leaf;
+  }
+  function resolveSidecarPath({ extRoot, fsImpl } = {}) {
+    const root = normalizeFsPath2(extRoot || "");
+    const deployed = joinPath2(root, "sidecar\\agent-sidecar.mjs");
+    const repo = joinPath2(root, "..\\sidecar\\agent-sidecar.mjs");
+    const fs = fsImpl || defaultFs2();
+    if (fs.existsSync(deployed)) return deployed;
+    if (fs.existsSync(repo)) return repo;
+    return deployed;
+  }
+  async function probeClaudeLogin({
+    resolveNode,
+    sidecarPath,
+    spawnImpl,
+    env,
+    timeoutMs = 3e4
+  } = {}) {
+    const resolved = await resolveNode();
+    if (!resolved || resolved.ok === false) {
+      return { loggedIn: false, nodeOk: false, detail: resolved && resolved.detail || "node unavailable" };
+    }
+    return await new Promise((resolve) => {
+      let settled = false;
+      let stderr = "";
+      let proc = null;
+      const spawn = spawnImpl || defaultSpawn();
+      const spawnEnv = Object.assign({}, getCepEnv2(), env || {});
+      delete spawnEnv.ANTHROPIC_API_KEY;
+      function finish(result) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      }
+      const timer = setTimeout(() => {
+        if (proc && proc.kill) {
+          try {
+            proc.kill();
+          } catch (e) {
+          }
+        }
+        finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: "probe timeout" });
+      }, timeoutMs);
+      try {
+        proc = spawn(resolved.nodePath, [sidecarPath, "--probe"], {
+          stdio: "pipe",
+          windowsHide: true,
+          env: spawnEnv
+        });
+      } catch (e) {
+        finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: e && e.message ? e.message : String(e) });
+        return;
+      }
+      const onMessage = createNdjsonReader((message) => {
+        if (!message || message.t !== "probe-result") return;
+        finish({
+          loggedIn: !!message.loggedIn,
+          nodeOk: true,
+          nodeVersion: resolved.version,
+          detail: message.detail || message.reason || ""
+        });
+      });
+      if (proc.stdout && proc.stdout.on) proc.stdout.on("data", onMessage);
+      if (proc.stderr && proc.stderr.on) {
+        proc.stderr.on("data", (chunk) => {
+          stderr += String(chunk || "");
+          if (stderr.length > 4e3) stderr = stderr.slice(-4e3);
+        });
+      }
+      if (proc.on) {
+        proc.on("error", (err) => {
+          finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: err && err.message ? err.message : String(err) });
+        });
+        proc.on("exit", () => {
+          finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: stderr.trim() || "probe exited without result" });
+        });
+      }
+    });
+  }
+
+  // src/cep/claudeAgentBackend.js
+  var READY_TIMEOUT_MS = 15e3;
+  var STDERR_TAIL_LIMIT = 4096;
+  var FIXED_NODE_CANDIDATE = "C:\\Program Files\\nodejs\\node.exe";
+  function getCepRequire3() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+      return globalThis.window.cep_node.require;
+    }
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    throw new Error("CEP Node require is unavailable");
+  }
+  function getCepEnv3() {
+    return globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env || {};
+  }
+  function execFileAsync(execFileImpl, file, args, env) {
+    return new Promise((resolve) => {
+      execFileImpl(file, args, { windowsHide: true, env }, (err, stdout, stderr) => {
+        resolve({ err, stdout: String(stdout || ""), stderr: String(stderr || "") });
+      });
+    });
+  }
+  function nodeCandidates(stdout) {
+    const seen = /* @__PURE__ */ new Set();
+    const candidates = String(stdout || "").split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    candidates.push(FIXED_NODE_CANDIDATE);
+    return candidates.filter((candidate) => {
+      if (seen.has(candidate)) return false;
+      seen.add(candidate);
+      return true;
+    });
+  }
+  function parseMajor(version) {
+    const match = String(version || "").trim().match(/^v(\d+)/);
+    return match ? Number(match[1]) : 0;
+  }
+  async function resolveSystemNode({ execFileImpl, env } = {}) {
+    const execFile = execFileImpl || getCepRequire3()("child_process").execFile;
+    const processEnv = env || getCepEnv3();
+    const where = await execFileAsync(execFile, "where", ["node"], processEnv);
+    const candidates = nodeCandidates(where.err ? "" : where.stdout);
+    for (const candidate of candidates) {
+      const checked = await execFileAsync(execFile, candidate, ["--version"], processEnv);
+      if (checked.err) continue;
+      const version = String(checked.stdout || checked.stderr || "").trim();
+      if (parseMajor(version) >= 18) return { ok: true, nodePath: candidate, version };
+    }
+    return { ok: false, detail: "No system Node 18+ found." };
+  }
+  function clone2(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+  }
+  function nodeMissingMessage(lang) {
+    if (lang === "zh") return "\u5185\u5D4C\u5BF9\u8BDD\u9700\u8981\u7CFB\u7EDF Node 18+\uFF08\u672A\u68C0\u6D4B\u5230\uFF09\u3002\u5B89\u88C5 Node.js LTS \u540E\u91CD\u8BD5\u3002";
+    return "Embedded chat needs system Node 18+. Install Node.js LTS and retry.";
+  }
+  function sanitizeEnv(env) {
+    const copy = Object.assign({}, env || {});
+    delete copy.ANTHROPIC_API_KEY;
+    return copy;
+  }
+  function appendTail(tail, chunk) {
+    const next = tail + String(chunk || "");
+    return next.length > STDERR_TAIL_LIMIT ? next.slice(next.length - STDERR_TAIL_LIMIT) : next;
+  }
+  function createClaudeAgentBackend({
+    resolveNode = resolveSystemNode,
+    sidecarPath,
+    getMcpSpec,
+    getToolMeta,
+    getModel,
+    getPermissionMode,
+    onEvent,
+    lang = "zh",
+    spawnImpl,
+    env
+  }) {
+    let proc = null;
+    let startPromise = null;
+    let pendingReadyReject = null;
+    let pendingReadyTimer = null;
+    let ready = false;
+    let stopping = false;
+    let stderrTail = "";
+    let transcript = [];
+    let activeRun = null;
+    let activeResolve = null;
+    let activeAssistantText = "";
+    function emit(evt) {
+      if (onEvent) onEvent(evt);
+    }
+    function getSpawn() {
+      if (spawnImpl) return spawnImpl;
+      return getCepRequire3()("child_process").spawn;
+    }
+    function writeMessage(message) {
+      if (!proc || !proc.stdin || !proc.stdin.write) return;
+      proc.stdin.write(JSON.stringify(message) + "\n");
+    }
+    function finishActive() {
+      if (!activeResolve) {
+        activeRun = null;
+        activeAssistantText = "";
+        return;
+      }
+      const resolve = activeResolve;
+      activeResolve = null;
+      activeRun = null;
+      activeAssistantText = "";
+      resolve();
+    }
+    function handleSidecarMessage(message) {
+      if (!message || message.t === "ready") return;
+      if (message.t !== "event") return;
+      const event = message.event;
+      if (!event) return;
+      if (event.type === "text-delta") activeAssistantText += String(event.text || "");
+      emit(event);
+      if (event.type === "turn-end") {
+        transcript.push({ role: "assistant", text: activeAssistantText });
+        finishActive();
+      }
+      if (event.type === "error") finishActive();
+    }
+    function exitDetail(code, signal) {
+      const suffix = signal ? String(code) + " " + signal : String(code);
+      return stderrTail ? suffix + " " + stderrTail : suffix;
+    }
+    function clearReadyWait() {
+      if (pendingReadyTimer) clearTimeout(pendingReadyTimer);
+      pendingReadyTimer = null;
+      pendingReadyReject = null;
+    }
+    function handleExit(code, signal) {
+      const wasStopping = stopping;
+      const wasReady = ready;
+      const detail = exitDetail(code, signal);
+      const rejectReady = pendingReadyReject;
+      proc = null;
+      ready = false;
+      startPromise = null;
+      stopping = false;
+      if (wasStopping) return;
+      if (!wasReady && rejectReady) {
+        clearReadyWait();
+        rejectReady(new Error("sidecar exited: " + detail));
+        return;
+      }
+      if (activeRun) {
+        emit({ type: "error", kind: "mcp", message: "sidecar exited: " + detail });
+        finishActive();
+      }
+    }
+    function handleProcError(error) {
+      const rejectReady = pendingReadyReject;
+      proc = null;
+      ready = false;
+      startPromise = null;
+      if (rejectReady) {
+        clearReadyWait();
+        rejectReady(error instanceof Error ? error : new Error("sidecar error"));
+        return;
+      }
+      if (activeRun) {
+        emit({ type: "error", kind: "mcp", message: error && error.message ? error.message : "sidecar error" });
+        finishActive();
+      }
+    }
+    async function startSidecar() {
+      if (proc && ready) return true;
+      if (startPromise) return startPromise;
+      startPromise = (async () => {
+        const node = await resolveNode();
+        if (!node || !node.ok) {
+          emit({ type: "error", kind: "mcp", message: nodeMissingMessage(lang) });
+          return false;
+        }
+        const mcpSpec = await getMcpSpec();
+        const meta = await getToolMeta();
+        const spawn = getSpawn();
+        const spawnEnv = sanitizeEnv(env || getCepEnv3());
+        stderrTail = "";
+        stopping = false;
+        ready = false;
+        let readyResolve;
+        let readyReject;
+        const readyPromise = new Promise((resolve, reject) => {
+          readyResolve = resolve;
+          readyReject = reject;
+        });
+        pendingReadyReject = readyReject;
+        pendingReadyTimer = setTimeout(() => {
+          pendingReadyTimer = null;
+          pendingReadyReject = null;
+          try {
+            stopping = true;
+            if (proc) proc.kill();
+          } catch (e) {
+          }
+          readyReject(new Error("sidecar ready timed out"));
+        }, READY_TIMEOUT_MS);
+        try {
+          proc = spawn(node.nodePath, [
+            sidecarPath,
+            "--mcp",
+            JSON.stringify(mcpSpec),
+            "--allowed-tools",
+            JSON.stringify(meta.allowedTools),
+            "--annotations",
+            JSON.stringify(meta.annotations),
+            "--model",
+            getModel(),
+            "--lang",
+            lang
+          ], {
+            stdio: "pipe",
+            windowsHide: true,
+            env: spawnEnv
+          });
+        } catch (e) {
+          clearReadyWait();
+          throw e;
+        }
+        const reader = createNdjsonReader((message) => {
+          if (message && message.t === "ready") {
+            ready = true;
+            clearReadyWait();
+            readyResolve(true);
+            return;
+          }
+          handleSidecarMessage(message);
+        });
+        if (proc.stdout && proc.stdout.on) proc.stdout.on("data", reader);
+        if (proc.stderr && proc.stderr.on) proc.stderr.on("data", (chunk) => {
+          stderrTail = appendTail(stderrTail, chunk);
+        });
+        proc.on("exit", (code, signal) => handleExit(code, signal));
+        proc.on("error", (error) => {
+          handleProcError(error);
+        });
+        await readyPromise;
+        return true;
+      })();
+      try {
+        return await startPromise;
+      } catch (e) {
+        emit({ type: "error", kind: "mcp", message: e && e.message ? e.message : "Failed to start sidecar." });
+        return false;
+      } finally {
+        startPromise = null;
+      }
+    }
+    async function sendUser(text) {
+      if (activeRun) return activeRun;
+      activeAssistantText = "";
+      activeRun = new Promise((resolve) => {
+        activeResolve = resolve;
+      });
+      const ok = await startSidecar();
+      if (!ok) {
+        finishActive();
+        return activeRun;
+      }
+      const userText = String(text || "");
+      transcript.push({ role: "user", text: userText });
+      writeMessage({ t: "user", text: userText, permissionMode: getPermissionMode(), model: getModel() });
+      return activeRun;
+    }
+    function approve(toolUseId, decision) {
+      writeMessage({ t: "approve", id: toolUseId, decision });
+    }
+    function stop() {
+      writeMessage({ t: "stop" });
+    }
+    function reset() {
+      stopping = true;
+      if (proc) {
+        try {
+          proc.kill();
+        } catch (e) {
+        }
+      }
+      proc = null;
+      ready = false;
+      startPromise = null;
+      transcript = [];
+      finishActive();
+      stderrTail = "";
+      stopping = false;
+    }
+    return {
+      sendUser,
+      approve,
+      stop,
+      reset,
+      getMessages: () => clone2(transcript)
+    };
   }
 
   // src/lib/chatEntries.js
@@ -11407,7 +11888,7 @@
       }
     };
   }
-  function getCepRequire2() {
+  function getCepRequire4() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -11420,7 +11901,7 @@
     function start(port) {
       onStatus("starting", port);
       try {
-        const cepRequire4 = getCepRequire2();
+        const cepRequire4 = getCepRequire4();
         const path = cepRequire4("path");
         const extRoot = normalizeCepPath(cs2.getSystemPath("extension"));
         const hostPath = path.join(extRoot, "host", "server.js");
@@ -11469,6 +11950,9 @@
       regenConfirm: "\u91CD\u65B0\u751F\u6210",
       cancel: "\u53D6\u6D88",
       noKeyHint: "\u5148\u5728\u8BBE\u7F6E\u91CC\u914D\u7F6E Anthropic API Key",
+      probingHint: "\u6B63\u5728\u68C0\u6D4B Claude \u767B\u5F55\u6001\u2026",
+      notLoggedInHint: "\u8BA2\u9605\u672A\u767B\u5F55\uFF1A\u5728\u7EC8\u7AEF\u8FD0\u884C claude /login\uFF0C\u518D\u5230\u8BBE\u7F6E\u91CC\u91CD\u65B0\u68C0\u6D4B",
+      noNodeHint: "\u5185\u5D4C\u5BF9\u8BDD\u9700\u8981\u7CFB\u7EDF Node 18+",
       pausedHint: "\u5DF2\u6682\u505C \u2014 \u6062\u590D\u540E\u624D\u80FD\u53D1\u9001",
       goSettings: "\u53BB\u8BBE\u7F6E"
     },
@@ -11491,6 +11975,9 @@
       regenConfirm: "Regenerate",
       cancel: "Cancel",
       noKeyHint: "Set your Anthropic API key in Settings first",
+      probingHint: "Checking Claude login\u2026",
+      notLoggedInHint: "Not logged in: run claude /login in a terminal, then re-check in Settings",
+      noNodeHint: "Embedded chat needs system Node 18+",
       pausedHint: "Paused \u2014 resume to send",
       goSettings: "Open Settings"
     }
@@ -11574,33 +12061,79 @@
     });
     const [model, setModel] = import_react37.default.useState(() => readPref("ae_mcp_model", DEFAULT_MODEL));
     const [permissionMode, setPermissionMode] = import_react37.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
+    const [backendPref, setBackendPref] = import_react37.default.useState(() => readPref("ae_mcp_backend", "subscription"));
+    const [probe, setProbe] = import_react37.default.useState(null);
     const [chatEntries, setChatEntries] = import_react37.default.useState([]);
     const [chatStreaming, setChatStreaming] = import_react37.default.useState(false);
     const prefsRef = import_react37.default.useRef({ apiKey, model, permissionMode });
     prefsRef.current = { apiKey, model, permissionMode };
-    const chatLoop = import_react37.default.useMemo(() => {
-      const mcp = createMcpClient({});
+    const extRoot = cs2 && cs2.getSystemPath ? cs2.getSystemPath("extension") : "";
+    const sidecarPath = import_react37.default.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
+    const mcp = import_react37.default.useMemo(() => createMcpClient({}), []);
+    const handleChatEvent = import_react37.default.useCallback((evt) => {
+      if (evt.type === "turn-start") setChatStreaming(true);
+      if (evt.type === "turn-end" || evt.type === "error") setChatStreaming(false);
+      setChatEntries((entries) => reduceEvent(entries, evt));
+    }, []);
+    const byokLoop = import_react37.default.useMemo(() => {
       return createAgentLoop({
         getApiKey: () => prefsRef.current.apiKey,
         getModel: () => prefsRef.current.model,
         getPermissionMode: () => prefsRef.current.permissionMode,
         mcp,
         lang,
-        onEvent: (evt) => {
-          if (evt.type === "turn-start") setChatStreaming(true);
-          if (evt.type === "turn-end" || evt.type === "error") setChatStreaming(false);
-          setChatEntries((entries) => reduceEvent(entries, evt));
-        }
+        onEvent: handleChatEvent
       });
-    }, []);
+    }, [mcp, handleChatEvent]);
+    const claudeBackend = import_react37.default.useMemo(() => createClaudeAgentBackend({
+      resolveNode: resolveSystemNode,
+      sidecarPath,
+      getMcpSpec: () => resolveMcpCommand({ extRoot }),
+      getToolMeta: async () => deriveToolMeta(await mcp.listTools()),
+      getModel: () => prefsRef.current.model,
+      getPermissionMode: () => prefsRef.current.permissionMode,
+      lang,
+      onEvent: handleChatEvent
+    }), [extRoot, sidecarPath, mcp, handleChatEvent]);
+    const effective = pickBackend({ pref: backendPref, probe, hasApiKey: !!apiKey });
+    const activeBackend = effective.backend === "subscription" ? claudeBackend : byokLoop;
+    const activeBackendRef = import_react37.default.useRef(null);
+    const runClaudeProbe = import_react37.default.useCallback(() => {
+      let alive = true;
+      setProbe(null);
+      probeClaudeLogin({
+        resolveNode: resolveSystemNode,
+        sidecarPath
+      }).then((result) => {
+        if (alive) setProbe(result);
+      }).catch((e) => {
+        if (alive) setProbe({ loggedIn: false, nodeOk: false, detail: e && e.message ? e.message : String(e) });
+      });
+      return () => {
+        alive = false;
+      };
+    }, [sidecarPath]);
+    import_react37.default.useEffect(() => {
+      if (backendPref !== "subscription") return void 0;
+      return runClaudeProbe();
+    }, [backendPref, runClaudeProbe]);
+    import_react37.default.useEffect(() => {
+      const decision = shouldResetOnBackendChange(activeBackendRef.current, effective.backend);
+      activeBackendRef.current = decision.nextReal;
+      if (!decision.reset) return;
+      byokLoop.reset();
+      claudeBackend.reset();
+      setChatEntries([]);
+      setChatStreaming(false);
+    }, [effective.backend, byokLoop, claudeBackend]);
     const sendChat = (text) => {
       const trimmed = String(text || "").trim();
       if (!trimmed) return;
       setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: "user-text", text: trimmed }));
-      chatLoop.sendUser(trimmed);
+      activeBackend.sendUser(trimmed);
     };
     const newChatSession = () => {
-      chatLoop.reset();
+      activeBackend.reset();
       setChatStreaming(false);
       setChatEntries([]);
     };
@@ -11715,6 +12248,9 @@
       { id: "activity", icon: "list-checks", label: t.activity },
       { id: "settings", icon: "settings", label: t.settings }
     ];
+    const backendDisabledHint = effective.reason === "probing" ? t.probingHint : effective.reason === "not-logged-in" ? t.notLoggedInHint : effective.reason === "no-node" ? t.noNodeHint : effective.reason === "no-key" ? t.noKeyHint : "";
+    const composerDisabled = paused || effective.backend === "none";
+    const claudeStatus = probe === null ? { state: "checking" } : probe.nodeOk === false ? { state: "no-node", detail: probe.detail } : probe.loggedIn === false ? { state: "not-logged-in", detail: probe.detail } : { state: "ready", nodeVersion: probe.nodeVersion };
     return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(import_react37.default.Fragment, { children: [
       /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         StatusBar,
@@ -11738,13 +12274,13 @@
             lang,
             entries: chatEntries,
             streaming: chatStreaming,
-            composerDisabled: paused || !apiKey,
-            disabledHint: paused ? t.pausedHint : !apiKey ? t.noKeyHint : "",
+            composerDisabled,
+            disabledHint: paused ? t.pausedHint : composerDisabled ? backendDisabledHint : "",
             noticeActionLabel: paused ? t.resume : t.goSettings,
             onNoticeAction: () => paused ? togglePause() : setTab("settings"),
             onSend: sendChat,
-            onStop: () => chatLoop.stop(),
-            onApprove: (id, decision) => chatLoop.approve(id, decision),
+            onStop: () => activeBackend.stop(),
+            onApprove: (id, decision) => activeBackend.approve(id, decision),
             onNewSession: newChatSession
           }
         ) : null,
@@ -11794,6 +12330,13 @@
               setModel(m);
               writePref("ae_mcp_model", m);
             },
+            backend: backendPref,
+            onBackendChange: (m) => {
+              setBackendPref(m);
+              writePref("ae_mcp_backend", m);
+            },
+            claudeStatus,
+            onRecheckClaude: runClaudeProbe,
             permissionMode,
             onPermissionMode: (m) => {
               setPermissionMode(m);

--- a/plugin/host/runtime-safevalue.test.js
+++ b/plugin/host/runtime-safevalue.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadRuntime() {
+    function TextDocument(t) {
+        this.text = t;
+    }
+
+    const context = {
+        AEMCP: undefined,
+        JSON: JSON,
+        Array: Array,
+        Object: Object,
+        String: String,
+        Number: Number,
+        Boolean: Boolean,
+        TextDocument: TextDocument,
+    };
+    vm.createContext(context);
+    const runtime = fs.readFileSync(
+        path.join(__dirname, '..', 'jsx', 'runtime.jsx'),
+        'utf8'
+    );
+    vm.runInContext(runtime, context, {filename: 'runtime.jsx'});
+    return context;
+}
+
+function withThrowingGetter(obj) {
+    Object.defineProperty(obj, 'boxTextOnly', {
+        enumerable: true,
+        get: function () {
+            throw new Error('box-text-only getter');
+        },
+    });
+    return obj;
+}
+
+test('safeValue serializes TextDocument as text despite throwing getters', () => {
+    const context = loadRuntime();
+    const td = withThrowingGetter(new context.TextDocument('hi'));
+
+    assert.strictEqual(context.AEMCP.safeValue(td), 'hi');
+    assert.doesNotThrow(function () {
+        JSON.stringify({previous: context.AEMCP.safeValue(td)});
+    });
+});
+
+test('safeValue degrades non-stringifiable ordinary objects without throwing', () => {
+    const context = loadRuntime();
+    const obj = withThrowingGetter({a: 1});
+
+    assert.doesNotThrow(function () {
+        assert.strictEqual(context.AEMCP.safeValue(obj), '[object Object]');
+    });
+});
+
+test('safeValue passes primitives and nullish values through predictably', () => {
+    const context = loadRuntime();
+
+    assert.strictEqual(context.AEMCP.safeValue(7), 7);
+    assert.strictEqual(context.AEMCP.safeValue(true), true);
+    assert.strictEqual(context.AEMCP.safeValue('x'), 'x');
+    assert.strictEqual(context.AEMCP.safeValue(null), null);
+    assert.strictEqual(context.AEMCP.safeValue(undefined), null);
+    // Spread into a host-realm array: safeValue builds its result inside the
+    // vm context, whose Array.prototype fails deepStrictEqual's prototype check.
+    assert.deepStrictEqual(
+        [...context.AEMCP.safeValue([1, undefined, 'z'])],
+        [1, null, 'z']
+    );
+});
+
+test('safeValue keeps normally stringifiable objects on the probe path', () => {
+    const context = loadRuntime();
+    const obj = {a: 1};
+
+    assert.strictEqual(context.AEMCP.safeValue(obj), obj);
+});

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -143,18 +143,30 @@ function wrapForEvalScriptTransport(code) {
         '}' +
         'return out+"\\"";' +
         '}' +
+        'try{' +
         'var __aemcp_value=eval(' + quoteAsciiJsString(code) + ');' +
         'return "{\\"ok\\":true,\\"result\\":"+__aemcp_quote(__aemcp_value)+"}";' +
+        '}catch(e){' +
+        'var __aemcp_detail=String(e);' +
+        'if(e&&e.line){__aemcp_detail+=" (line "+e.line+")";}' +
+        'return "{\\"ok\\":false,\\"error\\":"+__aemcp_quote(__aemcp_detail)+"}";' +
+        '}' +
         '})()'
     );
 }
 
 function decodeEvalScriptTransportResult(text) {
     let payload = null;
+    if (String(text || '').trim() === '') {
+        throw new Error('evalScript returned no output (ExtendScript engine did not run the transport envelope)');
+    }
     try {
-        payload = JSON.parse(String(text || ''));
+        payload = JSON.parse(String(text));
     } catch (e) {
         throw new Error('invalid evalScript transport envelope: ' + String(text || '').slice(0, 120));
+    }
+    if (payload && payload.ok === false && typeof payload.error === 'string') {
+        throw new Error('ExtendScript error: ' + payload.error);
     }
     if (!payload || payload.ok !== true || typeof payload.result !== 'string') {
         throw new Error('invalid evalScript transport envelope shape');

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -97,6 +97,71 @@ function wrapWithUndoGroup(code, undoGroup) {
     );
 }
 
+function quoteAsciiJsString(value) {
+    const s = String(value);
+    let out = '"';
+    for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i);
+        switch (c) {
+            case 8: out += '\\b'; break;
+            case 9: out += '\\t'; break;
+            case 10: out += '\\n'; break;
+            case 12: out += '\\f'; break;
+            case 13: out += '\\r'; break;
+            case 34: out += '\\"'; break;
+            case 92: out += '\\\\'; break;
+            default:
+                if (c < 32 || c > 126) {
+                    out += '\\u' + ('0000' + c.toString(16)).slice(-4);
+                } else {
+                    out += s.charAt(i);
+                }
+        }
+    }
+    return out + '"';
+}
+
+// CEP can corrupt non-ASCII result text when CSInterface.evalScript crosses
+// the ExtendScript -> panel boundary on localized Windows installs. Return an
+// ASCII-only JSON envelope from JSX, then decode it in Node before HTTP JSON.
+function wrapForEvalScriptTransport(code) {
+    return (
+        '(function(){' +
+        'function __aemcp_quote(v){' +
+        'var s=String(v),out="\\"";' +
+        'for(var i=0;i<s.length;i++){' +
+        'var c=s.charCodeAt(i);' +
+        'if(c===8){out+="\\\\b";}' +
+        'else if(c===9){out+="\\\\t";}' +
+        'else if(c===10){out+="\\\\n";}' +
+        'else if(c===12){out+="\\\\f";}' +
+        'else if(c===13){out+="\\\\r";}' +
+        'else if(c===34){out+="\\\\\\"";}' +
+        'else if(c===92){out+="\\\\\\\\";}' +
+        'else if(c<32||c>126){out+="\\\\u"+("0000"+c.toString(16)).slice(-4);}' +
+        'else{out+=s.charAt(i);}' +
+        '}' +
+        'return out+"\\"";' +
+        '}' +
+        'var __aemcp_value=eval(' + quoteAsciiJsString(code) + ');' +
+        'return "{\\"ok\\":true,\\"result\\":"+__aemcp_quote(__aemcp_value)+"}";' +
+        '})()'
+    );
+}
+
+function decodeEvalScriptTransportResult(text) {
+    let payload = null;
+    try {
+        payload = JSON.parse(String(text || ''));
+    } catch (e) {
+        throw new Error('invalid evalScript transport envelope: ' + String(text || '').slice(0, 120));
+    }
+    if (!payload || payload.ok !== true || typeof payload.result !== 'string') {
+        throw new Error('invalid evalScript transport envelope shape');
+    }
+    return payload.result;
+}
+
 function buildApp() {
     const a = express();
     a.use(express.json({ limit: '5mb' }));
@@ -161,10 +226,12 @@ function buildApp() {
         // forwarded but unused; later sub-specs will wire it to the checkpoint
         // store.
         const wrapped = undoGroup ? wrapWithUndoGroup(code, undoGroup) : code;
+        const transported = wrapForEvalScriptTransport(wrapped);
 
         const startedAt = Date.now();
         try {
-            const result = await jsxBridge.evalScript(wrapped, t);
+            const encoded = await jsxBridge.evalScript(transported, t);
+            const result = decodeEvalScriptTransportResult(encoded);
             activity.record({ client, undoGroup: undoGroup || null, ok: true, durationMs: Date.now() - startedAt });
             res.json({ ok: true, result: result || '' });
         } catch (e) {
@@ -225,6 +292,8 @@ module.exports = {
     setCSInterface: jsxBridge.setCSInterface,
     // Exported for unit-testing the wrap shape without spinning up Express.
     wrapWithUndoGroup,
+    wrapForEvalScriptTransport,
+    decodeEvalScriptTransportResult,
     // Exported so tests can build the app and inject a known token without
     // touching the real token file.
     buildApp,

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -72,7 +72,7 @@ function startApp() {
     // Inject a known token and a stub CSInterface so /exec can "run".
     server._setExecToken('known-secret-token');
     server.setCSInterface({
-        evalScript: function (jsx, cb) { cb('stub-result'); },
+        evalScript: function (jsx, cb) { cb('{"ok":true,"result":"stub-result"}'); },
     });
     const app = server.buildApp();
     return new Promise((resolve) => {
@@ -80,6 +80,10 @@ function startApp() {
             resolve({ srv: srv, port: srv.address().port });
         });
     });
+}
+
+function decodeTransportEnvelope(result) {
+    return JSON.parse(result).result;
 }
 
 function get(port, pathname, headers) {
@@ -156,6 +160,51 @@ test('/exec returns 200 with the correct token', async () => {
     } finally {
         srv.close();
     }
+});
+
+test('/exec decodes the evalScript transport envelope before responding', async () => {
+    delete require.cache[require.resolve('./server')];
+    delete require.cache[require.resolve('./jsx-bridge')];
+    const server = require('./server');
+    server.activity._reset();
+    server.setPaused(false);
+    server._setExecToken('known-secret-token');
+    server.setCSInterface({
+        evalScript: function (jsx, cb) {
+            assert.ok(/^[\x00-\x7f]*$/.test(jsx), 'transport wrapper must be ASCII-only');
+            cb('{"ok":true,"result":"\\u6e90\\u6587\\u672c"}');
+        },
+    });
+    const app = server.buildApp();
+    const srv = await new Promise((resolve) => {
+        const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    try {
+        const r = await post(
+            srv.address().port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: '"源文本"' }
+        );
+        assert.strictEqual(r.status, 200);
+        assert.strictEqual(r.body.ok, true);
+        assert.strictEqual(r.body.result, '源文本');
+    } finally {
+        srv.close();
+    }
+});
+
+test('wrapForEvalScriptTransport returns an ASCII-only envelope for localized results', () => {
+    delete require.cache[require.resolve('./server')];
+    const server = require('./server');
+    const wrapped = server.wrapForEvalScriptTransport('"源文本"');
+
+    assert.ok(/^[\x00-\x7f]*$/.test(wrapped), 'wrapper source must be ASCII-only');
+    assert.match(wrapped, /\\u6e90\\u6587\\u672c/);
+
+    const payload = eval(wrapped); // eslint-disable-line no-eval
+    assert.ok(/^[\x00-\x7f]*$/.test(payload), 'evalScript payload must be ASCII-only');
+    assert.strictEqual(decodeTransportEnvelope(payload), '源文本');
 });
 
 test('/exec returns 503 while paused and resumes after unpause', async () => {

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -207,6 +207,78 @@ test('wrapForEvalScriptTransport returns an ASCII-only envelope for localized re
     assert.strictEqual(decodeTransportEnvelope(payload), '源文本');
 });
 
+test('wrapForEvalScriptTransport returns an error envelope for thrown ExtendScript errors', () => {
+    delete require.cache[require.resolve('./server')];
+    const server = require('./server');
+    const wrapped = server.wrapForEvalScriptTransport('throw new Error("boom")');
+
+    assert.ok(/^[\x00-\x7f]*$/.test(wrapped), 'wrapper source must be ASCII-only');
+    const payload = eval(wrapped); // eslint-disable-line no-eval
+    assert.ok(/^[\x00-\x7f]*$/.test(payload), 'evalScript payload must be ASCII-only');
+    assert.throws(
+        () => server.decodeEvalScriptTransportResult(payload),
+        /ExtendScript error: Error: boom/
+    );
+});
+
+test('/exec reports empty evalScript output as no output', async () => {
+    delete require.cache[require.resolve('./server')];
+    delete require.cache[require.resolve('./jsx-bridge')];
+    const server = require('./server');
+    server.activity._reset();
+    server.setPaused(false);
+    server._setExecToken('known-secret-token');
+    server.setCSInterface({
+        evalScript: function (jsx, cb) { cb(''); },
+    });
+    const app = server.buildApp();
+    const srv = await new Promise((resolve) => {
+        const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    try {
+        const r = await post(
+            srv.address().port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: 'throw new Error("boom")' }
+        );
+        assert.strictEqual(r.status, 200);
+        assert.strictEqual(r.body.ok, false);
+        assert.match(r.body.error, /no output/);
+    } finally {
+        srv.close();
+    }
+});
+
+test('/exec reports decoded ExtendScript transport errors', async () => {
+    delete require.cache[require.resolve('./server')];
+    delete require.cache[require.resolve('./jsx-bridge')];
+    const server = require('./server');
+    server.activity._reset();
+    server.setPaused(false);
+    server._setExecToken('known-secret-token');
+    server.setCSInterface({
+        evalScript: function (jsx, cb) { cb('{"ok":false,"error":"\\u7206\\u70b8"}'); },
+    });
+    const app = server.buildApp();
+    const srv = await new Promise((resolve) => {
+        const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    try {
+        const r = await post(
+            srv.address().port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: 'throw new Error("boom")' }
+        );
+        assert.strictEqual(r.status, 200);
+        assert.strictEqual(r.body.ok, false);
+        assert.match(r.body.error, /爆炸/);
+    } finally {
+        srv.close();
+    }
+});
+
 test('/exec returns 503 while paused and resumes after unpause', async () => {
     const { srv, port } = await startApp();
     const server = require('./server');

--- a/plugin/jsx/runtime.jsx
+++ b/plugin/jsx/runtime.jsx
@@ -218,7 +218,41 @@ if (!Object.entries) {
 // ---------------------------------------------------------------------------
 if (typeof AEMCP === 'undefined') { AEMCP = {}; }
 
-AEMCP.version = '0.1.0';
+AEMCP.version = '0.2.0';
+
+// Map a property value to something JSON.stringify can serialize, never
+// throwing. TextDocument flattens to its .text string BEFORE the generic
+// object path (stringifying a TextDocument touches box-text-only getters that
+// throw on point text, and point/box text should yield the same shape).
+// Primitives pass through; arrays recurse; other host objects (Shape,
+// KeyframeEase, ...) are kept as-is when a stringify probe succeeds, else
+// degrade to String(v), else null. Uncaught throws must never escape a
+// template: AE 2026 surfaces them as EMPTY evalScript output (not the
+// "EvalScript error." sentinel), which callers see as "returned no value".
+AEMCP.safeValue = function (v) {
+    if (v === null || typeof v === 'undefined') return null;
+    var t = typeof v;
+    if (t === 'number' || t === 'boolean' || t === 'string') return v;
+    try {
+        if (typeof TextDocument !== 'undefined' && v instanceof TextDocument) {
+            return String(v.text);
+        }
+    } catch (eTd) {}
+    if (v instanceof Array) {
+        var out = [];
+        for (var i = 0; i < v.length; i++) {
+            try { out.push(AEMCP.safeValue(v[i])); } catch (eEl) { out.push(null); }
+        }
+        return out;
+    }
+    if (t === 'object') {
+        try { JSON.stringify(v); return v; } catch (eProbe) {}
+        try { return String(v); } catch (eStr) {}
+        return null;
+    }
+    try { return String(v); } catch (eOther) {}
+    return null;
+};
 
 // Count of a node's child properties, or -1 when `node` is a leaf Property /
 // not a group. try/catch shields against leaf nodes that lack numProperties.

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node build.mjs",
     "watch": "node build.mjs --watch",
-    "test": "node --test test/*.test.js"
+    "test": "node --test"
   },
   "dependencies": {
     "lucide-react": "0.453.0",

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -171,7 +171,7 @@ function Shell({ cs }) {
   prefsRef.current = { apiKey, model, permissionMode };
   const extRoot = cs && cs.getSystemPath ? cs.getSystemPath('extension') : '';
   const sidecarPath = React.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
-  const mcp = React.useMemo(() => createMcpClient({}), []);
+  const mcp = React.useMemo(() => createMcpClient({ extRoot }), [extRoot]);
   const handleChatEvent = React.useCallback((evt) => {
     if (evt.type === 'turn-start') setChatStreaming(true);
     if (evt.type === 'turn-end' || evt.type === 'error') setChatStreaming(false);

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -10,8 +10,11 @@ import { WizardScreen } from '../screens/WizardScreen';
 import { ConnectionDrawer } from '../screens/ConnectionDrawer';
 import { ChatScreen } from '../screens/ChatScreen';
 import { createAgentLoop } from '../lib/agentLoop';
-import { createMcpClient } from '../cep/mcpClient';
+import { pickBackend, deriveToolMeta, shouldResetOnBackendChange } from '../lib/backendSelect';
+import { createMcpClient, resolveMcpCommand } from '../cep/mcpClient';
 import { createApiKeyStore } from '../cep/apiKey';
+import { probeClaudeLogin, resolveSidecarPath } from '../cep/claudeAuth';
+import { createClaudeAgentBackend, resolveSystemNode } from '../cep/claudeAgentBackend';
 import { reduceEvent } from '../lib/chatEntries';
 import { DEFAULT_MODEL, FALLBACK_MODEL } from '../lib/anthropic';
 import { useActivity } from '../cep/useActivity';
@@ -41,6 +44,9 @@ const T = {
     regenConfirm: '重新生成',
     cancel: '取消',
     noKeyHint: '先在设置里配置 Anthropic API Key',
+    probingHint: '正在检测 Claude 登录态…',
+    notLoggedInHint: '订阅未登录：在终端运行 claude /login，再到设置里重新检测',
+    noNodeHint: '内嵌对话需要系统 Node 18+',
     pausedHint: '已暂停 — 恢复后才能发送',
     goSettings: '去设置',
   },
@@ -63,6 +69,9 @@ const T = {
     regenConfirm: 'Regenerate',
     cancel: 'Cancel',
     noKeyHint: 'Set your Anthropic API key in Settings first',
+    probingHint: 'Checking Claude login…',
+    notLoggedInHint: 'Not logged in: run claude /login in a terminal, then re-check in Settings',
+    noNodeHint: 'Embedded chat needs system Node 18+',
     pausedHint: 'Paused — resume to send',
     goSettings: 'Open Settings',
   },
@@ -154,40 +163,91 @@ function Shell({ cs }) {
   });
   const [model, setModel] = React.useState(() => readPref('ae_mcp_model', DEFAULT_MODEL));
   const [permissionMode, setPermissionMode] = React.useState(() => readPref('ae_mcp_perm_mode', 'manual'));
+  const [backendPref, setBackendPref] = React.useState(() => readPref('ae_mcp_backend', 'subscription'));
+  const [probe, setProbe] = React.useState(null);
   const [chatEntries, setChatEntries] = React.useState([]);
   const [chatStreaming, setChatStreaming] = React.useState(false);
   const prefsRef = React.useRef({ apiKey, model, permissionMode });
   prefsRef.current = { apiKey, model, permissionMode };
+  const extRoot = cs && cs.getSystemPath ? cs.getSystemPath('extension') : '';
+  const sidecarPath = React.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
+  const mcp = React.useMemo(() => createMcpClient({}), []);
+  const handleChatEvent = React.useCallback((evt) => {
+    if (evt.type === 'turn-start') setChatStreaming(true);
+    if (evt.type === 'turn-end' || evt.type === 'error') setChatStreaming(false);
+    setChatEntries((entries) => reduceEvent(entries, evt));
+  }, []);
 
-  const chatLoop = React.useMemo(() => {
-    const mcp = createMcpClient({});
+  const byokLoop = React.useMemo(() => {
     return createAgentLoop({
       getApiKey: () => prefsRef.current.apiKey,
       getModel: () => prefsRef.current.model,
       getPermissionMode: () => prefsRef.current.permissionMode,
       mcp,
       lang,
-      onEvent: (evt) => {
-        if (evt.type === 'turn-start') setChatStreaming(true);
-        if (evt.type === 'turn-end' || evt.type === 'error') setChatStreaming(false);
-        setChatEntries((entries) => reduceEvent(entries, evt));
-      },
+      onEvent: handleChatEvent,
     });
     // lang only affects the system prompt of FUTURE turns; recreating the loop
     // on language switch would drop the conversation, so we intentionally bind
     // the initial value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [mcp, handleChatEvent]);
+
+  // Same as the BYOK loop: lang only affects future system prompts, so avoid
+  // recreating the backend and silently dropping its conversation on language switch.
+  const claudeBackend = React.useMemo(() => createClaudeAgentBackend({
+    resolveNode: resolveSystemNode,
+    sidecarPath,
+    getMcpSpec: () => resolveMcpCommand({ extRoot }),
+    getToolMeta: async () => deriveToolMeta(await mcp.listTools()),
+    getModel: () => prefsRef.current.model,
+    getPermissionMode: () => prefsRef.current.permissionMode,
+    lang,
+    onEvent: handleChatEvent,
+  }), [extRoot, sidecarPath, mcp, handleChatEvent]);
+
+  const effective = pickBackend({ pref: backendPref, probe, hasApiKey: !!apiKey });
+  const activeBackend = effective.backend === 'subscription' ? claudeBackend : byokLoop;
+  const activeBackendRef = React.useRef(null);
+
+  const runClaudeProbe = React.useCallback(() => {
+    let alive = true;
+    setProbe(null);
+    probeClaudeLogin({
+      resolveNode: resolveSystemNode,
+      sidecarPath,
+    }).then((result) => {
+      if (alive) setProbe(result);
+    }).catch((e) => {
+      if (alive) setProbe({ loggedIn: false, nodeOk: false, detail: e && e.message ? e.message : String(e) });
+    });
+    return () => { alive = false; };
+  }, [sidecarPath]);
+
+  React.useEffect(() => {
+    if (backendPref !== 'subscription') return undefined;
+    return runClaudeProbe();
+  }, [backendPref, runClaudeProbe]);
+
+  React.useEffect(() => {
+    const decision = shouldResetOnBackendChange(activeBackendRef.current, effective.backend);
+    activeBackendRef.current = decision.nextReal;
+    if (!decision.reset) return;
+    byokLoop.reset();
+    claudeBackend.reset();
+    setChatEntries([]);
+    setChatStreaming(false);
+  }, [effective.backend, byokLoop, claudeBackend]);
 
   const sendChat = (text) => {
     const trimmed = String(text || '').trim();
     if (!trimmed) return;
     setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: 'user-text', text: trimmed }));
-    chatLoop.sendUser(trimmed);
+    activeBackend.sendUser(trimmed);
   };
 
   const newChatSession = () => {
-    chatLoop.reset();
+    activeBackend.reset();
     setChatStreaming(false);
     setChatEntries([]);
   };
@@ -310,6 +370,16 @@ function Shell({ cs }) {
     { id: 'activity', icon: 'list-checks', label: t.activity },
     { id: 'settings', icon: 'settings', label: t.settings },
   ];
+  const backendDisabledHint = effective.reason === 'probing' ? t.probingHint
+    : effective.reason === 'not-logged-in' ? t.notLoggedInHint
+    : effective.reason === 'no-node' ? t.noNodeHint
+    : effective.reason === 'no-key' ? t.noKeyHint
+    : '';
+  const composerDisabled = paused || effective.backend === 'none';
+  const claudeStatus = probe === null ? { state: 'checking' }
+    : probe.nodeOk === false ? { state: 'no-node', detail: probe.detail }
+    : probe.loggedIn === false ? { state: 'not-logged-in', detail: probe.detail }
+    : { state: 'ready', nodeVersion: probe.nodeVersion };
 
   return (
     <React.Fragment>
@@ -329,13 +399,13 @@ function Shell({ cs }) {
             lang={lang}
             entries={chatEntries}
             streaming={chatStreaming}
-            composerDisabled={paused || !apiKey}
-            disabledHint={paused ? t.pausedHint : !apiKey ? t.noKeyHint : ''}
+            composerDisabled={composerDisabled}
+            disabledHint={paused ? t.pausedHint : composerDisabled ? backendDisabledHint : ''}
             noticeActionLabel={paused ? t.resume : t.goSettings}
             onNoticeAction={() => (paused ? togglePause() : setTab('settings'))}
             onSend={sendChat}
-            onStop={() => chatLoop.stop()}
-            onApprove={(id, decision) => chatLoop.approve(id, decision)}
+            onStop={() => activeBackend.stop()}
+            onApprove={(id, decision) => activeBackend.approve(id, decision)}
             onNewSession={newChatSession}
           />
         ) : null}
@@ -375,6 +445,10 @@ function Shell({ cs }) {
             validateKey={validateAnthropicKey}
             model={model}
             onModelChange={(m) => { setModel(m); writePref('ae_mcp_model', m); }}
+            backend={backendPref}
+            onBackendChange={(m) => { setBackendPref(m); writePref('ae_mcp_backend', m); }}
+            claudeStatus={claudeStatus}
+            onRecheckClaude={runClaudeProbe}
             permissionMode={permissionMode}
             onPermissionMode={(m) => { setPermissionMode(m); writePref('ae_mcp_perm_mode', m); }}
           />

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -8,6 +8,12 @@ import { SettingsScreen } from '../screens/SettingsScreen';
 import { ActivityScreen } from '../screens/ActivityScreen';
 import { WizardScreen } from '../screens/WizardScreen';
 import { ConnectionDrawer } from '../screens/ConnectionDrawer';
+import { ChatScreen } from '../screens/ChatScreen';
+import { createAgentLoop } from '../lib/agentLoop';
+import { createMcpClient } from '../cep/mcpClient';
+import { createApiKeyStore } from '../cep/apiKey';
+import { reduceEvent } from '../lib/chatEntries';
+import { DEFAULT_MODEL, FALLBACK_MODEL } from '../lib/anthropic';
 import { useActivity } from '../cep/useActivity';
 import { useHandshake } from '../cep/useHandshake';
 import { isWizardDone, markWizardDone } from '../cep/firstRun';
@@ -34,6 +40,9 @@ const T = {
     regenBody: '所有已连接的 AI 客户端会立即失去访问权限，需要重启它们才能重新连接。',
     regenConfirm: '重新生成',
     cancel: '取消',
+    noKeyHint: '先在设置里配置 Anthropic API Key',
+    pausedHint: '已暂停 — 恢复后才能发送',
+    goSettings: '去设置',
   },
   en: {
     connected: 'Service running',
@@ -53,8 +62,46 @@ const T = {
     regenBody: 'Every connected AI client loses access immediately and must be restarted to reconnect.',
     regenConfirm: 'Regenerate',
     cancel: 'Cancel',
+    noKeyHint: 'Set your Anthropic API key in Settings first',
+    pausedHint: 'Paused — resume to send',
+    goSettings: 'Open Settings',
   },
 };
+
+function readPref(key, fallback) {
+  try {
+    const v = window.localStorage.getItem(key);
+    return v || fallback;
+  } catch (e) { return fallback; }
+}
+function writePref(key, value) {
+  try { window.localStorage.setItem(key, value); } catch (e) { /* best-effort */ }
+}
+
+async function validateAnthropicKey(key) {
+  // /v1/models is not CORS-enabled for direct browser access (verified in AE:
+  // the preflight fails), so validate against /v1/messages — the endpoint the
+  // chat actually uses — with a 1-token haiku ping. 401/403 = invalid key.
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: FALLBACK_MODEL,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  });
+  // Return {ok,status} (not a bare bool) so Settings can tell a rejected key
+  // (401→"invalid key") from a transient failure (network throw→"try again").
+  // A 401 is auth-normalized to status 401 regardless of the real code.
+  const ok = r.ok;
+  return { ok, status: ok ? 200 : (r.status === 403 ? 401 : r.status) };
+}
 
 const CLIENT_NAMES = {
   builtin: { zh: '面板内置对话', en: 'Built-in chat' },
@@ -97,6 +144,53 @@ function Shell({ cs }) {
   const [clients, setClients] = React.useState([]);
   const [confirmRegen, setConfirmRegen] = React.useState(false);
   const [tokenEpoch, setTokenEpoch] = React.useState(0);
+
+  // Embedded chat: API key, model/permission prefs, entry feed, agent loop
+  const keyStore = React.useMemo(() => {
+    try { return createApiKeyStore(); } catch (e) { return null; }
+  }, []);
+  const [apiKey, setApiKey] = React.useState(() => {
+    try { return keyStore ? keyStore.readKey() : ''; } catch (e) { return ''; }
+  });
+  const [model, setModel] = React.useState(() => readPref('ae_mcp_model', DEFAULT_MODEL));
+  const [permissionMode, setPermissionMode] = React.useState(() => readPref('ae_mcp_perm_mode', 'manual'));
+  const [chatEntries, setChatEntries] = React.useState([]);
+  const [chatStreaming, setChatStreaming] = React.useState(false);
+  const prefsRef = React.useRef({ apiKey, model, permissionMode });
+  prefsRef.current = { apiKey, model, permissionMode };
+
+  const chatLoop = React.useMemo(() => {
+    const mcp = createMcpClient({});
+    return createAgentLoop({
+      getApiKey: () => prefsRef.current.apiKey,
+      getModel: () => prefsRef.current.model,
+      getPermissionMode: () => prefsRef.current.permissionMode,
+      mcp,
+      lang,
+      onEvent: (evt) => {
+        if (evt.type === 'turn-start') setChatStreaming(true);
+        if (evt.type === 'turn-end' || evt.type === 'error') setChatStreaming(false);
+        setChatEntries((entries) => reduceEvent(entries, evt));
+      },
+    });
+    // lang only affects the system prompt of FUTURE turns; recreating the loop
+    // on language switch would drop the conversation, so we intentionally bind
+    // the initial value.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const sendChat = (text) => {
+    const trimmed = String(text || '').trim();
+    if (!trimmed) return;
+    setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: 'user-text', text: trimmed }));
+    chatLoop.sendUser(trimmed);
+  };
+
+  const newChatSession = () => {
+    chatLoop.reset();
+    setChatStreaming(false);
+    setChatEntries([]);
+  };
 
   const pushLog = React.useCallback((m) => {
     setLogs((xs) => [...xs.slice(-199), `[${new Date().toLocaleTimeString()}] ${m}`]);
@@ -230,7 +324,21 @@ function Shell({ cs }) {
         settingsTitle={t.settings}
       />
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', position: 'relative' }}>
-        {tab === 'chat' ? <EmptyState icon="message-square" title={t.chatEmptyT} caption={t.chatEmptyB} /> : null}
+        {tab === 'chat' ? (
+          <ChatScreen
+            lang={lang}
+            entries={chatEntries}
+            streaming={chatStreaming}
+            composerDisabled={paused || !apiKey}
+            disabledHint={paused ? t.pausedHint : !apiKey ? t.noKeyHint : ''}
+            noticeActionLabel={paused ? t.resume : t.goSettings}
+            onNoticeAction={() => (paused ? togglePause() : setTab('settings'))}
+            onSend={sendChat}
+            onStop={() => chatLoop.stop()}
+            onApprove={(id, decision) => chatLoop.approve(id, decision)}
+            onNewSession={newChatSession}
+          />
+        ) : null}
         {tab === 'activity' ? (
           <ActivityScreen
             events={events}
@@ -261,6 +369,14 @@ function Shell({ cs }) {
             onRegenToken={() => setConfirmRegen(true)}
             hostVersion={(connInfo && connInfo.hostVersion) || '-'}
             pythonVersion={(connInfo && connInfo.pythonVersion) || '-'}
+            apiKey={apiKey}
+            onSaveApiKey={(k) => { if (keyStore) keyStore.writeKey(k); setApiKey(k); }}
+            onClearApiKey={() => { if (keyStore) keyStore.clearKey(); setApiKey(''); }}
+            validateKey={validateAnthropicKey}
+            model={model}
+            onModelChange={(m) => { setModel(m); writePref('ae_mcp_model', m); }}
+            permissionMode={permissionMode}
+            onPermissionMode={(m) => { setPermissionMode(m); writePref('ae_mcp_perm_mode', m); }}
           />
         ) : null}
       </div>

--- a/plugin/panel/src/cep/apiKey.js
+++ b/plugin/panel/src/cep/apiKey.js
@@ -1,0 +1,81 @@
+const KEY_FILE = 'anthropic-key';
+
+function cepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) return globalThis.window.cep_node.require;
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  return null;
+}
+
+function defaultDeps() {
+  const req = cepRequire();
+  if (!req) throw new Error('CEP Node require is unavailable');
+  return {
+    fs: req('fs'),
+    os: req('os'),
+    path: req('path'),
+    pid: req('process') && req('process').pid,
+  };
+}
+
+export function createApiKeyStore(deps = defaultDeps()) {
+  const fs = deps.fs;
+  const os = deps.os;
+  const path = deps.path;
+
+  function keyDir() {
+    return path.join(os.homedir(), '.ae-mcp');
+  }
+
+  function keyPath() {
+    return path.join(keyDir(), KEY_FILE);
+  }
+
+  function readKey() {
+    try {
+      return fs.readFileSync(keyPath(), 'utf8').trim();
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return '';
+      throw e;
+    }
+  }
+
+  function writeKey(key) {
+    const value = String(key || '').trim();
+    const dir = keyDir();
+    const file = keyPath();
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const pid = deps.pid || 0;
+    const tmp = path.join(dir, `${KEY_FILE}.${pid}.${Date.now()}.tmp`);
+    fs.writeFileSync(tmp, value, 'utf8');
+    try {
+      fs.chmodSync(tmp, 0o600);
+    } catch (e) {
+      // Best effort only. Windows and some filesystems ignore or reject chmod.
+    }
+    fs.renameSync(tmp, file);
+    return value;
+  }
+
+  function clearKey() {
+    try {
+      fs.unlinkSync(keyPath());
+    } catch (e) {
+      if (!e || e.code !== 'ENOENT') throw e;
+    }
+  }
+
+  return { keyDir, keyPath, readKey, writeKey, clearKey };
+}
+
+export function readKey(deps) {
+  return createApiKeyStore(deps).readKey();
+}
+
+export function writeKey(key, deps) {
+  return createApiKeyStore(deps).writeKey(key);
+}
+
+export function clearKey(deps) {
+  return createApiKeyStore(deps).clearKey();
+}

--- a/plugin/panel/src/cep/claudeAgentBackend.js
+++ b/plugin/panel/src/cep/claudeAgentBackend.js
@@ -1,0 +1,331 @@
+import { createNdjsonReader } from '../lib/ndjson.js';
+
+const READY_TIMEOUT_MS = 15000;
+const STDERR_TAIL_LIMIT = 4096;
+const FIXED_NODE_CANDIDATE = 'C:\\Program Files\\nodejs\\node.exe';
+
+function getCepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+    return globalThis.window.cep_node.require;
+  }
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  throw new Error('CEP Node require is unavailable');
+}
+
+function getCepEnv() {
+  return (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env) || {};
+}
+
+function execFileAsync(execFileImpl, file, args, env) {
+  return new Promise((resolve) => {
+    execFileImpl(file, args, { windowsHide: true, env }, (err, stdout, stderr) => {
+      resolve({ err, stdout: String(stdout || ''), stderr: String(stderr || '') });
+    });
+  });
+}
+
+function nodeCandidates(stdout) {
+  const seen = new Set();
+  const candidates = String(stdout || '').split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  candidates.push(FIXED_NODE_CANDIDATE);
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate)) return false;
+    seen.add(candidate);
+    return true;
+  });
+}
+
+function parseMajor(version) {
+  const match = String(version || '').trim().match(/^v(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+export async function resolveSystemNode({ execFileImpl, env } = {}) {
+  const execFile = execFileImpl || getCepRequire()('child_process').execFile;
+  const processEnv = env || getCepEnv();
+  const where = await execFileAsync(execFile, 'where', ['node'], processEnv);
+  const candidates = nodeCandidates(where.err ? '' : where.stdout);
+
+  for (const candidate of candidates) {
+    const checked = await execFileAsync(execFile, candidate, ['--version'], processEnv);
+    if (checked.err) continue;
+    const version = String(checked.stdout || checked.stderr || '').trim();
+    if (parseMajor(version) >= 18) return { ok: true, nodePath: candidate, version };
+  }
+
+  return { ok: false, detail: 'No system Node 18+ found.' };
+}
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function nodeMissingMessage(lang) {
+  if (lang === 'zh') return '内嵌对话需要系统 Node 18+（未检测到）。安装 Node.js LTS 后重试。';
+  return 'Embedded chat needs system Node 18+. Install Node.js LTS and retry.';
+}
+
+function sanitizeEnv(env) {
+  const copy = Object.assign({}, env || {});
+  delete copy.ANTHROPIC_API_KEY;
+  return copy;
+}
+
+function appendTail(tail, chunk) {
+  const next = tail + String(chunk || '');
+  return next.length > STDERR_TAIL_LIMIT ? next.slice(next.length - STDERR_TAIL_LIMIT) : next;
+}
+
+export function createClaudeAgentBackend({
+  resolveNode = resolveSystemNode,
+  sidecarPath,
+  getMcpSpec,
+  getToolMeta,
+  getModel,
+  getPermissionMode,
+  onEvent,
+  lang = 'zh',
+  spawnImpl,
+  env,
+}) {
+  let proc = null;
+  let startPromise = null;
+  let pendingReadyReject = null;
+  let pendingReadyTimer = null;
+  let ready = false;
+  let stopping = false;
+  let stderrTail = '';
+  let transcript = [];
+  let activeRun = null;
+  let activeResolve = null;
+  let activeAssistantText = '';
+
+  function emit(evt) {
+    if (onEvent) onEvent(evt);
+  }
+
+  function getSpawn() {
+    if (spawnImpl) return spawnImpl;
+    return getCepRequire()('child_process').spawn;
+  }
+
+  function writeMessage(message) {
+    if (!proc || !proc.stdin || !proc.stdin.write) return;
+    proc.stdin.write(JSON.stringify(message) + '\n');
+  }
+
+  function finishActive() {
+    if (!activeResolve) {
+      activeRun = null;
+      activeAssistantText = '';
+      return;
+    }
+    const resolve = activeResolve;
+    activeResolve = null;
+    activeRun = null;
+    activeAssistantText = '';
+    resolve();
+  }
+
+  function handleSidecarMessage(message) {
+    if (!message || message.t === 'ready') return;
+    if (message.t !== 'event') return;
+
+    const event = message.event;
+    if (!event) return;
+    if (event.type === 'text-delta') activeAssistantText += String(event.text || '');
+    emit(event);
+    if (event.type === 'turn-end') {
+      transcript.push({ role: 'assistant', text: activeAssistantText });
+      finishActive();
+    }
+    if (event.type === 'error') finishActive();
+  }
+
+  function exitDetail(code, signal) {
+    const suffix = signal ? String(code) + ' ' + signal : String(code);
+    return stderrTail ? suffix + ' ' + stderrTail : suffix;
+  }
+
+  function clearReadyWait() {
+    if (pendingReadyTimer) clearTimeout(pendingReadyTimer);
+    pendingReadyTimer = null;
+    pendingReadyReject = null;
+  }
+
+  function handleExit(code, signal) {
+    const wasStopping = stopping;
+    const wasReady = ready;
+    const detail = exitDetail(code, signal);
+    const rejectReady = pendingReadyReject;
+    proc = null;
+    ready = false;
+    startPromise = null;
+    stopping = false;
+    if (wasStopping) return;
+    if (!wasReady && rejectReady) {
+      clearReadyWait();
+      rejectReady(new Error('sidecar exited: ' + detail));
+      return;
+    }
+    if (activeRun) {
+      emit({ type: 'error', kind: 'mcp', message: 'sidecar exited: ' + detail });
+      finishActive();
+    }
+  }
+
+  function handleProcError(error) {
+    const rejectReady = pendingReadyReject;
+    proc = null;
+    ready = false;
+    startPromise = null;
+    if (rejectReady) {
+      clearReadyWait();
+      rejectReady(error instanceof Error ? error : new Error('sidecar error'));
+      return;
+    }
+    if (activeRun) {
+      emit({ type: 'error', kind: 'mcp', message: error && error.message ? error.message : 'sidecar error' });
+      finishActive();
+    }
+  }
+
+  async function startSidecar() {
+    if (proc && ready) return true;
+    if (startPromise) return startPromise;
+
+    startPromise = (async () => {
+      const node = await resolveNode();
+      if (!node || !node.ok) {
+        emit({ type: 'error', kind: 'mcp', message: nodeMissingMessage(lang) });
+        return false;
+      }
+
+      const mcpSpec = await getMcpSpec();
+      const meta = await getToolMeta();
+      const spawn = getSpawn();
+      const spawnEnv = sanitizeEnv(env || getCepEnv());
+      stderrTail = '';
+      stopping = false;
+      ready = false;
+
+      let readyResolve;
+      let readyReject;
+      const readyPromise = new Promise((resolve, reject) => {
+        readyResolve = resolve;
+        readyReject = reject;
+      });
+      pendingReadyReject = readyReject;
+      pendingReadyTimer = setTimeout(() => {
+        pendingReadyTimer = null;
+        pendingReadyReject = null;
+        try {
+          stopping = true;
+          if (proc) proc.kill();
+        } catch (e) {
+          // best effort
+        }
+        readyReject(new Error('sidecar ready timed out'));
+      }, READY_TIMEOUT_MS);
+
+      try {
+        proc = spawn(node.nodePath, [
+          sidecarPath,
+          '--mcp', JSON.stringify(mcpSpec),
+          '--allowed-tools', JSON.stringify(meta.allowedTools),
+          '--annotations', JSON.stringify(meta.annotations),
+          '--model', getModel(),
+          '--lang', lang,
+        ], {
+          stdio: 'pipe',
+          windowsHide: true,
+          env: spawnEnv,
+        });
+      } catch (e) {
+        clearReadyWait();
+        throw e;
+      }
+
+      const reader = createNdjsonReader((message) => {
+        if (message && message.t === 'ready') {
+          ready = true;
+          clearReadyWait();
+          readyResolve(true);
+          return;
+        }
+        handleSidecarMessage(message);
+      });
+      if (proc.stdout && proc.stdout.on) proc.stdout.on('data', reader);
+      if (proc.stderr && proc.stderr.on) proc.stderr.on('data', (chunk) => {
+        stderrTail = appendTail(stderrTail, chunk);
+      });
+      proc.on('exit', (code, signal) => handleExit(code, signal));
+      proc.on('error', (error) => {
+        handleProcError(error);
+      });
+
+      await readyPromise;
+      return true;
+    })();
+
+    try {
+      return await startPromise;
+    } catch (e) {
+      emit({ type: 'error', kind: 'mcp', message: e && e.message ? e.message : 'Failed to start sidecar.' });
+      return false;
+    } finally {
+      startPromise = null;
+    }
+  }
+
+  async function sendUser(text) {
+    if (activeRun) return activeRun;
+
+    activeAssistantText = '';
+    activeRun = new Promise((resolve) => {
+      activeResolve = resolve;
+    });
+
+    const ok = await startSidecar();
+    if (!ok) {
+      finishActive();
+      return activeRun;
+    }
+
+    const userText = String(text || '');
+    transcript.push({ role: 'user', text: userText });
+    writeMessage({ t: 'user', text: userText, permissionMode: getPermissionMode(), model: getModel() });
+    return activeRun;
+  }
+
+  function approve(toolUseId, decision) {
+    writeMessage({ t: 'approve', id: toolUseId, decision });
+  }
+
+  function stop() {
+    writeMessage({ t: 'stop' });
+  }
+
+  function reset() {
+    stopping = true;
+    if (proc) {
+      try { proc.kill(); } catch (e) { /* best effort */ }
+    }
+    proc = null;
+    ready = false;
+    startPromise = null;
+    transcript = [];
+    finishActive();
+    stderrTail = '';
+    stopping = false;
+  }
+
+  return {
+    sendUser,
+    approve,
+    stop,
+    reset,
+    getMessages: () => clone(transcript),
+  };
+}

--- a/plugin/panel/src/cep/claudeAuth.js
+++ b/plugin/panel/src/cep/claudeAuth.js
@@ -1,0 +1,115 @@
+import { createNdjsonReader } from '../lib/ndjson.js';
+
+function getCepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+    return globalThis.window.cep_node.require;
+  }
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  throw new Error('CEP Node require is unavailable');
+}
+
+function getCepEnv() {
+  return (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env) || {};
+}
+
+function normalizeFsPath(value) {
+  let text = String(value || '').replace(/\//g, '\\');
+  text = text.replace(/\\+$/, '');
+  return text;
+}
+
+function defaultFs() {
+  return getCepRequire()('fs');
+}
+
+function defaultSpawn() {
+  return getCepRequire()('child_process').spawn;
+}
+
+function joinPath(base, leaf) {
+  return normalizeFsPath(base) + '\\' + leaf;
+}
+
+export function resolveSidecarPath({ extRoot, fsImpl } = {}) {
+  const root = normalizeFsPath(extRoot || '');
+  const deployed = joinPath(root, 'sidecar\\agent-sidecar.mjs');
+  const repo = joinPath(root, '..\\sidecar\\agent-sidecar.mjs');
+  const fs = fsImpl || defaultFs();
+  if (fs.existsSync(deployed)) return deployed;
+  if (fs.existsSync(repo)) return repo;
+  return deployed;
+}
+
+export async function probeClaudeLogin({
+  resolveNode,
+  sidecarPath,
+  spawnImpl,
+  env,
+  timeoutMs = 30000,
+} = {}) {
+  const resolved = await resolveNode();
+  if (!resolved || resolved.ok === false) {
+    return { loggedIn: false, nodeOk: false, detail: (resolved && resolved.detail) || 'node unavailable' };
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let stderr = '';
+    let proc = null;
+    const spawn = spawnImpl || defaultSpawn();
+    const spawnEnv = Object.assign({}, getCepEnv(), env || {});
+    delete spawnEnv.ANTHROPIC_API_KEY;
+
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    }
+
+    const timer = setTimeout(() => {
+      if (proc && proc.kill) {
+        try { proc.kill(); } catch (e) { /* best effort */ }
+      }
+      finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: 'probe timeout' });
+    }, timeoutMs);
+
+    try {
+      proc = spawn(resolved.nodePath, [sidecarPath, '--probe'], {
+        stdio: 'pipe',
+        windowsHide: true,
+        env: spawnEnv,
+      });
+    } catch (e) {
+      finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: e && e.message ? e.message : String(e) });
+      return;
+    }
+
+    const onMessage = createNdjsonReader((message) => {
+      if (!message || message.t !== 'probe-result') return;
+      finish({
+        loggedIn: !!message.loggedIn,
+        nodeOk: true,
+        nodeVersion: resolved.version,
+        detail: message.detail || message.reason || '',
+      });
+    });
+
+    if (proc.stdout && proc.stdout.on) proc.stdout.on('data', onMessage);
+    if (proc.stderr && proc.stderr.on) {
+      proc.stderr.on('data', (chunk) => {
+        stderr += String(chunk || '');
+        if (stderr.length > 4000) stderr = stderr.slice(-4000);
+      });
+    }
+    if (proc.on) {
+      proc.on('error', (err) => {
+        finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: err && err.message ? err.message : String(err) });
+      });
+      proc.on('exit', () => {
+        finish({ loggedIn: false, nodeOk: true, nodeVersion: resolved.version, detail: stderr.trim() || 'probe exited without result' });
+      });
+    }
+  });
+}

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,0 +1,302 @@
+const DEFAULT_TIMEOUT_MS = 30000;
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+const PANEL_VERSION = '0.3.2';
+
+function getCepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+    return globalThis.window.cep_node.require;
+  }
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  throw new Error('CEP Node require is unavailable');
+}
+
+function getCepEnv() {
+  return (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env) || {};
+}
+
+function normalizeFsPath(value) {
+  let text = String(value || '').replace(/\//g, '\\');
+  text = text.replace(/\\+$/, '');
+  return text;
+}
+
+function dirname(value) {
+  const normalized = normalizeFsPath(value);
+  const index = normalized.lastIndexOf('\\');
+  if (index <= 0) return '';
+  return normalized.slice(0, index);
+}
+
+function joinPath(base, leaf) {
+  return normalizeFsPath(base) + '\\' + leaf;
+}
+
+function firstWhereHit(stdout) {
+  return String(stdout || '').split(/\r?\n/).map((line) => line.trim()).find(Boolean) || '';
+}
+
+function defaultWhereImpl() {
+  const childProcess = getCepRequire()('child_process');
+  return new Promise((resolve) => {
+    childProcess.execFile('where', ['ae-mcp'], { windowsHide: true }, (err, stdout) => {
+      resolve(err ? '' : stdout);
+    });
+  });
+}
+
+function defaultFs() {
+  return getCepRequire()('fs');
+}
+
+function findProjectRoot({ extRoot, repoRoot, fsImpl }) {
+  if (repoRoot && fsImpl.existsSync(joinPath(repoRoot, 'pyproject.toml'))) return normalizeFsPath(repoRoot);
+
+  let current = normalizeFsPath(extRoot);
+  while (current) {
+    if (fsImpl.existsSync(joinPath(current, 'pyproject.toml'))) return current;
+    const parent = dirname(current);
+    if (!parent || parent === current) break;
+    current = parent;
+  }
+  return '';
+}
+
+export async function resolveMcpCommand({
+  explicitPath,
+  whereImpl = defaultWhereImpl,
+  fsImpl,
+  extRoot = '',
+  repoRoot = '',
+} = {}) {
+  const configured = String(explicitPath || '').trim();
+  if (configured) return { command: configured, args: [], source: 'explicit' };
+
+  const found = firstWhereHit(await whereImpl('ae-mcp'));
+  if (found) return { command: found, args: [], source: 'where' };
+
+  const fs = fsImpl || defaultFs();
+  const projectRoot = findProjectRoot({ extRoot, repoRoot, fsImpl: fs });
+  if (projectRoot) {
+    return { command: 'uv', args: ['run', '--project', projectRoot, 'ae-mcp'], source: 'uv' };
+  }
+
+  throw new Error('Unable to find ae-mcp. Configure the ae-mcp executable path, add ae-mcp to PATH, or run from a checkout containing pyproject.toml for uv run --project.');
+}
+
+export function _createRpc(stdinWrite, onLine, options = {}) {
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  let nextId = 1;
+  let buffer = '';
+  const pending = new Map();
+
+  function rejectPending(id, error) {
+    const entry = pending.get(id);
+    if (!entry) return;
+    pending.delete(id);
+    clearTimeout(entry.timer);
+    entry.reject(error);
+  }
+
+  function handleMessage(message) {
+    if (!message || message.id === undefined || message.id === null) return;
+    const entry = pending.get(message.id);
+    if (!entry) return;
+    pending.delete(message.id);
+    clearTimeout(entry.timer);
+    if (message.error) {
+      const error = new Error(message.error.message || 'JSON-RPC request failed');
+      error.code = message.error.code;
+      error.data = message.error.data;
+      entry.reject(error);
+    } else {
+      entry.resolve(message.result);
+    }
+  }
+
+  function handleChunk(chunk) {
+    buffer += String(chunk || '');
+    let index = buffer.indexOf('\n');
+    while (index !== -1) {
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (line) {
+        try {
+          handleMessage(JSON.parse(line));
+        } catch (e) {
+          // Ignore stderr-style contamination defensively; valid MCP stdout is JSON lines.
+        }
+      }
+      index = buffer.indexOf('\n');
+    }
+  }
+
+  if (onLine) onLine(handleChunk);
+
+  function writeMessage(message) {
+    stdinWrite(JSON.stringify(message) + '\n');
+  }
+
+  function request(method, params) {
+    const id = nextId++;
+    const message = { jsonrpc: '2.0', id, method };
+    if (params !== undefined) message.params = params;
+    const promise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => rejectPending(id, new Error(method + ' timed out after ' + timeoutMs + 'ms')), timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+    });
+    writeMessage(message);
+    return promise;
+  }
+
+  function notify(method, params) {
+    const message = { jsonrpc: '2.0', method };
+    if (params !== undefined) message.params = params;
+    writeMessage(message);
+  }
+
+  function close(reason = new Error('MCP process closed')) {
+    for (const id of Array.from(pending.keys())) rejectPending(id, reason);
+  }
+
+  return { request, notify, handleChunk, close };
+}
+
+export function createMcpClient({
+  spawnImpl,
+  resolveCommand = resolveMcpCommand,
+  env,
+  onCrash,
+  extRoot,
+  repoRoot,
+  packageVersion = PANEL_VERSION,
+  retryDelays = [1000, 2000, 4000],
+} = {}) {
+  let proc = null;
+  let rpc = null;
+  let tools = null;
+  let status = 'idle';
+  let startPromise = null;
+  let retryCount = 0;
+  let lastError = null;
+  let stopped = false;
+  let restartTimer = null;
+
+  function currentState() {
+    return { status, retryCount, error: lastError, tools };
+  }
+
+  function getSpawn() {
+    if (spawnImpl) return spawnImpl;
+    return getCepRequire()('child_process').spawn;
+  }
+
+  function attachBeforeUnload() {
+    if (globalThis.window && globalThis.window.addEventListener) {
+      globalThis.window.addEventListener('beforeunload', () => stop());
+    }
+  }
+
+  async function start() {
+    if (status === 'ready') return currentState();
+    if (startPromise) return startPromise;
+    stopped = false;
+    status = 'starting';
+    startPromise = (async () => {
+      const commandSpec = await resolveCommand({ extRoot, repoRoot });
+      const spawn = getSpawn();
+      const spawnEnv = Object.assign({}, getCepEnv(), env || {}, { AE_MCP_BACKEND: 'ae-mcp' });
+      proc = spawn(commandSpec.command, commandSpec.args || [], {
+        stdio: 'pipe',
+        windowsHide: true,
+        env: spawnEnv,
+      });
+      rpc = _createRpc(
+        (line) => proc.stdin.write(line),
+        (handler) => proc.stdout.on('data', handler),
+      );
+      proc.on('exit', (code, signal) => handleExit(code, signal));
+      proc.on('error', (err) => handleCrash(err));
+      if (proc.stderr && proc.stderr.on) proc.stderr.on('data', () => {});
+
+      await rpc.request('initialize', {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        clientInfo: { name: 'panel-chat', version: packageVersion },
+        capabilities: {},
+      });
+      rpc.notify('notifications/initialized');
+      const listed = await rpc.request('tools/list', {});
+      tools = listed && Array.isArray(listed.tools) ? listed.tools : [];
+      status = 'ready';
+      retryCount = 0;
+      lastError = null;
+      attachBeforeUnload();
+      return currentState();
+    })();
+
+    try {
+      return await startPromise;
+    } catch (e) {
+      status = 'error';
+      lastError = e;
+      throw e;
+    } finally {
+      startPromise = null;
+    }
+  }
+
+  function handleCrash(error) {
+    if (stopped) return;
+    status = 'crashed';
+    lastError = error;
+    if (rpc) rpc.close(error instanceof Error ? error : new Error('MCP process crashed'));
+    if (onCrash) onCrash(error);
+    scheduleRestart();
+  }
+
+  function handleExit(code, signal) {
+    if (stopped) return;
+    handleCrash(new Error('MCP process exited: ' + code + (signal ? ' ' + signal : '')));
+  }
+
+  function scheduleRestart() {
+    if (retryCount >= retryDelays.length) {
+      status = 'error';
+      return;
+    }
+    const delay = retryDelays[retryCount++];
+    clearTimeout(restartTimer);
+    restartTimer = setTimeout(() => {
+      start().catch((err) => {
+        lastError = err;
+        scheduleRestart();
+      });
+    }, delay);
+  }
+
+  async function listTools() {
+    await start();
+    return tools || [];
+  }
+
+  async function callTool(name, args = {}) {
+    await start();
+    return rpc.request('tools/call', { name, arguments: args });
+  }
+
+  function stop() {
+    stopped = true;
+    clearTimeout(restartTimer);
+    restartTimer = null;
+    status = 'stopped';
+    if (rpc) rpc.close(new Error('MCP client stopped'));
+    if (proc) {
+      try { proc.kill(); } catch (e) { /* best effort */ }
+    }
+    proc = null;
+    rpc = null;
+    startPromise = null;
+  }
+
+  return { start, listTools, callTool, stop, state: currentState };
+}

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,3 +1,5 @@
+import { createNdjsonReader } from '../lib/ndjson.js';
+
 const DEFAULT_TIMEOUT_MS = 30000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 const PANEL_VERSION = '0.3.2';
@@ -87,7 +89,6 @@ export async function resolveMcpCommand({
 export function _createRpc(stdinWrite, onLine, options = {}) {
   const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
   let nextId = 1;
-  let buffer = '';
   const pending = new Map();
 
   function rejectPending(id, error) {
@@ -114,22 +115,7 @@ export function _createRpc(stdinWrite, onLine, options = {}) {
     }
   }
 
-  function handleChunk(chunk) {
-    buffer += String(chunk || '');
-    let index = buffer.indexOf('\n');
-    while (index !== -1) {
-      const line = buffer.slice(0, index).trim();
-      buffer = buffer.slice(index + 1);
-      if (line) {
-        try {
-          handleMessage(JSON.parse(line));
-        } catch (e) {
-          // Ignore stderr-style contamination defensively; valid MCP stdout is JSON lines.
-        }
-      }
-      index = buffer.indexOf('\n');
-    }
-  }
+  const handleChunk = createNdjsonReader(handleMessage);
 
   if (onLine) onLine(handleChunk);
 

--- a/plugin/panel/src/lib/agentLoop.js
+++ b/plugin/panel/src/lib/agentLoop.js
@@ -1,0 +1,225 @@
+import { DEFAULT_MODEL, buildSystemPrompt, sendAnthropicMessage } from './anthropic.js';
+
+const MAX_TOOL_ROUNDS = 25;
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function toolText(result) {
+  const content = result && Array.isArray(result.content) ? result.content : [];
+  const text = content.filter((item) => item && item.type === 'text').map((item) => item.text || '').join('\n');
+  if (text) return text;
+  if (result === undefined) return '';
+  try {
+    return JSON.stringify(result);
+  } catch (e) {
+    return String(result);
+  }
+}
+
+function normalizeErrorKind(error) {
+  if (error && error.name === 'AbortError') return 'aborted';
+  return (error && error.kind) || 'network';
+}
+
+function shouldBypassApproval({ mode, tool, sessionAllowed }) {
+  if (sessionAllowed) return true;
+  if (mode === 'none') return true;
+  const annotations = (tool && tool.annotations) || {};
+  if (mode === 'manual') return annotations.readOnlyHint === true;
+  if (mode === 'auto') return annotations.destructiveHint !== true;
+  return false;
+}
+
+function approvalRisk(tool) {
+  const annotations = (tool && tool.annotations) || {};
+  return annotations.destructiveHint === true ? 'destructive' : 'write';
+}
+
+function getToolUses(message) {
+  return ((message && message.content) || []).filter((block) => block && block.type === 'tool_use');
+}
+
+function makeToolResult(toolUseId, text, isError) {
+  return { type: 'tool_result', tool_use_id: toolUseId, content: text, is_error: Boolean(isError) };
+}
+
+export function createAgentLoop({
+  getApiKey,
+  getModel,
+  mcp,
+  getPermissionMode,
+  onEvent,
+  anthropic = sendAnthropicMessage,
+  maxToolRounds = MAX_TOOL_ROUNDS,
+  lang = 'zh',
+}) {
+  let messages = [];
+  let activeController = null;
+  let activeRun = null;
+  const pendingApprovals = new Map();
+  const sessionAllowedTools = new Set();
+
+  function emit(evt) {
+    if (onEvent) onEvent(evt);
+  }
+
+  function resetPendingApprovals() {
+    for (const [id, pending] of pendingApprovals) {
+      pending.resolve({ decision: 'abort' });
+      pendingApprovals.delete(id);
+    }
+  }
+
+  async function waitForApproval(toolUse) {
+    return await new Promise((resolve) => {
+      pendingApprovals.set(toolUse.id, { name: toolUse.name, resolve });
+    });
+  }
+
+  async function executeTool(toolUse) {
+    const start = Date.now();
+    try {
+      const result = await mcp.callTool(toolUse.name, toolUse.input || {});
+      const text = toolText(result);
+      const isError = Boolean(result && result.isError);
+      emit({ type: 'tool-result', toolUseId: toolUse.id, ok: !isError, text, durationMs: Date.now() - start });
+      return makeToolResult(toolUse.id, text, isError);
+    } catch (e) {
+      const text = e && e.message ? e.message : 'MCP tool call failed.';
+      emit({ type: 'tool-result', toolUseId: toolUse.id, ok: false, text, durationMs: Date.now() - start });
+      return makeToolResult(toolUse.id, text, true);
+    }
+  }
+
+  async function handleToolUse(toolUse, toolByName) {
+    emit({ type: 'tool-start', toolUseId: toolUse.id, name: toolUse.name, input: clone(toolUse.input || {}) });
+
+    const tool = toolByName.get(toolUse.name) || {};
+    const mode = (getPermissionMode && getPermissionMode()) || 'manual';
+    const sessionAllowed = sessionAllowedTools.has(toolUse.name);
+    if (!shouldBypassApproval({ mode, tool, sessionAllowed })) {
+      emit({
+        type: 'approval-required',
+        toolUseId: toolUse.id,
+        name: toolUse.name,
+        input: clone(toolUse.input || {}),
+        risk: approvalRisk(tool),
+      });
+      const approved = await waitForApproval(toolUse);
+      pendingApprovals.delete(toolUse.id);
+      if (approved.decision === 'abort') throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+      if (approved.decision === 'deny') {
+        emit({ type: 'tool-denied', toolUseId: toolUse.id });
+        return makeToolResult(toolUse.id, 'User denied this action.', true);
+      }
+      if (approved.decision === 'allow-session') sessionAllowedTools.add(toolUse.name);
+    }
+
+    return await executeTool(toolUse);
+  }
+
+  async function sendUser(text) {
+    if (activeRun) return activeRun;
+
+    const userMessage = { role: 'user', content: String(text || '') };
+    messages.push(userMessage);
+    emit({ type: 'turn-start' });
+
+    const controller = new AbortController();
+    activeController = controller;
+
+    activeRun = (async () => {
+      try {
+        const tools = await mcp.listTools();
+        const toolByName = new Map((tools || []).map((tool) => [tool.name, tool]));
+        let toolRounds = 0;
+
+        while (true) {
+          if (toolRounds >= maxToolRounds) {
+            emit({ type: 'error', kind: 'mcp', message: 'Stopped after 25 consecutive tool rounds.' });
+            return;
+          }
+
+          const result = await anthropic({
+            apiKey: getApiKey && getApiKey(),
+            model: (getModel && getModel()) || DEFAULT_MODEL,
+            system: buildSystemPrompt(lang),
+            messages: clone(messages),
+            tools,
+            signal: controller.signal,
+            onTextDelta: (delta) => emit({ type: 'text-delta', text: delta }),
+          });
+
+          const assistantMessage = result.assistantMessage || { role: 'assistant', content: [] };
+          messages.push(assistantMessage);
+
+          const toolUses = getToolUses(assistantMessage);
+          if (result.stopReason !== 'tool_use' || toolUses.length === 0) {
+            emit({ type: 'turn-end', stopReason: result.stopReason || 'end_turn' });
+            return;
+          }
+
+          toolRounds += 1;
+          const toolResults = [];
+          for (const toolUse of toolUses) {
+            toolResults.push(await handleToolUse(toolUse, toolByName));
+          }
+          messages.push({ role: 'user', content: toolResults });
+        }
+      } catch (e) {
+        const kind = normalizeErrorKind(e);
+        // If we bailed out after the assistant's tool_use message entered the
+        // history but before its tool_results did (abort during an approval
+        // wait is the concrete case), the next request would be rejected by
+        // the API, which requires a tool_result for every tool_use. Close the
+        // gap with synthetic cancelled results so the conversation stays
+        // continuable.
+        repairDanglingToolUses();
+        emit({ type: 'error', kind, message: e && e.message ? e.message : 'Agent loop failed.' });
+      } finally {
+        activeController = null;
+        activeRun = null;
+      }
+    })();
+
+    return await activeRun;
+  }
+
+  function repairDanglingToolUses() {
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+    const uses = getToolUses(last);
+    if (!uses.length) return;
+    messages.push({
+      role: 'user',
+      content: uses.map((use) => makeToolResult(use.id, 'Cancelled by user.', true)),
+    });
+  }
+
+  function approve(toolUseId, decision) {
+    const pending = pendingApprovals.get(toolUseId);
+    if (!pending) return;
+    pending.resolve({ decision });
+  }
+
+  function stop() {
+    if (activeController) activeController.abort();
+    resetPendingApprovals();
+  }
+
+  function reset() {
+    stop();
+    messages = [];
+    sessionAllowedTools.clear();
+  }
+
+  return {
+    sendUser,
+    approve,
+    stop,
+    reset,
+    getMessages: () => clone(messages),
+  };
+}

--- a/plugin/panel/src/lib/agentLoop.js
+++ b/plugin/panel/src/lib/agentLoop.js
@@ -67,8 +67,9 @@ export function createAgentLoop({
 
   function resetPendingApprovals() {
     for (const [id, pending] of pendingApprovals) {
-      pending.resolve({ decision: 'abort' });
       pendingApprovals.delete(id);
+      emit({ type: 'tool-denied', toolUseId: id });
+      pending.resolve({ decision: 'abort' });
     }
   }
 

--- a/plugin/panel/src/lib/anthropic.js
+++ b/plugin/panel/src/lib/anthropic.js
@@ -1,0 +1,149 @@
+import { createSseParser } from './sse.js';
+
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const FALLBACK_MODEL = 'claude-haiku-4-5-20251001';
+
+export function buildSystemPrompt(lang = 'zh') {
+  if (lang === 'en') {
+    return [
+      'You are a concise After Effects assistant inside the AE MCP panel.',
+      'Understand the user goal, then choose appropriate MCP tools before operating.',
+      'Name target comps, layers, properties, or files in quotes before changing them.',
+      'Prefer read-only inspection before edits when context is missing.',
+      'Summarize tool results plainly and ask only when a required detail is missing.',
+    ].join(' ');
+  }
+  return [
+    '你是 AE MCP 面板内的简洁 After Effects 助手。',
+    '先理解用户目标，再选择合适的 MCP 工具操作 AE。',
+    '修改前用引号明示目标合成、图层、属性或文件。',
+    '缺少上下文时优先用只读工具检查。',
+    '用简明语言总结工具结果，只在缺少必要信息时追问。',
+  ].join(' ');
+}
+
+export function mapMcpToolsToAnthropic(tools = []) {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description || '',
+    input_schema: tool.inputSchema || tool.input_schema || {},
+  }));
+}
+
+function classifyHttpError(status, fallbackMessage) {
+  if (status === 401 || status === 403) return { kind: 'auth', message: 'Anthropic authentication failed.' };
+  if (status === 429) return { kind: 'rate_limit', message: 'Anthropic rate limit reached.' };
+  if (status === 529 || status >= 500) return { kind: 'overloaded', message: 'Anthropic service is overloaded.' };
+  return { kind: 'network', message: fallbackMessage || 'Anthropic request failed.' };
+}
+
+function toError(kind, message) {
+  const error = new Error(message);
+  error.kind = kind;
+  return error;
+}
+
+function parseAnthropicEvent(data, state, onTextDelta) {
+  if (data.type === 'content_block_start') {
+    const block = data.content_block || {};
+    if (block.type === 'text') {
+      state.blocks.set(data.index, { type: 'text', text: block.text || '' });
+    } else if (block.type === 'tool_use') {
+      state.blocks.set(data.index, {
+        type: 'tool_use',
+        id: block.id,
+        name: block.name,
+        inputJson: '',
+        startInput: block.input || {},
+      });
+    }
+  } else if (data.type === 'content_block_delta') {
+    const block = state.blocks.get(data.index);
+    if (!block || !data.delta) return;
+    if (data.delta.type === 'text_delta') {
+      const text = data.delta.text || '';
+      block.text += text;
+      if (text) onTextDelta(text);
+    } else if (data.delta.type === 'input_json_delta') {
+      block.inputJson += data.delta.partial_json || '';
+    }
+  } else if (data.type === 'message_delta' && data.delta) {
+    state.stopReason = data.delta.stop_reason || state.stopReason;
+  }
+}
+
+function finishBlocks(blocks) {
+  return Array.from(blocks.values()).map((block) => {
+    if (block.type === 'tool_use') {
+      let input = block.startInput || {};
+      if (block.inputJson) input = JSON.parse(block.inputJson);
+      return { type: 'tool_use', id: block.id, name: block.name, input };
+    }
+    return block;
+  });
+}
+
+export async function sendAnthropicMessage({
+  apiKey,
+  model = DEFAULT_MODEL,
+  system = buildSystemPrompt('zh'),
+  messages,
+  tools,
+  signal,
+  fetchImpl = globalThis.fetch,
+  onTextDelta = () => {},
+} = {}) {
+  if (!apiKey) throw toError('auth', 'Anthropic API key is missing.');
+  if (!fetchImpl) throw toError('network', 'fetch is unavailable in this runtime.');
+
+  let response;
+  try {
+    response = await fetchImpl('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      signal,
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 8192,
+        system,
+        messages,
+        tools: mapMcpToolsToAnthropic(tools),
+        stream: true,
+      }),
+    });
+  } catch (e) {
+    if (e && e.name === 'AbortError') throw e;
+    throw toError('network', e && e.message ? e.message : 'Anthropic network request failed.');
+  }
+
+  if (!response.ok) {
+    let detail = '';
+    try { detail = await response.text(); } catch (e) { /* best effort */ }
+    const classified = classifyHttpError(response.status, detail);
+    throw toError(classified.kind, classified.message);
+  }
+
+  const reader = response.body && response.body.getReader ? response.body.getReader() : null;
+  if (!reader) throw toError('network', 'Anthropic response body is not streamable.');
+
+  const decoder = new TextDecoder();
+  const state = { blocks: new Map(), stopReason: 'end_turn' };
+  const parser = createSseParser(({ data }) => parseAnthropicEvent(data, state, onTextDelta));
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    parser.feed(decoder.decode(chunk.value, { stream: true }));
+  }
+  parser.feed(decoder.decode());
+
+  return {
+    assistantMessage: { role: 'assistant', content: finishBlocks(state.blocks) },
+    stopReason: state.stopReason,
+  };
+}

--- a/plugin/panel/src/lib/backendSelect.js
+++ b/plugin/panel/src/lib/backendSelect.js
@@ -1,0 +1,33 @@
+export function pickBackend({ pref, probe, hasApiKey }) {
+  if (pref === 'byok') {
+    return hasApiKey ? { backend: 'byok', reason: 'ok' } : { backend: 'none', reason: 'no-key' };
+  }
+
+  if (probe === null) return { backend: 'none', reason: 'probing' };
+  if (!probe.nodeOk) return hasApiKey ? { backend: 'byok', reason: 'no-node' } : { backend: 'none', reason: 'no-node' };
+  if (!probe.loggedIn) return hasApiKey ? { backend: 'byok', reason: 'not-logged-in' } : { backend: 'none', reason: 'not-logged-in' };
+  return { backend: 'subscription', reason: 'ok' };
+}
+
+export function deriveToolMeta(tools) {
+  const allowedTools = [];
+  const annotations = {};
+
+  for (const tool of tools || []) {
+    const name = 'mcp__ae__' + tool.name;
+    const ann = (tool && tool.annotations) || {};
+    const readOnly = ann.readOnlyHint === true;
+    const destructive = ann.destructiveHint === true;
+    if (readOnly) allowedTools.push(name);
+    annotations[name] = { readOnly, destructive };
+  }
+
+  return { allowedTools, annotations };
+}
+
+export function shouldResetOnBackendChange(prevReal, next) {
+  if (next !== 'subscription' && next !== 'byok') return { reset: false, nextReal: prevReal || null };
+  if (!prevReal) return { reset: false, nextReal: next };
+  if (prevReal === next) return { reset: false, nextReal: prevReal };
+  return { reset: true, nextReal: next };
+}

--- a/plugin/panel/src/lib/chatEntries.js
+++ b/plugin/panel/src/lib/chatEntries.js
@@ -1,0 +1,101 @@
+function nextId(entries, prefix) {
+  return `${prefix}-${entries.length + 1}`;
+}
+
+function updateTool(entries, toolUseId, updater) {
+  return entries.map((entry) => {
+    if (entry.type !== 'tool-call' || entry.toolUseId !== toolUseId) return entry;
+    return updater(entry);
+  });
+}
+
+export function reduceEvent(entries, evt) {
+  const current = Array.isArray(entries) ? entries : [];
+  if (!evt || !evt.type) return current;
+
+  switch (evt.type) {
+    case 'turn-start':
+      return current;
+
+    case 'text-delta': {
+      const text = String(evt.text || '');
+      if (!text) return current;
+      const last = current[current.length - 1];
+      if (last && last.type === 'ai-text') {
+        return current.slice(0, -1).concat({ ...last, text: `${last.text || ''}${text}` });
+      }
+      return current.concat({ id: nextId(current, 'ai'), type: 'ai-text', text });
+    }
+
+    case 'tool-start':
+      return current.concat({
+        id: evt.toolUseId || nextId(current, 'tool'),
+        type: 'tool-call',
+        toolUseId: evt.toolUseId,
+        name: evt.name || '',
+        input: evt.input,
+        state: 'running',
+      });
+
+    case 'approval-required':
+      if (!current.some((entry) => entry.type === 'tool-call' && entry.toolUseId === evt.toolUseId)) {
+        return current.concat({
+          id: evt.toolUseId || nextId(current, 'tool'),
+          type: 'tool-call',
+          toolUseId: evt.toolUseId,
+          name: evt.name || '',
+          input: evt.input,
+          risk: evt.risk,
+          state: 'awaiting-approval',
+        });
+      }
+      return updateTool(current, evt.toolUseId, (entry) => ({
+        ...entry,
+        name: evt.name || entry.name,
+        input: evt.input === undefined ? entry.input : evt.input,
+        risk: evt.risk,
+        state: 'awaiting-approval',
+      }));
+
+    case 'tool-result':
+      if (!current.some((entry) => entry.type === 'tool-call' && entry.toolUseId === evt.toolUseId)) {
+        return current.concat({
+          id: evt.toolUseId || nextId(current, 'tool'),
+          type: 'tool-call',
+          toolUseId: evt.toolUseId,
+          name: evt.name || '',
+          state: evt.ok ? 'ok' : 'error',
+          ok: !!evt.ok,
+          text: evt.text || '',
+          durationMs: evt.durationMs,
+        });
+      }
+      return updateTool(current, evt.toolUseId, (entry) => ({
+        ...entry,
+        state: evt.ok ? 'ok' : 'error',
+        ok: !!evt.ok,
+        text: evt.text || '',
+        durationMs: evt.durationMs,
+      }));
+
+    case 'tool-denied':
+      return updateTool(current, evt.toolUseId, (entry) => ({
+        ...entry,
+        state: 'denied',
+      }));
+
+    case 'turn-end':
+      return current;
+
+    case 'error':
+      return current.concat({
+        id: nextId(current, 'error'),
+        type: 'error',
+        kind: evt.kind,
+        message: evt.message || '',
+      });
+
+    default:
+      return current;
+  }
+}

--- a/plugin/panel/src/lib/ndjson.js
+++ b/plugin/panel/src/lib/ndjson.js
@@ -1,0 +1,33 @@
+// Newline-delimited JSON framing shared by stdio transports (MCP client,
+// claude-agent sidecar). Pure functions; no CEP or Node dependencies.
+
+// Accumulates stream chunks and invokes onLine(line) for every complete,
+// trimmed, non-empty line. Handles lines torn across chunks and CRLF.
+export function createLineSplitter(onLine) {
+  let buffer = '';
+  return function push(chunk) {
+    buffer += String(chunk || '');
+    let index = buffer.indexOf('\n');
+    while (index !== -1) {
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (line) onLine(line);
+      index = buffer.indexOf('\n');
+    }
+  };
+}
+
+// Line splitter that JSON-parses each line and invokes onMessage(message).
+// Non-JSON lines (stray log contamination) are skipped silently; valid
+// stdio protocol output is JSON lines only.
+export function createNdjsonReader(onMessage) {
+  return createLineSplitter((line) => {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (e) {
+      return;
+    }
+    onMessage(message);
+  });
+}

--- a/plugin/panel/src/lib/sse.js
+++ b/plugin/panel/src/lib/sse.js
@@ -1,0 +1,40 @@
+export function createSseParser(onEvent) {
+  let buffer = '';
+
+  function parseFrame(frame) {
+    let event = '';
+    let data = '';
+    const lines = frame.replace(/\r\n/g, '\n').split('\n');
+    for (const line of lines) {
+      if (line.startsWith('event:')) {
+        event = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        data += line.slice(5).trimStart();
+      }
+    }
+
+    const trimmed = data.trim();
+    if (!trimmed || trimmed === '[DONE]') return;
+
+    try {
+      onEvent({ event, data: JSON.parse(trimmed) });
+    } catch (e) {
+      // Keep streaming on malformed keep-alive or diagnostic frames.
+    }
+  }
+
+  function feed(chunkText) {
+    buffer += String(chunkText || '');
+    buffer = buffer.replace(/\r\n/g, '\n');
+
+    let splitAt = buffer.indexOf('\n\n');
+    while (splitAt !== -1) {
+      const frame = buffer.slice(0, splitAt);
+      buffer = buffer.slice(splitAt + 2);
+      parseFrame(frame);
+      splitAt = buffer.indexOf('\n\n');
+    }
+  }
+
+  return { feed };
+}

--- a/plugin/panel/src/screens/ChatScreen.jsx
+++ b/plugin/panel/src/screens/ChatScreen.jsx
@@ -137,6 +137,8 @@ export function ChatScreen({
   onApprove,
   onNewSession,
   promptCards,
+  noticeActionLabel,
+  onNoticeAction,
 }) {
   const t = C[lang] || C.zh;
   const [draft, setDraft] = React.useState('');
@@ -204,7 +206,7 @@ export function ChatScreen({
           streaming={streaming}
           disabled={composerDisabled}
           placeholder={t.placeholder}
-          notice={disabledHint ? <Notice text={disabledHint} actionLabel={t.noticeAction} onAction={onNewSession} /> : null}
+          notice={disabledHint ? <Notice text={disabledHint} actionLabel={noticeActionLabel || t.noticeAction} onAction={onNoticeAction || onNewSession} /> : null}
         />
       </div>
     </div>

--- a/plugin/panel/src/screens/ChatScreen.jsx
+++ b/plugin/panel/src/screens/ChatScreen.jsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { Icon } from '../components/core/Icon';
+import { Button } from '../components/core/Button';
+import { ChatBubble } from '../components/chat/ChatBubble';
+import { ToolCallCard } from '../components/chat/ToolCallCard';
+import { ApprovalCard } from '../components/chat/ApprovalCard';
+import { PromptCard } from '../components/chat/PromptCard';
+import { Composer } from '../components/chat/Composer';
+import { AIAvatar } from '../components/chat/AIAvatar';
+import { eventTitle } from '../lib/activityModel';
+
+const C = {
+  zh: {
+    hello: '你好！我可以直接操作当前打开的 AE 工程。试试这些：',
+    keyTitle: '在设置里粘贴 Anthropic API Key',
+    keyCaption: '保存并验证后，就可以在这里让 AI 操作你的工程。',
+    newSession: '新会话',
+    placeholder: '描述你想在 AE 里做什么…',
+    noticeAction: '新会话',
+    errorTitle: '对话出错',
+    denied: '已拒绝',
+    running: '执行中',
+    ok: '完成',
+    failed: '失败',
+    awaiting: '等待批准',
+  },
+  en: {
+    hello: 'Hi! I can operate the open AE project directly. Try one of these:',
+    keyTitle: 'Paste an Anthropic API Key in Settings',
+    keyCaption: 'After saving and validating it, AI can operate your project here.',
+    newSession: 'New session',
+    placeholder: 'Describe what to do in AE…',
+    noticeAction: 'New session',
+    errorTitle: 'Chat error',
+    denied: 'Denied',
+    running: 'Running',
+    ok: 'Done',
+    failed: 'Failed',
+    awaiting: 'Awaiting approval',
+  },
+};
+
+const DEFAULT_PROMPTS = {
+  zh: [
+    { icon: 'type', title: '创建一个标题动画', caption: '新建文本图层并加入位置关键帧' },
+    { icon: 'layers', title: '整理工程素材', caption: '按类型把素材归进文件夹' },
+    { icon: 'clapperboard', title: '给画面加电影感调色', caption: '添加调整图层与 Lumetri 预设' },
+  ],
+  en: [
+    { icon: 'type', title: 'Create a title animation', caption: 'New text layer with position keyframes' },
+    { icon: 'layers', title: 'Organize project assets', caption: 'Sort footage into folders by type' },
+    { icon: 'clapperboard', title: 'Cinematic color grade', caption: 'Adjustment layer + Lumetri preset' },
+  ],
+};
+
+function Notice({ text, actionLabel, onAction }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '5px 8px', background: 'var(--bg-well)', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-md)' }}>
+      <Icon name="plug" size={12} color="var(--text-tertiary)" />
+      <span style={{ flex: 1, minWidth: 0, font: '400 11px/1.35 var(--font-ui)', color: 'var(--text-secondary)' }}>{text}</span>
+      {onAction ? <Button size="sm" variant="secondary" onClick={onAction}>{actionLabel}</Button> : null}
+    </div>
+  );
+}
+
+function statusForTool(state) {
+  if (state === 'running' || state === 'awaiting-approval') return 'running';
+  if (state === 'error' || state === 'denied') return 'error';
+  return 'success';
+}
+
+function toolTarget(entry, t) {
+  if (entry.state === 'awaiting-approval') return t.awaiting;
+  if (entry.state === 'running') return t.running;
+  if (entry.state === 'denied') return t.denied;
+  if (entry.state === 'error') return t.failed;
+  return t.ok;
+}
+
+function titleForTool(entry, lang) {
+  return eventTitle({ undoGroup: `MCP ${entry.name || ''}` }, lang);
+}
+
+function Entry({ entry, lang, onApprove }) {
+  const t = C[lang] || C.zh;
+  if (entry.type === 'user-text') {
+    return <ChatBubble role="user">{entry.text}</ChatBubble>;
+  }
+  if (entry.type === 'ai-text') {
+    return <ChatBubble role="ai">{entry.text}</ChatBubble>;
+  }
+  if (entry.type === 'tool-call') {
+    const highRisk = entry.risk === 'destructive';
+    return (
+      <div style={{ paddingLeft: 28, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <ToolCallCard
+          verb={titleForTool(entry, lang)}
+          target={toolTarget(entry, t)}
+          status={statusForTool(entry.state)}
+          params={entry.input}
+          errorMessage={entry.state === 'error' ? entry.text : null}
+        />
+        {entry.state === 'awaiting-approval' ? (
+          <ApprovalCard
+            risk={highRisk ? 'high' : 'normal'}
+            lang={lang}
+            title={titleForTool(entry, lang)}
+            description={entry.name}
+            params={entry.input}
+            onAllow={() => onApprove && onApprove(entry.toolUseId, 'allow')}
+            onDeny={() => onApprove && onApprove(entry.toolUseId, 'deny')}
+            onAllowSession={highRisk ? null : () => onApprove && onApprove(entry.toolUseId, 'allow-session')}
+          />
+        ) : null}
+      </div>
+    );
+  }
+  if (entry.type === 'error') {
+    return (
+      <div style={{ paddingLeft: 28 }}>
+        <ToolCallCard verb={t.errorTitle} target={entry.kind} status="error" errorMessage={entry.message} />
+      </div>
+    );
+  }
+  return null;
+}
+
+/* Chat tab. entries are folded from agentLoop events by lib/chatEntries.js. */
+export function ChatScreen({
+  lang = 'zh',
+  entries = [],
+  streaming = false,
+  composerDisabled = false,
+  disabledHint = '',
+  onSend,
+  onStop,
+  onApprove,
+  onNewSession,
+  promptCards,
+}) {
+  const t = C[lang] || C.zh;
+  const [draft, setDraft] = React.useState('');
+  const logRef = React.useRef(null);
+  const hasEntries = entries.length > 0;
+  const prompts = promptCards || DEFAULT_PROMPTS[lang] || DEFAULT_PROMPTS.zh;
+
+  React.useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [entries, streaming]);
+
+  const send = () => {
+    const text = draft.trim();
+    if (!text || composerDisabled || streaming) return;
+    if (onSend) onSend(text);
+    setDraft('');
+  };
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <div ref={logRef} style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 'var(--space-3)', display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+        {!hasEntries && composerDisabled ? (
+          <React.Fragment>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, padding: 'var(--space-5) 0 var(--space-2)', textAlign: 'center' }}>
+              <AIAvatar size={32} />
+              <div style={{ font: '600 12px/1.35 var(--font-ui)', color: 'var(--text-primary)', maxWidth: 240 }}>{disabledHint || t.keyTitle}</div>
+              <div style={{ font: '400 11px/1.45 var(--font-ui)', color: 'var(--text-tertiary)', maxWidth: 250 }}>{t.keyCaption}</div>
+            </div>
+          </React.Fragment>
+        ) : null}
+
+        {!hasEntries && !composerDisabled ? (
+          <React.Fragment>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, padding: 'var(--space-5) 0 var(--space-2)', textAlign: 'center' }}>
+              <AIAvatar size={32} />
+              <div style={{ font: '400 12px/1.55 var(--font-ui)', color: 'var(--text-secondary)', maxWidth: 240 }}>{t.hello}</div>
+            </div>
+            {prompts.map((card) => (
+              <PromptCard
+                key={card.id || card.title}
+                icon={card.icon}
+                title={card.title}
+                caption={card.caption}
+                onClick={() => {
+                  if (card.onClick) card.onClick(card);
+                  else if (onSend) onSend(card.prompt || card.title);
+                }}
+              />
+            ))}
+          </React.Fragment>
+        ) : null}
+
+        {entries.map((entry) => (
+          <Entry key={entry.id} entry={entry} lang={lang} onApprove={onApprove} />
+        ))}
+      </div>
+
+      <div style={{ flex: 'none', padding: 'var(--space-2) var(--space-3) var(--space-3)', borderTop: '1px solid var(--border-subtle)' }}>
+        <Composer
+          value={draft}
+          onChange={setDraft}
+          onSend={send}
+          onStop={onStop}
+          streaming={streaming}
+          disabled={composerDisabled}
+          placeholder={t.placeholder}
+          notice={disabledHint ? <Notice text={disabledHint} actionLabel={t.noticeAction} onAction={onNewSession} /> : null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -8,18 +8,25 @@ import { Segmented } from '../components/core/Segmented';
 import { Input } from '../components/forms/Input';
 import { Select } from '../components/forms/Select';
 import { Field } from '../components/forms/Field';
+import { Toast } from '../components/shell/Toast';
 import { copyText } from '../lib/clipboard';
 
 const S = {
   zh: {
     ai: 'AI 服务',
-    aiDisabled: 'P5 接通内嵌对话后启用。',
     conn: '连接',
     sec: '安全',
     gen: '通用',
     about: '关于',
     apiKey: 'API Key',
     apiKeyCap: '仅保存在本机，不会上传',
+    saveVerify: '保存并验证',
+    validating: '正在验证…',
+    saved: 'API Key 已保存并验证',
+    invalidKey: '无效 key',
+    verifyFailed: '验证失败，请稍后重试',
+    clear: '清除',
+    cleared: 'API Key 已清除',
     model: '模型',
     port: '端口',
     portHint: '默认 11488',
@@ -58,13 +65,19 @@ const S = {
   },
   en: {
     ai: 'AI service',
-    aiDisabled: 'Enabled in P5 when built-in chat is wired.',
     conn: 'Connection',
     sec: 'Security',
     gen: 'General',
     about: 'About',
     apiKey: 'API Key',
     apiKeyCap: 'Stored locally, never uploaded',
+    saveVerify: 'Save and verify',
+    validating: 'Validating…',
+    saved: 'API Key saved and verified',
+    invalidKey: 'Invalid key',
+    verifyFailed: 'Verification failed. Try again later.',
+    clear: 'Clear',
+    cleared: 'API Key cleared',
     model: 'Model',
     port: 'Port',
     portHint: 'Default 11488',
@@ -185,19 +198,28 @@ export function SettingsScreen({
   onRegenToken,
   hostVersion = '-',
   pythonVersion = '-',
+  apiKey = '',
+  onSaveApiKey,
+  onClearApiKey,
+  validateKey,
+  model = 'claude-sonnet-4-6',
+  onModelChange,
+  permissionMode = 'manual',
+  onPermissionMode,
 }) {
   const t = S[lang] || S.zh;
-  const [key, setKey] = React.useState('');
-  const [model, setModel] = React.useState('sonnet');
+  const [key, setKey] = React.useState(apiKey);
+  const [aiBusy, setAiBusy] = React.useState(false);
+  const [aiToast, setAiToast] = React.useState(null);
   const [draftPort, setDraftPort] = React.useState(String(port));
   const [tokenRaw, setTokenRaw] = React.useState('');
   const [autostart, setAutostart] = React.useState(true);
-  const [perm, setPerm] = React.useState('manual');
   const [logLevel, setLogLevel] = React.useState('info');
   const [copied, setCopied] = React.useState('');
 
   React.useEffect(() => setDraftPort(String(port)), [port]);
   React.useEffect(() => setTokenRaw(readTokenValue()), []);
+  React.useEffect(() => setKey(apiKey), [apiKey]);
 
   const copy = (label, text) => {
     copyText(text).then(() => {
@@ -205,8 +227,35 @@ export function SettingsScreen({
       setTimeout(() => setCopied(''), 1200);
     }).catch(() => {});
   };
-  const permCap = perm === 'manual' ? t.permCap1 : perm === 'auto' ? t.permCap2 : t.permCap3;
+  const permCap = permissionMode === 'manual' ? t.permCap1 : permissionMode === 'auto' ? t.permCap2 : t.permCap3;
   const tokenDisplay = tokenRaw ? maskToken(tokenRaw) : t.tokenMissing;
+  const saveApiKey = () => {
+    if (aiBusy) return;
+    setAiBusy(true);
+    setAiToast(null);
+    Promise.resolve(validateKey ? validateKey(key) : true).then((result) => {
+      const ok = result === true || (result && result.ok === true) || (result && result.status === 200);
+      const status = result && typeof result === 'object' ? result.status : null;
+      if (!ok) {
+        setAiToast({ type: 'error', message: status === 401 ? t.invalidKey : t.verifyFailed });
+        return null;
+      }
+      return Promise.resolve(onSaveApiKey ? onSaveApiKey(key) : null).then(() => {
+        setAiToast({ type: 'ok', message: t.saved });
+      });
+    }).catch((e) => {
+      const status = e && (e.status || (e.response && e.response.status));
+      setAiToast({ type: 'error', message: status === 401 ? t.invalidKey : t.verifyFailed });
+    }).finally(() => setAiBusy(false));
+  };
+  const clearApiKey = () => {
+    setKey('');
+    Promise.resolve(onClearApiKey ? onClearApiKey() : null).then(() => {
+      setAiToast({ type: 'info', message: t.cleared });
+    }).catch(() => {
+      setAiToast({ type: 'error', message: t.verifyFailed });
+    });
+  };
   const regenerate = () => {
     if (!onRegenToken) return;
     const result = onRegenToken();
@@ -219,16 +268,21 @@ export function SettingsScreen({
 
   return (
     <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 'var(--space-3)', display: 'flex', flexDirection: 'column', gap: 'var(--space-5)' }}>
-      <Section title={t.ai} disabled caption={t.aiDisabled}>
+      <Section title={t.ai}>
         <Field label={t.apiKey} caption={t.apiKeyCap}>
-          <Input secret disabled value={key} onChange={setKey} placeholder="sk-ant-..." />
+          <div style={{ display: 'flex', gap: 6 }}>
+            <Input secret value={key} onChange={setKey} placeholder="sk-ant-..." style={{ flex: 1 }} />
+            <Button variant="primary" disabled={aiBusy || !key.trim()} onClick={saveApiKey}>{aiBusy ? t.validating : t.saveVerify}</Button>
+            <Button variant="secondary" disabled={aiBusy} onClick={clearApiKey}>{t.clear}</Button>
+          </div>
         </Field>
         <Field label={t.model}>
-          <Select disabled value={model} onChange={setModel} options={[
-            { value: 'sonnet', label: 'Claude Sonnet' },
-            { value: 'haiku', label: 'Claude Haiku' },
+          <Select value={model} onChange={onModelChange} options={[
+            { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+            { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
           ]} />
         </Field>
+        {aiToast ? <Toast type={aiToast.type} message={aiToast.message} onClose={() => setAiToast(null)} /> : null}
       </Section>
 
       <Section title={t.conn}>
@@ -257,7 +311,7 @@ export function SettingsScreen({
 
       <Section title={t.sec}>
         <Field label={t.permTitle} caption={permCap}>
-          <Segmented full value={perm} onChange={setPerm} options={[
+          <Segmented full value={permissionMode} onChange={onPermissionMode} options={[
             { value: 'manual', label: t.perm1 },
             { value: 'auto', label: t.perm2 },
             { value: 'none', label: t.perm3 },

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -18,6 +18,15 @@ const S = {
     sec: '安全',
     gen: '通用',
     about: '关于',
+    backend: '后端',
+    backendSub: '订阅',
+    backendByok: 'BYOK',
+    claudeReady: '已登录 ✓',
+    claudeNotLoggedIn: '未登录',
+    claudeChecking: '检测中…',
+    claudeNoNode: '需要 Node 18+',
+    claudeLoginCap: '在终端运行 claude /login 完成登录，然后点「重新检测」',
+    recheckClaude: '重新检测',
     apiKey: 'API Key',
     apiKeyCap: '仅保存在本机，不会上传',
     saveVerify: '保存并验证',
@@ -69,6 +78,15 @@ const S = {
     sec: 'Security',
     gen: 'General',
     about: 'About',
+    backend: 'Backend',
+    backendSub: 'Subscription',
+    backendByok: 'BYOK',
+    claudeReady: 'Logged in ✓',
+    claudeNotLoggedIn: 'Not logged in',
+    claudeChecking: 'Checking…',
+    claudeNoNode: 'Needs Node 18+',
+    claudeLoginCap: 'Run claude /login in a terminal, then click Re-check',
+    recheckClaude: 'Re-check',
     apiKey: 'API Key',
     apiKeyCap: 'Stored locally, never uploaded',
     saveVerify: 'Save and verify',
@@ -204,6 +222,10 @@ export function SettingsScreen({
   validateKey,
   model = 'claude-sonnet-4-6',
   onModelChange,
+  backend = 'subscription',
+  onBackendChange,
+  claudeStatus = { state: 'checking' },
+  onRecheckClaude,
   permissionMode = 'manual',
   onPermissionMode,
 }) {
@@ -229,6 +251,9 @@ export function SettingsScreen({
   };
   const permCap = permissionMode === 'manual' ? t.permCap1 : permissionMode === 'auto' ? t.permCap2 : t.permCap3;
   const tokenDisplay = tokenRaw ? maskToken(tokenRaw) : t.tokenMissing;
+  const claudeState = (claudeStatus && claudeStatus.state) || 'checking';
+  const claudeBadgeStatus = claudeState === 'ready' ? 'ok' : claudeState === 'not-logged-in' ? 'warn' : claudeState === 'no-node' ? 'error' : 'neutral';
+  const claudeBadgeText = claudeState === 'ready' ? t.claudeReady : claudeState === 'not-logged-in' ? t.claudeNotLoggedIn : claudeState === 'no-node' ? t.claudeNoNode : t.claudeChecking;
   const saveApiKey = () => {
     if (aiBusy) return;
     setAiBusy(true);
@@ -269,13 +294,29 @@ export function SettingsScreen({
   return (
     <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 'var(--space-3)', display: 'flex', flexDirection: 'column', gap: 'var(--space-5)' }}>
       <Section title={t.ai}>
-        <Field label={t.apiKey} caption={t.apiKeyCap}>
-          <div style={{ display: 'flex', gap: 6 }}>
-            <Input secret value={key} onChange={setKey} placeholder="sk-ant-..." style={{ flex: 1 }} />
-            <Button variant="primary" disabled={aiBusy || !key.trim()} onClick={saveApiKey}>{aiBusy ? t.validating : t.saveVerify}</Button>
-            <Button variant="secondary" disabled={aiBusy} onClick={clearApiKey}>{t.clear}</Button>
-          </div>
+        <Field label={t.backend}>
+          <Segmented full value={backend} onChange={onBackendChange} options={[
+            { value: 'subscription', label: t.backendSub },
+            { value: 'byok', label: t.backendByok },
+          ]} />
         </Field>
+        {backend === 'subscription' ? (
+          <Field label={t.backendSub} caption={claudeState === 'not-logged-in' ? t.claudeLoginCap : (claudeStatus && claudeStatus.detail) || null}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <Badge status={claudeBadgeStatus}>{claudeBadgeText}</Badge>
+              {claudeState === 'ready' && claudeStatus.nodeVersion ? <span style={{ flex: 1, font: '400 11px/1 var(--font-mono)', color: 'var(--text-secondary)' }}>Node v{claudeStatus.nodeVersion}</span> : <span style={{ flex: 1 }} />}
+              <Button variant="secondary" icon="rotate-cw" disabled={claudeState === 'checking'} onClick={onRecheckClaude}>{t.recheckClaude}</Button>
+            </div>
+          </Field>
+        ) : (
+          <Field label={t.apiKey} caption={t.apiKeyCap}>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <Input secret value={key} onChange={setKey} placeholder="sk-ant-..." style={{ flex: 1 }} />
+              <Button variant="primary" disabled={aiBusy || !key.trim()} onClick={saveApiKey}>{aiBusy ? t.validating : t.saveVerify}</Button>
+              <Button variant="secondary" disabled={aiBusy} onClick={clearApiKey}>{t.clear}</Button>
+            </div>
+          </Field>
+        )}
         <Field label={t.model}>
           <Select value={model} onChange={onModelChange} options={[
             { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -304,7 +304,7 @@ export function SettingsScreen({
           <Field label={t.backendSub} caption={claudeState === 'not-logged-in' ? t.claudeLoginCap : (claudeStatus && claudeStatus.detail) || null}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <Badge status={claudeBadgeStatus}>{claudeBadgeText}</Badge>
-              {claudeState === 'ready' && claudeStatus.nodeVersion ? <span style={{ flex: 1, font: '400 11px/1 var(--font-mono)', color: 'var(--text-secondary)' }}>Node v{claudeStatus.nodeVersion}</span> : <span style={{ flex: 1 }} />}
+              {claudeState === 'ready' && claudeStatus.nodeVersion ? <span style={{ flex: 1, font: '400 11px/1 var(--font-mono)', color: 'var(--text-secondary)' }}>Node {String(claudeStatus.nodeVersion).replace(/^v?/, 'v')}</span> : <span style={{ flex: 1 }} />}
               <Button variant="secondary" icon="rotate-cw" disabled={claudeState === 'checking'} onClick={onRecheckClaude}>{t.recheckClaude}</Button>
             </div>
           </Field>

--- a/plugin/panel/test/agentLoop.test.js
+++ b/plugin/panel/test/agentLoop.test.js
@@ -233,6 +233,10 @@ test('createAgentLoop repairs dangling tool_use when stopped during approval', a
   loop.stop();
   await run;
 
+  assert.deepEqual(events.filter((evt) => evt.type === 'tool-denied'), [
+    { type: 'tool-denied', toolUseId: 'tu_stop' },
+  ]);
+
   // History must stay continuable: the recorded assistant tool_use needs a
   // matching tool_result before the next user message.
   const messages = loop.getMessages();

--- a/plugin/panel/test/agentLoop.test.js
+++ b/plugin/panel/test/agentLoop.test.js
@@ -1,0 +1,251 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSseParser } from '../src/lib/sse.js';
+import { createAgentLoop } from '../src/lib/agentLoop.js';
+
+function sseFrame(event, data) {
+  return 'event: ' + event + '\n' + 'data: ' + JSON.stringify(data) + '\n\n';
+}
+
+function textTurn(text, stopReason = 'end_turn') {
+  return [
+    sseFrame('message_start', { type: 'message_start' }),
+    sseFrame('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+    sseFrame('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } }),
+    sseFrame('content_block_stop', { type: 'content_block_stop', index: 0 }),
+    sseFrame('message_delta', { type: 'message_delta', delta: { stop_reason: stopReason } }),
+    sseFrame('message_stop', { type: 'message_stop' }),
+  ].join('');
+}
+
+function toolTurn({ id = 'tu_1', name = 'ae.newText', input = { text: 'Hi' } } = {}) {
+  const json = JSON.stringify(input);
+  return [
+    sseFrame('message_start', { type: 'message_start' }),
+    sseFrame('content_block_start', { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id, name, input: {} } }),
+    sseFrame('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: json.slice(0, 5) } }),
+    sseFrame('content_block_delta', { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: json.slice(5) } }),
+    sseFrame('content_block_stop', { type: 'content_block_stop', index: 0 }),
+    sseFrame('message_delta', { type: 'message_delta', delta: { stop_reason: 'tool_use' } }),
+    sseFrame('message_stop', { type: 'message_stop' }),
+  ].join('');
+}
+
+function anthropicFromSse(turns, calls = []) {
+  return async function fakeAnthropic(options) {
+    calls.push({ messages: structuredClone(options.messages), tools: options.tools });
+    const sse = turns.shift();
+    if (!sse) throw new Error('No fake Anthropic turn queued');
+
+    const blocks = new Map();
+    let stopReason = 'end_turn';
+    const parser = createSseParser(({ data }) => {
+      if (data.type === 'content_block_start') {
+        const block = data.content_block;
+        if (block.type === 'text') blocks.set(data.index, { type: 'text', text: block.text || '' });
+        if (block.type === 'tool_use') blocks.set(data.index, { type: 'tool_use', id: block.id, name: block.name, inputJson: '' });
+      }
+      if (data.type === 'content_block_delta') {
+        const block = blocks.get(data.index);
+        if (data.delta.type === 'text_delta') {
+          block.text += data.delta.text;
+          options.onTextDelta(data.delta.text);
+        }
+        if (data.delta.type === 'input_json_delta') block.inputJson += data.delta.partial_json;
+      }
+      if (data.type === 'message_delta') stopReason = data.delta.stop_reason;
+    });
+    parser.feed(sse);
+
+    const content = Array.from(blocks.values()).map((block) => {
+      if (block.type === 'tool_use') {
+        return { type: 'tool_use', id: block.id, name: block.name, input: JSON.parse(block.inputJson || '{}') };
+      }
+      return block;
+    });
+    return { assistantMessage: { role: 'assistant', content }, stopReason };
+  };
+}
+
+function makeMcp({ tools, resultText = 'ok', isError = false } = {}) {
+  const calls = [];
+  return {
+    calls,
+    listTools: async () => tools || [
+      { name: 'ae.overview', description: 'read', inputSchema: {}, annotations: { readOnlyHint: true } },
+      { name: 'ae.newText', description: 'write', inputSchema: {}, annotations: { readOnlyHint: false } },
+      { name: 'ae.exec', description: 'danger', inputSchema: {}, annotations: { destructiveHint: true } },
+    ],
+    callTool: async (name, args) => {
+      calls.push({ name, args });
+      return { content: [{ type: 'text', text: resultText }], isError };
+    },
+  };
+}
+
+function makeLoop({ anthropic, mcp = makeMcp(), mode = 'none', events = [] }) {
+  return createAgentLoop({
+    getApiKey: () => 'sk-test',
+    getModel: () => 'claude-sonnet-4-6',
+    getPermissionMode: () => mode,
+    mcp,
+    anthropic,
+    onEvent: (evt) => events.push(evt),
+  });
+}
+
+async function waitFor(events, type) {
+  for (let i = 0; i < 50; i++) {
+    const found = events.find((evt) => evt.type === type);
+    if (found) return found;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error('Timed out waiting for ' + type);
+}
+
+test('createAgentLoop streams a pure text turn into history', async () => {
+  const events = [];
+  const loop = makeLoop({ anthropic: anthropicFromSse([textTurn('Hello')]), events });
+
+  await loop.sendUser('Say hi');
+
+  assert.deepEqual(events.map((evt) => evt.type), ['turn-start', 'text-delta', 'turn-end']);
+  assert.equal(events[1].text, 'Hello');
+  assert.equal(events[2].stopReason, 'end_turn');
+  assert.deepEqual(loop.getMessages(), [
+    { role: 'user', content: 'Say hi' },
+    { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
+  ]);
+});
+
+test('createAgentLoop runs a tool directly and continues after tool_result', async () => {
+  const events = [];
+  const calls = [];
+  const mcp = makeMcp();
+  const loop = makeLoop({ anthropic: anthropicFromSse([toolTurn(), textTurn('Done')], calls), mcp, mode: 'auto', events });
+
+  await loop.sendUser('Create text');
+
+  assert.deepEqual(mcp.calls, [{ name: 'ae.newText', args: { text: 'Hi' } }]);
+  assert.deepEqual(events.map((evt) => evt.type), ['turn-start', 'tool-start', 'tool-result', 'text-delta', 'turn-end']);
+  assert.equal(calls[1].messages.at(-1).content[0].type, 'tool_result');
+  assert.equal(calls[1].messages.at(-1).content[0].content, 'ok');
+});
+
+test('createAgentLoop waits for manual approval and resumes on allow', async () => {
+  const events = [];
+  const mcp = makeMcp();
+  const loop = makeLoop({ anthropic: anthropicFromSse([toolTurn(), textTurn('Allowed')]), mcp, mode: 'manual', events });
+
+  const pending = loop.sendUser('Create text');
+  const approval = await waitFor(events, 'approval-required');
+  loop.approve(approval.toolUseId, 'allow');
+  await pending;
+
+  assert.equal(approval.risk, 'write');
+  assert.deepEqual(mcp.calls, [{ name: 'ae.newText', args: { text: 'Hi' } }]);
+  assert.equal(events.find((evt) => evt.type === 'tool-result').ok, true);
+});
+
+test('createAgentLoop sends denied tool_result back to the model', async () => {
+  const events = [];
+  const calls = [];
+  const loop = makeLoop({ anthropic: anthropicFromSse([toolTurn(), textTurn('Denied noted')], calls), mode: 'manual', events });
+
+  const pending = loop.sendUser('Create text');
+  const approval = await waitFor(events, 'approval-required');
+  loop.approve(approval.toolUseId, 'deny');
+  await pending;
+
+  const result = calls[1].messages.at(-1).content[0];
+  assert.equal(result.type, 'tool_result');
+  assert.equal(result.is_error, true);
+  assert.equal(result.content, 'User denied this action.');
+  assert.equal(events.some((evt) => evt.type === 'tool-denied'), true);
+});
+
+test('createAgentLoop allow-session lets the same tool run directly later', async () => {
+  const events = [];
+  const mcp = makeMcp();
+  const loop = makeLoop({
+    anthropic: anthropicFromSse([toolTurn({ id: 'tu_1' }), textTurn('One'), toolTurn({ id: 'tu_2' }), textTurn('Two')]),
+    mcp,
+    mode: 'manual',
+    events,
+  });
+
+  const first = loop.sendUser('First');
+  const approval = await waitFor(events, 'approval-required');
+  loop.approve(approval.toolUseId, 'allow-session');
+  await first;
+  await loop.sendUser('Second');
+
+  assert.equal(events.filter((evt) => evt.type === 'approval-required').length, 1);
+  assert.equal(mcp.calls.length, 2);
+});
+
+test('createAgentLoop stop aborts fetch and keeps only the user message', async () => {
+  const events = [];
+  const anthropic = async ({ signal, onTextDelta }) => {
+    onTextDelta('partial');
+    await new Promise((resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      });
+    });
+  };
+  const loop = makeLoop({ anthropic, events });
+
+  const pending = loop.sendUser('Long task');
+  await waitFor(events, 'text-delta');
+  loop.stop();
+  await pending;
+
+  assert.equal(events.at(-1).type, 'error');
+  assert.equal(events.at(-1).kind, 'aborted');
+  assert.deepEqual(loop.getMessages(), [{ role: 'user', content: 'Long task' }]);
+});
+
+test('createAgentLoop stops after 25 consecutive tool rounds', async () => {
+  const events = [];
+  const mcp = makeMcp();
+  const turns = Array.from({ length: 25 }, (_, i) => toolTurn({ id: 'tu_' + i, name: 'ae.overview', input: { i } }));
+  const loop = makeLoop({ anthropic: anthropicFromSse(turns), mcp, mode: 'none', events });
+
+  await loop.sendUser('Loop tools');
+
+  const error = events.find((evt) => evt.type === 'error');
+  assert.equal(error.kind, 'mcp');
+  assert.match(error.message, /25/);
+  assert.equal(mcp.calls.length, 25);
+});
+
+test('createAgentLoop repairs dangling tool_use when stopped during approval', async () => {
+  const events = [];
+  const turns = [toolTurn({ id: 'tu_stop', name: 'ae.newText' }), textTurn('Done.')];
+  const calls = [];
+  const loop = makeLoop({ anthropic: anthropicFromSse(turns, calls), mode: 'manual', events });
+
+  const run = loop.sendUser('make a layer');
+  await waitFor(events, 'approval-required');
+  loop.stop();
+  await run;
+
+  // History must stay continuable: the recorded assistant tool_use needs a
+  // matching tool_result before the next user message.
+  const messages = loop.getMessages();
+  const assistantIdx = messages.findIndex((m) => m.role === 'assistant');
+  assert.ok(assistantIdx >= 0);
+  const repair = messages[assistantIdx + 1];
+  assert.equal(repair.role, 'user');
+  assert.equal(repair.content[0].type, 'tool_result');
+  assert.equal(repair.content[0].tool_use_id, 'tu_stop');
+  assert.equal(repair.content[0].is_error, true);
+
+  // And a follow-up send must reach Anthropic without throwing.
+  await loop.sendUser('never mind, just say hi');
+  const sent = calls[calls.length - 1].messages;
+  assert.equal(sent[sent.length - 1].content, 'never mind, just say hi');
+});

--- a/plugin/panel/test/anthropic.test.js
+++ b/plugin/panel/test/anthropic.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sendAnthropicMessage } from '../src/lib/anthropic.js';
+
+function sseFrame(event, data) {
+  return 'event: ' + event + '\n' + 'data: ' + JSON.stringify(data) + '\n\n';
+}
+
+function streamFromText(text) {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+}
+
+test('sendAnthropicMessage parses tool input from input_json_delta after empty start input', async () => {
+  const body = [
+    sseFrame('content_block_start', {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: 'tu_1', name: 'ae.newText', input: {} },
+    }),
+    sseFrame('content_block_delta', {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"text":"Hi"}' },
+    }),
+    sseFrame('content_block_stop', { type: 'content_block_stop', index: 0 }),
+    sseFrame('message_delta', { type: 'message_delta', delta: { stop_reason: 'tool_use' } }),
+    sseFrame('message_stop', { type: 'message_stop' }),
+  ].join('');
+
+  const result = await sendAnthropicMessage({
+    apiKey: 'sk-test',
+    messages: [{ role: 'user', content: 'make text' }],
+    tools: [],
+    fetchImpl: async () => ({ ok: true, body: streamFromText(body) }),
+  });
+
+  assert.deepEqual(result, {
+    assistantMessage: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'ae.newText', input: { text: 'Hi' } }],
+    },
+    stopReason: 'tool_use',
+  });
+});

--- a/plugin/panel/test/apiKey.test.js
+++ b/plugin/panel/test/apiKey.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApiKeyStore } from '../src/cep/apiKey.js';
+
+function makeDeps() {
+  const files = new Map();
+  const dirs = new Set();
+  const chmods = [];
+  const fs = {
+    existsSync(p) {
+      return dirs.has(p) || files.has(p);
+    },
+    mkdirSync(p) {
+      dirs.add(p);
+    },
+    readFileSync(p) {
+      if (!files.has(p)) {
+        const e = new Error('missing');
+        e.code = 'ENOENT';
+        throw e;
+      }
+      return files.get(p);
+    },
+    writeFileSync(p, value) {
+      files.set(p, value);
+    },
+    chmodSync(p, mode) {
+      chmods.push([p, mode]);
+    },
+    renameSync(from, to) {
+      files.set(to, files.get(from));
+      files.delete(from);
+    },
+    unlinkSync(p) {
+      if (!files.has(p)) {
+        const e = new Error('missing');
+        e.code = 'ENOENT';
+        throw e;
+      }
+      files.delete(p);
+    },
+  };
+  const path = {
+    join(...parts) {
+      return parts.join('/');
+    },
+  };
+  const os = { homedir: () => '/home/user' };
+  return { fs, path, os, pid: 42, files, dirs, chmods };
+}
+
+test('readKey returns empty string when the key file is missing', () => {
+  const deps = makeDeps();
+  const store = createApiKeyStore(deps);
+  assert.equal(store.readKey(), '');
+});
+
+test('writeKey atomically writes, chmods, renames, and readKey trims the stored value', () => {
+  const deps = makeDeps();
+  const store = createApiKeyStore(deps);
+  assert.equal(store.writeKey('  sk-ant-test  '), 'sk-ant-test');
+  assert.equal(store.readKey(), 'sk-ant-test');
+  assert.equal(deps.dirs.has('/home/user/.ae-mcp'), true);
+  assert.equal(deps.files.has('/home/user/.ae-mcp/anthropic-key'), true);
+  assert.equal(deps.chmods.length, 1);
+  assert.equal(deps.chmods[0][1], 0o600);
+});
+
+test('clearKey removes an existing key and ignores missing files', () => {
+  const deps = makeDeps();
+  const store = createApiKeyStore(deps);
+  store.writeKey('sk-ant-test');
+  store.clearKey();
+  assert.equal(store.readKey(), '');
+  assert.doesNotThrow(() => store.clearKey());
+});

--- a/plugin/panel/test/backendSelect.test.js
+++ b/plugin/panel/test/backendSelect.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickBackend, deriveToolMeta, shouldResetOnBackendChange } from '../src/lib/backendSelect.js';
+
+test('pickBackend follows subscription and BYOK selection rules', () => {
+  const cases = [
+    [{ pref: 'byok', probe: null, hasApiKey: true }, { backend: 'byok', reason: 'ok' }],
+    [{ pref: 'byok', probe: null, hasApiKey: false }, { backend: 'none', reason: 'no-key' }],
+    [{ pref: 'subscription', probe: null, hasApiKey: true }, { backend: 'none', reason: 'probing' }],
+    [{ pref: 'subscription', probe: null, hasApiKey: false }, { backend: 'none', reason: 'probing' }],
+    [{ pref: 'subscription', probe: { nodeOk: false, loggedIn: false }, hasApiKey: true }, { backend: 'byok', reason: 'no-node' }],
+    [{ pref: 'subscription', probe: { nodeOk: false, loggedIn: false }, hasApiKey: false }, { backend: 'none', reason: 'no-node' }],
+    [{ pref: 'subscription', probe: { nodeOk: true, loggedIn: false }, hasApiKey: true }, { backend: 'byok', reason: 'not-logged-in' }],
+    [{ pref: 'subscription', probe: { nodeOk: true, loggedIn: false }, hasApiKey: false }, { backend: 'none', reason: 'not-logged-in' }],
+    [{ pref: 'subscription', probe: { nodeOk: true, loggedIn: true }, hasApiKey: false }, { backend: 'subscription', reason: 'ok' }],
+  ];
+
+  for (const [input, expected] of cases) {
+    assert.deepEqual(pickBackend(input), expected);
+  }
+});
+
+test('deriveToolMeta maps AE tools for Claude Agent SDK metadata', () => {
+  const meta = deriveToolMeta([
+    { name: 'overview', annotations: { readOnlyHint: true } },
+    { name: 'deleteLayer', annotations: { destructiveHint: true } },
+    { name: 'newText' },
+  ]);
+
+  assert.deepEqual(meta.allowedTools, ['mcp__ae__overview']);
+  assert.deepEqual(meta.annotations, {
+    mcp__ae__overview: { readOnly: true, destructive: false },
+    mcp__ae__deleteLayer: { readOnly: false, destructive: true },
+    mcp__ae__newText: { readOnly: false, destructive: false },
+  });
+});
+
+test('shouldResetOnBackendChange ignores none and resets only on real backend changes', () => {
+  const run = (sequence) => {
+    let prevReal = null;
+    const resets = [];
+    for (const next of sequence) {
+      const decision = shouldResetOnBackendChange(prevReal, next);
+      if (decision.nextReal) prevReal = decision.nextReal;
+      if (decision.reset) resets.push(next);
+    }
+    return resets;
+  };
+
+  assert.deepEqual(run(['subscription', 'none', 'subscription']), []);
+  assert.deepEqual(run(['subscription', 'none', 'byok']), ['byok']);
+  assert.deepEqual(run(['none', 'subscription']), []);
+  assert.deepEqual(run(['none', 'byok', 'subscription']), ['subscription']);
+});

--- a/plugin/panel/test/chatEntries.test.js
+++ b/plugin/panel/test/chatEntries.test.js
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { reduceEvent } from '../src/lib/chatEntries.js';
+
+test('text deltas merge into one ai-text entry', () => {
+  let entries = [];
+  entries = reduceEvent(entries, { type: 'turn-start' });
+  entries = reduceEvent(entries, { type: 'text-delta', text: 'Hello' });
+  entries = reduceEvent(entries, { type: 'text-delta', text: ', AE' });
+  entries = reduceEvent(entries, { type: 'turn-end', stopReason: 'end_turn' });
+  assert.deepEqual(entries, [{ id: 'ai-1', type: 'ai-text', text: 'Hello, AE' }]);
+});
+
+test('tool-start to approval-required to tool-result updates one tool-call entry', () => {
+  let entries = [];
+  entries = reduceEvent(entries, { type: 'tool-start', toolUseId: 'u1', name: 'ae.createText', input: { text: 'Title' } });
+  entries = reduceEvent(entries, { type: 'approval-required', toolUseId: 'u1', name: 'ae.createText', input: { text: 'Title' }, risk: 'write' });
+  entries = reduceEvent(entries, { type: 'tool-result', toolUseId: 'u1', ok: true, text: 'created', durationMs: 12 });
+  assert.deepEqual(entries, [{
+    id: 'u1',
+    type: 'tool-call',
+    toolUseId: 'u1',
+    name: 'ae.createText',
+    input: { text: 'Title' },
+    risk: 'write',
+    state: 'ok',
+    ok: true,
+    text: 'created',
+    durationMs: 12,
+  }]);
+});
+
+test('tool-denied marks a pending tool as denied', () => {
+  let entries = [];
+  entries = reduceEvent(entries, { type: 'tool-start', toolUseId: 'u2', name: 'ae.exec', input: {} });
+  entries = reduceEvent(entries, { type: 'approval-required', toolUseId: 'u2', name: 'ae.exec', input: {}, risk: 'destructive' });
+  entries = reduceEvent(entries, { type: 'tool-denied', toolUseId: 'u2' });
+  assert.equal(entries[0].state, 'denied');
+  assert.equal(entries[0].risk, 'destructive');
+});
+
+test('failed tool-result marks a tool as error with returned text', () => {
+  let entries = [];
+  entries = reduceEvent(entries, { type: 'tool-start', toolUseId: 'u3', name: 'ae.rename', input: {} });
+  entries = reduceEvent(entries, { type: 'tool-result', toolUseId: 'u3', ok: false, text: 'Layer locked', durationMs: 5 });
+  assert.equal(entries[0].state, 'error');
+  assert.equal(entries[0].text, 'Layer locked');
+});
+
+test('error event appends an error entry', () => {
+  const entries = reduceEvent([], { type: 'error', kind: 'auth', message: 'Invalid key' });
+  assert.deepEqual(entries, [{ id: 'error-1', type: 'error', kind: 'auth', message: 'Invalid key' }]);
+});

--- a/plugin/panel/test/claudeAgentBackend.test.js
+++ b/plugin/panel/test/claudeAgentBackend.test.js
@@ -1,0 +1,353 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createClaudeAgentBackend, resolveSystemNode } from '../src/cep/claudeAgentBackend.js';
+
+function makeProc() {
+  const stdoutHandlers = [];
+  const stderrHandlers = [];
+  const exitHandlers = [];
+  const errorHandlers = [];
+  const writes = [];
+  let killed = false;
+
+  return {
+    writes,
+    get killed() {
+      return killed;
+    },
+    stdin: {
+      write(line) {
+        writes.push(line);
+      },
+    },
+    stdout: {
+      on(event, handler) {
+        if (event === 'data') stdoutHandlers.push(handler);
+      },
+    },
+    stderr: {
+      on(event, handler) {
+        if (event === 'data') stderrHandlers.push(handler);
+      },
+    },
+    on(event, handler) {
+      if (event === 'exit') exitHandlers.push(handler);
+      if (event === 'error') errorHandlers.push(handler);
+    },
+    kill() {
+      killed = true;
+    },
+    pushStdout(message) {
+      const line = typeof message === 'string' ? message : JSON.stringify(message) + '\n';
+      for (const handler of stdoutHandlers) handler(line);
+    },
+    pushStderr(text) {
+      for (const handler of stderrHandlers) handler(text);
+    },
+    exit(code = 0, signal = null) {
+      for (const handler of exitHandlers) handler(code, signal);
+    },
+    error(error) {
+      for (const handler of errorHandlers) handler(error);
+    },
+  };
+}
+
+function makeSpawn() {
+  const calls = [];
+  const procs = [];
+  function spawn(command, args, options) {
+    const proc = makeProc();
+    calls.push({ command, args, options, proc });
+    procs.push(proc);
+    return proc;
+  }
+  return { spawn, calls, procs };
+}
+
+function makeBackend(options = {}) {
+  const events = [];
+  const spawned = makeSpawn();
+  const backend = createClaudeAgentBackend({
+    resolveNode: async () => ({ ok: true, nodePath: 'C:\\Node\\node.exe', version: 'v22.1.0' }),
+    sidecarPath: 'C:\\ae-mcp\\agent-sidecar.mjs',
+    getMcpSpec: async () => ({ command: 'ae-mcp', args: ['--stdio'], env: { A: 'B' } }),
+    getToolMeta: async () => ({ allowedTools: ['ae.overview'], annotations: { 'ae.overview': { readOnlyHint: true } } }),
+    getModel: () => 'claude-test',
+    getPermissionMode: () => 'manual',
+    onEvent: (evt) => events.push(evt),
+    spawnImpl: spawned.spawn,
+    env: { PATH: 'C:\\Node', ANTHROPIC_API_KEY: 'sk-test' },
+    ...options,
+  });
+  return { backend, events, spawned };
+}
+
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function parseWrites(proc) {
+  return proc.writes.map((line) => JSON.parse(line));
+}
+
+test('createClaudeAgentBackend writes user only after ready handshake', async () => {
+  const { backend, spawned } = makeBackend();
+
+  const pending = backend.sendUser('hello');
+  await flush();
+
+  assert.equal(spawned.calls.length, 1);
+  assert.deepEqual(spawned.procs[0].writes, []);
+
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+
+  assert.deepEqual(parseWrites(spawned.procs[0]), [
+    { t: 'user', text: 'hello', permissionMode: 'manual', model: 'claude-test' },
+  ]);
+
+  spawned.procs[0].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await pending;
+});
+
+test('createClaudeAgentBackend strips Anthropic key and passes sidecar args', async () => {
+  const mcpSpec = { command: 'ae-mcp', args: ['--stdio'], env: { X: 'Y' } };
+  const meta = { allowedTools: ['ae.one', 'ae.two'], annotations: { 'ae.two': { destructiveHint: true } } };
+  const { backend, spawned } = makeBackend({
+    getMcpSpec: async () => mcpSpec,
+    getToolMeta: async () => meta,
+    getModel: () => 'claude-4',
+    lang: 'en',
+  });
+
+  const pending = backend.sendUser('inspect args');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+
+  const call = spawned.calls[0];
+  assert.equal(call.command, 'C:\\Node\\node.exe');
+  assert.equal(call.options.stdio, 'pipe');
+  assert.equal(call.options.windowsHide, true);
+  assert.equal(Object.hasOwn(call.options.env, 'ANTHROPIC_API_KEY'), false);
+  assert.equal(call.options.env.PATH, 'C:\\Node');
+  assert.equal(call.args[0], 'C:\\ae-mcp\\agent-sidecar.mjs');
+
+  const argValue = (flag) => call.args[call.args.indexOf(flag) + 1];
+  assert.deepEqual(JSON.parse(argValue('--mcp')), mcpSpec);
+  assert.deepEqual(JSON.parse(argValue('--allowed-tools')), meta.allowedTools);
+  assert.deepEqual(JSON.parse(argValue('--annotations')), meta.annotations);
+  assert.equal(argValue('--model'), 'claude-4');
+  assert.equal(argValue('--lang'), 'en');
+
+  spawned.procs[0].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await pending;
+});
+
+test('createClaudeAgentBackend forwards all sidecar event shapes unchanged', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const pending = backend.sendUser('events');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+
+  const sidecarEvents = [
+    { type: 'turn-start' },
+    { type: 'text-delta', text: 'hi' },
+    { type: 'tool-start', toolUseId: 'u1', name: 'ae.tool', input: { x: 1 } },
+    { type: 'approval-required', toolUseId: 'u1', name: 'ae.tool', input: { x: 1 }, risk: 'write' },
+    { type: 'tool-denied', toolUseId: 'u1' },
+    { type: 'tool-result', toolUseId: 'u1', ok: true, text: 'ok', durationMs: 12 },
+    { type: 'turn-end', stopReason: 'end_turn' },
+    { type: 'error', kind: 'mcp', message: 'late error' },
+  ];
+  for (const event of sidecarEvents) spawned.procs[0].pushStdout({ t: 'event', event });
+
+  await pending;
+  assert.deepEqual(events, sidecarEvents);
+});
+
+test('createClaudeAgentBackend approve and stop write protocol lines', async () => {
+  const { backend, spawned } = makeBackend();
+  const pending = backend.sendUser('need tool');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+
+  backend.approve('u1', 'allow-session');
+  backend.stop();
+
+  assert.deepEqual(parseWrites(spawned.procs[0]), [
+    { t: 'user', text: 'need tool', permissionMode: 'manual', model: 'claude-test' },
+    { t: 'approve', id: 'u1', decision: 'allow-session' },
+    { t: 'stop' },
+  ]);
+
+  spawned.procs[0].pushStdout({ t: 'event', event: { type: 'error', kind: 'aborted', message: 'aborted' } });
+  await pending;
+});
+
+test('createClaudeAgentBackend reports missing system Node without spawning', async () => {
+  const events = [];
+  const spawned = makeSpawn();
+  const backend = createClaudeAgentBackend({
+    resolveNode: async () => ({ ok: false, detail: 'not found' }),
+    sidecarPath: 'C:\\sidecar.mjs',
+    getMcpSpec: async () => ({}),
+    getToolMeta: async () => ({ allowedTools: [], annotations: {} }),
+    getModel: () => 'claude-test',
+    getPermissionMode: () => 'manual',
+    onEvent: (evt) => events.push(evt),
+    spawnImpl: spawned.spawn,
+    lang: 'en',
+  });
+
+  await backend.sendUser('hello');
+
+  assert.equal(spawned.calls.length, 0);
+  assert.deepEqual(events, [{
+    type: 'error',
+    kind: 'mcp',
+    message: 'Embedded chat needs system Node 18+. Install Node.js LTS and retry.',
+  }]);
+});
+
+test('createClaudeAgentBackend sendUser promise resolves on turn-end or error', async () => {
+  const first = makeBackend();
+  let resolved = false;
+  const pending = first.backend.sendUser('first').then(() => {
+    resolved = true;
+  });
+  await flush();
+  first.spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+  assert.equal(resolved, false);
+  first.spawned.procs[0].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await pending;
+  assert.equal(resolved, true);
+
+  const second = makeBackend();
+  const errorPending = second.backend.sendUser('second');
+  await flush();
+  second.spawned.procs[0].pushStdout({ t: 'ready' });
+  second.spawned.procs[0].pushStdout({ t: 'event', event: { type: 'error', kind: 'mcp', message: 'failed' } });
+  await errorPending;
+});
+
+test('createClaudeAgentBackend reuses a ready process for a second turn', async () => {
+  const { backend, spawned } = makeBackend();
+
+  const first = backend.sendUser('one');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await first;
+
+  const second = backend.sendUser('two');
+  await flush();
+
+  assert.equal(spawned.calls.length, 1);
+  assert.deepEqual(parseWrites(spawned.procs[0]), [
+    { t: 'user', text: 'one', permissionMode: 'manual', model: 'claude-test' },
+    { t: 'user', text: 'two', permissionMode: 'manual', model: 'claude-test' },
+  ]);
+
+  spawned.procs[0].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await second;
+});
+
+test('createClaudeAgentBackend reset kills sidecar and next send respawns', async () => {
+  const { backend, spawned } = makeBackend();
+
+  const first = backend.sendUser('one');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+  backend.reset();
+
+  assert.equal(spawned.procs[0].killed, true);
+  await first;
+
+  const second = backend.sendUser('two');
+  await flush();
+  assert.equal(spawned.calls.length, 2);
+  spawned.procs[1].pushStdout({ t: 'ready' });
+  spawned.procs[1].pushStdout({ t: 'event', event: { type: 'turn-end', stopReason: 'end_turn' } });
+  await second;
+});
+
+test('createClaudeAgentBackend reports unexpected exit during active turn', async () => {
+  const { backend, events, spawned } = makeBackend();
+
+  const pending = backend.sendUser('crash');
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  spawned.procs[0].pushStderr('tail detail');
+  spawned.procs[0].exit(7);
+  await pending;
+
+  const event = events.find((evt) => evt.type === 'error');
+  assert.equal(event.kind, 'mcp');
+  assert.match(event.message, /sidecar exited: 7 tail detail/);
+});
+
+test('createClaudeAgentBackend reports exactly one immediate error when sidecar exits before ready', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const startedAt = Date.now();
+
+  const pending = backend.sendUser('boot crash');
+  await flush();
+  spawned.procs[0].pushStderr('startup failure');
+  spawned.procs[0].exit(9);
+  await pending;
+
+  assert.ok(Date.now() - startedAt < 1000);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'error');
+  assert.equal(events[0].kind, 'mcp');
+  assert.match(events[0].message, /sidecar exited: 9 startup failure/);
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(events.length, 1);
+});
+
+test('resolveSystemNode returns first Node 18+ candidate from where output', async () => {
+  const calls = [];
+  const execFileImpl = (file, args, options, callback) => {
+    calls.push({ file, args, options });
+    if (file === 'where') {
+      callback(null, 'C:\\Old\\node.exe\r\nC:\\New\\node.exe\r\n');
+      return;
+    }
+    if (file === 'C:\\Old\\node.exe') {
+      callback(null, 'v17.9.1\n');
+      return;
+    }
+    if (file === 'C:\\New\\node.exe') {
+      callback(null, 'v22.2.0\n');
+      return;
+    }
+    callback(null, 'v20.0.0\n');
+  };
+
+  const result = await resolveSystemNode({ execFileImpl, env: { PATH: 'x' } });
+
+  assert.deepEqual(result, { ok: true, nodePath: 'C:\\New\\node.exe', version: 'v22.2.0' });
+  assert.deepEqual(calls.map((call) => call.options.windowsHide), [true, true, true]);
+});
+
+test('resolveSystemNode returns ok false when every candidate is below Node 18', async () => {
+  const execFileImpl = (file, args, options, callback) => {
+    if (file === 'where') {
+      callback(null, 'C:\\Old\\node.exe\r\n');
+      return;
+    }
+    callback(null, 'v17.9.1\n');
+  };
+
+  const result = await resolveSystemNode({ execFileImpl, env: {} });
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /Node 18/);
+});

--- a/plugin/panel/test/claudeAuth.test.js
+++ b/plugin/panel/test/claudeAuth.test.js
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { probeClaudeLogin, resolveSidecarPath } from '../src/cep/claudeAuth.js';
+
+function makeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.kill = () => { proc.killed = true; };
+  return proc;
+}
+
+async function nextTick() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test('resolveSidecarPath returns deployed sidecar when present', () => {
+  const hits = new Set(['C:\\ext\\sidecar\\agent-sidecar.mjs']);
+  const result = resolveSidecarPath({
+    extRoot: 'C:/ext/',
+    fsImpl: { existsSync: (p) => hits.has(p) },
+  });
+
+  assert.equal(result, 'C:\\ext\\sidecar\\agent-sidecar.mjs');
+});
+
+test('resolveSidecarPath returns repo sidecar when deployed path is missing', () => {
+  const hits = new Set(['C:\\repo\\plugin\\panel\\..\\sidecar\\agent-sidecar.mjs']);
+  const result = resolveSidecarPath({
+    extRoot: 'C:/repo/plugin/panel',
+    fsImpl: { existsSync: (p) => hits.has(p) },
+  });
+
+  assert.equal(result, 'C:\\repo\\plugin\\panel\\..\\sidecar\\agent-sidecar.mjs');
+});
+
+test('resolveSidecarPath returns deployed candidate when neither exists', () => {
+  const result = resolveSidecarPath({
+    extRoot: 'C:/missing',
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.equal(result, 'C:\\missing\\sidecar\\agent-sidecar.mjs');
+});
+
+test('probeClaudeLogin resolves logged in probe-result', async () => {
+  const proc = makeProc();
+  let spawnArgs;
+  const resultPromise = probeClaudeLogin({
+    resolveNode: async () => ({ ok: true, nodePath: 'node.exe', version: '20.0.0' }),
+    sidecarPath: 'sidecar.mjs',
+    env: { ANTHROPIC_API_KEY: 'secret', KEEP: 'yes' },
+    spawnImpl: (cmd, args, opts) => {
+      spawnArgs = { cmd, args, opts };
+      return proc;
+    },
+  });
+  await nextTick();
+  proc.stdout.emit('data', '{"t":"probe-result","ok":true,"loggedIn":true,"detail":"ready"}\n');
+
+  assert.deepEqual(await resultPromise, { loggedIn: true, nodeOk: true, nodeVersion: '20.0.0', detail: 'ready' });
+  assert.equal(spawnArgs.cmd, 'node.exe');
+  assert.deepEqual(spawnArgs.args, ['sidecar.mjs', '--probe']);
+  assert.equal(spawnArgs.opts.stdio, 'pipe');
+  assert.equal(spawnArgs.opts.windowsHide, true);
+  assert.equal(spawnArgs.opts.env.ANTHROPIC_API_KEY, undefined);
+  assert.equal(spawnArgs.opts.env.KEEP, 'yes');
+});
+
+test('probeClaudeLogin resolves not logged in probe-result', async () => {
+  const proc = makeProc();
+  const resultPromise = probeClaudeLogin({
+    resolveNode: async () => ({ ok: true, nodePath: 'node.exe', version: '18.19.0' }),
+    sidecarPath: 'sidecar.mjs',
+    spawnImpl: () => proc,
+  });
+  await nextTick();
+  proc.stdout.emit('data', '{"t":"probe-result","ok":false,"loggedIn":false,"reason":"login required"}\n');
+
+  assert.deepEqual(await resultPromise, { loggedIn: false, nodeOk: true, nodeVersion: '18.19.0', detail: 'login required' });
+});
+
+test('probeClaudeLogin kills process on timeout', async () => {
+  const proc = makeProc();
+  const result = await probeClaudeLogin({
+    resolveNode: async () => ({ ok: true, nodePath: 'node.exe', version: '20.0.0' }),
+    sidecarPath: 'sidecar.mjs',
+    spawnImpl: () => proc,
+    timeoutMs: 1,
+  });
+
+  assert.equal(proc.killed, true);
+  assert.deepEqual(result, { loggedIn: false, nodeOk: true, nodeVersion: '20.0.0', detail: 'probe timeout' });
+});
+
+test('probeClaudeLogin reports stderr tail when process exits without result', async () => {
+  const proc = makeProc();
+  const resultPromise = probeClaudeLogin({
+    resolveNode: async () => ({ ok: true, nodePath: 'node.exe', version: '20.0.0' }),
+    sidecarPath: 'sidecar.mjs',
+    spawnImpl: () => proc,
+  });
+  await nextTick();
+  proc.stderr.emit('data', 'first\n');
+  proc.stderr.emit('data', 'last error\n');
+  proc.emit('exit', 1);
+
+  assert.deepEqual(await resultPromise, { loggedIn: false, nodeOk: true, nodeVersion: '20.0.0', detail: 'first\nlast error' });
+});
+
+test('probeClaudeLogin reports resolveNode failure and does not spawn', async () => {
+  let spawned = false;
+  const result = await probeClaudeLogin({
+    resolveNode: async () => ({ ok: false, detail: 'node missing' }),
+    sidecarPath: 'sidecar.mjs',
+    spawnImpl: () => { spawned = true; },
+  });
+
+  assert.equal(spawned, false);
+  assert.deepEqual(result, { loggedIn: false, nodeOk: false, detail: 'node missing' });
+});

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { _createRpc, resolveMcpCommand } from '../src/cep/mcpClient.js';
+
+function makeRpc(timeoutMs = 50) {
+  const writes = [];
+  let pushChunk = null;
+  const rpc = _createRpc(
+    (text) => writes.push(text),
+    (handler) => { pushChunk = handler; },
+    { timeoutMs },
+  );
+  return { rpc, writes, pushChunk: (text) => pushChunk(text) };
+}
+
+test('_createRpc pairs requests with out-of-order responses', async () => {
+  const io = makeRpc();
+
+  const first = io.rpc.request('first', { a: 1 });
+  const second = io.rpc.request('second', { b: 2 });
+  const sent = io.writes.map((line) => JSON.parse(line));
+
+  io.pushChunk(JSON.stringify({ jsonrpc: '2.0', id: sent[1].id, result: 'two' }) + '\n');
+  io.pushChunk(JSON.stringify({ jsonrpc: '2.0', id: sent[0].id, result: 'one' }) + '\n');
+
+  assert.equal(await first, 'one');
+  assert.equal(await second, 'two');
+});
+
+test('_createRpc buffers torn lines before parsing JSON-RPC frames', async () => {
+  const io = makeRpc();
+
+  const pending = io.rpc.request('split', {});
+  const id = JSON.parse(io.writes[0]).id;
+
+  io.pushChunk('{"jsonrpc":"2.0","id":');
+  io.pushChunk(String(id) + ',"result":{"ok":true}}\n');
+
+  assert.deepEqual(await pending, { ok: true });
+});
+
+test('_createRpc rejects timed out requests', async () => {
+  const io = makeRpc(5);
+
+  await assert.rejects(io.rpc.request('slow', {}), /timed out/);
+});
+
+test('_createRpc rejects JSON-RPC error responses', async () => {
+  const io = makeRpc();
+
+  const pending = io.rpc.request('bad', {});
+  const id = JSON.parse(io.writes[0]).id;
+  io.pushChunk(JSON.stringify({ jsonrpc: '2.0', id, error: { code: -1, message: 'nope' } }) + '\n');
+
+  await assert.rejects(pending, /nope/);
+});
+
+test('resolveMcpCommand prefers an explicit executable path', async () => {
+  const result = await resolveMcpCommand({
+    explicitPath: 'C:/tools/ae-mcp.exe',
+    whereImpl: () => { throw new Error('should not call where'); },
+  });
+
+  assert.deepEqual(result, { command: 'C:/tools/ae-mcp.exe', args: [], source: 'explicit' });
+});
+
+test('resolveMcpCommand uses where ae-mcp when no explicit path is configured', async () => {
+  const result = await resolveMcpCommand({
+    whereImpl: async () => 'C:\\Tools\\ae-mcp.exe\r\n',
+  });
+
+  assert.deepEqual(result, { command: 'C:\\Tools\\ae-mcp.exe', args: [], source: 'where' });
+});
+
+test('resolveMcpCommand falls back to uv project command in development mode', async () => {
+  const result = await resolveMcpCommand({
+    whereImpl: async () => '',
+    extRoot: 'E:/Code/ae-mcp-codex-p5a/plugin/panel',
+    fsImpl: { existsSync: (p) => p === 'E:\\Code\\ae-mcp-codex-p5a\\pyproject.toml' },
+  });
+
+  assert.equal(result.command, 'uv');
+  assert.deepEqual(result.args.slice(0, 3), ['run', '--project', 'E:\\Code\\ae-mcp-codex-p5a']);
+  assert.equal(result.args[3], 'ae-mcp');
+  assert.equal(result.source, 'uv');
+});
+
+test('resolveMcpCommand reports a repair hint when no executable can be found', async () => {
+  await assert.rejects(
+    resolveMcpCommand({
+      whereImpl: async () => '',
+      extRoot: 'E:/missing/plugin/panel',
+      fsImpl: { existsSync: () => false },
+    }),
+    /Unable to find ae-mcp/,
+  );
+});

--- a/plugin/panel/test/ndjson.test.js
+++ b/plugin/panel/test/ndjson.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createLineSplitter, createNdjsonReader } from '../src/lib/ndjson.js';
+
+test('createLineSplitter emits every complete line in a chunk', () => {
+  const lines = [];
+  const push = createLineSplitter((line) => lines.push(line));
+
+  push('one\ntwo\nthree\n');
+
+  assert.deepEqual(lines, ['one', 'two', 'three']);
+});
+
+test('createLineSplitter buffers lines torn across chunks', () => {
+  const lines = [];
+  const push = createLineSplitter((line) => lines.push(line));
+
+  push('{"a":');
+  assert.deepEqual(lines, []);
+  push('1}\n{"b":2}\n');
+
+  assert.deepEqual(lines, ['{"a":1}', '{"b":2}']);
+});
+
+test('createLineSplitter trims CRLF and skips blank lines', () => {
+  const lines = [];
+  const push = createLineSplitter((line) => lines.push(line));
+
+  push('one\r\n\r\n  \ntwo\r\n');
+
+  assert.deepEqual(lines, ['one', 'two']);
+});
+
+test('createNdjsonReader parses JSON lines and skips contamination', () => {
+  const messages = [];
+  const push = createNdjsonReader((message) => messages.push(message));
+
+  push('{"t":"ready"}\nnot json at all\n{"t":"event","n":2}\n');
+
+  assert.deepEqual(messages, [{ t: 'ready' }, { t: 'event', n: 2 }]);
+});

--- a/plugin/panel/test/sse.test.js
+++ b/plugin/panel/test/sse.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSseParser } from '../src/lib/sse.js';
+
+test('createSseParser parses a frame split across chunks', () => {
+  const events = [];
+  const parser = createSseParser((evt) => events.push(evt));
+
+  parser.feed('event: message_start\r\ndata: {"type":"message_');
+  parser.feed('start","message":{"id":"m1"}}\r\n\r\n');
+
+  assert.deepEqual(events, [{ event: 'message_start', data: { type: 'message_start', message: { id: 'm1' } } }]);
+});
+
+test('createSseParser parses multiple frames from one chunk', () => {
+  const events = [];
+  const parser = createSseParser((evt) => events.push(evt));
+
+  parser.feed('event: a\ndata: {"n":1}\n\nevent: b\ndata: {"n":2}\n\n');
+
+  assert.deepEqual(events, [
+    { event: 'a', data: { n: 1 } },
+    { event: 'b', data: { n: 2 } },
+  ]);
+});
+
+test('createSseParser tolerates CRLF and multi-line data fields', () => {
+  const events = [];
+  const parser = createSseParser((evt) => events.push(evt));
+
+  parser.feed('event: content_block_delta\r\ndata: {"partial":"hel"\r\ndata: ,"tail":"lo"}\r\n\r\n');
+
+  assert.deepEqual(events, [
+    { event: 'content_block_delta', data: { partial: 'hel', tail: 'lo' } },
+  ]);
+});
+
+test('createSseParser ignores non-JSON data and done frames', () => {
+  const events = [];
+  const parser = createSseParser((evt) => events.push(evt));
+
+  parser.feed('event: ping\ndata: keep-alive\n\ndata: [DONE]\n\nevent: ok\ndata: {"done":true}\n\n');
+
+  assert.deepEqual(events, [{ event: 'ok', data: { done: true } }]);
+});

--- a/plugin/sidecar/agent-sidecar.mjs
+++ b/plugin/sidecar/agent-sidecar.mjs
@@ -1,0 +1,47 @@
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { createSidecar, parseArgv } from './lib.mjs'
+
+let argvOptions
+try {
+  argvOptions = parseArgv(process.argv.slice(2))
+} catch (error) {
+  process.stderr.write(`${error && error.message ? error.message : String(error)}\n`)
+  process.exit(1)
+}
+
+const sidecar = createSidecar({
+  queryFn: query,
+  writeLine: (obj) => {
+    process.stdout.write(`${JSON.stringify(obj)}\n`)
+  },
+  argvOptions,
+  env: process.env
+})
+
+if (argvOptions.probe) {
+  const exitCode = await sidecar.runProbe()
+  process.exit(exitCode)
+}
+
+let buffer = ''
+
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => {
+  buffer += chunk
+
+  let newlineIndex = buffer.indexOf('\n')
+  while (newlineIndex !== -1) {
+    const line = buffer.slice(0, newlineIndex).replace(/\r$/, '')
+    buffer = buffer.slice(newlineIndex + 1)
+    sidecar.handleLine(line)
+    newlineIndex = buffer.indexOf('\n')
+  }
+})
+
+process.stdin.on('end', () => {
+  const line = buffer.replace(/\r$/, '')
+  buffer = ''
+  if (line) {
+    sidecar.handleLine(line)
+  }
+})

--- a/plugin/sidecar/lib.mjs
+++ b/plugin/sidecar/lib.mjs
@@ -1,0 +1,459 @@
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
+
+const DISALLOWED_TOOLS = [
+  'Bash',
+  'Edit',
+  'Write',
+  'PowerShell',
+  'Task',
+  'WebFetch',
+  'WebSearch'
+]
+
+const AUTH_RE = /\/login|logged|credential|authentication/i
+
+const SYSTEM_PROMPTS = {
+  zh: '你是 After Effects 面板内的助手。只使用 ae_ 前缀工具操作 After Effects。回答简短，优先直接完成用户请求。',
+  en: 'You are an assistant inside an After Effects panel. Use only ae_ prefixed tools to operate After Effects. Keep replies brief and focus on completing the user request.'
+}
+
+export function parseArgv(argv) {
+  const options = {
+    probe: false,
+    model: DEFAULT_MODEL,
+    lang: 'zh',
+    mcp: null,
+    allowedTools: [],
+    annotations: {}
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--probe') {
+      options.probe = true
+    } else if (arg === '--mcp') {
+      options.mcp = parseJsonArg(argv[++i], '--mcp')
+    } else if (arg === '--allowed-tools') {
+      options.allowedTools = parseJsonArg(argv[++i], '--allowed-tools')
+    } else if (arg === '--annotations') {
+      options.annotations = parseJsonArg(argv[++i], '--annotations')
+    } else if (arg === '--model') {
+      options.model = argv[++i] || DEFAULT_MODEL
+    } else if (arg === '--lang') {
+      const lang = argv[++i]
+      options.lang = lang === 'en' ? 'en' : 'zh'
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date.now }) {
+  if (typeof queryFn !== 'function') {
+    throw new Error('queryFn is required')
+  }
+  if (typeof writeLine !== 'function') {
+    throw new Error('writeLine is required')
+  }
+
+  const options = normalizeOptions(argvOptions)
+  const baseEnv = cleanEnv(env || {})
+  const approvals = new Map()
+  const sessionAllowedTools = new Set()
+  const toolUses = []
+  let sessionId = null
+  let approvalSeq = 0
+  let activeTurn = null
+
+  if (!options.probe) {
+    writeLine({ t: 'ready' })
+  }
+
+  function emitEvent(event) {
+    writeLine({ t: 'event', event })
+  }
+
+  function handleLine(line) {
+    const trimmed = String(line || '').trim()
+    if (!trimmed) {
+      return
+    }
+
+    let message
+    try {
+      message = JSON.parse(trimmed)
+    } catch (error) {
+      emitEvent({ type: 'error', kind: 'network', message: `Invalid JSON: ${truncateDetail(error)}` })
+      return
+    }
+
+    if (message.t === 'user') {
+      startTurn(message)
+    } else if (message.t === 'approve') {
+      handleApproval(message)
+    } else if (message.t === 'stop') {
+      stopTurn()
+    }
+  }
+
+  function startTurn(message) {
+    const controller = new AbortController()
+    const turn = {
+      permissionMode: normalizePermissionMode(message.permissionMode),
+      controller,
+      stopRequested: false,
+      abortedEventSent: false
+    }
+    activeTurn = turn
+
+    emitEvent({ type: 'turn-start' })
+
+    runTurn(message, turn).finally(() => {
+      if (activeTurn === turn) {
+        activeTurn = null
+      }
+    })
+  }
+
+  async function runTurn(message, turn) {
+    try {
+      const model = typeof message.model === 'string' && message.model ? message.model : options.model
+      const queryOptions = buildTurnOptions({ model, turn })
+
+      for await (const sdkMessage of queryFn({
+        prompt: String(message.text || ''),
+        options: queryOptions
+      })) {
+        handleSdkMessage(sdkMessage, turn)
+      }
+    } catch (error) {
+      if (turn.stopRequested) {
+        emitAbortedOnce(turn)
+        return
+      }
+      emitEvent({ type: 'error', kind: classifyError(error), message: truncateDetail(error) })
+    }
+  }
+
+  function buildTurnOptions({ model, turn }) {
+    const queryOptions = {
+      model,
+      mcpServers: buildMcpServers(),
+      allowedTools: options.allowedTools,
+      disallowedTools: DISALLOWED_TOOLS,
+      settingSources: [],
+      systemPrompt: SYSTEM_PROMPTS[options.lang],
+      canUseTool: async (toolName, input) => canUseTool(toolName, input, turn),
+      env: baseEnv,
+      abortController: turn.controller
+    }
+
+    if (sessionId) {
+      queryOptions.resume = sessionId
+    }
+
+    return queryOptions
+  }
+
+  function buildMcpServers() {
+    if (!options.mcp) {
+      return {}
+    }
+
+    return {
+      ae: {
+        type: 'stdio',
+        command: options.mcp.command,
+        args: Array.isArray(options.mcp.args) ? options.mcp.args : [],
+        env: {
+          ...(isPlainObject(options.mcp.env) ? options.mcp.env : {}),
+          AE_MCP_BACKEND: 'ae-mcp'
+        }
+      }
+    }
+  }
+
+  function handleSdkMessage(message, turn) {
+    if (!message || typeof message !== 'object') {
+      return
+    }
+
+    if (message.type === 'assistant') {
+      for (const block of getContentBlocks(message)) {
+        if (block && block.type === 'text') {
+          emitEvent({ type: 'text-delta', text: String(block.text || '') })
+        } else if (block && block.type === 'tool_use') {
+          const toolUseId = String(block.id || '')
+          toolUses.push({
+            id: toolUseId,
+            name: String(block.name || ''),
+            startedAt: now(),
+            claimed: false
+          })
+          emitEvent({
+            type: 'tool-start',
+            toolUseId,
+            name: String(block.name || ''),
+            input: normalizeInput(block.input)
+          })
+        }
+      }
+    } else if (message.type === 'user') {
+      for (const block of getContentBlocks(message)) {
+        if (block && block.type === 'tool_result') {
+          const toolUseId = String(block.tool_use_id || '')
+          const toolUse = toolUses.find((item) => item.id === toolUseId)
+          emitEvent({
+            type: 'tool-result',
+            toolUseId,
+            ok: block.is_error !== true,
+            text: toolResultText(block.content),
+            durationMs: toolUse ? Math.max(0, now() - toolUse.startedAt) : 0
+          })
+        }
+      }
+    } else if (message.type === 'result') {
+      if (message.session_id) {
+        sessionId = message.session_id
+      }
+
+      if (turn.stopRequested) {
+        emitAbortedOnce(turn)
+      } else if (message.is_error) {
+        emitEvent({
+          type: 'error',
+          kind: classifyError(message.result || message),
+          message: truncateDetail(message.result || message)
+        })
+      } else {
+        emitEvent({
+          type: 'turn-end',
+          stopReason: message.subtype === 'success' ? 'end_turn' : String(message.subtype || 'end_turn')
+        })
+      }
+    }
+  }
+
+  async function canUseTool(toolName, input, turn) {
+    const name = String(toolName || '')
+    if (!name.startsWith('mcp__ae__')) {
+      return { behavior: 'deny', message: 'panel denied non-ae tool' }
+    }
+
+    if (sessionAllowedTools.has(name)) {
+      return { behavior: 'allow', updatedInput: input }
+    }
+
+    const annotation = options.annotations[name] || {}
+    const destructive = annotation.destructive === true
+    if (turn.permissionMode === 'none' || (turn.permissionMode === 'auto' && !destructive)) {
+      return { behavior: 'allow', updatedInput: input }
+    }
+
+    const toolUseId = claimToolUseId(name)
+    const risk = destructive ? 'destructive' : 'write'
+
+    emitEvent({
+      type: 'approval-required',
+      toolUseId,
+      name,
+      input: normalizeInput(input),
+      risk
+    })
+
+    return await new Promise((resolve) => {
+      approvals.set(toolUseId, {
+        name,
+        input,
+        resolve
+      })
+    })
+  }
+
+  function claimToolUseId(name) {
+    const toolUse = toolUses.find((item) => item.name === name && !item.claimed)
+    if (toolUse) {
+      toolUse.claimed = true
+      return toolUse.id
+    }
+
+    approvalSeq += 1
+    return `appr-${approvalSeq}`
+  }
+
+  function handleApproval(message) {
+    const id = String(message.id || '')
+    const pending = approvals.get(id)
+    if (!pending) {
+      return
+    }
+    approvals.delete(id)
+
+    if (message.decision === 'allow' || message.decision === 'allow-session') {
+      if (message.decision === 'allow-session') {
+        sessionAllowedTools.add(pending.name)
+      }
+      pending.resolve({ behavior: 'allow', updatedInput: pending.input })
+    } else {
+      emitEvent({ type: 'tool-denied', toolUseId: id })
+      pending.resolve({ behavior: 'deny', message: 'User denied this action.' })
+    }
+  }
+
+  function stopTurn() {
+    if (!activeTurn) {
+      return
+    }
+
+    activeTurn.stopRequested = true
+    activeTurn.controller.abort()
+    emitAbortedOnce(activeTurn)
+  }
+
+  function emitAbortedOnce(turn) {
+    if (turn.abortedEventSent) {
+      return
+    }
+    turn.abortedEventSent = true
+    emitEvent({ type: 'error', kind: 'aborted', message: 'Turn aborted.' })
+  }
+
+  async function runProbe() {
+    try {
+      let sawResult = false
+      for await (const message of queryFn({
+        prompt: 'Reply with exactly: pong',
+        options: {
+          model: options.model,
+          maxTurns: 1,
+          allowedTools: [],
+          disallowedTools: DISALLOWED_TOOLS,
+          settingSources: [],
+          env: baseEnv
+        }
+      })) {
+        if (message && message.type === 'result') {
+          sawResult = true
+          if (message.is_error) {
+            const detail = truncateDetail(message.result || message)
+            const auth = AUTH_RE.test(detail)
+            writeLine({
+              t: 'probe-result',
+              ok: false,
+              loggedIn: false,
+              reason: auth ? 'not-logged-in' : 'query-failed',
+              detail
+            })
+            return auth ? 2 : 3
+          }
+        }
+      }
+
+      if (sawResult) {
+        writeLine({ t: 'probe-result', ok: true, loggedIn: true, reason: null, detail: '' })
+        return 0
+      }
+
+      writeLine({
+        t: 'probe-result',
+        ok: false,
+        loggedIn: true,
+        reason: 'query-failed',
+        detail: 'query completed without result'
+      })
+      return 3
+    } catch (error) {
+      const detail = truncateDetail(error)
+      const auth = AUTH_RE.test(detail)
+      writeLine({
+        t: 'probe-result',
+        ok: false,
+        loggedIn: !auth,
+        reason: auth ? 'not-logged-in' : 'query-failed',
+        detail
+      })
+      return auth ? 2 : 3
+    }
+  }
+
+  return { handleLine, runProbe }
+}
+
+function normalizeOptions(argvOptions = {}) {
+  return {
+    probe: argvOptions.probe === true,
+    model: argvOptions.model || DEFAULT_MODEL,
+    lang: argvOptions.lang === 'en' ? 'en' : 'zh',
+    mcp: argvOptions.mcp || null,
+    allowedTools: Array.isArray(argvOptions.allowedTools) ? argvOptions.allowedTools : [],
+    annotations: isPlainObject(argvOptions.annotations) ? argvOptions.annotations : {}
+  }
+}
+
+function parseJsonArg(value, name) {
+  if (typeof value !== 'string') {
+    throw new Error(`${name} requires a JSON value`)
+  }
+  return JSON.parse(value)
+}
+
+function cleanEnv(inputEnv) {
+  const output = { ...inputEnv }
+  delete output.ANTHROPIC_API_KEY
+  return output
+}
+
+function normalizePermissionMode(mode) {
+  if (mode === 'manual' || mode === 'auto' || mode === 'none') {
+    return mode
+  }
+  return 'manual'
+}
+
+function getContentBlocks(message) {
+  const content = message && message.message && message.message.content
+  return Array.isArray(content) ? content : []
+}
+
+function toolResultText(content) {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter((item) => item && item.type === 'text')
+      .map((item) => String(item.text || ''))
+      .join('')
+  }
+  return ''
+}
+
+function normalizeInput(input) {
+  return isPlainObject(input) ? input : {}
+}
+
+function classifyError(error) {
+  return AUTH_RE.test(truncateDetail(error)) ? 'auth' : 'network'
+}
+
+function truncateDetail(error) {
+  let detail
+  if (typeof error === 'string') {
+    detail = error
+  } else if (error && typeof error.message === 'string') {
+    detail = error.message
+  } else {
+    try {
+      detail = JSON.stringify(error)
+    } catch {
+      detail = String(error)
+    }
+  }
+  return String(detail || '').slice(0, 500)
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/plugin/sidecar/lib.mjs
+++ b/plugin/sidecar/lib.mjs
@@ -109,6 +109,9 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
     }
     activeTurn = turn
 
+    toolUses.length = 0
+    ignoredToolUseIds.clear()
+
     emitEvent({ type: 'turn-start' })
 
     runTurn(message, turn).finally(() => {

--- a/plugin/sidecar/lib.mjs
+++ b/plugin/sidecar/lib.mjs
@@ -112,6 +112,7 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
     emitEvent({ type: 'turn-start' })
 
     runTurn(message, turn).finally(() => {
+      drainApprovals('Turn ended.')
       if (activeTurn === turn) {
         activeTurn = null
       }
@@ -339,7 +340,16 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
 
     activeTurn.stopRequested = true
     activeTurn.controller.abort()
+    drainApprovals('Turn was stopped.')
     emitAbortedOnce(activeTurn)
+  }
+
+  function drainApprovals(message) {
+    for (const [id, pending] of approvals) {
+      approvals.delete(id)
+      emitEvent({ type: 'tool-denied', toolUseId: id })
+      pending.resolve({ behavior: 'deny', message })
+    }
   }
 
   function emitAbortedOnce(turn) {

--- a/plugin/sidecar/lib.mjs
+++ b/plugin/sidecar/lib.mjs
@@ -63,6 +63,7 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
   const approvals = new Map()
   const sessionAllowedTools = new Set()
   const toolUses = []
+  const ignoredToolUseIds = new Set()
   let sessionId = null
   let approvalSeq = 0
   let activeTurn = null
@@ -144,7 +145,8 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
       allowedTools: options.allowedTools,
       disallowedTools: DISALLOWED_TOOLS,
       settingSources: [],
-      systemPrompt: SYSTEM_PROMPTS[options.lang],
+      agents: buildAgents(),
+      agent: 'ae',
       canUseTool: async (toolName, input) => canUseTool(toolName, input, turn),
       env: baseEnv,
       abortController: turn.controller
@@ -175,6 +177,19 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
     }
   }
 
+  function buildAgents() {
+    return {
+      ae: {
+        description: 'After Effects panel assistant',
+        prompt: SYSTEM_PROMPTS[options.lang],
+        tools: uniqueToolList([
+          ...Object.keys(options.annotations),
+          ...options.allowedTools
+        ])
+      }
+    }
+  }
+
   function handleSdkMessage(message, turn) {
     if (!message || typeof message !== 'object') {
       return
@@ -186,16 +201,24 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
           emitEvent({ type: 'text-delta', text: String(block.text || '') })
         } else if (block && block.type === 'tool_use') {
           const toolUseId = String(block.id || '')
+          const name = String(block.name || '')
+          if (!name.startsWith('mcp__ae__')) {
+            if (toolUseId) {
+              ignoredToolUseIds.add(toolUseId)
+            }
+            continue
+          }
+
           toolUses.push({
             id: toolUseId,
-            name: String(block.name || ''),
+            name,
             startedAt: now(),
             claimed: false
           })
           emitEvent({
             type: 'tool-start',
             toolUseId,
-            name: String(block.name || ''),
+            name,
             input: normalizeInput(block.input)
           })
         }
@@ -204,6 +227,10 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
       for (const block of getContentBlocks(message)) {
         if (block && block.type === 'tool_result') {
           const toolUseId = String(block.tool_use_id || '')
+          if (ignoredToolUseIds.has(toolUseId)) {
+            continue
+          }
+
           const toolUse = toolUses.find((item) => item.id === toolUseId)
           emitEvent({
             type: 'tool-result',
@@ -239,7 +266,10 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
   async function canUseTool(toolName, input, turn) {
     const name = String(toolName || '')
     if (!name.startsWith('mcp__ae__')) {
-      return { behavior: 'deny', message: 'panel denied non-ae tool' }
+      return {
+        behavior: 'deny',
+        message: 'Only After Effects (mcp__ae__*) tools are available in this panel.'
+      }
     }
 
     if (sessionAllowedTools.has(name)) {
@@ -428,6 +458,19 @@ function toolResultText(content) {
       .join('')
   }
   return ''
+}
+
+function uniqueToolList(items) {
+  const seen = new Set()
+  const result = []
+  for (const item of items) {
+    if (typeof item !== 'string' || seen.has(item)) {
+      continue
+    }
+    seen.add(item)
+    result.push(item)
+  }
+  return result
 }
 
 function normalizeInput(input) {

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,0 +1,1453 @@
+{
+  "name": "ae-mcp-agent-sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ae-mcp-agent-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.173"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.174.tgz",
+      "integrity": "sha512-cgBzLUzlcviLW8k8jSwV7EFKiPhsWNW0tJ2g39LXTntPfZ9R1vEGLZLw+6Zkr6/1ONvkfa7WzPRwdaYXwgF3hA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.174",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.174"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.174.tgz",
+      "integrity": "sha512-Trv4FwXnig/XbcEFdkSW1FVzhfYl74PrWXiX98ypfaAgfCecg9ltDIPsuLCTv9oSiu4Di8uPIZBPfUT7ro+yXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.174.tgz",
+      "integrity": "sha512-+8tYTgh4G5mdudphDVGbZzJLpOfL03YNBb+eHGRMzbptWQuIm4R1Tu8dD1T6qAZ7Ytt7E9unww9cUK4sQbDrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.174.tgz",
+      "integrity": "sha512-+YIvqujjx9v82Yuep+7di3MTubwvAxPY6ZEz5aY/PWS2ZEfSUCFcNJpGkk3Y84l4VdPo/rYOXxa2/j9nlbeOmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.174.tgz",
+      "integrity": "sha512-D1Z133VLqCfK8ZBsQR6Eu2fbNh/dGrisaSY+CZ9Ni5gHItPRLCCnS/Iqag7dWEXLlZnh7SJqT5yxRd+hkW0bFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.174.tgz",
+      "integrity": "sha512-j5dNEAaKZU3XnGj0McE4v1SyXd7W1lNm16Erk4xTTFfPsZdwJThqwJ3T80clH3mwCrNeE0OGBQRYZ+Gg8HkILQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.174.tgz",
+      "integrity": "sha512-GJ7cBnbthPd7Pb5uVSQ6AZqWI+MeRMlqXAkdjDGs7mRD1aEpDGFeXrBiOekbsiT6oN+cFbCVDrN9OuMhYf1OIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.174.tgz",
+      "integrity": "sha512-ASw4oIea5457ndIVjv0uz86Ij1M2e0rdRBBfV98Qa1vORfi9RVAyPisbObJEpow0vLPIGYdGDdZ4cB90lr38sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.174",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.174.tgz",
+      "integrity": "sha512-KJO1aTznfbA/eDn+Odak3L+NdvuPRcTxevycpxbwq64Pn1wm2LkUNJARvmc5TBT1lVRT+LOcxOV7tqaegyzA5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.104.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -7,6 +7,6 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.173"
   },
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test"
   }
 }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ae-mcp-agent-sidecar",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.173"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/plugin/sidecar/test/sidecar.test.js
+++ b/plugin/sidecar/test/sidecar.test.js
@@ -417,6 +417,39 @@ test('query failure drains pending approval', async () => {
   ])
 })
 
+test('approval ids stay scoped to the current turn', async () => {
+  const writes = []
+  let callCount = 0
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      callCount += 1
+      const id = callCount === 1 ? 'tool-1' : 'tool-2'
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id, name: 'mcp__ae__write', input: {} }] }
+      }
+      await options.canUseTool('mcp__ae__write', {})
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'first', permissionMode: 'none' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'second', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 1)
+
+  assert.deepEqual(events(writes).filter((event) => event.type === 'approval-required').map((event) => event.toolUseId), [
+    'tool-2'
+  ])
+
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-2', decision: 'allow' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 2)
+})
+
 test('query login failures map to auth errors', async () => {
   const writes = []
   const sidecar = createSidecar({

--- a/plugin/sidecar/test/sidecar.test.js
+++ b/plugin/sidecar/test/sidecar.test.js
@@ -353,6 +353,70 @@ test('stop aborts active turn and emits aborted error', async () => {
   ])
 })
 
+test('stop drains pending approval and stale allow-session does not affect later turns', async () => {
+  const writes = []
+  const decisions = []
+  let callCount = 0
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      callCount += 1
+      const id = callCount === 1 ? 'tool-1' : 'tool-2'
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id, name: 'mcp__ae__write', input: {} }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__write', {}))
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'first', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 1)
+  sidecar.handleLine(JSON.stringify({ t: 'stop' }))
+  await waitFor(() => eventCount(writes, 'tool-denied') === 1 && decisions.length === 1)
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-1', decision: 'allow-session' }))
+  await waitFor(() => eventCount(writes, 'error') === 1)
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'second', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 2)
+
+  assert.deepEqual(decisions[0], { behavior: 'deny', message: 'Turn was stopped.' })
+  assert.deepEqual(events(writes).filter((event) => event.type === 'tool-denied'), [
+    { type: 'tool-denied', toolUseId: 'tool-1' }
+  ])
+  assert.deepEqual(events(writes).filter((event) => event.type === 'approval-required').map((event) => event.toolUseId), [
+    'tool-1',
+    'tool-2'
+  ])
+})
+
+test('query failure drains pending approval', async () => {
+  const writes = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'mcp__ae__write', input: {} }] }
+      }
+      options.canUseTool('mcp__ae__write', {})
+      throw new Error('sdk failed')
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'fail', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'tool-denied') === 1)
+
+  assert.deepEqual(events(writes).filter((event) => event.type === 'tool-denied'), [
+    { type: 'tool-denied', toolUseId: 'tool-1' }
+  ])
+})
+
 test('query login failures map to auth errors', async () => {
   const writes = []
   const sidecar = createSidecar({

--- a/plugin/sidecar/test/sidecar.test.js
+++ b/plugin/sidecar/test/sidecar.test.js
@@ -77,7 +77,8 @@ test('passes session resume on the second user turn', async () => {
     },
     writeLine: (obj) => writes.push(obj),
     argvOptions: defaultOptions,
-    env: {}
+    env: {},
+    now: () => 10
   })
 
   sidecar.handleLine(JSON.stringify({ t: 'user', text: 'one', permissionMode: 'none' }))
@@ -87,6 +88,93 @@ test('passes session resume on the second user turn', async () => {
 
   assert.equal(seenOptions[0].resume, undefined)
   assert.equal(seenOptions[1].resume, 'sess-1')
+})
+
+test('pins turn options to ae agent with annotations and allowed tools whitelist', async () => {
+  const writes = []
+  let seenOptions
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      seenOptions = options
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: {
+      ...defaultOptions,
+      allowedTools: ['mcp__ae__ae_ping', 'mcp__ae__ae_overview'],
+      annotations: {
+        mcp__ae__ae_ping: { readOnly: true, destructive: false },
+        mcp__ae__ae_write: { readOnly: false, destructive: true }
+      }
+    },
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'options', permissionMode: 'none' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.equal(seenOptions.agent, 'ae')
+  assert.deepEqual(seenOptions.agents.ae.tools, [
+    'mcp__ae__ae_ping',
+    'mcp__ae__ae_write',
+    'mcp__ae__ae_overview'
+  ])
+  assert.equal(typeof seenOptions.agents.ae.prompt, 'string')
+  assert.notEqual(seenOptions.agents.ae.prompt.length, 0)
+  assert.equal(Object.hasOwn(seenOptions, 'systemPrompt'), false)
+})
+
+test('filters non ae tool_use and tool_result events while preserving ae tools', async () => {
+  const writes = []
+  const sidecar = createSidecar({
+    queryFn: async function * () {
+      yield {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tool-search-1', name: 'ToolSearch', input: { query: 'ae' } },
+            { type: 'tool_use', id: 'tool-ae-1', name: 'mcp__ae__ae_ping', input: { ok: true } }
+          ]
+        }
+      }
+      yield {
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-search-1',
+              content: [{ type: 'text', text: 'search result' }],
+              is_error: false
+            },
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-ae-1',
+              content: [{ type: 'text', text: 'pong' }],
+              is_error: false
+            }
+          ]
+        }
+      }
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {},
+    now: () => 10
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'filter', permissionMode: 'none' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.equal(events(writes).some((event) => event.name === 'ToolSearch'), false)
+  assert.equal(events(writes).some((event) => event.toolUseId === 'tool-search-1'), false)
+  assert.deepEqual(events(writes).filter((event) => event.type === 'tool-start'), [
+    { type: 'tool-start', toolUseId: 'tool-ae-1', name: 'mcp__ae__ae_ping', input: { ok: true } }
+  ])
+  assert.deepEqual(events(writes).filter((event) => event.type === 'tool-result'), [
+    { type: 'tool-result', toolUseId: 'tool-ae-1', ok: true, text: 'pong', durationMs: 0 }
+  ])
 })
 
 test('manual approval allow and deny resolve canUseTool correctly', async () => {
@@ -229,7 +317,9 @@ test('non ae tool is denied without panel approval events', async () => {
   sidecar.handleLine(JSON.stringify({ t: 'user', text: 'bad', permissionMode: 'manual' }))
   await waitFor(() => eventCount(writes, 'turn-end') === 1)
 
-  assert.deepEqual(decisions, [{ behavior: 'deny', message: 'panel denied non-ae tool' }])
+  assert.deepEqual(decisions, [
+    { behavior: 'deny', message: 'Only After Effects (mcp__ae__*) tools are available in this panel.' }
+  ])
   assert.equal(eventCount(writes, 'approval-required'), 0)
   assert.equal(eventCount(writes, 'tool-denied'), 0)
 })

--- a/plugin/sidecar/test/sidecar.test.js
+++ b/plugin/sidecar/test/sidecar.test.js
@@ -1,0 +1,327 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createSidecar } from '../lib.mjs'
+
+const defaultOptions = {
+  probe: false,
+  model: 'test-model',
+  lang: 'zh',
+  mcp: {
+    command: 'uv',
+    args: ['run', 'ae-mcp'],
+    env: { EXTRA: '1' }
+  },
+  allowedTools: ['mcp__ae__ae_ping'],
+  annotations: {}
+}
+
+test('maps user turn, text, tool_use, tool_result, and result events', async () => {
+  const writes = []
+  let tick = 100
+  const sidecar = createSidecar({
+    queryFn: async function * () {
+      yield {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'tool_use', id: 'tool-1', name: 'mcp__ae__ae_ping', input: { ok: true } }
+          ]
+        }
+      }
+      yield {
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-1',
+              content: [{ type: 'text', text: 'pong' }],
+              is_error: false
+            }
+          ]
+        }
+      }
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {},
+    now: () => {
+      tick += 50
+      return tick
+    }
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'ping', permissionMode: 'none' }))
+  await waitFor(() => events(writes).some((event) => event.type === 'turn-end'))
+
+  assert.deepEqual(writes[0], { t: 'ready' })
+  assert.deepEqual(events(writes), [
+    { type: 'turn-start' },
+    { type: 'text-delta', text: 'hello' },
+    { type: 'tool-start', toolUseId: 'tool-1', name: 'mcp__ae__ae_ping', input: { ok: true } },
+    { type: 'tool-result', toolUseId: 'tool-1', ok: true, text: 'pong', durationMs: 50 },
+    { type: 'turn-end', stopReason: 'end_turn' }
+  ])
+})
+
+test('passes session resume on the second user turn', async () => {
+  const writes = []
+  const seenOptions = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      seenOptions.push(options)
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'one', permissionMode: 'none' }))
+  await waitFor(() => events(writes).filter((event) => event.type === 'turn-end').length === 1)
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'two', permissionMode: 'none' }))
+  await waitFor(() => events(writes).filter((event) => event.type === 'turn-end').length === 2)
+
+  assert.equal(seenOptions[0].resume, undefined)
+  assert.equal(seenOptions[1].resume, 'sess-1')
+})
+
+test('manual approval allow and deny resolve canUseTool correctly', async () => {
+  const writes = []
+  const decisions = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'mcp__ae__write', input: { a: 1 } }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__write', { a: 1 }))
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-2', name: 'mcp__ae__write', input: { a: 2 } }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__write', { a: 2 }))
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'write', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 1)
+  assert.deepEqual(lastEvent(writes), {
+    type: 'approval-required',
+    toolUseId: 'tool-1',
+    name: 'mcp__ae__write',
+    input: { a: 1 },
+    risk: 'write'
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-1', decision: 'allow' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 2)
+  assert.deepEqual(decisions[0], { behavior: 'allow', updatedInput: { a: 1 } })
+
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-2', decision: 'deny' }))
+  await waitFor(() => eventCount(writes, 'tool-denied') === 1)
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.deepEqual(decisions[1], { behavior: 'deny', message: 'User denied this action.' })
+  assert.deepEqual(events(writes).find((event) => event.type === 'tool-denied'), {
+    type: 'tool-denied',
+    toolUseId: 'tool-2'
+  })
+})
+
+test('allow-session permits the same tool name without another approval', async () => {
+  const writes = []
+  const decisions = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'mcp__ae__write', input: {} }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__write', {}))
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-2', name: 'mcp__ae__write', input: {} }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__write', {}))
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'write', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 1)
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-1', decision: 'allow-session' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.equal(eventCount(writes, 'approval-required'), 1)
+  assert.deepEqual(decisions, [
+    { behavior: 'allow', updatedInput: {} },
+    { behavior: 'allow', updatedInput: {} }
+  ])
+})
+
+test('auto mode allows non-destructive tools and requests approval for destructive tools', async () => {
+  const writes = []
+  const decisions = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      decisions.push(await options.canUseTool('mcp__ae__read', { read: true }))
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'mcp__ae__delete', input: { id: 1 } }] }
+      }
+      decisions.push(await options.canUseTool('mcp__ae__delete', { id: 1 }))
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: {
+      ...defaultOptions,
+      annotations: {
+        mcp__ae__read: { readOnly: true, destructive: false },
+        mcp__ae__delete: { readOnly: false, destructive: true }
+      }
+    },
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'auto', permissionMode: 'auto' }))
+  await waitFor(() => eventCount(writes, 'approval-required') === 1)
+  assert.deepEqual(lastEvent(writes), {
+    type: 'approval-required',
+    toolUseId: 'tool-1',
+    name: 'mcp__ae__delete',
+    input: { id: 1 },
+    risk: 'destructive'
+  })
+  sidecar.handleLine(JSON.stringify({ t: 'approve', id: 'tool-1', decision: 'allow' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.deepEqual(decisions, [
+    { behavior: 'allow', updatedInput: { read: true } },
+    { behavior: 'allow', updatedInput: { id: 1 } }
+  ])
+  assert.equal(eventCount(writes, 'approval-required'), 1)
+})
+
+test('non ae tool is denied without panel approval events', async () => {
+  const writes = []
+  const decisions = []
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      decisions.push(await options.canUseTool('Bash', { command: 'date' }))
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'bad', permissionMode: 'manual' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.deepEqual(decisions, [{ behavior: 'deny', message: 'panel denied non-ae tool' }])
+  assert.equal(eventCount(writes, 'approval-required'), 0)
+  assert.equal(eventCount(writes, 'tool-denied'), 0)
+})
+
+test('stop aborts active turn and emits aborted error', async () => {
+  const writes = []
+  let queryStarted
+  const started = new Promise((resolve) => {
+    queryStarted = resolve
+  })
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      queryStarted()
+      await new Promise((resolve, reject) => {
+        options.abortController.signal.addEventListener('abort', () => reject(new Error('aborted by test')))
+      })
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'long', permissionMode: 'none' }))
+  await started
+  sidecar.handleLine(JSON.stringify({ t: 'stop' }))
+  await waitFor(() => eventCount(writes, 'error') === 1)
+
+  assert.deepEqual(events(writes).filter((event) => event.type === 'error'), [
+    { type: 'error', kind: 'aborted', message: 'Turn aborted.' }
+  ])
+})
+
+test('query login failures map to auth errors', async () => {
+  const writes = []
+  const sidecar = createSidecar({
+    queryFn: async function * () {
+      throw new Error('Not logged in · Please run /login')
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {}
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'auth', permissionMode: 'none' }))
+  await waitFor(() => eventCount(writes, 'error') === 1)
+
+  assert.equal(events(writes).find((event) => event.type === 'error').kind, 'auth')
+})
+
+test('query options env removes ANTHROPIC_API_KEY', async () => {
+  const writes = []
+  let queryEnv
+  const sidecar = createSidecar({
+    queryFn: async function * ({ options }) {
+      queryEnv = options.env
+      yield { type: 'result', subtype: 'success', is_error: false, session_id: 'sess-1' }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {
+      ANTHROPIC_API_KEY: 'secret',
+      KEEP_ME: 'yes'
+    }
+  })
+
+  sidecar.handleLine(JSON.stringify({ t: 'user', text: 'env', permissionMode: 'none' }))
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+
+  assert.equal(queryEnv.ANTHROPIC_API_KEY, undefined)
+  assert.equal(queryEnv.KEEP_ME, 'yes')
+})
+
+function events(writes) {
+  return writes.filter((item) => item.t === 'event').map((item) => item.event)
+}
+
+function lastEvent(writes) {
+  const all = events(writes)
+  return all[all.length - 1]
+}
+
+function eventCount(writes, type) {
+  return events(writes).filter((event) => event.type === type).length
+}
+
+async function waitFor(predicate) {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > 1000) {
+      throw new Error('Timed out waiting for condition')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -45,17 +45,26 @@ if (Test-Path $stageDir) {
     Remove-Item -Recurse -Force $stageDir
 }
 
-Write-Host "[1/4] Staging plugin files..."
+Write-Host "[1/5] Staging plugin files..."
 Copy-Item -Recurse -Force $pluginSrc $stageDir
 if (Test-Path (Join-Path $stageDir 'host\node_modules')) {
     Remove-Item -Recurse -Force (Join-Path $stageDir 'host\node_modules')
+}
+if (Test-Path (Join-Path $stageDir 'panel')) {
+    Remove-Item -Recurse -Force (Join-Path $stageDir 'panel')
+}
+if (Test-Path (Join-Path $stageDir 'sidecar\node_modules')) {
+    Remove-Item -Recurse -Force (Join-Path $stageDir 'sidecar\node_modules')
+}
+if (Test-Path (Join-Path $stageDir 'sidecar\test')) {
+    Remove-Item -Recurse -Force (Join-Path $stageDir 'sidecar\test')
 }
 # Never ship the CEF remote-debug port file to end users: it opens a
 # remote-debugging port (the CEF context runs with node enabled), letting any
 # local process attach a DevTools/Node client. Strip it before signing.
 Remove-Item -Force (Join-Path $stageDir '.debug') -ErrorAction SilentlyContinue
 
-Write-Host "[2/4] Installing host production dependencies..."
+Write-Host "[2/5] Installing host production dependencies..."
 Push-Location (Join-Path $stageDir 'host')
 try {
     npm ci --omit=dev
@@ -63,14 +72,22 @@ try {
     Pop-Location
 }
 
-if (-not (Test-Path $CertPath)) {
-    Write-Host "[3/4] Creating self-signed ZXP certificate..."
-    & $ZxpSignCmd -selfSignedCert US CA ae-mcp ae-mcp $CertPassword $CertPath
-} else {
-    Write-Host "[3/4] Using existing certificate $CertPath"
+Write-Host "[3/5] Installing sidecar production dependencies..."
+Push-Location (Join-Path $stageDir 'sidecar')
+try {
+    npm ci --omit=dev
+} finally {
+    Pop-Location
 }
 
-Write-Host "[4/4] Signing package..."
+if (-not (Test-Path $CertPath)) {
+    Write-Host "[4/5] Creating self-signed ZXP certificate..."
+    & $ZxpSignCmd -selfSignedCert US CA ae-mcp ae-mcp $CertPassword $CertPath
+} else {
+    Write-Host "[4/5] Using existing certificate $CertPath"
+}
+
+Write-Host "[5/5] Signing package..."
 if (Test-Path $OutputPath) {
     Remove-Item -Force $OutputPath
 }


### PR DESCRIPTION
## Summary

- **Embedded chat (P5)** for the CEP panel with **two backends behind one event contract**: the Claude **subscription backend** (default) spawns a system-Node(>=18) sidecar running `@anthropic-ai/claude-agent-sdk` - auth inherits the user''s `claude /login` state, **zero keys/tokens stored**; **BYOK** (`~/.ae-mcp` Anthropic key) remains as fallback. ChatScreen/reduceEvent/ApprovalCard are shared verbatim by both.
- **Sidecar** (`plugin/sidecar/`): maps SDK messages onto the panel''s 8-event contract over NDJSON stdio, suspends `canUseTool` into panel approval cards (manual/auto/none modes), pins the main thread to an **ae-tool whitelist** via `options.agents` (builtins like Bash/ToolSearch never reach the model - spike-verified), per-turn session resume, `--probe` mode for login detection.
- **Panel**: `claudeAgentBackend` spawn wrapper (ready-handshake, env scrubbed of `ANTHROPIC_API_KEY`, verbatim event forwarding), backend selection (`pickBackend`: subscription -> BYOK -> disabled-with-guidance), settings UI with login/Node status + re-check, shared NDJSON framing extracted to `lib/ndjson`.
- Conversations reset only on real subscription<->BYOK switches; probing/disabled transitions never wipe chat.

## Test plan

- [x] Panel suite 77/77, sidecar suite 11/11 (fake query/spawn injection, no deps needed)
- [x] Build clean
- [x] **Real AE 2026 acceptance**: subscription E2E (streaming + read-only pass-through + correct answer about the live project); manual mode 4x ApprovalCard -> comp `P5Test` + `HELLO P5` text layer created in AE; deny path -> tool-denied -> model acknowledges; activity stream attribution (`claude-code/2.1.174`) + client registry entry; BYOK switch UI + no-key guidance + fake-key 401 toast; kill-switch pause blocks the composer
- [ ] Not live-tested: logged-out guidance flow (unit-tested; needs `claude /logout`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)