### PR TITLE
fix(core): match English property aliases on localized AE

### DIFF
--- a/packages/core/ae_mcp/instructions.py
+++ b/packages/core/ae_mcp/instructions.py
@@ -57,6 +57,10 @@ PROPERTY PATHS:
 LOCALIZATION:
   On localized AE, name-based effect references can fail. Prefer index form,
   e.g. effect("Value")(1) instead of effect("Value")("Slider").
+  ae_getProperties matches localized display names, matchNames, and English
+  aliases for common transform/text/mask properties. If an English query
+  returns 0 on localized AE, retry with matchName words ("text document",
+  "rotate") or discover paths via ae_scanPropertyTree.
 
 SAFETY & RECOVERY:
   ae_checkpoint snapshots the whole .aep; ae_revert restores a whole-project

--- a/packages/core/ae_mcp/jsx_templates/get_properties.jsx
+++ b/packages/core/ae_mcp/jsx_templates/get_properties.jsx
@@ -1,6 +1,19 @@
 // ae.getProperties — search property names across selected layers.
 // Placeholders: comp_expr, layer_ids_js, query_js, offset, limit.
 (function() {
+    var ALIAS = {
+        "ADBE Text Document": "source text",
+        "ADBE Rotate X": "x rotation",
+        "ADBE Rotate Y": "y rotation",
+        "ADBE Rotate Z": "rotation",
+        "ADBE Position_0": "x position",
+        "ADBE Position_1": "y position",
+        "ADBE Position_2": "z position",
+        "ADBE Mask Shape": "mask path",
+        "ADBE Mask Offset": "mask expansion",
+        "ADBE Vector Shape": "path"
+    };
+
     var comp = ${comp_expr};
     if (!comp) return JSON.stringify({ok:false,error:"no comp"});
     var layerIds = ${layer_ids_js};
@@ -20,7 +33,7 @@
     }
 
     function matches(name, matchName) {
-        var hay = (name + " " + matchName).toLowerCase();
+        var hay = (name + " " + matchName + " " + (ALIAS[matchName] || "")).toLowerCase();
         for (var gi = 0; gi < orGroups.length; gi++) {
             var grp = orGroups[gi];
             if (grp.length === 0) continue;
@@ -44,7 +57,7 @@
                 try { val = AEMCP.safeValue(prop.value); } catch (e) { }
                 var score = 0;
                 if (matchSegs[0] === "ADBE Transform Group") score += 10;
-                if (prop.name.toLowerCase().indexOf(orGroups[0][0] || "") !== -1) score += 5;
+                if ((prop.name + " " + (ALIAS[prop.matchName] || "")).toLowerCase().indexOf(orGroups[0][0] || "") !== -1) score += 5;
                 hits.push({
                     layerId: layerId,
                     propName: prop.name,
@@ -93,5 +106,18 @@
     var paged = hits.slice(offset, offset + limit);
     for (var pi2 = 0; pi2 < paged.length; pi2++) delete paged[pi2]._score;
 
-    return JSON.stringify({ok:true, total: total, results: paged, missingLayerIds:missing});
+    var hint = null;
+    if (total === 0) {
+        var lang = "";
+        try { lang = String(app.isoLanguage || ""); } catch (eLang) { }
+        if (lang && lang.indexOf("en") !== 0 && /[a-z]/.test(query.toLowerCase())) {
+            hint = "No matches. AE UI language is " + lang + ": property display names are localized, " +
+                "so English display-name words may miss. Query matchName terms instead (e.g. " +
+                "'text document' for Source Text, 'rotate' for Rotation) or run ae_scanPropertyTree " +
+                "to list matchName paths.";
+        }
+    }
+    var out = {ok:true, total: total, results: paged, missingLayerIds:missing};
+    if (hint) out.hint = hint;
+    return JSON.stringify(out);
 })()

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -257,7 +257,7 @@ class AeGetPropertiesArgs(_StrictModel):
     """ae.getProperties — search properties by name across selected layers."""
     comp_id: Optional[str] = Field(None, description="AE comp id. Omit for active.")
     layer_ids: List[Annotated[int, Field(ge=1)]] = Field(..., min_length=1, description="1-based layer indices to scan.")
-    query: str = Field(..., description="Multi-word AND; '|' separates OR groups.")
+    query: str = Field(..., description="Multi-word AND; '|' separates OR groups. Terms match display name + matchName + English aliases for common transform/text/mask props. On localized (non-English) AE prefer matchName words, e.g. 'text document'.")
     offset: int = Field(0, ge=0, description="Pagination offset.")
     limit: int = Field(50, ge=1, le=500, description="Pagination size.")
 

--- a/packages/core/tests/test_handlers_typed.py
+++ b/packages/core/tests/test_handlers_typed.py
@@ -184,6 +184,16 @@ def test_render_get_properties_substitutes_query():
     assert "AEMCP.safeValue(" in jsx
 
 
+def test_render_get_properties_includes_localized_alias_support():
+    from ae_mcp.handlers.typed import render_get_properties
+    args = schemas.AeGetPropertiesArgs(layer_ids=[1], query="source text")
+    jsx = render_get_properties(args)
+    assert '"ADBE Text Document"' in jsx
+    assert '"source text"' in jsx
+    assert "isoLanguage" in jsx
+    assert "ALIAS[matchName]" in jsx
+
+
 @pytest.mark.asyncio
 async def test_run_get_properties(mock_backend):
     mock_backend.set_response(


### PR DESCRIPTION
## 问题 / Problem

本地化（非英语）AE 的属性显示名是翻译过的：中文版里 Source Text 显示为「源文本」。`ae_getProperties` 用查询词对 `displayName + matchName` 做匹配，于是常见英文显示名查询在本地化 AE 上直接落空——`query="source text"` 对文本图层返回 `total: 0`（"source" 既不在「源文本」里也不在 "ADBE Text Document" 里），面板内嵌 agent 搜不到属性后只能盲试。

On localized AE the property display names are translated (zh-CN shows Source Text as 「源文本」). `ae_getProperties` matches the query against `displayName + matchName`, so common English display-name queries return zero hits on localized AE — the embedded panel agent ends up flying blind.

## 修复 / Fix

- `get_properties.jsx` 增加一张 **10 条的 `matchName → English alias` 小表**（Source Text / Rotation ×3 / Position 0-2 / Mask Path / Mask Expansion / shape Path），只收录英文显示词不在 matchName 里的叶子；别名同时接入匹配与打分。
- **零命中提示**：`total === 0` 且 `app.isoLanguage` 非 `en*`、查询含拉丁字母时，返回 `hint` 指导改用 matchName 词或 `ae_scanPropertyTree`。
- `schemas.py` / `instructions.py` 同步文档：本地化 AE 优先用 matchName 词查询。

A curated 10-entry **`matchName → English alias` table** in `get_properties.jsx` (only leaves whose English display words aren't matchName substrings), wired into both matching and scoring; a **zero-hit `hint`** when the AE UI language isn't English and the query contains ASCII; schema/instructions guidance updated.

已知边界 / Known limit: 效果参数的 matchName 是数字（`ADBE Slider Control-0001`），别名表覆盖不了——文档建议走 index 形式或 `ae_scanPropertyTree`。

## 验证 / Verification

- `uv run --project packages/core pytest packages/core/tests -q` → **275 passed**
- 中文版 AE 2026 真机（修复开发时验证）：`query="source text"` 对文本图层 `total: 0 → 1`（仅靠别名命中）；零命中场景 `hint` 如期出现。
  Verified on real zh-CN AE 2026 during development: `query="source text"` went 0 → 1 hits (alias-only match); the zero-hit hint fires as designed.

> 原分支基于 v0.4.0 发布前的 feat/panel-p5；已重整为基于当前 `main`（a5f9a48）的单提交，不含任何 release / CI / P5 反向 diff。
> Rebased from the pre-release stacked branch onto current `main` (a5f9a48) as a single commit; no release/CI/P5 reverse diffs included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
