### PR TITLE
chore(release): v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.8.2] — 2026-07-03
+
+#### ✨ 新增
+- **ZCode 接入**——外接客户端注册表新增 ZCode，并能生成正确的 `mcp.servers` 配置；面板内嵌 ZCode chat 后端接入 `zcode.cjs app-server`，补齐 session 协议、四档审批映射和 elicitation / `AskUserQuestion` 处理。
+- **只读一键诊断 `ae.diagnose`**——新增始终暴露的只读 verb，一次探测 host `/health`（现在会回显 Python 握手字段）、token 有效性、AE 响应和工程打开状态，方便客户端先定位连接断点。
+- **真实合成帧预览**——`ae_previewFrame` 现在优先用 `CompItem.saveFrameToPng` 渲染真实 comp 像素，viewer snapshot 只作为 fallback；预览文件进入受管的 `ae_mcp_previews` 临时会话目录，并自动清理超过 24 小时的陈旧会话。
+- **Provider profiles 扩展**——BYOK 支持 Anthropic-compatible Base URL 和自定义模型 ID，并按 Base URL 缓存模型列表；Codex 后端支持 OpenAI-compatible 自定义 provider，API key 本地保存，`wire_api` 固定为 `responses`。
+
+#### 🐛 修复 / 改进
+- **ZCode 失败模式可读**——真机验证出的 provider API key、模型配置、desktop OAuth runtime-headers 缺口等失败，现在在面板里显示为可读提示，不再冒出 `[object Object]`。coding-plan providers 可经 OAuth credential bridge 工作；`*-start-plan` providers 仍需要 ZCode 桌面端（captcha / runtime headers 目前还不能桥接）。
+- **禁止截图绕路**——server instructions 和 sidecar prompts 明确禁止用 OS screenshot / desktop automation 绕过 `ae_previewFrame`，把预览路径收回到 AE 渲染链路。
+- **CI 锁住 panel dist**——CI 现在验证 `plugin/client/dist/app.js` 与 panel 源码同步；新增 `.gitattributes`，统一 `eol=lf` 并把 dist bundle 标为 binary。
+
 ### [0.8.1] — 2026-06-14
 
 #### 🐛 修复 / 改进
@@ -171,6 +184,19 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.8.2] — 2026-07-03
+
+#### ✨ Added
+- **ZCode integration** — ZCode is now in the external-client registry with correct `mcp.servers` config generation; the embedded ZCode chat backend drives `zcode.cjs app-server` with session protocol support, four-tier approval mapping, and elicitation / `AskUserQuestion` handling.
+- **Read-only one-shot diagnostics with `ae.diagnose`** — a new always-exposed read-only verb probes host `/health` (now echoing Python handshake fields), token validity, AE responsiveness, and project-open state in one call.
+- **Real comp-pixel previews** — `ae_previewFrame` now renders through `CompItem.saveFrameToPng` first, using viewer snapshots only as a fallback; preview files live in a managed `ae_mcp_previews` temp session dir with automatic stale-session cleanup after 24 hours.
+- **Expanded provider profiles** — BYOK supports Anthropic-compatible base URLs and custom model IDs with a per-base-URL model cache; the Codex backend supports OpenAI-compatible custom providers with the API key stored locally and `wire_api` pinned to `responses`.
+
+#### 🐛 Fixed / Improved
+- **Readable ZCode failure hints** — live-tested provider API key, model config, and desktop OAuth runtime-headers failures now surface as panel hints instead of `[object Object]`. Coding-plan providers work through an OAuth credential bridge; `*-start-plan` providers still require the ZCode desktop app because captcha / runtime headers cannot be bridged yet.
+- **No screenshot workaround path** — server instructions and sidecar prompts now forbid OS-screenshot / desktop-automation substitutes for `ae_previewFrame`, keeping previews on the AE render path.
+- **CI guards the panel bundle** — CI now verifies `plugin/client/dist/app.js` is in sync with source; `.gitattributes` was added to enforce `eol=lf` and mark the dist bundle as binary.
 
 ### [0.8.1] — 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 终端用户从发布 tag 安装：
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
 ```
 
 面板安装使用 ZXP 包：推荐 aescripts ZXP Installer，也可用 ExMan Cmd。安装后打开 `Window -> Extensions -> ae-mcp`。
@@ -221,7 +221,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 End users install from the release tag:
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
 ```
 
 Install the panel from the ZXP package with aescripts ZXP Installer or ExMan Cmd. Then open `Window -> Extensions -> ae-mcp`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,7 +51,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 发布 tag 安装命令：
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
 ```
 
 安装后确认 launcher 可被外部客户端找到。不要把公共 PyPI 同名包写成用户安装路径。
@@ -184,7 +184,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 Release-tag install:
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.1#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
 ```
 
 After install, confirm the launcher is visible to external clients. Do not document the public PyPI name as the user install path.

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.8.1"
+version = "0.8.2"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/bridge/tests/test_http_bridge.py
+++ b/packages/bridge/tests/test_http_bridge.py
@@ -53,7 +53,7 @@ async def test_health_check_ok():
         # fields. health_check must stay True with the extras.
         return Response(200, json={
             "ok": True,
-            "pluginVersion": "0.8.1",
+            "pluginVersion": "0.8.2",
             "port": 11488,
             "pythonVersion": "1.27.2",
             "pythonLastSeenAt": 1719000000000,

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -104,7 +104,7 @@ async def test_probe_host_sends_python_identity_header(respx_mock):
             200,
             json={
                 "ok": True,
-                "pluginVersion": "0.8.1",
+                "pluginVersion": "0.8.2",
                 "port": 11488,
                 "pythonVersion": captured["python"],
                 "pythonLastSeenAt": 1719000000000,

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.8.1"
+version = "0.8.2"
 description = "Cross-platform mss-based screen capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.8.1"
+                   ExtensionBundleVersion="0.8.2"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.8.1" />
+        <Extension Id="com.aemcp.panel" Version="0.8.2" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -8266,7 +8266,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.8.1",
+    version: "0.8.2",
     private: true,
     type: "module",
     scripts: {
@@ -12056,7 +12056,7 @@
   // src/cep/mcpClient.js
   var DEFAULT_TIMEOUT_MS = 3e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.8.1";
+  var PANEL_VERSION = "0.8.2";
   function getCepRequire() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "lucide-react": "0.453.0",
         "react": "18.3.1",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -3,7 +3,7 @@ import { expertGuidanceEnv } from './externalClients.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.8.1';
+export const PANEL_VERSION = '0.8.2';
 
 function getCepRequire() {
   if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-agent-sidecar",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-agent-sidecar",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.173"
       }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -2,7 +2,7 @@
   "name": "ae-mcp-agent-sidecar",
   "private": true,
   "type": "module",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173"
   },

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "mcp" },
@@ -44,7 +44,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -70,7 +70,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
## Summary
- Bump 0.8.1 -> 0.8.2 across all version locations per docs/RELEASE.md (pyproject trio, host/panel/sidecar package.json + locks, CSXS manifest, PANEL_VERSION, README/RELEASE tag examples).
- Regenerate uv.lock, rebuild the panel bundle (dist carries 0.8.2), and add the CN/EN CHANGELOG entry covering PRs #37 and #38 (ZCode integration, ae.diagnose, real comp-frame previews, provider profiles, CI dist guard).

## Test plan
- [x] uv run pytest -q: 375 passed
- [x] host 47 / panel 213 / sidecar 22 node tests passed
- [x] dist rebuilt from npm ci; contains only 0.8.2 version string
