### PR TITLE
docs: refresh README to v0.8.2 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## 中文
 
-ae-mcp 是一个**后端无关**的 MCP server，让 AI 客户端驱动 Adobe After Effects。v0.7.0 既支持外部 MCP 客户端，也提供一个完整的 CEP 面板产品：面板内可直接对话、审批工具调用、诊断连接，并一键安装本地依赖。
+ae-mcp 是一个**后端无关**的 MCP server，让 AI 客户端驱动 Adobe After Effects。v0.8.2 支持外部 MCP 客户端和完整的 CEP 面板产品：面板内可直接对话、审批工具调用、诊断连接，并一键安装本地依赖。
 
 ```text
 MCP client
-  -> packages/core (ae_mcp, Python stdio MCP server, 31 ae_ tools)
+  -> packages/core (ae_mcp, Python stdio MCP server, 32 ae_ tools)
   -> backend (packages/bridge, httpx)
   -> CEP panel Node host (plugin/host, Express, 127.0.0.1:11488)
   -> CSInterface.evalScript
@@ -14,26 +14,26 @@ MCP client
   -> After Effects
 ```
 
-`packages/snapshot-mss` 提供跨平台 `mss` 截图后端，用于 `ae.snapshot` / preview 相关能力。
+`ae_previewFrame` 通过 `CompItem.saveFrameToPng` 渲染真实合成像素（viewer snapshot 仅作 fallback）；`packages/snapshot-mss` 提供跨平台 `mss` 截图后端，用于 `ae_snapshot` 屏幕捕获。
 
-### v0.7.0 状态
+### v0.8.2 状态
 
-- Python stdio MCP server 暴露 31 个 `ae_` 工具，工具名使用下划线形式（例如 `ae_ping`、`ae_previewFrame`），内部仍映射到 `ae.*` verbs。
+- Python stdio MCP server 暴露 32 个 `ae_` 工具，工具名使用下划线形式（例如 `ae_ping`、`ae_previewFrame`），内部仍映射到 `ae.*` verbs。
 - CEP 面板不再只是连接配置器：它包含内嵌 AI 对话、composer 便捷选择条、四档审批、首跑向导、活动流、kill switch 和连接诊断。
-- 内嵌后端有三类：**Claude 订阅**（默认；面板 spawn 系统 Node 跑 Claude Agent SDK sidecar，复用 `claude` 登录态，零 key / 零 token 落盘）、**BYOK**（用户自己的 Anthropic API key agent loop，可配置 Anthropic-compatible Base URL）、**Codex**（spawn `codex app-server`，可复用 Codex 登录态，也可配置 OpenAI-compatible 自定义 provider）。
-- OpenCode 在 v0.7.0 是**外接 MCP 客户端**，不是内嵌后端；内嵌 OpenCode 计划延后到 v0.7.1。
-- 外部客户端可通过面板生成的 MCP config 接入：Claude Desktop、Claude Code、Cursor、OpenCode、OpenClaw、AstrBot、Gemini Antigravity 等。
+- 内嵌后端有四类：**Claude 订阅**（默认；面板 spawn 系统 Node 跑 Claude Agent SDK sidecar，复用 `claude` 登录态，零 key / 零 token 落盘）、**BYOK**（Anthropic-compatible Base URL 和自定义模型 ID）、**Codex**（`codex app-server`，官方登录或 OpenAI-compatible 自定义 provider）、**ZCode**（驱动已安装 ZCode 桌面应用内置的 `zcode.cjs app-server`，使用 session protocol 和四档审批映射）。
+- OpenCode 仍是**外接 MCP 客户端**；内嵌 OpenCode 已实现，但在审批 gating 验证完成前暂不暴露。
+- 外部客户端可通过面板生成的 MCP config 接入：Claude Desktop、Claude Code、Cursor、OpenCode、OpenClaw、AstrBot、Gemini Antigravity、ZCode 等。
 
 OpenClaw、AstrBot 等 IM-bot 框架常驻或 Docker 化时，未必和 After Effects 在同一台机器。ae-mcp 默认通过 `127.0.0.1:11488` 打到 AE 面板，所以外接客户端必须与 AE 同机，或能访问该端口。
 
 ### 面板能力
 
-- 内嵌聊天：Claude 订阅 / BYOK / Codex。
+- 内嵌聊天：Claude 订阅 / BYOK / Codex / ZCode。
 - Composer 选择条：模型（带成本标识，会话内切换不清空对话）、思考深度（后端原生 effort 档位）、快速模式、审批档。
 - 审批四档：只读、手动、自动、免审。审批语义由工具 annotations 驱动，跨后端一致。
 - 首跑向导：检测并安装 `uv`、Node、Claude CLI、ae-mcp；安装命令会先原文展示；登录会拉起可见终端；安装后不需要重启 AE。
 - 活动流和 kill switch：可熔断所有 AI 操作。
