### PR TITLE
feat(panel): sync curated model lists - Claude Sonnet 5 default, GPT-5.4 mini

### DIFF
--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -11773,12 +11773,14 @@
   var CLAUDE_PRICE_USD_PER_MTOK = {
     "claude-fable-5": { input: 10, output: 50 },
     "claude-opus-4-8": { input: 5, output: 25 },
+    "claude-sonnet-5": { input: 3, output: 15 },
     "claude-sonnet-4-6": { input: 3, output: 15 },
     "claude-haiku-4-5-20251001": { input: 1, output: 5 }
   };
   var CLAUDE_MODELS = [
     { id: "claude-fable-5", label: "Fable 5", effortLevels: ["low", "medium", "high", "xhigh", "max"], adaptive: true },
     { id: "claude-opus-4-8", label: "Opus 4.8", effortLevels: ["low", "medium", "high", "xhigh", "max"], adaptive: true },
+    { id: "claude-sonnet-5", label: "Sonnet 5", effortLevels: ["low", "medium", "high", "xhigh"], adaptive: true },
     { id: "claude-sonnet-4-6", label: "Sonnet 4.6", effortLevels: ["low", "medium", "high", "max"], adaptive: true },
     { id: "claude-haiku-4-5-20251001", label: "Haiku 4.5", effortLevels: ["low", "medium", "high"], adaptive: false }
   ];
@@ -11803,7 +11805,7 @@
       id: "claude-sub",
       label: "\u8BA2\u9605",
       models: withCost(CLAUDE_MODELS),
-      defaultModelId: "claude-sonnet-4-6",
+      defaultModelId: "claude-sonnet-5",
       defaultEffort: "high",
       supportsFast: () => false,
       approvalModes: APPROVAL_MODES,
