### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.8.0] — 2026-06-14
+
+把 AE 操作专识沉淀进 ae-mcp 本体——跨后端、免沙箱，且**默认开、可一键关**：常驻成本由用户掌控。
+
+#### ✨ 新增
+- **AE 专家防错指导（默认开，可关）**——握手指令新增一段 ExtendScript 高频陷阱铁律（文字层取回-改-回写 / 字体 PostScript 名 / addProperty 两遍法 / 新建图层 prepend 顺序 / effect 子属性按索引）。由 `AE_MCP_EXPERT_GUIDANCE` 开关控制，是唯一的常驻 token 成本（每会话握手仅下发一次）；面板设置页一键开关。
+- **内置技能库（7 个，按需取、零常驻）**——`ae_skillList`/`ae_skillUse` 现自带一套打包技能：`extendscript-cookbook`（情景化 JSX 配方与坑）、`kinetic-typography`、`ease-and-timing`、`grade-stack`、`render-order`、`project-organization`、`glow-recipes`。走新的"内置只读技能目录"机制（用户同名技能可覆盖、内置不可删），随包发布；只有 agent 主动取用时才占 token。
+- **错误提示扩充**——新增「属性未与图层关联 / 字体名无效 / fontSize 超 1296」三条自动修复提示，并给 null 族提示补上"effect 子属性改用索引"的兜底。
+- **三后端都吃到指导**——mcpClient 捕获握手指令；BYOK 追加进 system；Codex 以首轮 preamble 注入（Codex 不转发 MCP 指令）；Claude 订阅经 Agent SDK 原生转发。
+
+#### 📦 说明
+- 开关默认开；介意常驻成本的用户可在设置页关掉，技能与错误提示不受影响、始终可用。
+- 内嵌后端要求不变（Claude 订阅 Node≥18 + 登录 / Codex CLI 登录 / BYOK Anthropic key）。
+
 ### [0.7.0] — 2026-06-13
 
 内嵌对话走向**多框架**，并把后端接入正式化：新增 **Codex 内嵌后端**之外，这一版把"内嵌后端接口"抽象成注册表 + 契约，新增**外接客户端注册表**（让任意 MCP 客户端一键接入），P6 的撤销/空结果标记，以及一次彻底的文档刷新。