-- 连接诊断：检查 host、token、Python 客户端信号、AE project、ExtendScript ping，并检测 `uv` / `node` / `claude`。
+- 连接诊断：检查 host、token、Python 客户端信号、AE project、ExtendScript ping，并检测 `uv` / `node` / `claude`；外部客户端也可运行 `ae_diagnose` 做一次性链路检查。
 
 ### Tool Surface
 
@@ -46,7 +46,7 @@ OpenClaw、AstrBot 等 IM-bot 框架常驻或 Docker 化时，未必和 After Ef
 | Rigging | `ae_createRig` |
 | Skill | `ae_skillList`, `ae_skillCreate`, `ae_skillEdit`, `ae_skillDelete`, `ae_skillUse` |
 | Checkpoint | `ae_checkpoint`, `ae_revert` |
-| Diagnostic | `ae_ping`, `ae_status` |
+| Diagnostic | `ae_ping`, `ae_status`, `ae_diagnose` |
 
 表达式工作流建议先跑 `ae_validateExpressions`，再做视觉检查。大改前建议使用 `ae_checkpoint` 或在 `ae_exec` 上传 `checkpoint_label`。
 
@@ -73,6 +73,7 @@ uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.
 - Claude 订阅：本机 Node >= 18，已安装并登录 Claude Code（`claude`）。
 - BYOK：Anthropic API key；需要代理或兼容服务时可在设置里填写 API Base URL 和自定义模型 ID。
 - Codex：已安装 Codex CLI。官方账号路径需要 `codex login`；自定义 provider 路径在设置里填写 API Base URL、API Key 和模型 ID。
+- ZCode：已安装 ZCode 桌面应用。API key 或 OAuth coding-plan provider 可在面板使用；`*-start-plan` 订阅 provider 仅限桌面应用，面板会快速失败并提示。
 
 外部 MCP 客户端配置示例：
 
@@ -107,7 +108,7 @@ cd ..\..
 .\scripts\install-plugin-dev.ps1
 ```
 
-macOS 开发脚本存在，但 v0.7.0 主要验证面仍以 Windows + AE live 为准。
+macOS 开发脚本存在，但 v0.8.2 主要验证面仍以 Windows + AE live 为准。
 
 ### 测试
 
@@ -160,11 +161,11 @@ ae-mcp 项目代码使用 MIT License，见 [LICENSE](LICENSE)。
 
 ## English
 
-ae-mcp is a **backend-agnostic** MCP server for driving Adobe After Effects from AI clients. In v0.7.0 it supports both external MCP clients and a full CEP panel product: built-in chat, tool approvals, connection diagnostics, and one-click local setup.
+ae-mcp is a **backend-agnostic** MCP server for driving Adobe After Effects from AI clients. In v0.8.2 it supports external MCP clients and a full CEP panel product: built-in chat, tool approvals, connection diagnostics, and one-click local setup.
 
 ```text
 MCP client
-  -> packages/core (ae_mcp, Python stdio MCP server, 31 ae_ tools)
+  -> packages/core (ae_mcp, Python stdio MCP server, 32 ae_ tools)
   -> backend (packages/bridge, httpx)
   -> CEP panel Node host (plugin/host, Express, 127.0.0.1:11488)
   -> CSInterface.evalScript
