### PR TITLE
release: v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.8.3] — 2026-07-03
+
+#### ✨ 新增
+- **Claude Sonnet 5 进入精选模型列表并成为新的 Claude 默认模型**（#40）；Codex 静态模型列表新增 **GPT-5.4 mini**。
+
+#### 🔧 改进
+- **BYOK / Codex API profile 字段统一**（#41）——两类 API profile 现在共用 `ApiProfileFields` 组件，减少重复表单逻辑。
+- **ZCode `*-start-plan` 边界写入工作流文档**（#42）——明确该类 provider 仍依赖桌面端能力。
+- **实时模型矩阵补齐 `claude-sonnet-5`**（#43）。
+- **README 刷新到 v0.8.2 状态**（#44、#45）——补齐 ZCode 后端、`ae_diagnose`、真实合成帧预览，并新增中英双语截图区。
+
 ### [0.8.2] — 2026-07-03
 
 #### ✨ 新增
@@ -184,6 +195,17 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.8.3] — 2026-07-03
+
+#### ✨ Added
+- **Claude Sonnet 5 is now in the curated model list and is the new Claude default** (#40); **GPT-5.4 mini** was added to the Codex static list.
+
+#### 🔧 Improved
+- **BYOK / Codex API profile fields are unified** (#41) — both profile types now share the `ApiProfileFields` component, reducing duplicated form logic.
+- **ZCode `*-start-plan` boundaries are documented in WORKFLOW.md** (#42) — these providers are explicitly desktop-only.
+- **The live model matrix now includes `claude-sonnet-5`** (#43).
+- **README refreshed to the v0.8.2 state** (#44, #45) — ZCode backend, `ae_diagnose`, real comp-frame previews, and bilingual screenshots are documented.
 
 ### [0.8.2] — 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 中文
 
-ae-mcp 是一个**后端无关**的 MCP server，让 AI 客户端驱动 Adobe After Effects。v0.8.2 支持外部 MCP 客户端和完整的 CEP 面板产品：面板内可直接对话、审批工具调用、诊断连接，并一键安装本地依赖。
+ae-mcp 是一个**后端无关**的 MCP server，让 AI 客户端驱动 Adobe After Effects。v0.8.3 支持外部 MCP 客户端和完整的 CEP 面板产品：面板内可直接对话、审批工具调用、诊断连接，并一键安装本地依赖。
 
 ```text
 MCP client
@@ -16,7 +16,7 @@ MCP client
 
 `ae_previewFrame` 通过 `CompItem.saveFrameToPng` 渲染真实合成像素（viewer snapshot 仅作 fallback）；`packages/snapshot-mss` 提供跨平台 `mss` 截图后端，用于 `ae_snapshot` 屏幕捕获。
 
-### v0.8.2 状态
+### v0.8.3 状态
 
 - Python stdio MCP server 暴露 32 个 `ae_` 工具，工具名使用下划线形式（例如 `ae_ping`、`ae_previewFrame`），内部仍映射到 `ae.*` verbs。
 - CEP 面板不再只是连接配置器：它包含内嵌 AI 对话、composer 便捷选择条、四档审批、首跑向导、活动流、kill switch 和连接诊断。
@@ -71,7 +71,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 终端用户从发布 tag 安装：
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/snapshot-mss
 ```
 
 面板安装使用 ZXP 包：推荐 aescripts ZXP Installer，也可用 ExMan Cmd。安装后打开 `Window -> Extensions -> ae-mcp`。
@@ -116,7 +116,7 @@ cd ..\..
 .\scripts\install-plugin-dev.ps1
 ```
 
-macOS 开发脚本存在，但 v0.8.2 主要验证面仍以 Windows + AE live 为准。
+macOS 开发脚本存在，但 v0.8.3 主要验证面仍以 Windows + AE live 为准。
 
 ### 测试
 
@@ -169,7 +169,7 @@ ae-mcp 项目代码使用 MIT License，见 [LICENSE](LICENSE)。
 
 ## English
 
-ae-mcp is a **backend-agnostic** MCP server for driving Adobe After Effects from AI clients. In v0.8.2 it supports external MCP clients and a full CEP panel product: built-in chat, tool approvals, connection diagnostics, and one-click local setup.
+ae-mcp is a **backend-agnostic** MCP server for driving Adobe After Effects from AI clients. In v0.8.3 it supports external MCP clients and a full CEP panel product: built-in chat, tool approvals, connection diagnostics, and one-click local setup.
 
 ```text
 MCP client
@@ -183,7 +183,7 @@ MCP client
 
 `ae_previewFrame` renders real comp pixels through `CompItem.saveFrameToPng` with viewer snapshot only as a fallback; `packages/snapshot-mss` provides the cross-platform `mss` screenshot backend for `ae_snapshot` screen capture.
 
-### v0.8.2 Status
+### v0.8.3 Status
 
 - The Python stdio MCP server exposes 32 `ae_` tools. MCP tool names use underscores, such as `ae_ping` and `ae_previewFrame`; internally they still map to `ae.*` verbs.
 - The CEP panel is no longer just a connection configurator. It includes built-in AI chat, composer controls, four approval modes, a first-run wizard, an activity stream, a kill switch, and connection diagnostics.
@@ -238,7 +238,7 @@ uv tool install --from packages/core ae-mcp --with packages/bridge --with packag
 End users install from the release tag:
 
 ```powershell
-uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
+uv tool install --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/snapshot-mss
 ```
 
 Install the panel from the ZXP package with aescripts ZXP Installer or ExMan Cmd. Then open `Window -> Extensions -> ae-mcp`.
@@ -283,7 +283,7 @@ cd ..\..
 .\scripts\install-plugin-dev.ps1
 ```
 
-The macOS development script exists, but v0.8.2 validation is primarily Windows + AE live.
+The macOS development script exists, but v0.8.3 validation is primarily Windows + AE live.
 
 ### Test
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,7 +51,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 发布 tag 安装命令：
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/snapshot-mss
 ```
 
 安装后确认 launcher 可被外部客户端找到。不要把公共 PyPI 同名包写成用户安装路径。
@@ -184,7 +184,7 @@ uv tool install --force --from packages/core ae-mcp --with packages/bridge --wit
 Release-tag install:
 
 ```powershell
-uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.2#subdirectory=packages/snapshot-mss
+uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/core ae-mcp --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/bridge --with git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.8.3#subdirectory=packages/snapshot-mss
 ```
 
 After install, confirm the launcher is visible to external clients. Do not document the public PyPI name as the user install path.

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.8.2"
+version = "0.8.3"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/bridge/tests/test_http_bridge.py
+++ b/packages/bridge/tests/test_http_bridge.py
@@ -53,7 +53,7 @@ async def test_health_check_ok():
         # fields. health_check must stay True with the extras.
         return Response(200, json={
             "ok": True,
-            "pluginVersion": "0.8.2",
+            "pluginVersion": "0.8.3",
             "port": 11488,
             "pythonVersion": "1.27.2",
             "pythonLastSeenAt": 1719000000000,

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -104,7 +104,7 @@ async def test_probe_host_sends_python_identity_header(respx_mock):
             200,
             json={
                 "ok": True,
-                "pluginVersion": "0.8.2",
+                "pluginVersion": "0.8.3",
                 "port": 11488,
                 "pythonVersion": captured["python"],
                 "pythonLastSeenAt": 1719000000000,

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.8.2"
+version = "0.8.3"
 description = "Cross-platform mss-based screen capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.8.2"
+                   ExtensionBundleVersion="0.8.3"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.8.2" />
+        <Extension Id="com.aemcp.panel" Version="0.8.3" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -8266,7 +8266,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.8.2",
+    version: "0.8.3",
     private: true,
     type: "module",
     scripts: {
@@ -12129,7 +12129,7 @@
   // src/cep/mcpClient.js
   var DEFAULT_TIMEOUT_MS = 3e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.8.2";
+  var PANEL_VERSION = "0.8.3";
   function getCepRequire() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "express": "^4.18.0"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "lucide-react": "0.453.0",
         "react": "18.3.1",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -3,7 +3,7 @@ import { expertGuidanceEnv } from './externalClients.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.8.2';
+export const PANEL_VERSION = '0.8.3';
 
 function getCepRequire() {
   if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-agent-sidecar",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-agent-sidecar",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.173"
       }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -2,7 +2,7 @@
   "name": "ae-mcp-agent-sidecar",
   "private": true,
   "type": "module",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173"
   },

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "mcp" },
@@ -44,7 +44,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -70,7 +70,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
Version bump 0.8.2 -> 0.8.3 across all 16 version locations, bilingual CHANGELOG entry, panel bundle rebuilt. Content since v0.8.2: Claude Sonnet 5 default + GPT-5.4 mini (#40), shared ApiProfileFields (#41), ZCode desktop-only boundary docs (#42), live matrix sync (#43), README refresh + screenshots (#44/#45). Local verification: pytest 375 passed; panel 216 passed; host/sidecar passed.

Made with [Cursor](https://cursor.com)