@@ -152,6 +166,20 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.8.0] — 2026-06-14
+
+Bake durable AE operating expertise into ae-mcp itself — cross-backend, sandbox-immune, **default-on but one-click off** so the standing cost stays user-controlled.
+
+#### ✨ Added
+- **AE expert anti-error guidance (default on, toggleable)** — the handshake instructions gain a block of high-frequency ExtendScript guardrails (text-layer retrieve-modify-setValue / PostScript font names / addProperty two-pass / new-layer prepend order / effect sub-property by index). Controlled by `AE_MCP_EXPERT_GUIDANCE` — the only always-on token cost (delivered once per session at handshake); one-click in Settings.
+- **Bundled skill library (7, on-demand, zero standing cost)** — `ae_skillList`/`ae_skillUse` now ship a packaged skill set: `extendscript-cookbook` (situational JSX recipes & traps), `kinetic-typography`, `ease-and-timing`, `grade-stack`, `render-order`, `project-organization`, `glow-recipes`. Via a new bundled read-only skills dir (user skills override by name; bundled can't be deleted), shipped with the package; tokens are spent only when an agent fetches one.
+- **More error hints** — three new auto-fix hints (detached property ref / invalid font name / fontSize over 1296) plus an effect-sub-property-by-index fallback on the null-family hint.
+- **Guidance reaches all three backends** — mcpClient captures the handshake instructions; BYOK appends them to its system prompt; Codex injects them as a first-turn preamble (Codex doesn't forward MCP instructions); the Claude subscription gets them natively via the Agent SDK.
+
+#### 📦 Notes
+- The toggle defaults on; cost-conscious users can switch it off in Settings — skills and error hints are unaffected and always available.
+- Embedded-backend requirements unchanged (Claude subscription Node≥18 + login / Codex CLI login / BYOK Anthropic key).
 
 ### [0.7.0] — 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 终端用户从发布 tag 安装：
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/snapshot-mss
 ```
 
 面板安装使用 ZXP 包：推荐 aescripts ZXP Installer，也可用 ExMan Cmd。安装后打开 `Window -> Extensions -> ae-mcp`。
@@ -221,7 +221,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 End users install from the release tag:
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/snapshot-mss
 ```
 
 Install the panel from the ZXP package with aescripts ZXP Installer or ExMan Cmd. Then open `Window -> Extensions -> ae-mcp`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,7 +51,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 发布 tag 安装命令：
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/snapshot-mss
 ```
 
 安装后确认 launcher 可被外部客户端找到。不要把公共 PyPI 同名包写成用户安装路径。
@@ -184,7 +184,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 Release-tag install:
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.7.0#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.0#subdirectory=packages/snapshot-mss
 ```
 
 After install, confirm the launcher is visible to external clients. Do not document the public PyPI name as the user install path.

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.7.0"
+version = "0.8.0"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.7.0"
+version = "0.8.0"
 description = "Cross-platform mss-based screen capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.7.0"
+                   ExtensionBundleVersion="0.8.0"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.7.0" />
+        <Extension Id="com.aemcp.panel" Version="0.8.0" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -8266,7 +8266,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.7.0",
+    version: "0.8.0",
     private: true,
     type: "module",
     scripts: {
@@ -8730,13 +8730,17 @@
       docsUrl: "https://opencode.ai/docs"
     }
   ];
-  function mcpConfigFor(client, port = 11488) {
+  function expertGuidanceEnv(on) {
+    return on ? {} : { AE_MCP_EXPERT_GUIDANCE: "0" };
+  }
+  function mcpConfigFor(client, port = 11488, expertGuidance = true) {
     return {
       mcpServers: {
         ae: {
           command: "ae-mcp",
           env: {
             AE_MCP_BACKEND: "ae-mcp",
+            ...expertGuidanceEnv(expertGuidance !== false),
             AE_MCP_PLUGIN_URL: `http://127.0.0.1:${port}`
           }
         }
@@ -8830,6 +8834,8 @@
       mins: (n) => `${n} \u5206\u949F\u524D`,
       hours: (n) => `${n} \u5C0F\u65F6\u524D`,
       language: "\u754C\u9762\u8BED\u8A00",
+      expertGuidance: "AE \u4E13\u5BB6\u9632\u9519\u6307\u5BFC",
+      expertGuidanceCap: "\u589E\u52A0\u6BCF\u4F1A\u8BDD\u4E00\u6B21\u6027\u63E1\u624B token\uFF0C\u6362\u66F4\u5C11\u7684 AE \u811A\u672C\u62A5\u9519",
       logLevel: "\u65E5\u5FD7\u7EA7\u522B",
       exportLog: "\u5BFC\u51FA\u65E5\u5FD7",
       mcp: "MCP \u914D\u7F6E",
@@ -8902,6 +8908,8 @@
       mins: (n) => `${n} min ago`,
       hours: (n) => `${n} h ago`,
       language: "Language",
+      expertGuidance: "AE expert anti-error guidance",
+      expertGuidanceCap: "Adds a one-time handshake token cost per session for fewer AE scripting errors",
       logLevel: "Log level",
       exportLog: "Export log",
       mcp: "MCP config",
@@ -9014,6 +9022,8 @@
     onModelChange,
     backend = "subscription",
     onBackendChange,
+    expertGuidance = true,
+    onExpertGuidance,
     claudeStatus = { state: "checking" },
     onRecheckClaude,
     codexStatus = { state: "checking" },
@@ -9136,7 +9146,7 @@
         ] }) })
       ] }),
       /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Section, { title: t.externalClients, caption: t.externalClientsCap, children: EXTERNAL_CLIENTS.map((externalClient) => {
-        const configText = JSON.stringify(mcpConfigFor(externalClient, Number(draftPort) || port || 11488), null, 2);
+        const configText = JSON.stringify(mcpConfigFor(externalClient, Number(draftPort) || port || 11488, expertGuidance), null, 2);
         return /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
           ExternalClientRow,
           {
@@ -9164,6 +9174,7 @@
         ))
       ] }),
       /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { title: t.gen, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { layout: "row", label: t.expertGuidance, caption: t.expertGuidanceCap, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Switch, { checked: expertGuidance, onChange: (v) => onExpertGuidance && onExpertGuidance(v) }) }),
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.language, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] }) }),
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.logLevel, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Select, { value: logLevel, onChange: setLogLevel, style: { flex: 1 }, options: [
@@ -11478,6 +11489,8 @@
         try {
           const tools = await mcp.listTools();
           const toolByName = new Map((tools || []).map((tool) => [tool.name, tool]));
+          const serverInstr = mcp.getServerInstructions && mcp.getServerInstructions() || "";
+          const system = serverInstr ? buildSystemPrompt(lang) + "\n\n" + serverInstr : buildSystemPrompt(lang);
           let toolRounds = 0;
           while (true) {
             if (toolRounds >= maxToolRounds) {
@@ -11487,7 +11500,7 @@
             const result = await anthropic({
               apiKey: getApiKey && getApiKey(),
               model: getModel && getModel() || DEFAULT_MODEL,
-              system: buildSystemPrompt(lang),
+              system,
               messages: clone(messages),
               tools,
               signal: controller.signal,
@@ -11800,7 +11813,7 @@
   // src/cep/mcpClient.js
   var DEFAULT_TIMEOUT_MS = 3e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.7.0";
+  var PANEL_VERSION = "0.8.0";
   function getCepRequire() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
@@ -11934,12 +11947,14 @@
     onCrash,
     extRoot,
     repoRoot,
+    getExpertGuidance = () => true,
     packageVersion = PANEL_VERSION,
     retryDelays = [1e3, 2e3, 4e3]
   } = {}) {
     let proc = null;
     let rpc = null;
     let tools = null;
+    let serverInstructions = "";
     let status = "idle";
     let startPromise = null;
     let retryCount = 0;
@@ -11966,7 +11981,10 @@
       startPromise = (async () => {
         const commandSpec = await resolveCommand({ extRoot, repoRoot });
         const spawn = getSpawn();
-        const spawnEnv = Object.assign({}, getCepEnv(), env || {}, { AE_MCP_BACKEND: "ae-mcp" });
+        const spawnEnv = Object.assign({}, getCepEnv(), env || {}, {
+          AE_MCP_BACKEND: "ae-mcp",
+          ...expertGuidanceEnv(getExpertGuidance())
+        });
         proc = spawn(commandSpec.command, commandSpec.args || [], {
           stdio: "pipe",
           windowsHide: true,
@@ -11980,11 +11998,12 @@
         proc.on("error", (err) => handleCrash(err));
         if (proc.stderr && proc.stderr.on) proc.stderr.on("data", () => {
         });
-        await rpc.request("initialize", {
+        const initResult = await rpc.request("initialize", {
           protocolVersion: MCP_PROTOCOL_VERSION,
           clientInfo: { name: "panel-chat", version: packageVersion },
           capabilities: {}
         });
+        serverInstructions = initResult && initResult.instructions || "";
         rpc.notify("notifications/initialized");
         const listed = await rpc.request("tools/list", {});
         tools = listed && Array.isArray(listed.tools) ? listed.tools : [];
@@ -12054,7 +12073,7 @@
       rpc = null;
       startPromise = null;
     }
-    return { start, listTools, callTool, stop, state: currentState };
+    return { start, listTools, callTool, stop, state: currentState, getServerInstructions: () => serverInstructions };
   }
 
   // src/cep/apiKey.js
@@ -12693,6 +12712,8 @@
     getPermissionMode,
     getMcpSpec,
     getToolMeta,
+    getExpertGuidance = () => true,
+    getServerInstructions = () => "",
     onEvent,
     lang = "zh",
     env
@@ -12703,6 +12724,7 @@
     let initializePromise = null;
     let initialized = false;
     let threadId = null;
+    let preambleSent = false;
     let currentTurnId = null;
     let stopping = false;
     let stderrTail = "";
@@ -12855,6 +12877,7 @@
       initializePromise = null;
       initialized = false;
       threadId = null;
+      preambleSent = false;
       if (wasStopping) return;
       if (activeRun) {
         emit({ type: "error", kind: "mcp", message: "codex app-server exited: " + detail });
@@ -12870,6 +12893,7 @@
       initializePromise = null;
       initialized = false;
       threadId = null;
+      preambleSent = false;
       if (activeRun) {
         emit({ type: "error", kind: "mcp", message: err.message });
         finishActive();
@@ -12948,7 +12972,8 @@
               command: mcpSpec.command,
               args: mcpSpec.args || [],
               env: Object.assign({}, mcpSpec.env || {}, {
-                AE_MCP_BACKEND: "ae-mcp"
+                AE_MCP_BACKEND: "ae-mcp",
+                ...expertGuidanceEnv(getExpertGuidance())
               })
             }
           }
@@ -12980,7 +13005,13 @@
         await ensureThread();
         const userText = String(text || "");
         transcript.push({ role: "user", text: userText });
-        rpc.request("turn/start", turnParams(userText), 18e4).catch((e) => {
+        let turnText = userText;
+        if (!preambleSent) {
+          const instr = (getServerInstructions() || "").trim();
+          if (instr) turnText = instr + "\n\n---\n\n" + userText;
+          preambleSent = true;
+        }
+        rpc.request("turn/start", turnParams(turnText), 18e4).catch((e) => {
           const message = e && e.message ? e.message : "Failed to start Codex turn.";
           emit({ type: "error", kind: /model/i.test(message) ? "model" : "mcp", message });
           finishActive();
@@ -13028,6 +13059,7 @@
       initializePromise = null;
       initialized = false;
       threadId = null;
+      preambleSent = false;
       currentTurnId = null;
       transcript = [];
       pendingApprovals.clear();
@@ -13204,6 +13236,7 @@
     getPermissionMode,
     getMcpSpec,
     getToolMeta,
+    getExpertGuidance = () => true,
     onEvent,
     env
   } = {}) {
@@ -13301,7 +13334,8 @@
             enabled: true,
             timeout: MCP_TIMEOUT_MS,
             environment: Object.assign({}, mcpSpec && mcpSpec.env || {}, {
-              AE_MCP_BACKEND: "ae-mcp"
+              AE_MCP_BACKEND: "ae-mcp",
+              ...expertGuidanceEnv(getExpertGuidance())
             })
           }
         }
@@ -14245,12 +14279,16 @@
     } catch (e) {
     }
   }
-  function buildMcpConfig(port) {
+  function buildMcpConfig(port, expertGuidance = true) {
     return {
       mcpServers: {
         ae: {
           command: "ae-mcp",
-          env: { AE_MCP_BACKEND: "ae-mcp", AE_MCP_PLUGIN_URL: "http://127.0.0.1:" + port }
+          env: Object.assign(
+            { AE_MCP_BACKEND: "ae-mcp" },
+            expertGuidanceEnv(expertGuidance !== false),
+            { AE_MCP_PLUGIN_URL: "http://127.0.0.1:" + port }
+          )
         }
       }
     };
@@ -14293,6 +14331,22 @@
       }
     }
     return { start, restart, getHost: () => host };
+  }
+
+  // src/lib/expertGuidance.js
+  var EXPERT_GUIDANCE_KEY = "ae-mcp.expertGuidance";
+  function loadExpertGuidance(storage) {
+    try {
+      return storage.getItem(EXPERT_GUIDANCE_KEY) !== "0";
+    } catch (e) {
+      return true;
+    }
+  }
+  function saveExpertGuidance(storage, on) {
+    try {
+      storage.setItem(EXPERT_GUIDANCE_KEY, on ? "1" : "0");
+    } catch (e) {
+    }
   }
 
   // src/app/App.jsx
@@ -14479,6 +14533,7 @@
     const [sessionFast, setSessionFast] = import_react40.default.useState(null);
     const [permissionMode, setPermissionMode] = import_react40.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
     const [backendPref, setBackendPref] = import_react40.default.useState(() => readPref("ae_mcp_backend", "subscription"));
+    const [expertGuidance, setExpertGuidance] = import_react40.default.useState(() => loadExpertGuidance(window.localStorage));
     const [probe, setProbe] = import_react40.default.useState(null);
     const [codexProbe, setCodexProbe] = import_react40.default.useState(null);
     const [codexModels, setCodexModels] = import_react40.default.useState(() => readCachedCodexModels(window.localStorage));
@@ -14526,7 +14581,10 @@
     };
     const extRoot = cs2 && cs2.getSystemPath ? cs2.getSystemPath("extension") : "";
     const sidecarPath = import_react40.default.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
-    const mcp = import_react40.default.useMemo(() => createMcpClient({ extRoot }), [extRoot]);
+    const mcp = import_react40.default.useMemo(() => createMcpClient({
+      extRoot,
+      getExpertGuidance: () => loadExpertGuidance(window.localStorage)
+    }), [extRoot]);
     const handleChatEvent = import_react40.default.useCallback((evt) => {
       if (evt.type === "turn-start") setChatStreaming(true);
       if (evt.type === "thinking") setThinkingActive(!!evt.active);
@@ -14567,6 +14625,8 @@
       getEffort: () => runtimeRef.current.effort,
       getFast: () => runtimeRef.current.fast,
       getToolMeta: async () => deriveToolMeta(await mcp.listTools()),
+      getExpertGuidance: () => loadExpertGuidance(window.localStorage),
+      getServerInstructions: () => mcp.getServerInstructions(),
       lang,
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
@@ -14576,6 +14636,7 @@
       getModel: () => runtimeRef.current.model,
       getPermissionMode: () => runtimeRef.current.permissionMode,
       getToolMeta: async () => deriveToolMeta(await mcp.listTools()),
+      getExpertGuidance: () => loadExpertGuidance(window.localStorage),
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
     }), [extRoot, mcp, handleChatEvent]);
@@ -14757,7 +14818,7 @@
       markWizardDone(window.localStorage);
       setWizardDone(true);
     };
-    const mcpConfigStr = JSON.stringify(buildMcpConfig(status.port), null, 2);
+    const mcpConfigStr = JSON.stringify(buildMcpConfig(status.port, expertGuidance), null, 2);
     const claudeStatus = probe === null ? { state: "checking" } : probe.nodeOk === false ? { state: "no-node", detail: probe.detail } : probe.loggedIn === false ? { state: "not-logged-in", detail: probe.detail } : { state: "ready", nodeVersion: probe.nodeVersion };
     const codexStatus = codexProbe === null ? { state: "checking" } : codexProbe.loggedIn === false ? { state: "not-logged-in", detail: codexProbe.detail } : { state: "ready", email: codexProbe.email, planType: codexProbe.planType };
     const openCodeStatus = openCodeProbe === null ? { state: "checking" } : openCodeProbe.loggedIn === false ? { state: "not-logged-in", detail: openCodeProbe.detail } : { state: "ready" };
@@ -14897,6 +14958,11 @@
             onBackendChange: (m) => {
               setBackendPref(m);
               writePref("ae_mcp_backend", m);
+            },
+            expertGuidance,
+            onExpertGuidance: (v) => {
+              setExpertGuidance(v);
+              saveExpertGuidance(window.localStorage, v);
             },
             claudeStatus,
             onRecheckClaude: runClaudeProbe,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "lucide-react": "0.453.0",
         "react": "18.3.1",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -3,7 +3,7 @@ import { expertGuidanceEnv } from './externalClients.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.7.0';
+export const PANEL_VERSION = '0.8.0';
 
 function getCepRequire() {
   if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-agent-sidecar",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-agent-sidecar",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.173"
       }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -2,7 +2,7 @@
   "name": "ae-mcp-agent-sidecar",
   "private": true,
   "type": "module",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173"
   },

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "mcp" },
@@ -44,7 +44,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -70,7 +70,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
Release v0.8.0 — AE expert/anti-error guidance + bundled skill library (toggle-gated). Follows `docs/RELEASE.md`.

- Bumped the 16 version locations 0.7.0 → 0.8.0 (Python trio pyproject + uv.lock, host/panel/sidecar package.json + lockfiles, CSXS manifest ×2, panel `PANEL_VERSION`, README/RELEASE install-tag examples).
- Rebuilt the panel bundle `plugin/client/dist/app.js` (carries 0.8.0).
- Added CN/EN CHANGELOG entries.

Verification: core `333 passed, 25 deselected`; panel `156 pass`. (Live + model-matrix smoke skipped to avoid closing the open AE project; feature already verified live against the installed binary on AE 2026.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)