@@ -172,26 +173,26 @@ MCP client
   -> After Effects
 ```
 
-`packages/snapshot-mss` provides the cross-platform `mss` screenshot backend used by `ae.snapshot` / preview-related features.
+`ae_previewFrame` renders real comp pixels through `CompItem.saveFrameToPng` with viewer snapshot only as a fallback; `packages/snapshot-mss` provides the cross-platform `mss` screenshot backend for `ae_snapshot` screen capture.
 
-### v0.7.0 Status
+### v0.8.2 Status
 
-- The Python stdio MCP server exposes 31 `ae_` tools. MCP tool names use underscores, such as `ae_ping` and `ae_previewFrame`; internally they still map to `ae.*` verbs.
+- The Python stdio MCP server exposes 32 `ae_` tools. MCP tool names use underscores, such as `ae_ping` and `ae_previewFrame`; internally they still map to `ae.*` verbs.
 - The CEP panel is no longer just a connection configurator. It includes built-in AI chat, composer controls, four approval modes, a first-run wizard, an activity stream, a kill switch, and connection diagnostics.
-- Embedded backends: **Claude subscription** (default; the panel spawns system Node to run a Claude Agent SDK sidecar, reusing the local `claude` login with no key/token stored), **BYOK** (Anthropic API key agent loop with an optional Anthropic-compatible base URL), and **Codex** (spawns `codex app-server`, reusing the Codex login or an OpenAI-compatible custom provider).
-- OpenCode is an **external MCP client** in v0.7.0, not an embedded backend. Embedded OpenCode is deferred to v0.7.1.
-- External clients can connect through the panel-generated MCP config: Claude Desktop, Claude Code, Cursor, OpenCode, OpenClaw, AstrBot, Gemini Antigravity, and similar clients.
+- Embedded backends: **Claude subscription** (default; the panel spawns system Node to run a Claude Agent SDK sidecar, reusing the local `claude` login with no key/token stored), **BYOK** (Anthropic-compatible base URL and custom model IDs), **Codex** (`codex app-server` with official login or an OpenAI-compatible custom provider), and **ZCode** (drives the installed ZCode desktop app's bundled `zcode.cjs app-server` with session protocol and four-tier approval mapping).
+- OpenCode remains an **external MCP client**. Embedded OpenCode is implemented but not yet exposed pending approval-gating verification.
+- External clients can connect through the panel-generated MCP config: Claude Desktop, Claude Code, Cursor, OpenCode, OpenClaw, AstrBot, Gemini Antigravity, ZCode, and similar clients.
 
 Long-running or Dockerized IM-bot frameworks such as OpenClaw and AstrBot may not run on the same machine as After Effects. ae-mcp reaches AE through `127.0.0.1:11488`, so the external client must run on the AE machine or otherwise be able to reach that port.
 
 ### Panel Features
 
-- Built-in chat: Claude subscription / BYOK / Codex.
+- Built-in chat: Claude subscription / BYOK / Codex / ZCode.
 - Composer controls: model with cost badges, per-session model switching without clearing the conversation, native reasoning effort, fast mode, and approval mode.
 - Approval modes: read-only, manual, auto, bypass. Tool annotations drive consistent behavior across backends.
 - First-run wizard: detects and installs `uv`, Node, Claude CLI, and ae-mcp; shows commands verbatim before running; opens visible login terminals; no AE restart required after Python-side install.
 - Activity stream and kill switch for stopping all AI operations.
-- Diagnostics for host, token, Python client signal, AE project, ExtendScript ping, plus `uv` / `node` / `claude` detection.
+- Diagnostics for host, token, Python client signal, AE project, ExtendScript ping, plus `uv` / `node` / `claude` detection. External clients can also run `ae_diagnose` for a one-shot chain check.
 
 ### Tool Surface
 
@@ -204,7 +205,7 @@ Long-running or Dockerized IM-bot frameworks such as OpenClaw and AstrBot may no
 | Rigging | `ae_createRig` |
 | Skill | `ae_skillList`, `ae_skillCreate`, `ae_skillEdit`, `ae_skillDelete`, `ae_skillUse` |
 | Checkpoint | `ae_checkpoint`, `ae_revert` |
-| Diagnostic | `ae_ping`, `ae_status` |
+| Diagnostic | `ae_ping`, `ae_status`, `ae_diagnose` |
 
 Expression workflows should run `ae_validateExpressions` before visual review. For risky edits, use `ae_checkpoint` or pass `checkpoint_label` to `ae_exec`.
 
@@ -231,6 +232,7 @@ Embedded backend requirements:
 - Claude subscription: local Node >= 18 and a logged-in Claude Code CLI (`claude`).
 - BYOK: an Anthropic API key; set API Base URL and a custom model ID in Settings when using a compatible proxy/provider.
 - Codex: an installed Codex CLI. The official account path needs `codex login`; the custom-provider path uses API Base URL, API key, and model ID from Settings.
+- ZCode: an installed ZCode desktop app. Providers with an API key or OAuth coding-plan credentials work in the panel; `*-start-plan` subscription providers are desktop-app-only, so the panel fails fast with a hint.
 
 External MCP client config:
 
@@ -265,7 +267,7 @@ cd ..\..
 .\scripts\install-plugin-dev.ps1
 ```
 
-The macOS development script exists, but v0.7.0 validation is primarily Windows + AE live.
+The macOS development script exists, but v0.8.2 validation is primarily Windows + AE live.
 
 ### Test
 


### PR DESCRIPTION
Update the bilingual README from the stale v0.7.0 narrative: 32 tools (ae_diagnose added to the Diagnostic row), four embedded backends including ZCode (with the start-plan desktop-only boundary), preview wording now reflects saveFrameToPng real comp frames with snapshot-mss backing ae_snapshot only, OpenCode 'deferred to v0.7.1' promise replaced with the actual implemented-but-not-exposed state, ZCode added to the external client list.