@@ -11843,7 +11845,8 @@
   function codexStaticDescriptor() {
     const models = [
       { id: "gpt-5.5", label: "GPT-5.5", effortLevels: ["low", "medium", "high", "xhigh"], cost: 2, adaptive: false },
-      { id: "gpt-5.4", label: "GPT-5.4", effortLevels: ["low", "medium", "high", "xhigh"], cost: 2, adaptive: false }
+      { id: "gpt-5.4", label: "GPT-5.4", effortLevels: ["low", "medium", "high", "xhigh"], cost: 2, adaptive: false },
+      { id: "gpt-5.4-mini", label: "GPT-5.4 mini", effortLevels: ["low", "medium", "high", "xhigh"], cost: 1, adaptive: false }
     ];
     return {
       id: "codex",

--- a/plugin/panel/src/lib/backendCapabilities.js
+++ b/plugin/panel/src/lib/backendCapabilities.js
@@ -3,13 +3,14 @@
 // Capability facts backed by official docs and observed backend behavior:
 // - subscription has NO plan-availability API; curated list + friendly
 //   open-turn error is the only honest shape.
-// - effort levels: low/medium/high/xhigh/max; xhigh is Fable/Opus 4.8 only;
+// - effort levels: low/medium/high/xhigh/max; Sonnet 5 supports xhigh;
 //   Sonnet 4.6 has no xhigh; Haiku hides unsupported tiers.
 // - fast mode: direct API only (BYOK), Opus 4.x only, 3x price.
 
 export const CLAUDE_PRICE_USD_PER_MTOK = {
   'claude-fable-5': { input: 10, output: 50 },
   'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-sonnet-5': { input: 3, output: 15 },
   'claude-sonnet-4-6': { input: 3, output: 15 },
   'claude-haiku-4-5-20251001': { input: 1, output: 5 },
 };
@@ -19,6 +20,7 @@ export const CLAUDE_PRICE_USD_PER_MTOK = {
 export const CLAUDE_MODELS = [
   { id: 'claude-fable-5', label: 'Fable 5', effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'], adaptive: true },
   { id: 'claude-opus-4-8', label: 'Opus 4.8', effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'], adaptive: true },
+  { id: 'claude-sonnet-5', label: 'Sonnet 5', effortLevels: ['low', 'medium', 'high', 'xhigh'], adaptive: true },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', effortLevels: ['low', 'medium', 'high', 'max'], adaptive: true },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', effortLevels: ['low', 'medium', 'high'], adaptive: false },
 ];
@@ -48,7 +50,7 @@ export function claudeSubDescriptor() {
     id: 'claude-sub',
     label: '订阅',
     models: withCost(CLAUDE_MODELS),
-    defaultModelId: 'claude-sonnet-4-6',
+    defaultModelId: 'claude-sonnet-5',
     defaultEffort: 'high',
     supportsFast: () => false,
     approvalModes: APPROVAL_MODES,
@@ -93,6 +95,7 @@ export function codexStaticDescriptor() {
   const models = [
     { id: 'gpt-5.5', label: 'GPT-5.5', effortLevels: ['low', 'medium', 'high', 'xhigh'], cost: 2, adaptive: false },
     { id: 'gpt-5.4', label: 'GPT-5.4', effortLevels: ['low', 'medium', 'high', 'xhigh'], cost: 2, adaptive: false },
+    { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', effortLevels: ['low', 'medium', 'high', 'xhigh'], cost: 1, adaptive: false },
   ];
   return {
     id: 'codex',

--- a/plugin/panel/test/backendCapabilities.test.js
+++ b/plugin/panel/test/backendCapabilities.test.js
@@ -13,8 +13,11 @@ test('claude-sub descriptor lists the full family with effort levels', () => {
   assert.equal(d.id, 'claude-sub');
   const ids = d.models.map((m) => m.id);
   assert.deepEqual(ids, [
-    'claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001',
+    'claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001',
   ]);
+  const sonnet5 = d.models.find((m) => m.id === 'claude-sonnet-5');
+  assert.deepEqual(sonnet5.effortLevels, ['low', 'medium', 'high', 'xhigh']);
+  assert.equal(sonnet5.effortLevels.includes('max'), false);
   const sonnet = d.models.find((m) => m.id === 'claude-sonnet-4-6');
   assert.deepEqual(sonnet.effortLevels, ['low', 'medium', 'high', 'max']);
   const fable = d.models.find((m) => m.id === 'claude-fable-5');
@@ -24,7 +27,7 @@ test('claude-sub descriptor lists the full family with effort levels', () => {
   assert.deepEqual(haiku.effortLevels, ['low', 'medium', 'high']);
   assert.equal(haiku.adaptive, false);
   assert.equal(fable.adaptive, true);
-  assert.equal(d.defaultModelId, 'claude-sonnet-4-6');
+  assert.equal(d.defaultModelId, 'claude-sonnet-5');
   assert.equal(d.defaultEffort, 'high');
   assert.equal(d.supportsFast('claude-opus-4-8'), false);
 });
@@ -37,6 +40,7 @@ test('byok descriptor enables fast only for opus models', () => {
 
 test('cost tiers derive from the price map', () => {
   assert.equal(costTier('claude-haiku-4-5-20251001'), 1);
+  assert.equal(costTier('claude-sonnet-5'), 2);
   assert.equal(costTier('claude-fable-5'), 4);
 });
 
@@ -116,7 +120,14 @@ test('codexDescriptorFromModels falls back to static descriptor for empty input'
   const staticDescriptor = codexStaticDescriptor();
   assert.equal(fallback.id, staticDescriptor.id);
   assert.equal(fallback.label, staticDescriptor.label);
-  assert.deepEqual(fallback.models.map((m) => m.id), ['gpt-5.5', 'gpt-5.4']);
+  assert.deepEqual(fallback.models.map((m) => m.id), ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini']);
+  assert.deepEqual(fallback.models.find((m) => m.id === 'gpt-5.4-mini'), {
+    id: 'gpt-5.4-mini',
+    label: 'GPT-5.4 mini',
+    effortLevels: ['low', 'medium', 'high', 'xhigh'],
+    cost: 1,
+    adaptive: false,
+  });
   assert.equal(fallback.defaultEffort, 'medium');
   assert.equal(fallback.supportsFast('gpt-5.5'), true);
 });
@@ -126,7 +137,7 @@ test('descriptorWithCustomModel promotes a user-supplied model id without losing
 
   assert.equal(descriptor.defaultModelId, 'provider/custom-model');
   assert.equal(descriptor.models[0].id, 'provider/custom-model');
-  assert.deepEqual(descriptor.models.slice(1).map((m) => m.id), ['gpt-5.5', 'gpt-5.4']);
+  assert.deepEqual(descriptor.models.slice(1).map((m) => m.id), ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini']);
 });
 
 test('zcodeStaticDescriptor keeps model metadata but does not advertise per-turn model switching', () => {


### PR DESCRIPTION
## Summary
- Add `claude-sonnet-5` to the curated Claude model list (adaptive thinking, effort low/medium/high/xhigh — no max per official effort docs) and make it the claude-sub/BYOK default, matching Anthropic making Sonnet 5 the default across plans. Price table uses standard $3/$15 per MTok.
- Add `gpt-5.4-mini` to the Codex static fallback (cost tier 1); default stays `gpt-5.5`.
- Panel dist rebuilt.

## Test plan
- [x] panel node --test: 213 passed (assertions added for sonnet-5 effort set, new default, gpt-5.4-mini shape)
