### PR TITLE
feat(panel): provider dialect auto-detection and cc-switch metadata inheritance

### DIFF
--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -11258,6 +11258,10 @@
     const text = String(value || "").trim();
     return text === "responses" || text === "chat" ? text : DEFAULT_CODEX_WIRE_API;
   }
+  function normalizeCodexAuthScheme(value) {
+    const text = String(value || "").trim();
+    return text === "x-api-key" || text === "none" || text === "bearer" ? text : "bearer";
+  }
   function tomlString(value) {
     return JSON.stringify(String(value || ""));
   }
@@ -11269,6 +11273,7 @@
       codexBaseUrl,
       codexProviderId: normalizeProviderId(firstValue(input.codexProviderId, env.AE_MCP_CODEX_PROVIDER_ID)),
       codexWireApi: normalizeCodexWireApi(firstValue(input.codexWireApi, env.AE_MCP_CODEX_WIRE_API)),
+      codexAuthScheme: normalizeCodexAuthScheme(firstValue(input.codexAuthScheme, env.AE_MCP_CODEX_AUTH_SCHEME)),
       anthropicBaseUrl
     };
   }
@@ -13679,7 +13684,9 @@
       channel: "custom",
       source: { zh: "\u81EA\u5B9A\u4E49 provider", en: "Custom provider" },
       checking: false,
-      ok: Boolean(customProvider && customProvider.baseUrl && customProvider.apiKey && (!codexProbe || codexProbe.runtimeOk !== false)),
+      ok: Boolean(
+        customProvider && customProvider.protocol === "openai-compatible" && customProvider.baseUrl && customProvider.apiKey && (!codexProbe || codexProbe.runtimeOk !== false)
+      ),
       detail: customProvider && customProvider.baseUrl ? customProvider.baseUrl : "",
       fixHint: { zh: "\u5728\u300CProvider \u7BA1\u7406\u300D\u65B0\u589E/\u9009\u62E9\u4E00\u4E2A OpenAI \u517C\u5BB9 provider\uFF08Base URL + Key\uFF09\u3002", en: "Add or pick an OpenAI-compatible provider (base URL + key) in Provider Manager." }
     };
@@ -13746,7 +13753,7 @@
   }
 
   // src/lib/backendSelect.js
-  function pickBackend({ pref, channels = {}, lockedChannel = "", nodeOk = true }) {
+  function pickBackend({ pref, channels = {}, lockedChannel = "", nodeOk = true, apiProvider = null }) {
     const group = pref === "codex" || pref === "zcode" ? pref : "claude";
     const list = channels[group] || [];
     if (list.some((c) => c && c.checking)) {
@@ -13764,11 +13771,21 @@
     }
     if (group === "claude") {
       if (chosen.channel === "api") {
-        return { backend: nodeOk ? "claude-api" : "byok", reason: "ok", channel: "api", fixHint: null };
+        const canUseAgentSdk = nodeOk && isOfficialAnthropicProvider(apiProvider);
+        return { backend: canUseAgentSdk ? "claude-api" : "byok", reason: "ok", channel: "api", fixHint: null };
       }
       return { backend: "subscription", reason: "ok", channel: "subscription", fixHint: null };
     }
     return { backend: group, reason: "ok", channel: chosen.channel, fixHint: null };
+  }
+  function isOfficialAnthropicProvider(provider) {
+    const baseUrl = provider && provider.baseUrl ? String(provider.baseUrl) : "https://api.anthropic.com";
+    try {
+      const host = new URL(baseUrl).hostname.toLowerCase();
+      return host === "api.anthropic.com";
+    } catch (e) {
+      return /(^|\/)api\.anthropic\.com(\/|$)/i.test(baseUrl);
+    }
   }
   function deriveToolMeta(tools) {
     const allowedTools = [];
@@ -14160,6 +14177,490 @@
     });
   }
 
+  // src/cep/codexResponsesRoute.js
+  function getCepRequire5() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+      return globalThis.window.cep_node.require;
+    }
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    throw new Error("CEP Node require is unavailable");
+  }
+  function normalizeOpenAiRoot(baseUrl) {
+    return String(baseUrl || "").replace(/\/+$/, "").replace(/\/v1$/, "") + "/v1";
+  }
+  function authHeaders(authScheme, apiKey) {
+    if (authScheme === "x-api-key") return { "x-api-key": String(apiKey || "") };
+    if (authScheme === "none") return {};
+    return { Authorization: "Bearer " + String(apiKey || "") };
+  }
+  function textFromContent(content) {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    return content.map((part) => {
+      if (!part || typeof part !== "object") return "";
+      if (part.text !== void 0) return String(part.text || "");
+      if (part.content !== void 0) return String(part.content || "");
+      return "";
+    }).join("");
+  }
+  function toolArguments(value) {
+    if (value === void 0 || value === null) return "{}";
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value);
+    } catch (e) {
+      return "{}";
+    }
+  }
+  function responsesToolToChatTool(tool) {
+    if (!tool || typeof tool !== "object") return null;
+    const type = String(tool.type || "function");
+    if (type !== "function") return null;
+    if (tool.function && typeof tool.function === "object") {
+      const fn2 = {
+        name: String(tool.function.name || tool.name || ""),
+        description: tool.function.description !== void 0 ? tool.function.description : tool.description,
+        parameters: tool.function.parameters !== void 0 ? tool.function.parameters : tool.parameters || {}
+      };
+      if (tool.function.strict !== void 0 || tool.strict !== void 0) {
+        fn2.strict = tool.function.strict !== void 0 ? tool.function.strict : tool.strict;
+      }
+      return { type: "function", function: fn2 };
+    }
+    const name = String(tool.name || "");
+    if (!name) return null;
+    const fn = {
+      name,
+      description: tool.description,
+      parameters: tool.parameters || {}
+    };
+    if (tool.strict !== void 0) fn.strict = tool.strict;
+    return { type: "function", function: fn };
+  }
+  function responsesToolsToChatTools(tools) {
+    if (!Array.isArray(tools)) return [];
+    return tools.map(responsesToolToChatTool).filter(Boolean);
+  }
+  function responsesToolChoiceToChat(toolChoice) {
+    if (!toolChoice || typeof toolChoice !== "object") return toolChoice;
+    if (toolChoice.type === "function") {
+      return { type: "function", function: { name: String(toolChoice.name || toolChoice.function && toolChoice.function.name || "") } };
+    }
+    return toolChoice;
+  }
+  function functionCallToChatToolCall(item) {
+    const callId = String(item.call_id || item.id || "");
+    return {
+      id: callId,
+      type: "function",
+      function: {
+        name: String(item.name || ""),
+        arguments: toolArguments(item.arguments)
+      }
+    };
+  }
+  function inputToMessages(input) {
+    if (typeof input === "string") return [{ role: "user", content: input }];
+    if (!Array.isArray(input)) return [{ role: "user", content: String(input || "") }];
+    const messages = [];
+    let pendingToolCalls = [];
+    function flushToolCalls() {
+      if (!pendingToolCalls.length) return;
+      messages.push({ role: "assistant", content: null, tool_calls: pendingToolCalls });
+      pendingToolCalls = [];
+    }
+    for (const item of input) {
+      if (!item || typeof item !== "object") continue;
+      const type = String(item.type || "");
+      if (type === "function_call") {
+        pendingToolCalls.push(functionCallToChatToolCall(item));
+        continue;
+      }
+      if (type === "function_call_output") {
+        flushToolCalls();
+        messages.push({
+          role: "tool",
+          tool_call_id: String(item.call_id || item.id || ""),
+          content: typeof item.output === "string" ? item.output : toolArguments(item.output)
+        });
+        continue;
+      }
+      if (type === "reasoning") continue;
+      flushToolCalls();
+      if (type === "message" || item.role || item.content !== void 0 || item.text !== void 0) {
+        const role = item.role === "assistant" || item.role === "system" ? item.role : "user";
+        const content = textFromContent(item.content !== void 0 ? item.content : item.text);
+        if (content || role === "assistant") messages.push({ role, content: content || "" });
+      }
+    }
+    flushToolCalls();
+    return messages.length ? messages : [{ role: "user", content: "" }];
+  }
+  function responsesBodyToChatBody(body = {}) {
+    const messages = [];
+    if (body.instructions) messages.push({ role: "system", content: String(body.instructions) });
+    messages.push(...inputToMessages(body.input));
+    const chat = {
+      model: body.model,
+      messages,
+      stream: body.stream !== false
+    };
+    const maxTokens = body.max_output_tokens || body.max_tokens;
+    if (maxTokens !== void 0) chat.max_tokens = maxTokens;
+    if (body.temperature !== void 0) chat.temperature = body.temperature;
+    if (body.top_p !== void 0) chat.top_p = body.top_p;
+    const tools = responsesToolsToChatTools(body.tools);
+    if (tools.length) chat.tools = tools;
+    if (body.tool_choice !== void 0 && tools.length) chat.tool_choice = responsesToolChoiceToChat(body.tool_choice);
+    if (body.parallel_tool_calls !== void 0 && tools.length) chat.parallel_tool_calls = body.parallel_tool_calls;
+    return chat;
+  }
+  function responseId() {
+    return "resp_" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+  }
+  function sse(res, event, data) {
+    res.write("event: " + event + "\n");
+    res.write("data: " + JSON.stringify({ type: event, ...data }) + "\n\n");
+  }
+  function chatToolCallsToResponseOutput(message) {
+    const toolCalls = Array.isArray(message && message.tool_calls) ? message.tool_calls : [];
+    return toolCalls.map((toolCall, index) => {
+      const callId = String(toolCall && toolCall.id || "call_" + index);
+      const fn = toolCall && toolCall.function || {};
+      return {
+        type: "function_call",
+        id: "fc_" + callId,
+        call_id: callId,
+        name: String(fn.name || ""),
+        arguments: toolArguments(fn.arguments),
+        status: "completed"
+      };
+    }).filter((item) => item.name);
+  }
+  function messageOutputItem(id, text) {
+    return {
+      id: "msg_" + id.slice(5),
+      type: "message",
+      status: "completed",
+      role: "assistant",
+      content: [{ type: "output_text", text: String(text || "") }]
+    };
+  }
+  function chatMessageToResponseOutput(id, message) {
+    const output = [];
+    const text = message && typeof message.content === "string" ? message.content : "";
+    if (text) output.push(messageOutputItem(id, text));
+    output.push(...chatToolCallsToResponseOutput(message));
+    if (!output.length) output.push(messageOutputItem(id, ""));
+    return output;
+  }
+  function createStreamState(res, id, model) {
+    let started = false;
+    let nextOutputIndex = 0;
+    let textIndex = null;
+    let text = "";
+    const tools = /* @__PURE__ */ new Map();
+    const completed = [];
+    function ensureStarted() {
+      if (started) return;
+      started = true;
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive"
+      });
+      sse(res, "response.created", { response: { id, object: "response", status: "in_progress", model, output: [] } });
+    }
+    function ensureTextItem() {
+      ensureStarted();
+      if (textIndex !== null) return textIndex;
+      textIndex = nextOutputIndex++;
+      const item = { id: "msg_" + id.slice(5), type: "message", status: "in_progress", role: "assistant", content: [] };
+      sse(res, "response.output_item.added", { output_index: textIndex, item });
+      sse(res, "response.content_part.added", { output_index: textIndex, content_index: 0, part: { type: "output_text", text: "" } });
+      return textIndex;
+    }
+    function pushTextDelta(delta) {
+      if (!delta) return;
+      const outputIndex = ensureTextItem();
+      text += String(delta);
+      sse(res, "response.output_text.delta", { output_index: outputIndex, content_index: 0, delta: String(delta) });
+    }
+    function pushToolCallDelta(toolCall) {
+      ensureStarted();
+      const chatIndex = Number.isFinite(toolCall && toolCall.index) ? toolCall.index : 0;
+      const fn = toolCall && toolCall.function || {};
+      let state = tools.get(chatIndex);
+      if (!state) {
+        state = { callId: "", name: "", arguments: "", outputIndex: null, itemId: "", added: false };
+        tools.set(chatIndex, state);
+      }
+      if (toolCall && toolCall.id) state.callId = String(toolCall.id);
+      if (fn.name) state.name = String(fn.name);
+      if (fn.arguments) state.arguments += String(fn.arguments);
+      if (!state.added && state.callId && state.name) {
+        state.added = true;
+        state.outputIndex = nextOutputIndex++;
+        state.itemId = "fc_" + state.callId;
+        const item = {
+          type: "function_call",
+          id: state.itemId,
+          call_id: state.callId,
+          name: state.name,
+          arguments: "",
+          status: "in_progress"
+        };
+        sse(res, "response.output_item.added", { output_index: state.outputIndex, item });
+        if (state.arguments) {
+          sse(res, "response.function_call_arguments.delta", {
+            item_id: state.itemId,
+            output_index: state.outputIndex,
+            delta: state.arguments
+          });
+        }
+        return;
+      }
+      if (state.added && fn.arguments) {
+        sse(res, "response.function_call_arguments.delta", {
+          item_id: state.itemId,
+          output_index: state.outputIndex,
+          delta: String(fn.arguments)
+        });
+      }
+    }
+    function finish() {
+      ensureStarted();
+      if (textIndex !== null) {
+        const item = messageOutputItem(id, text);
+        sse(res, "response.output_text.done", { output_index: textIndex, content_index: 0, text });
+        sse(res, "response.content_part.done", { output_index: textIndex, content_index: 0, part: item.content[0] });
+        sse(res, "response.output_item.done", { output_index: textIndex, item });
+        completed.push(item);
+      }
+      for (const state of tools.values()) {
+        if (!state.added || !state.name) continue;
+        const item = {
+          type: "function_call",
+          id: state.itemId || "fc_" + state.callId,
+          call_id: state.callId || state.itemId,
+          name: state.name,
+          arguments: state.arguments || "{}",
+          status: "completed"
+        };
+        sse(res, "response.function_call_arguments.done", {
+          item_id: item.id,
+          output_index: state.outputIndex,
+          arguments: item.arguments
+        });
+        sse(res, "response.output_item.done", { output_index: state.outputIndex, item });
+        completed.push(item);
+      }
+      if (!completed.length) completed.push(messageOutputItem(id, ""));
+      sse(res, "response.completed", {
+        response: { id, object: "response", status: "completed", model, output: completed }
+      });
+      res.end();
+    }
+    return { pushTextDelta, pushToolCallDelta, finish, ensureStarted };
+  }
+  function sendJson(res, status, body) {
+    res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(JSON.stringify(body));
+  }
+  function readBody(req) {
+    return new Promise((resolve, reject) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => resolve(body));
+      req.on("error", reject);
+    });
+  }
+  function requestUpstream({ requireImpl, upstreamBaseUrl, apiKey, authScheme, path, method, body, onResponse }) {
+    return new Promise((resolve, reject) => {
+      let endpoint;
+      try {
+        endpoint = new URL(normalizeOpenAiRoot(upstreamBaseUrl) + path);
+      } catch (e) {
+        reject(new Error("Invalid upstream base URL"));
+        return;
+      }
+      const reqImpl = requireImpl(endpoint.protocol === "http:" ? "http" : "https");
+      const payload = body === void 0 ? null : JSON.stringify(body);
+      const headers = { ...authHeaders(authScheme, apiKey) };
+      if (payload !== null) headers["Content-Type"] = "application/json";
+      const req = reqImpl.request({
+        hostname: endpoint.hostname,
+        port: endpoint.port || void 0,
+        protocol: endpoint.protocol,
+        path: endpoint.pathname + endpoint.search,
+        method,
+        headers
+      }, async (upstream) => {
+        try {
+          await onResponse(upstream);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      req.on("error", reject);
+      if (payload !== null) req.write(payload);
+      req.end();
+    });
+  }
+  function proxyModels({ req, res, requireImpl, upstreamBaseUrl, apiKey, authScheme }) {
+    return requestUpstream({
+      requireImpl,
+      upstreamBaseUrl,
+      apiKey,
+      authScheme,
+      path: "/models",
+      method: "GET",
+      onResponse: async (upstream) => {
+        res.writeHead(upstream.statusCode || 502, upstream.headers || {});
+        upstream.on("data", (chunk) => res.write(chunk));
+        upstream.on("end", () => res.end());
+      }
+    }).catch((e) => sendJson(res, 502, { error: { message: e.message || "Provider route failed" } }));
+  }
+  async function handleResponses({ req, res, requireImpl, upstreamBaseUrl, apiKey, authScheme }) {
+    let body;
+    try {
+      body = JSON.parse(await readBody(req) || "{}");
+    } catch (e) {
+      sendJson(res, 400, { error: { message: "Invalid JSON request body" } });
+      return;
+    }
+    const chatBody = responsesBodyToChatBody(body);
+    const id = responseId();
+    if (chatBody.stream === false) {
+      await requestUpstream({
+        requireImpl,
+        upstreamBaseUrl,
+        apiKey,
+        authScheme,
+        path: "/chat/completions",
+        method: "POST",
+        body: chatBody,
+        onResponse: async (upstream) => {
+          let text = "";
+          upstream.on("data", (chunk) => {
+            text += chunk;
+          });
+          upstream.on("end", () => {
+            if ((upstream.statusCode || 0) >= 300) {
+              sendJson(res, upstream.statusCode || 502, { error: { message: "Upstream chat completion failed" } });
+              return;
+            }
+            let message = { content: "" };
+            try {
+              const parsed = JSON.parse(text);
+              message = parsed.choices && parsed.choices[0] && parsed.choices[0].message || message;
+            } catch (e) {
+              message = { content: "" };
+            }
+            sendJson(res, 200, {
+              id,
+              object: "response",
+              status: "completed",
+              model: chatBody.model,
+              output: chatMessageToResponseOutput(id, message)
+            });
+          });
+        }
+      }).catch((e) => sendJson(res, 502, { error: { message: e.message || "Provider route failed" } }));
+      return;
+    }
+    const stream = createStreamState(res, id, chatBody.model);
+    await requestUpstream({
+      requireImpl,
+      upstreamBaseUrl,
+      apiKey,
+      authScheme,
+      path: "/chat/completions",
+      method: "POST",
+      body: chatBody,
+      onResponse: async (upstream) => {
+        if ((upstream.statusCode || 0) >= 300) {
+          let detail = "";
+          upstream.on("data", (chunk) => {
+            detail += chunk;
+          });
+          upstream.on("end", () => sendJson(res, upstream.statusCode || 502, { error: { message: "Upstream chat completion failed", detail: detail.slice(0, 512) } }));
+          return;
+        }
+        stream.ensureStarted();
+        let buffer = "";
+        upstream.on("data", (chunk) => {
+          buffer += String(chunk || "");
+          const lines = buffer.split(/\r?\n/);
+          buffer = lines.pop() || "";
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data:")) continue;
+            const data = trimmed.slice(5).trim();
+            if (!data || data === "[DONE]") continue;
+            try {
+              const json = JSON.parse(data);
+              const delta = json.choices && json.choices[0] && json.choices[0].delta;
+              if (!delta) continue;
+              if (delta.content) stream.pushTextDelta(delta.content);
+              if (Array.isArray(delta.tool_calls)) {
+                for (const toolCall of delta.tool_calls) stream.pushToolCallDelta(toolCall);
+              }
+            } catch (e) {
+            }
+          }
+        });
+        upstream.on("end", () => stream.finish());
+      }
+    }).catch((e) => {
+      if (!res.headersSent) sendJson(res, 502, { error: { message: e.message || "Provider route failed" } });
+      else res.end();
+    });
+  }
+  function createCodexResponsesRoute({ upstreamBaseUrl, apiKey, authScheme = "bearer", requireImpl } = {}) {
+    const reqImpl = requireImpl || getCepRequire5();
+    let server = null;
+    let baseUrl = "";
+    const token = "ae-mcp-route-" + Math.random().toString(36).slice(2);
+    return {
+      async start() {
+        if (server && baseUrl) return { baseUrl, apiKey: token };
+        const http = reqImpl("http");
+        server = http.createServer((req, res) => {
+          const path = String(req.url || "").split("?")[0].replace(/^\/v1/, "") || "/";
+          if (req.method === "GET" && path === "/models") {
+            proxyModels({ req, res, requireImpl: reqImpl, upstreamBaseUrl, apiKey, authScheme });
+            return;
+          }
+          if (req.method === "POST" && (path === "/responses" || path === "/responses/compact")) {
+            handleResponses({ req, res, requireImpl: reqImpl, upstreamBaseUrl, apiKey, authScheme });
+            return;
+          }
+          sendJson(res, 404, { error: { message: "Unknown Codex provider route path" } });
+        });
+        await new Promise((resolve, reject) => {
+          server.on("error", reject);
+          server.listen(0, "127.0.0.1", () => resolve());
+        });
+        const address = server.address();
+        baseUrl = "http://127.0.0.1:" + address.port;
+        return { baseUrl, apiKey: token };
+      },
+      async close() {
+        if (!server) return;
+        const closing = server;
+        server = null;
+        baseUrl = "";
+        await new Promise((resolve) => closing.close(resolve));
+      }
+    };
+  }
+
   // src/cep/codexBackend.js
   var RPC_TIMEOUT_MS2 = 3e4;
   var STDERR_TAIL_LIMIT3 = 4096;
@@ -14167,7 +14668,7 @@
     granular: { mcp_elicitations: true, rules: false, sandbox_approval: false }
   };
   var SANDBOX_POLICY = { type: "readOnly" };
-  function getCepRequire5() {
+  function getCepRequire6() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -14200,7 +14701,7 @@
     if (parent) return parent;
     if (env && (env.TEMP || env.TMP)) return env.TEMP || env.TMP;
     try {
-      return getCepRequire5()("os").tmpdir();
+      return getCepRequire6()("os").tmpdir();
     } catch (e) {
       return ".";
     }
@@ -14327,7 +14828,7 @@
   }
   function getHomedir() {
     try {
-      return getCepRequire5()("os").homedir();
+      return getCepRequire6()("os").homedir();
     } catch (e) {
       return "";
     }
@@ -14338,7 +14839,7 @@
     let execFile = execFileImpl;
     if (!execFile) {
       try {
-        execFile = getCepRequire5()("child_process").execFile;
+        execFile = getCepRequire6()("child_process").execFile;
       } catch (e) {
         return { ok: false, cliPath: "", version: "", detail: "child_process unavailable" };
       }
@@ -14370,6 +14871,7 @@
     // panel only supplies the missing API key env var the provider needs (no
     // `-c model_provider=...` override).
     getCliConfigProvider = () => null,
+    createResponsesRoute = createCodexResponsesRoute,
     resolveCli = resolveCodexCli,
     onEvent,
     lang = "zh",
@@ -14391,14 +14893,21 @@
     let activeAssistantText = "";
     let toolMeta = { allowedTools: [], annotations: {} };
     let lastCliInfo = null;
+    let providerRoute = null;
     const pendingApprovals = /* @__PURE__ */ new Map();
     const sessionAllowedTools = /* @__PURE__ */ new Set();
+    function closeProviderRoute() {
+      const route = providerRoute;
+      providerRoute = null;
+      if (route && route.close) Promise.resolve(route.close()).catch(() => {
+      });
+    }
     function emit(evt) {
       if (onEvent) onEvent(evt);
     }
     function getSpawn() {
       if (spawnImpl) return spawnImpl;
-      return getCepRequire5()("child_process").spawn;
+      return getCepRequire6()("child_process").spawn;
     }
     function currentEnv() {
       return Object.assign({}, getCepEnv5(), env || {});
@@ -14537,6 +15046,7 @@
       initialized = false;
       threadId = null;
       preambleSent = false;
+      closeProviderRoute();
       if (wasStopping) return;
       if (activeRun) {
         emit({ type: "error", kind: "mcp", message: "codex app-server exited: " + detail });
@@ -14553,6 +15063,7 @@
       initialized = false;
       threadId = null;
       preambleSent = false;
+      closeProviderRoute();
       if (activeRun) {
         emit({ type: "error", kind: "mcp", message: err.message });
         finishActive();
@@ -14565,12 +15076,28 @@
         const spawn = getSpawn();
         const spawnEnv = ensureUserEnv(currentEnv(), { homedir: getHomedir() });
         const providerProfile = normalizeProviderProfile(getProviderProfile ? getProviderProfile() : {}, spawnEnv);
+        let runtimeProviderProfile = providerProfile;
+        if (providerProfile.codexBaseUrl && providerProfile.codexWireApi === "chat") {
+          closeProviderRoute();
+          providerRoute = createResponsesRoute({
+            upstreamBaseUrl: providerProfile.codexBaseUrl,
+            apiKey: providerProfile.codexApiKey,
+            authScheme: providerProfile.codexAuthScheme
+          });
+          const routeInfo = await providerRoute.start();
+          runtimeProviderProfile = {
+            ...providerProfile,
+            codexBaseUrl: routeInfo.baseUrl,
+            codexApiKey: routeInfo.apiKey,
+            codexWireApi: "responses"
+          };
+        }
         stderrTail = "";
         stopping = false;
         const cliOverride = spawnEnv.AE_MCP_CODEX_CLI ? { ok: true, cliPath: String(spawnEnv.AE_MCP_CODEX_CLI), version: "" } : null;
         lastCliInfo = cliOverride || lastCliInfo;
         const command = cliOverride ? cliOverride.cliPath : "codex";
-        let spawnEnvWithCreds = codexSpawnEnv(providerProfile, spawnEnv);
+        let spawnEnvWithCreds = codexSpawnEnv(runtimeProviderProfile, spawnEnv);
         if (!providerProfile.codexBaseUrl) {
           const cliConfig = getCliConfigProvider ? getCliConfigProvider() : null;
           const envKey = cliConfig && cliConfig.provider && String(cliConfig.provider.envKey || "").trim();
@@ -14578,7 +15105,7 @@
             spawnEnvWithCreds = Object.assign({}, spawnEnvWithCreds, { [envKey]: cliConfig.apiKey });
           }
         }
-        proc = spawn(command, codexAppServerArgs(providerProfile), {
+        proc = spawn(command, codexAppServerArgs(runtimeProviderProfile), {
           stdio: "pipe",
           windowsHide: true,
           shell: true,
@@ -14716,6 +15243,7 @@
     }
     function reset() {
       stopping = true;
+      closeProviderRoute();
       drainApprovals();
       if (rpc) rpc.close(new Error("Codex backend reset"));
       if (proc) {
@@ -14756,7 +15284,7 @@
       try {
         let execFileImpl = null;
         try {
-          execFileImpl = getCepRequire5()("child_process").execFile;
+          execFileImpl = getCepRequire6()("child_process").execFile;
         } catch (e) {
         }
         cliInfo = await resolveCli({ env: spawnEnv, execFileImpl });
@@ -14817,7 +15345,7 @@
   var READY_POLL_MS = 250;
   var DEFAULT_PROVIDER_ID = "opencode";
   var DEFAULT_MODEL_ID = "north-mini-code-free";
-  function getCepRequire6() {
+  function getCepRequire7() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -14834,13 +15362,13 @@
     throw new Error("fetch is unavailable");
   }
   function defaultFs3() {
-    return getCepRequire6()("fs");
+    return getCepRequire7()("fs");
   }
   function defaultOs() {
-    return getCepRequire6()("os");
+    return getCepRequire7()("os");
   }
   function defaultPath() {
-    return getCepRequire6()("path");
+    return getCepRequire7()("path");
   }
   function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -14857,7 +15385,7 @@
     return "ae-opencode-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2);
   }
   async function defaultGetPort() {
-    const net = getCepRequire6()("net");
+    const net = getCepRequire7()("net");
     return new Promise((resolve, reject) => {
       const server = net.createServer();
       server.on("error", reject);
@@ -15086,7 +15614,7 @@
         writeConfig(mcpSpec);
         port = await getPort();
         baseUrl = "http://127.0.0.1:" + port;
-        const spawn = spawnImpl || getCepRequire6()("child_process").spawn;
+        const spawn = spawnImpl || getCepRequire7()("child_process").spawn;
         const spawnEnv = Object.assign({}, currentEnv(), { XDG_CONFIG_HOME: configHome });
         stderrTail = "";
         stopping = false;
@@ -15621,7 +16149,7 @@
   }
 
   // src/cep/modelProbe.js
-  function getCepRequire7() {
+  function getCepRequire8() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -15661,7 +16189,7 @@
     }
     let https;
     try {
-      https = httpsImpl || getCepRequire7()(endpoint.protocol === "http:" ? "http" : "https");
+      https = httpsImpl || getCepRequire8()(endpoint.protocol === "http:" ? "http" : "https");
     } catch (e) {
       return Promise.resolve({ ok: false, status: 0, models: [], detail: e.message });
     }
@@ -15704,7 +16232,7 @@
   }
 
   // src/cep/providerDetect.js
-  function getCepRequire8() {
+  function getCepRequire9() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -15715,7 +16243,7 @@
   function normalizeRoot(baseUrl) {
     return String(baseUrl || "").replace(/\/+$/, "").replace(/\/v1$/, "");
   }
-  function authHeaders(authScheme, apiKey) {
+  function authHeaders2(authScheme, apiKey) {
     if (authScheme === "bearer") return { Authorization: "Bearer " + String(apiKey || "") };
     if (authScheme === "x-api-key") return { "x-api-key": String(apiKey || "") };
     return {};
@@ -15748,7 +16276,7 @@
       }
       let https;
       try {
-        https = httpsImpl || getCepRequire8()(endpoint.protocol === "http:" ? "http" : "https");
+        https = httpsImpl || getCepRequire9()(endpoint.protocol === "http:" ? "http" : "https");
       } catch (e) {
         resolve({ ok: false, network: true, status: 0, body: "", detail: safeDetail(e.message) });
         return;
@@ -15811,7 +16339,7 @@
       const result = await requestProvider({
         url: root + "/v1/models",
         method: "GET",
-        headers: authHeaders(candidate, apiKey),
+        headers: authHeaders2(candidate, apiKey),
         httpsImpl,
         timeoutMs
       });
@@ -15862,7 +16390,7 @@
       const result = await requestProvider({
         url: root + wire.path,
         method: "POST",
-        headers: authHeaders(authScheme, apiKey),
+        headers: authHeaders2(authScheme, apiKey),
         body: wire.body,
         httpsImpl,
         timeoutMs
@@ -15998,7 +16526,7 @@
     openai_responses: "responses",
     openai_chat: "chat"
   };
-  function getCepRequire9() {
+  function getCepRequire10() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16083,7 +16611,7 @@
   function detectCcSwitch({ env = {}, fsImpl } = {}) {
     let fs;
     try {
-      fs = fsImpl || getCepRequire9()("fs");
+      fs = fsImpl || getCepRequire10()("fs");
     } catch (e) {
       return null;
     }
@@ -16103,7 +16631,7 @@
   }
 
   // src/cep/claudeSettingsImport.js
-  function getCepRequire10() {
+  function getCepRequire11() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16116,7 +16644,7 @@
     if (!home) return null;
     let fs;
     try {
-      fs = fsImpl || getCepRequire10()("fs");
+      fs = fsImpl || getCepRequire11()("fs");
     } catch (e) {
       return null;
     }
@@ -16134,7 +16662,7 @@
   }
 
   // src/cep/codexConfig.js
-  function getCepRequire11() {
+  function getCepRequire12() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16189,7 +16717,7 @@
     if (!home) return null;
     let fs;
     try {
-      fs = fsImpl || getCepRequire11()("fs");
+      fs = fsImpl || getCepRequire12()("fs");
     } catch (e) {
       return null;
     }
@@ -16414,7 +16942,7 @@
   // src/cep/modelsApi.js
   var CACHE_KEY = "ae_mcp_byok_models";
   var TTL_MS = 24 * 60 * 60 * 1e3;
-  function getCepRequire12() {
+  function getCepRequire13() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16423,7 +16951,7 @@
     throw new Error("CEP Node require is unavailable");
   }
   function fetchAnthropicModels({ apiKey, baseUrl = "", httpsImpl, timeoutMs = 8e3 } = {}) {
-    const https = httpsImpl || getCepRequire12()("https");
+    const https = httpsImpl || getCepRequire13()("https");
     return new Promise((resolve) => {
       let endpoint;
       try {
@@ -16539,7 +17067,7 @@
 
   // src/cep/wizardActions.js
   var OUTPUT_TAIL = 8192;
-  function getCepRequire13() {
+  function getCepRequire14() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16564,7 +17092,7 @@
     return globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env || {};
   }
   async function detectAeMcp({ execFileImpl, env, fsImpl }) {
-    const execFile = execFileImpl || getCepRequire13()("child_process").execFile;
+    const execFile = execFileImpl || getCepRequire14()("child_process").execFile;
     const whereHit = await new Promise((resolve) => {
       execFile("where", ["ae-mcp"], { windowsHide: true, env }, (err, stdout) => {
         resolve(err ? "" : String(stdout || "").split(/\r?\n/).map((l) => l.trim()).find(Boolean) || "");
@@ -16574,7 +17102,7 @@
     const profile = (env || getCepEnvSafe()).USERPROFILE || "";
     if (profile) {
       const shim = profile.replace(/[\\/]+$/, "") + "\\.local\\bin\\ae-mcp.exe";
-      const fs = fsImpl || getCepRequire13()("fs");
+      const fs = fsImpl || getCepRequire14()("fs");
       if (fs.existsSync(shim)) return { ok: true, version: shim };
     }
     return { ok: false };
@@ -16582,7 +17110,7 @@
   async function detectTool(id, { execFileImpl, env, fsImpl } = {}) {
     if (id === "aeMcp") return detectAeMcp({ execFileImpl, env, fsImpl });
     const spec = DETECT[id];
-    const execFile = execFileImpl || getCepRequire13()("child_process").execFile;
+    const execFile = execFileImpl || getCepRequire14()("child_process").execFile;
     return execVersion(execFile, spec.file, spec.args, env, spec.shell);
   }
   var REPO = "https://github.com/JUNKDOGE-JOE/after-effects-mcp";
@@ -16597,7 +17125,7 @@
     };
   }
   function runAction({ file, args, spawnImpl, env, onChunk }) {
-    const spawn = spawnImpl || getCepRequire13()("child_process").spawn;
+    const spawn = spawnImpl || getCepRequire14()("child_process").spawn;
     return new Promise((resolve) => {
       let output = "";
       const push = (chunk) => {
@@ -16621,11 +17149,11 @@
     return [file, ...args.map((a) => /\s/.test(a) ? `"${a}"` : a)].join(" ");
   }
   function detectRepoRoot({ extRoot, fsImpl }) {
-    return findProjectRoot({ extRoot, repoRoot: "", fsImpl: fsImpl || getCepRequire13()("fs") });
+    return findProjectRoot({ extRoot, repoRoot: "", fsImpl: fsImpl || getCepRequire14()("fs") });
   }
   var LOGIN_COMMANDS = { claude: "claude", codex: "codex login" };
   function openLoginTerminal({ tool, spawnImpl } = {}) {
-    const spawn = spawnImpl || getCepRequire13()("child_process").spawn;
+    const spawn = spawnImpl || getCepRequire14()("child_process").spawn;
     const command = LOGIN_COMMANDS[tool] || LOGIN_COMMANDS.claude;
     const child = spawn("cmd", ["/c", "start", "ae-mcp login", "pwsh", "-NoExit", "-Command", command], {
       detached: true,
@@ -16943,7 +17471,7 @@
       }
     };
   }
-  function getCepRequire14() {
+  function getCepRequire15() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16956,7 +17484,7 @@
     function start(port) {
       onStatus("starting", port);
       try {
-        const cepRequire5 = getCepRequire14();
+        const cepRequire5 = getCepRequire15();
         const path = cepRequire5("path");
         const extRoot = normalizeCepPath(cs2.getSystemPath("extension"));
         const hostPath = path.join(extRoot, "host", "server.js");
@@ -17040,7 +17568,7 @@
   }
 
   // src/cep/logExportFs.js
-  function getCepRequire15() {
+  function getCepRequire16() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -17049,7 +17577,7 @@
     throw new Error("CEP Node require is unavailable");
   }
   function writeLogExport({ text, fileName, deps }) {
-    const req = deps ? null : getCepRequire15();
+    const req = deps ? null : getCepRequire16();
     const fs = deps ? deps.fs : req("fs");
     const os = deps ? deps.os : req("os");
     const path = deps ? deps.path : req("path");
@@ -17060,7 +17588,7 @@
     return file;
   }
   function revealInExplorer(filePath, execImpl, onError) {
-    const exec = execImpl || getCepRequire15()("child_process").exec;
+    const exec = execImpl || getCepRequire16()("child_process").exec;
     const winPath = String(filePath).replace(/\//g, "\\");
     exec('explorer.exe /select,"' + winPath + '"', { windowsHide: true }, (err) => {
       if (err && onError) onError(err);
@@ -17261,15 +17789,24 @@
     const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
     const claudeApiProvider = import_react40.default.useMemo(() => {
       const fromStore = providers.find((p) => p.id === claudeProviderId) || null;
-      if (fromStore && fromStore.baseUrl && fromStore.apiKey) return fromStore;
+      if (fromStore && fromStore.protocol === "anthropic" && fromStore.baseUrl && fromStore.apiKey) return fromStore;
       if (apiKey) return { id: "legacy-anthropic", name: "Claude API", protocol: "anthropic", baseUrl: anthropicBaseUrl || "https://api.anthropic.com", apiKey, probedModels: [], probedAt: 0 };
-      return fromStore;
+      return null;
     }, [providers, claudeProviderId, apiKey, anthropicBaseUrl]);
     const codexCustomProvider = import_react40.default.useMemo(() => {
       const fromStore = providers.find((p) => p.id === codexProviderId) || null;
-      if (fromStore && fromStore.baseUrl && fromStore.apiKey) return fromStore;
-      if (codexBaseUrl) return { id: "legacy-codex", name: "Codex custom", protocol: "openai-compatible", baseUrl: codexBaseUrl, apiKey: codexApiKey, probedModels: [], probedAt: 0 };
-      return fromStore;
+      if (fromStore && fromStore.protocol === "openai-compatible" && fromStore.baseUrl && fromStore.apiKey) return fromStore;
+      if (codexBaseUrl) return {
+        id: "legacy-codex",
+        name: "Codex custom",
+        protocol: "openai-compatible",
+        baseUrl: codexBaseUrl,
+        apiKey: codexApiKey,
+        dialect: { wireApi: "chat", authScheme: "bearer", source: "manual", updatedAt: 0 },
+        probedModels: [],
+        probedAt: 0
+      };
+      return null;
     }, [providers, codexProviderId, codexBaseUrl, codexApiKey]);
     const [providerProbing, setProviderProbing] = import_react40.default.useState("");
     const [providerProbeErrors, setProviderProbeErrors] = import_react40.default.useState({});
@@ -17317,9 +17854,12 @@
           const result = await runProviderManagerProbe(p, options);
           setProviderProbing("");
           if (result.ok && providerStore) {
+            const prev = providerStore.get(p.id);
             providerStore.upsert(result.entry);
             setProviders(providerStore.list());
             setProviderProbeErrors((errs) => ({ ...errs, [p.id]: "" }));
+            const dialectChanged = JSON.stringify(prev && prev.dialect) !== JSON.stringify(result.entry.dialect);
+            if (dialectChanged && codexProviderId === p.id) codexBackend.reset();
           } else {
             setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || "Provider probe failed" }));
           }
@@ -17379,9 +17919,17 @@
         codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
         codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl
       };
-      if (codexCustomProvider && codexCustomProvider.dialect) input.codexWireApi = codexCustomProvider.dialect.wireApi;
+      if (codexCustomProvider && codexCustomProvider.protocol === "openai-compatible") {
+        if (codexCustomProvider.dialect && codexCustomProvider.dialect.wireApi) {
+          input.codexWireApi = codexCustomProvider.dialect.wireApi;
+        }
+        if (codexCustomProvider.dialect && codexCustomProvider.dialect.authScheme) {
+          input.codexAuthScheme = codexCustomProvider.dialect.authScheme;
+        }
+      }
       return normalizeProviderProfile(input);
     }, [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
+    const codexDialectKey = codexCustomProvider && codexCustomProvider.dialect ? JSON.stringify(codexCustomProvider.dialect) : "";
     const runtimeRef = import_react40.default.useRef({ apiKey, apiBaseUrl: providerProfile.anthropicBaseUrl, providerProfile, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: "subscription", claudeApiProvider: null, codexCliConfigProvider: null });
     const extRoot = cs2 && cs2.getSystemPath ? cs2.getSystemPath("extension") : "";
     const sidecarPath = import_react40.default.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
@@ -17444,6 +17992,11 @@
     import_react40.default.useEffect(() => () => {
       codexBackend.reset();
     }, [codexBackend]);
+    import_react40.default.useEffect(() => {
+      if (!codexCustomProvider) return void 0;
+      codexBackend.reset();
+      return void 0;
+    }, [codexDialectKey, codexCustomProvider && codexCustomProvider.id]);
     const openCodeBackend = import_react40.default.useMemo(() => createOpenCodeBackend({
       getMcpSpec: () => resolveMcpCommand({ extRoot }),
       getModel: () => runtimeRef.current.model,
@@ -17468,7 +18021,7 @@
       zcodeBackend.reset();
     }, [zcodeBackend]);
     const nodeOk = !(probe && probe.nodeOk === false);
-    const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk });
+    const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk, apiProvider: claudeApiProvider });
     runtimeRef.current = {
       apiKey: claudeApiProvider ? claudeApiProvider.apiKey : apiKey,
       apiBaseUrl: providerProfile.anthropicBaseUrl,

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -11254,8 +11254,9 @@
     const safe = raw.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || DEFAULT_CODEX_PROVIDER_ID;
     return RESERVED_CODEX_PROVIDER_IDS.has(safe) ? safe + "-custom" : safe;
   }
-  function normalizeCodexWireApi() {
-    return DEFAULT_CODEX_WIRE_API;
+  function normalizeCodexWireApi(value) {
+    const text = String(value || "").trim();
+    return text === "responses" || text === "chat" ? text : DEFAULT_CODEX_WIRE_API;
   }
   function tomlString(value) {
     return JSON.stringify(String(value || ""));
@@ -11267,7 +11268,7 @@
       codexApiKey: firstValue(input.codexApiKey, env.AE_MCP_CODEX_API_KEY),
       codexBaseUrl,
       codexProviderId: normalizeProviderId(firstValue(input.codexProviderId, env.AE_MCP_CODEX_PROVIDER_ID)),
-      codexWireApi: normalizeCodexWireApi(),
+      codexWireApi: normalizeCodexWireApi(firstValue(input.codexWireApi, env.AE_MCP_CODEX_WIRE_API)),
       anthropicBaseUrl
     };
   }
@@ -12368,6 +12369,9 @@
   function zcodeProtocolApiFormat(provider, kind) {
     const direct = provider && (provider.apiFormat || provider.api_format);
     if (direct) return direct;
+    const dialect = provider && provider.dialect && typeof provider.dialect === "object" ? provider.dialect : null;
+    if (kind === "openai-compatible" && dialect && dialect.wireApi === "responses") return "openai-responses";
+    if (kind === "openai-compatible" && dialect && dialect.wireApi === "chat") return "openai-chat-completions";
     if (kind === "openai") return "openai-responses";
     if (kind === "openai-compatible") return "openai-chat-completions";
     return "anthropic-messages";
@@ -15361,6 +15365,9 @@
 
   // src/cep/providerStore.js
   var PROTOCOLS = /* @__PURE__ */ new Set(["anthropic", "openai-compatible"]);
+  var DIALECT_WIRE_APIS = /* @__PURE__ */ new Set(["responses", "chat"]);
+  var DIALECT_AUTH_SCHEMES = /* @__PURE__ */ new Set(["bearer", "x-api-key", "none"]);
+  var DIALECT_SOURCES = /* @__PURE__ */ new Set(["ccswitch-import", "detected", "manual"]);
   var FILE_NAME = "providers.json";
   function cepRequire3() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) return globalThis.window.cep_node.require;
@@ -15383,7 +15390,7 @@
     if (!id) throw new Error("Provider entry needs an id");
     const protocol = String(input.protocol || "openai-compatible");
     if (!PROTOCOLS.has(protocol)) throw new Error("Unsupported provider protocol: " + protocol);
-    return {
+    const entry = {
       id,
       name: String(input.name || "").trim() || id,
       protocol,
@@ -15392,6 +15399,19 @@
       probedModels: Array.isArray(input.probedModels) ? input.probedModels : [],
       probedAt: Number(input.probedAt) || 0
     };
+    const dialect = input.dialect && typeof input.dialect === "object" ? input.dialect : null;
+    const wireApi = dialect ? String(dialect.wireApi || "").trim() : "";
+    const authScheme = dialect ? String(dialect.authScheme || "").trim() : "";
+    if (DIALECT_WIRE_APIS.has(wireApi) && DIALECT_AUTH_SCHEMES.has(authScheme)) {
+      const source = String(dialect.source || "").trim();
+      entry.dialect = {
+        wireApi,
+        authScheme,
+        source: DIALECT_SOURCES.has(source) ? source : "manual",
+        updatedAt: typeof dialect.updatedAt === "number" && Number.isFinite(dialect.updatedAt) ? dialect.updatedAt : 0
+      };
+    }
+    return entry;
   }
   function createProviderStore(deps = defaultDeps2()) {
     const { fs, os, path } = deps;
@@ -15508,11 +15528,29 @@
     return { id, name, protocol: draft.protocol, baseUrl: draft.baseUrl, apiKey: draft.apiKey };
   }
 
+  // src/lib/providerDialectBadge.js
+  var DEFAULT_DIALECT_SOURCE_LABELS = {
+    "ccswitch-import": { zh: "\u6765\u81EA cc-switch", en: "from cc-switch" },
+    detected: { zh: "\u81EA\u52A8\u68C0\u6D4B", en: "auto-detected" },
+    manual: { zh: "\u624B\u52A8\u8BBE\u7F6E", en: "manual" }
+  };
+  function providerDialectBadge(dialect, lang = "zh", sourceLabels = DEFAULT_DIALECT_SOURCE_LABELS) {
+    if (!dialect || typeof dialect !== "object") return null;
+    const wireApi = String(dialect.wireApi || "").trim();
+    const authScheme = String(dialect.authScheme || "").trim();
+    if (!wireApi || !authScheme) return null;
+    const source = sourceLabels[dialect.source] || sourceLabels.manual || DEFAULT_DIALECT_SOURCE_LABELS.manual;
+    return {
+      label: wireApi + " \xB7 " + authScheme,
+      title: source[lang] || source.zh || source.en || ""
+    };
+  }
+
   // src/components/settings/ProviderManagerSection.jsx
   var import_jsx_runtime35 = __toESM(require_jsx_runtime(), 1);
   var L2 = {
-    zh: { title: "Provider \u7BA1\u7406", add: "\u65B0\u589E", edit: "\u7F16\u8F91", del: "\u5220\u9664", probe: "\u63A2\u6D4B\u6A21\u578B", probing: "\u63A2\u6D4B\u4E2D\u2026", save: "\u4FDD\u5B58", cancel: "\u53D6\u6D88", name: "\u540D\u79F0", protocol: "\u534F\u8BAE", baseUrl: "Base URL", apiKey: "API Key", keyCap: "\u4EC5\u4FDD\u5B58\u5728\u672C\u673A ~/.ae-mcp/providers.json", models: (n) => `${n} \u4E2A\u6A21\u578B`, probeFailed: "\u63A2\u6D4B\u5931\u8D25\uFF08\u53EF\u624B\u586B\u6A21\u578B ID \u7EE7\u7EED\u4F7F\u7528\uFF09\uFF1A", importCc: "\u4ECE cc-switch \u5BFC\u5165" },
-    en: { title: "Provider manager", add: "Add", edit: "Edit", del: "Delete", probe: "Probe models", probing: "Probing\u2026", save: "Save", cancel: "Cancel", name: "Name", protocol: "Protocol", baseUrl: "Base URL", apiKey: "API Key", keyCap: "Stored locally in ~/.ae-mcp/providers.json", models: (n) => `${n} models`, probeFailed: "Probe failed (manual model id still works): ", importCc: "Import from cc-switch" }
+    zh: { title: "Provider \u7BA1\u7406", add: "\u65B0\u589E", edit: "\u7F16\u8F91", del: "\u5220\u9664", probe: "\u63A2\u6D4B\u6A21\u578B", redetect: "\u91CD\u65B0\u68C0\u6D4B", probing: "\u63A2\u6D4B\u4E2D\u2026", save: "\u4FDD\u5B58", cancel: "\u53D6\u6D88", name: "\u540D\u79F0", protocol: "\u534F\u8BAE", baseUrl: "Base URL", apiKey: "API Key", keyCap: "\u4EC5\u4FDD\u5B58\u5728\u672C\u673A ~/.ae-mcp/providers.json", models: (n) => `${n} \u4E2A\u6A21\u578B`, probeFailed: "\u63A2\u6D4B\u5931\u8D25\uFF08\u53EF\u624B\u586B\u6A21\u578B ID \u7EE7\u7EED\u4F7F\u7528\uFF09\uFF1A", importCc: "\u4ECE cc-switch \u5BFC\u5165", dialectSource: { "ccswitch-import": { zh: "\u6765\u81EA cc-switch" }, detected: { zh: "\u81EA\u52A8\u68C0\u6D4B" }, manual: { zh: "\u624B\u52A8\u8BBE\u7F6E" } } },
+    en: { title: "Provider manager", add: "Add", edit: "Edit", del: "Delete", probe: "Probe models", redetect: "Re-detect", probing: "Probing\u2026", save: "Save", cancel: "Cancel", name: "Name", protocol: "Protocol", baseUrl: "Base URL", apiKey: "API Key", keyCap: "Stored locally in ~/.ae-mcp/providers.json", models: (n) => `${n} models`, probeFailed: "Probe failed (manual model id still works): ", importCc: "Import from cc-switch", dialectSource: { "ccswitch-import": { en: "from cc-switch" }, detected: { en: "auto-detected" }, manual: { en: "manual" } } }
   };
   function ProviderManagerSection({ lang = "zh", providers = [], onUpsert, onRemove, onProbe, probing = "", probeErrors = {}, ccSwitch = null, onImportCcSwitch }) {
     const t = L2[lang] || L2.zh;
@@ -15538,24 +15576,29 @@
       ] }),
       /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
         ccSwitch && onImportCcSwitch ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "secondary", size: "sm", icon: "download", onClick: onImportCcSwitch, children: t.importCc }) : null,
-        providers.map((p) => /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4, padding: "6px 8px", border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { style: { flex: 1, minWidth: 0, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: p.name }),
-            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Badge, { status: "neutral", children: p.protocol }),
-            p.probedModels.length ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Badge, { status: "ok", children: t.models(p.probedModels.length) }) : null,
-            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", disabled: probing === p.id, onClick: () => onProbe(p), children: probing === p.id ? t.probing : t.probe }),
-            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
-              setDraft(draftFromEntry(p));
-              setError("");
-            }, children: t.edit }),
-            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => onRemove(p.id), children: t.del })
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: p.baseUrl }),
-          probeErrors[p.id] ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: [
-            t.probeFailed,
-            probeErrors[p.id]
-          ] }) : null
-        ] }, p.id)),
+        providers.map((p) => {
+          const dialectBadge = providerDialectBadge(p.dialect, lang, t.dialectSource);
+          return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4, padding: "6px 8px", border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { style: { flex: 1, minWidth: 0, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: p.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Badge, { status: "neutral", children: p.protocol }),
+              dialectBadge ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { title: dialectBadge.title, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Badge, { status: "neutral", children: dialectBadge.label }) }) : null,
+              p.probedModels.length ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Badge, { status: "ok", children: t.models(p.probedModels.length) }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", disabled: probing === p.id, onClick: () => onProbe(p), children: probing === p.id ? t.probing : t.probe }),
+              p.dialect ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", disabled: probing === p.id, onClick: () => onProbe(p, { forceDetect: true }), children: probing === p.id ? t.probing : t.redetect }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
+                setDraft(draftFromEntry(p));
+                setError("");
+              }, children: t.edit }),
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => onRemove(p.id), children: t.del })
+            ] }),
+            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: p.baseUrl }),
+            probeErrors[p.id] ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: [
+              t.probeFailed,
+              probeErrors[p.id]
+            ] }) : null
+          ] }, p.id);
+        }),
         draft ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px", border: "1px solid var(--border-strong)", borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Field, { label: t.name, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Input, { value: draft.name, onChange: (v) => setDraft({ ...draft, name: v }) }) }),
           /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Field, { label: t.protocol, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Select, { value: draft.protocol, onChange: (v) => setDraft({ ...draft, protocol: v }), options: [
@@ -15586,10 +15629,18 @@
     if (globalThis.require) return globalThis.require;
     throw new Error("CEP Node require is unavailable");
   }
-  function probeHeaders(protocol, apiKey) {
+  function authSchemeFromDialect(dialect) {
+    if (!dialect) return "";
+    if (typeof dialect === "string") return dialect;
+    return String(dialect.authScheme || "").trim();
+  }
+  function probeHeaders(protocol, apiKey, dialect) {
     if (protocol === "anthropic") {
       return { "x-api-key": String(apiKey || ""), "anthropic-version": "2023-06-01" };
     }
+    const authScheme = authSchemeFromDialect(dialect);
+    if (authScheme === "x-api-key") return { "x-api-key": String(apiKey || "") };
+    if (authScheme === "none") return {};
     return { Authorization: "Bearer " + String(apiKey || "") };
   }
   function parseModelsList(json) {
@@ -15600,7 +15651,7 @@
       return { id: String(id), label: String(m.display_name || m.displayName || id) };
     }).filter(Boolean);
   }
-  function probeProviderModels({ baseUrl, apiKey, protocol = "openai-compatible", httpsImpl, timeoutMs = 8e3 } = {}) {
+  function probeProviderModels({ baseUrl, apiKey, protocol = "openai-compatible", dialect, authScheme, httpsImpl, timeoutMs = 8e3 } = {}) {
     let endpoint;
     try {
       const root = String(baseUrl || "").replace(/\/+$/, "").replace(/\/v1$/, "");
@@ -15621,7 +15672,7 @@
         protocol: endpoint.protocol,
         path: endpoint.pathname + endpoint.search,
         method: "GET",
-        headers: probeHeaders(protocol, apiKey)
+        headers: probeHeaders(protocol, apiKey, dialect || authScheme)
       }, (res) => {
         let body = "";
         res.on("data", (chunk) => {
@@ -15652,9 +15703,302 @@
     });
   }
 
+  // src/cep/providerDetect.js
+  function getCepRequire8() {
+    if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+      return globalThis.window.cep_node.require;
+    }
+    if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+    if (globalThis.require) return globalThis.require;
+    throw new Error("CEP Node require is unavailable");
+  }
+  function normalizeRoot(baseUrl) {
+    return String(baseUrl || "").replace(/\/+$/, "").replace(/\/v1$/, "");
+  }
+  function authHeaders(authScheme, apiKey) {
+    if (authScheme === "bearer") return { Authorization: "Bearer " + String(apiKey || "") };
+    if (authScheme === "x-api-key") return { "x-api-key": String(apiKey || "") };
+    return {};
+  }
+  function authCandidates(apiKey) {
+    return String(apiKey || "") ? ["bearer", "x-api-key", "none"] : ["none"];
+  }
+  function safeDetail(message) {
+    return String(message || "request failed");
+  }
+  function parseJson(value) {
+    try {
+      return { ok: true, value: JSON.parse(value || "") };
+    } catch (e) {
+      return { ok: false, value: null };
+    }
+  }
+  function isJsonErrorObject(body) {
+    const parsed = parseJson(body);
+    return parsed.ok && parsed.value && typeof parsed.value === "object" && parsed.value.error && typeof parsed.value.error === "object" && !Array.isArray(parsed.value.error);
+  }
+  function requestProvider({ url, method, headers, body, httpsImpl, timeoutMs }) {
+    return new Promise((resolve) => {
+      let endpoint;
+      try {
+        endpoint = new URL(url);
+      } catch (e) {
+        resolve({ ok: false, network: true, status: 0, body: "", detail: "Invalid base URL" });
+        return;
+      }
+      let https;
+      try {
+        https = httpsImpl || getCepRequire8()(endpoint.protocol === "http:" ? "http" : "https");
+      } catch (e) {
+        resolve({ ok: false, network: true, status: 0, body: "", detail: safeDetail(e.message) });
+        return;
+      }
+      const payload = body === void 0 ? null : JSON.stringify(body);
+      const reqHeaders = Object.assign({}, headers || {});
+      if (payload !== null) {
+        reqHeaders["Content-Type"] = "application/json";
+      }
+      let settled = false;
+      function finish(result) {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      }
+      const req = https.request({
+        hostname: endpoint.hostname,
+        port: endpoint.port || void 0,
+        protocol: endpoint.protocol,
+        path: endpoint.pathname + endpoint.search,
+        method,
+        headers: reqHeaders
+      }, (res) => {
+        let responseBody = "";
+        res.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        res.on("end", () => finish({
+          ok: true,
+          network: false,
+          status: res.statusCode || 0,
+          body: responseBody,
+          detail: ""
+        }));
+      });
+      req.on("error", (err) => finish({
+        ok: false,
+        network: true,
+        status: 0,
+        body: "",
+        detail: err && err.message ? err.message : "request failed"
+      }));
+      if (req.setTimeout) {
+        req.setTimeout(timeoutMs, () => {
+          try {
+            req.destroy();
+          } catch (e) {
+          }
+          finish({ ok: false, network: true, status: 0, body: "", detail: "timeout" });
+        });
+      }
+      if (payload !== null && req.write) req.write(payload);
+      req.end();
+    });
+  }
+  async function detectAuth({ root, apiKey, httpsImpl, timeoutMs, tried }) {
+    let saw200WithoutModels = false;
+    let sawNonAuthStatus = false;
+    for (const candidate of authCandidates(apiKey)) {
+      const result = await requestProvider({
+        url: root + "/v1/models",
+        method: "GET",
+        headers: authHeaders(candidate, apiKey),
+        httpsImpl,
+        timeoutMs
+      });
+      if (result.network) {
+        tried.push({ step: "auth", candidate, status: 0, outcome: "network" });
+        return { ok: false, reason: "network", detail: "Network error while probing provider models" };
+      }
+      if (result.status === 200) {
+        const parsed = parseJson(result.body);
+        const models = parsed.ok ? parseModelsList(parsed.value) : [];
+        if (models.length) {
+          tried.push({ step: "auth", candidate, status: 200, outcome: "accepted" });
+          return { ok: true, authScheme: candidate, models };
+        }
+        saw200WithoutModels = true;
+        tried.push({ step: "auth", candidate, status: 200, outcome: "no-models" });
+      } else if (result.status === 401 || result.status === 403) {
+        tried.push({ step: "auth", candidate, status: result.status, outcome: "rejected" });
+      } else {
+        sawNonAuthStatus = true;
+        tried.push({ step: "auth", candidate, status: result.status, outcome: "rejected" });
+      }
+    }
+    if (saw200WithoutModels) {
+      return { ok: false, reason: "no-models", detail: "Provider model endpoint did not return a usable model list" };
+    }
+    return {
+      ok: false,
+      reason: "auth",
+      detail: sawNonAuthStatus ? "No authentication scheme returned a usable provider model list" : "Provider rejected all applicable authentication schemes"
+    };
+  }
+  function wireRequest(wireApi, model) {
+    if (wireApi === "responses") {
+      return {
+        path: "/v1/responses",
+        body: { model, input: "ping", max_output_tokens: 16, stream: false }
+      };
+    }
+    return {
+      path: "/v1/chat/completions",
+      body: { model, messages: [{ role: "user", content: "ping" }], max_tokens: 16, stream: false }
+    };
+  }
+  async function detectWire({ root, apiKey, authScheme, model, httpsImpl, timeoutMs, tried }) {
+    for (const candidate of ["responses", "chat"]) {
+      const wire = wireRequest(candidate, model);
+      const result = await requestProvider({
+        url: root + wire.path,
+        method: "POST",
+        headers: authHeaders(authScheme, apiKey),
+        body: wire.body,
+        httpsImpl,
+        timeoutMs
+      });
+      if (result.network) {
+        tried.push({ step: "wire", candidate, status: 0, outcome: "network" });
+        return { ok: false, reason: "network", detail: "Network error while probing provider wire API" };
+      }
+      if (result.status === 200 || result.status === 400 && isJsonErrorObject(result.body)) {
+        tried.push({ step: "wire", candidate, status: result.status, outcome: "accepted" });
+        return { ok: true, wireApi: candidate };
+      }
+      if (result.status === 401 || result.status === 403) {
+        tried.push({ step: "wire", candidate, status: result.status, outcome: "auth-mismatch" });
+        return { ok: false, reason: "auth-mismatch", detail: "Provider wire API rejected the authentication scheme accepted by the model endpoint" };
+      }
+      tried.push({ step: "wire", candidate, status: result.status, outcome: "rejected" });
+    }
+    return { ok: false, reason: "wire-undetected", detail: "Provider did not accept the supported Responses or Chat wire APIs" };
+  }
+  async function detectProviderDialect({
+    baseUrl,
+    apiKey,
+    protocol = "openai-compatible",
+    httpsImpl,
+    timeoutMs = 8e3,
+    now = Date.now
+  } = {}) {
+    const tried = [];
+    try {
+      if (protocol === "anthropic") {
+        return { ok: false, reason: "not-applicable", tried, detail: "Anthropic providers use a fixed dialect and do not need detection" };
+      }
+      let root;
+      try {
+        root = normalizeRoot(baseUrl);
+        new URL(root + "/v1/models");
+      } catch (e) {
+        return { ok: false, reason: "network", tried, detail: "Invalid base URL" };
+      }
+      const auth = await detectAuth({ root, apiKey, httpsImpl, timeoutMs, tried });
+      if (!auth.ok) return Object.assign({ tried }, auth);
+      const model = auth.models[0] && auth.models[0].id;
+      if (!model) {
+        return { ok: false, reason: "no-models", tried, detail: "Provider model endpoint did not return a usable model list" };
+      }
+      const wire = await detectWire({ root, apiKey, authScheme: auth.authScheme, model, httpsImpl, timeoutMs, tried });
+      if (!wire.ok) return Object.assign({ tried }, wire);
+      return {
+        ok: true,
+        dialect: {
+          wireApi: wire.wireApi,
+          authScheme: auth.authScheme,
+          source: "detected",
+          updatedAt: now()
+        },
+        models: auth.models,
+        tried
+      };
+    } catch (e) {
+      return { ok: false, reason: "network", tried, detail: safeDetail(e && e.message ? e.message : "Provider detection failed") };
+    }
+  }
+
+  // src/app/providerProbeFlow.js
+  function isAuthFailure(result) {
+    return result && (result.status === 401 || result.status === 403);
+  }
+  function detectionDetail(result) {
+    if (!result) return "";
+    const reason = result.reason ? String(result.reason) : "failed";
+    const detail = result.detail ? ": " + String(result.detail) : "";
+    return "dialect detection " + reason + detail;
+  }
+  function probeFailureDetail(result, detectResult) {
+    const primary = result && result.detail ? String(result.detail) : "HTTP " + (result && result.status ? result.status : 0);
+    const detected = detectionDetail(detectResult);
+    return detected ? primary + " (" + detected + ")" : primary;
+  }
+  function probedEntry(provider, result, now) {
+    return {
+      ...provider,
+      probedModels: result.models || [],
+      probedAt: now()
+    };
+  }
+  function detectedEntry(provider, result, now) {
+    return {
+      ...provider,
+      dialect: result.dialect,
+      probedModels: result.models || [],
+      probedAt: now()
+    };
+  }
+  async function runProviderManagerProbe(provider, {
+    probeProviderModelsImpl = probeProviderModels,
+    detectProviderDialectImpl = detectProviderDialect,
+    now = Date.now,
+    forceDetect = false
+  } = {}) {
+    const p = provider || {};
+    const canDetect = p.protocol === "openai-compatible";
+    if (forceDetect && canDetect) {
+      const detectResult2 = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+      if (detectResult2.ok) return { ok: true, entry: detectedEntry(p, detectResult2, now), result: detectResult2 };
+      const result2 = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, dialect: p.dialect });
+      if (result2.ok) return { ok: true, entry: probedEntry(p, result2, now), result: result2, detectResult: detectResult2 };
+      return { ok: false, detail: probeFailureDetail(result2, detectResult2), result: result2, detectResult: detectResult2 };
+    }
+    if (p.dialect) {
+      const result2 = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, dialect: p.dialect });
+      if (result2.ok) return { ok: true, entry: probedEntry(p, result2, now), result: result2 };
+      if (canDetect && isAuthFailure(result2)) {
+        const detected = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+        if (detected.ok) return { ok: true, entry: detectedEntry(p, detected, now), result: detected };
+        return { ok: false, detail: probeFailureDetail(result2, detected), result: result2, detectResult: detected };
+      }
+      return { ok: false, detail: probeFailureDetail(result2), result: result2 };
+    }
+    let detectResult = null;
+    if (canDetect) {
+      detectResult = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+      if (detectResult.ok) return { ok: true, entry: detectedEntry(p, detectResult, now), result: detectResult };
+    }
+    const result = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol });
+    if (result.ok) return { ok: true, entry: probedEntry(p, result, now), result };
+    return { ok: false, detail: probeFailureDetail(result, detectResult), result, detectResult };
+  }
+
   // src/cep/ccSwitch.js
   var CONFIG_NAMES = ["config.json", "providers.json"];
-  function getCepRequire8() {
+  var API_FORMAT_TO_WIRE_API = {
+    openai_responses: "responses",
+    openai_chat: "chat"
+  };
+  function getCepRequire9() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -15680,7 +16024,49 @@
     if (parsed.providers && typeof parsed.providers === "object") return Object.values(parsed.providers);
     return [];
   }
-  function ccSwitchProviderEntries(list) {
+  function objectValue(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  }
+  function hasOwn(obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+  }
+  function wireApiFromApiFormat(value) {
+    return API_FORMAT_TO_WIRE_API[String(value || "").trim().toLowerCase()] || "";
+  }
+  function wireApiFromConfig(config) {
+    if (typeof config !== "string") return "";
+    const match = config.match(/(?:^|\n)\s*wire_api\s*=\s*["'](responses|chat)["']/i);
+    return match ? match[1].toLowerCase() : "";
+  }
+  function inferWireApi(p, settingsConfig) {
+    const meta = objectValue(p.meta);
+    return wireApiFromApiFormat(meta.apiFormat || meta.api_format) || wireApiFromApiFormat(p.apiFormat || p.api_format) || wireApiFromConfig(settingsConfig.config);
+  }
+  function authSchemeFromApiKeyField(value) {
+    const field = String(value || "").trim();
+    if (field === "ANTHROPIC_API_KEY") return "x-api-key";
+    if (/x[-_]?api[-_]?key/i.test(field)) return "x-api-key";
+    return "";
+  }
+  function inferAuthScheme(p, settingsConfig) {
+    const meta = objectValue(p.meta);
+    const fromApiKeyField = authSchemeFromApiKeyField(meta.apiKeyField || meta.api_key_field);
+    if (fromApiKeyField) return fromApiKeyField;
+    const env = objectValue(settingsConfig.env);
+    const auth = objectValue(settingsConfig.auth);
+    if (hasOwn(env, "ANTHROPIC_AUTH_TOKEN")) return "bearer";
+    if (hasOwn(env, "ANTHROPIC_API_KEY")) return "x-api-key";
+    if (hasOwn(auth, "OPENAI_API_KEY") || hasOwn(env, "OPENAI_API_KEY")) return "bearer";
+    return "";
+  }
+  function inferDialect(p, now) {
+    const settingsConfig = objectValue(p.settingsConfig || p.settings_config);
+    const wireApi = inferWireApi(p, settingsConfig);
+    const authScheme = inferAuthScheme(p, settingsConfig);
+    if (!wireApi || !authScheme) return null;
+    return { wireApi, authScheme, source: "ccswitch-import", updatedAt: now() };
+  }
+  function ccSwitchProviderEntries(list, { now = Date.now } = {}) {
     return (Array.isArray(list) ? list : []).map((p) => {
       if (!p || typeof p !== "object") return null;
       const name = String(p.name || p.title || p.id || "").trim();
@@ -15688,13 +16074,16 @@
       const apiKey = String(p.apiKey || p.api_key || p.key || p.token || "").trim();
       if (!name || !baseUrl) return null;
       const protocol = /anthropic/i.test(String(p.type || p.protocol || p.kind || "")) ? "anthropic" : "openai-compatible";
-      return { id: "ccswitch-" + name.replace(/[^A-Za-z0-9_-]+/g, "-").toLowerCase(), name, protocol, baseUrl, apiKey };
+      const entry = { id: "ccswitch-" + name.replace(/[^A-Za-z0-9_-]+/g, "-").toLowerCase(), name, protocol, baseUrl, apiKey };
+      const dialect = inferDialect(p, now);
+      if (dialect) entry.dialect = dialect;
+      return entry;
     }).filter(Boolean);
   }
   function detectCcSwitch({ env = {}, fsImpl } = {}) {
     let fs;
     try {
-      fs = fsImpl || getCepRequire8()("fs");
+      fs = fsImpl || getCepRequire9()("fs");
     } catch (e) {
       return null;
     }
@@ -15714,7 +16103,7 @@
   }
 
   // src/cep/claudeSettingsImport.js
-  function getCepRequire9() {
+  function getCepRequire10() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -15727,7 +16116,7 @@
     if (!home) return null;
     let fs;
     try {
-      fs = fsImpl || getCepRequire9()("fs");
+      fs = fsImpl || getCepRequire10()("fs");
     } catch (e) {
       return null;
     }
@@ -15745,7 +16134,7 @@
   }
 
   // src/cep/codexConfig.js
-  function getCepRequire10() {
+  function getCepRequire11() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -15800,7 +16189,7 @@
     if (!home) return null;
     let fs;
     try {
-      fs = fsImpl || getCepRequire10()("fs");
+      fs = fsImpl || getCepRequire11()("fs");
     } catch (e) {
       return null;
     }
@@ -16025,7 +16414,7 @@
   // src/cep/modelsApi.js
   var CACHE_KEY = "ae_mcp_byok_models";
   var TTL_MS = 24 * 60 * 60 * 1e3;
-  function getCepRequire11() {
+  function getCepRequire12() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16034,7 +16423,7 @@
     throw new Error("CEP Node require is unavailable");
   }
   function fetchAnthropicModels({ apiKey, baseUrl = "", httpsImpl, timeoutMs = 8e3 } = {}) {
-    const https = httpsImpl || getCepRequire11()("https");
+    const https = httpsImpl || getCepRequire12()("https");
     return new Promise((resolve) => {
       let endpoint;
       try {
@@ -16150,7 +16539,7 @@
 
   // src/cep/wizardActions.js
   var OUTPUT_TAIL = 8192;
-  function getCepRequire12() {
+  function getCepRequire13() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16175,7 +16564,7 @@
     return globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.process && globalThis.window.cep_node.process.env || {};
   }
   async function detectAeMcp({ execFileImpl, env, fsImpl }) {
-    const execFile = execFileImpl || getCepRequire12()("child_process").execFile;
+    const execFile = execFileImpl || getCepRequire13()("child_process").execFile;
     const whereHit = await new Promise((resolve) => {
       execFile("where", ["ae-mcp"], { windowsHide: true, env }, (err, stdout) => {
         resolve(err ? "" : String(stdout || "").split(/\r?\n/).map((l) => l.trim()).find(Boolean) || "");
@@ -16185,7 +16574,7 @@
     const profile = (env || getCepEnvSafe()).USERPROFILE || "";
     if (profile) {
       const shim = profile.replace(/[\\/]+$/, "") + "\\.local\\bin\\ae-mcp.exe";
-      const fs = fsImpl || getCepRequire12()("fs");
+      const fs = fsImpl || getCepRequire13()("fs");
       if (fs.existsSync(shim)) return { ok: true, version: shim };
     }
     return { ok: false };
@@ -16193,7 +16582,7 @@
   async function detectTool(id, { execFileImpl, env, fsImpl } = {}) {
     if (id === "aeMcp") return detectAeMcp({ execFileImpl, env, fsImpl });
     const spec = DETECT[id];
-    const execFile = execFileImpl || getCepRequire12()("child_process").execFile;
+    const execFile = execFileImpl || getCepRequire13()("child_process").execFile;
     return execVersion(execFile, spec.file, spec.args, env, spec.shell);
   }
   var REPO = "https://github.com/JUNKDOGE-JOE/after-effects-mcp";
@@ -16208,7 +16597,7 @@
     };
   }
   function runAction({ file, args, spawnImpl, env, onChunk }) {
-    const spawn = spawnImpl || getCepRequire12()("child_process").spawn;
+    const spawn = spawnImpl || getCepRequire13()("child_process").spawn;
     return new Promise((resolve) => {
       let output = "";
       const push = (chunk) => {
@@ -16232,11 +16621,11 @@
     return [file, ...args.map((a) => /\s/.test(a) ? `"${a}"` : a)].join(" ");
   }
   function detectRepoRoot({ extRoot, fsImpl }) {
-    return findProjectRoot({ extRoot, repoRoot: "", fsImpl: fsImpl || getCepRequire12()("fs") });
+    return findProjectRoot({ extRoot, repoRoot: "", fsImpl: fsImpl || getCepRequire13()("fs") });
   }
   var LOGIN_COMMANDS = { claude: "claude", codex: "codex login" };
   function openLoginTerminal({ tool, spawnImpl } = {}) {
-    const spawn = spawnImpl || getCepRequire12()("child_process").spawn;
+    const spawn = spawnImpl || getCepRequire13()("child_process").spawn;
     const command = LOGIN_COMMANDS[tool] || LOGIN_COMMANDS.claude;
     const child = spawn("cmd", ["/c", "start", "ae-mcp login", "pwsh", "-NoExit", "-Command", command], {
       detached: true,
@@ -16554,7 +16943,7 @@
       }
     };
   }
-  function getCepRequire13() {
+  function getCepRequire14() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16567,7 +16956,7 @@
     function start(port) {
       onStatus("starting", port);
       try {
-        const cepRequire5 = getCepRequire13();
+        const cepRequire5 = getCepRequire14();
         const path = cepRequire5("path");
         const extRoot = normalizeCepPath(cs2.getSystemPath("extension"));
         const hostPath = path.join(extRoot, "host", "server.js");
@@ -16651,7 +17040,7 @@
   }
 
   // src/cep/logExportFs.js
-  function getCepRequire14() {
+  function getCepRequire15() {
     if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
       return globalThis.window.cep_node.require;
     }
@@ -16660,7 +17049,7 @@
     throw new Error("CEP Node require is unavailable");
   }
   function writeLogExport({ text, fileName, deps }) {
-    const req = deps ? null : getCepRequire14();
+    const req = deps ? null : getCepRequire15();
     const fs = deps ? deps.fs : req("fs");
     const os = deps ? deps.os : req("os");
     const path = deps ? deps.path : req("path");
@@ -16671,7 +17060,7 @@
     return file;
   }
   function revealInExplorer(filePath, execImpl, onError) {
-    const exec = execImpl || getCepRequire14()("child_process").exec;
+    const exec = execImpl || getCepRequire15()("child_process").exec;
     const winPath = String(filePath).replace(/\//g, "\\");
     exec('explorer.exe /select,"' + winPath + '"', { windowsHide: true }, (err) => {
       if (err && onError) onError(err);
@@ -16923,16 +17312,16 @@
             writePref("ae_mcp_codex_provider", "");
           }
         },
-        onProbe: async (p) => {
+        onProbe: async (p, options = {}) => {
           setProviderProbing(p.id);
-          const result = await probeProviderModels({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol });
+          const result = await runProviderManagerProbe(p, options);
           setProviderProbing("");
           if (result.ok && providerStore) {
-            providerStore.upsert({ ...p, probedModels: result.models, probedAt: Date.now() });
+            providerStore.upsert(result.entry);
             setProviders(providerStore.list());
             setProviderProbeErrors((errs) => ({ ...errs, [p.id]: "" }));
           } else {
-            setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || "HTTP " + result.status }));
+            setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || "Provider probe failed" }));
           }
         }
       }
@@ -16984,11 +17373,15 @@
         return null;
       }
     }, []);
-    const providerProfile = import_react40.default.useMemo(() => normalizeProviderProfile({
-      anthropicBaseUrl: claudeApiProvider ? claudeApiProvider.baseUrl : anthropicBaseUrl,
-      codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
-      codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl
-    }), [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
+    const providerProfile = import_react40.default.useMemo(() => {
+      const input = {
+        anthropicBaseUrl: claudeApiProvider ? claudeApiProvider.baseUrl : anthropicBaseUrl,
+        codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
+        codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl
+      };
+      if (codexCustomProvider && codexCustomProvider.dialect) input.codexWireApi = codexCustomProvider.dialect.wireApi;
+      return normalizeProviderProfile(input);
+    }, [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
     const runtimeRef = import_react40.default.useRef({ apiKey, apiBaseUrl: providerProfile.anthropicBaseUrl, providerProfile, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: "subscription", claudeApiProvider: null, codexCliConfigProvider: null });
     const extRoot = cs2 && cs2.getSystemPath ? cs2.getSystemPath("extension") : "";
     const sidecarPath = import_react40.default.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -267,15 +267,24 @@ function Shell({ cs }) {
   const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
   const claudeApiProvider = React.useMemo(() => {
     const fromStore = providers.find((p) => p.id === claudeProviderId) || null;
-    if (fromStore && fromStore.baseUrl && fromStore.apiKey) return fromStore;
+    if (fromStore && fromStore.protocol === 'anthropic' && fromStore.baseUrl && fromStore.apiKey) return fromStore;
     if (apiKey) return { id: 'legacy-anthropic', name: 'Claude API', protocol: 'anthropic', baseUrl: anthropicBaseUrl || 'https://api.anthropic.com', apiKey, probedModels: [], probedAt: 0 };
-    return fromStore;
+    return null;
   }, [providers, claudeProviderId, apiKey, anthropicBaseUrl]);
   const codexCustomProvider = React.useMemo(() => {
     const fromStore = providers.find((p) => p.id === codexProviderId) || null;
-    if (fromStore && fromStore.baseUrl && fromStore.apiKey) return fromStore;
-    if (codexBaseUrl) return { id: 'legacy-codex', name: 'Codex custom', protocol: 'openai-compatible', baseUrl: codexBaseUrl, apiKey: codexApiKey, probedModels: [], probedAt: 0 };
-    return fromStore;
+    if (fromStore && fromStore.protocol === 'openai-compatible' && fromStore.baseUrl && fromStore.apiKey) return fromStore;
+    if (codexBaseUrl) return {
+      id: 'legacy-codex',
+      name: 'Codex custom',
+      protocol: 'openai-compatible',
+      baseUrl: codexBaseUrl,
+      apiKey: codexApiKey,
+      dialect: { wireApi: 'chat', authScheme: 'bearer', source: 'manual', updatedAt: 0 },
+      probedModels: [],
+      probedAt: 0,
+    };
+    return null;
   }, [providers, codexProviderId, codexBaseUrl, codexApiKey]);
 
   const [providerProbing, setProviderProbing] = React.useState('');
@@ -313,9 +322,14 @@ function Shell({ cs }) {
         const result = await runProviderManagerProbe(p, options);
         setProviderProbing('');
         if (result.ok && providerStore) {
+          const prev = providerStore.get(p.id);
           providerStore.upsert(result.entry);
           setProviders(providerStore.list());
           setProviderProbeErrors((errs) => ({ ...errs, [p.id]: '' }));
+          // Dialect/auth changes must rebuild Codex app-server; an already-running
+          // process still points at the old upstream wire API.
+          const dialectChanged = JSON.stringify(prev && prev.dialect) !== JSON.stringify(result.entry.dialect);
+          if (dialectChanged && codexProviderId === p.id) codexBackend.reset();
         } else {
           setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || 'Provider probe failed' }));
         }
@@ -356,9 +370,22 @@ function Shell({ cs }) {
       codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
       codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl,
     };
-    if (codexCustomProvider && codexCustomProvider.dialect) input.codexWireApi = codexCustomProvider.dialect.wireApi;
+    if (codexCustomProvider && codexCustomProvider.protocol === 'openai-compatible') {
+      // Only route when dialect says chat. Missing dialect stays on Codex's
+      // native responses path until Provider Manager probe writes a dialect.
+      if (codexCustomProvider.dialect && codexCustomProvider.dialect.wireApi) {
+        input.codexWireApi = codexCustomProvider.dialect.wireApi;
+      }
+      if (codexCustomProvider.dialect && codexCustomProvider.dialect.authScheme) {
+        input.codexAuthScheme = codexCustomProvider.dialect.authScheme;
+      }
+    }
     return normalizeProviderProfile(input);
   }, [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
+  const codexDialectKey = codexCustomProvider && codexCustomProvider.dialect
+    ? JSON.stringify(codexCustomProvider.dialect)
+    : '';
+
   const runtimeRef = React.useRef({ apiKey, apiBaseUrl: providerProfile.anthropicBaseUrl, providerProfile, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: 'subscription', claudeApiProvider: null, codexCliConfigProvider: null });
   const extRoot = cs && cs.getSystemPath ? cs.getSystemPath('extension') : '';
   const sidecarPath = React.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);
@@ -432,6 +459,12 @@ function Shell({ cs }) {
     codexBackend.reset();
   }, [codexBackend]);
 
+  React.useEffect(() => {
+    if (!codexCustomProvider) return undefined;
+    codexBackend.reset();
+    return undefined;
+  }, [codexDialectKey, codexCustomProvider && codexCustomProvider.id]);
+
   const openCodeBackend = React.useMemo(() => createOpenCodeBackend({
     getMcpSpec: () => resolveMcpCommand({ extRoot }),
     getModel: () => runtimeRef.current.model,
@@ -459,7 +492,7 @@ function Shell({ cs }) {
   }, [zcodeBackend]);
 
   const nodeOk = !(probe && probe.nodeOk === false);
-  const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk });
+  const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk, apiProvider: claudeApiProvider });
   runtimeRef.current = {
     apiKey: claudeApiProvider ? claudeApiProvider.apiKey : apiKey,
     apiBaseUrl: providerProfile.anthropicBaseUrl,
@@ -1008,3 +1041,6 @@ function Shell({ cs }) {
 export function App({ cs }) {
   return <LangProvider><Shell cs={cs} /></LangProvider>;
 }
+
+
+

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -23,6 +23,7 @@ import { claudeChannels, codexChannels, zcodeChannels, migrateBackendPref } from
 import { createProviderStore } from '../cep/providerStore';
 import { ProviderManagerSection } from '../components/settings/ProviderManagerSection';
 import { probeProviderModels } from '../cep/modelProbe';
+import { runProviderManagerProbe } from './providerProbeFlow.js';
 import { detectCcSwitch } from '../cep/ccSwitch';
 import { readClaudeSettingsEnv } from '../cep/claudeSettingsImport';
 import { readCodexCliConfig, resolveCodexProviderApiKey } from '../cep/codexConfig';
@@ -309,14 +310,14 @@ function Shell({ cs }) {
       }}
       onProbe={async (p) => {
         setProviderProbing(p.id);
-        const result = await probeProviderModels({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol });
+        const result = await runProviderManagerProbe(p);
         setProviderProbing('');
         if (result.ok && providerStore) {
-          providerStore.upsert({ ...p, probedModels: result.models, probedAt: Date.now() });
+          providerStore.upsert(result.entry);
           setProviders(providerStore.list());
           setProviderProbeErrors((errs) => ({ ...errs, [p.id]: '' }));
         } else {
-          setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || ('HTTP ' + result.status) }));
+          setProviderProbeErrors((errs) => ({ ...errs, [p.id]: result.detail || 'Provider probe failed' }));
         }
       }}
     />
@@ -349,11 +350,15 @@ function Shell({ cs }) {
   const claudeSettingsHint = React.useMemo(() => {
     try { return readClaudeSettingsEnv({ env: (window.cep_node && window.cep_node.process && window.cep_node.process.env) || {} }); } catch (e) { return null; }
   }, []);
-  const providerProfile = React.useMemo(() => normalizeProviderProfile({
-    anthropicBaseUrl: claudeApiProvider ? claudeApiProvider.baseUrl : anthropicBaseUrl,
-    codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
-    codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl,
-  }), [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
+  const providerProfile = React.useMemo(() => {
+    const input = {
+      anthropicBaseUrl: claudeApiProvider ? claudeApiProvider.baseUrl : anthropicBaseUrl,
+      codexApiKey: codexCustomProvider ? codexCustomProvider.apiKey : codexApiKey,
+      codexBaseUrl: codexCustomProvider ? codexCustomProvider.baseUrl : codexBaseUrl,
+    };
+    if (codexCustomProvider && codexCustomProvider.dialect) input.codexWireApi = codexCustomProvider.dialect.wireApi;
+    return normalizeProviderProfile(input);
+  }, [claudeApiProvider, anthropicBaseUrl, codexCustomProvider, codexApiKey, codexBaseUrl]);
   const runtimeRef = React.useRef({ apiKey, apiBaseUrl: providerProfile.anthropicBaseUrl, providerProfile, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: 'subscription', claudeApiProvider: null, codexCliConfigProvider: null });
   const extRoot = cs && cs.getSystemPath ? cs.getSystemPath('extension') : '';
   const sidecarPath = React.useMemo(() => resolveSidecarPath({ extRoot }), [extRoot]);

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -308,9 +308,9 @@ function Shell({ cs }) {
         if (claudeProviderId === id) { setClaudeProviderId(''); writePref('ae_mcp_claude_provider', ''); }
         if (codexProviderId === id) { setCodexProviderId(''); writePref('ae_mcp_codex_provider', ''); }
       }}
-      onProbe={async (p) => {
+      onProbe={async (p, options = {}) => {
         setProviderProbing(p.id);
-        const result = await runProviderManagerProbe(p);
+        const result = await runProviderManagerProbe(p, options);
         setProviderProbing('');
         if (result.ok && providerStore) {
           providerStore.upsert(result.entry);

--- a/plugin/panel/src/app/providerProbeFlow.js
+++ b/plugin/panel/src/app/providerProbeFlow.js
@@ -1,0 +1,66 @@
+import { probeProviderModels } from '../cep/modelProbe.js';
+import { detectProviderDialect } from '../cep/providerDetect.js';
+
+function isAuthFailure(result) {
+  return result && (result.status === 401 || result.status === 403);
+}
+
+function detectionDetail(result) {
+  if (!result) return '';
+  const reason = result.reason ? String(result.reason) : 'failed';
+  const detail = result.detail ? ': ' + String(result.detail) : '';
+  return 'dialect detection ' + reason + detail;
+}
+
+function probeFailureDetail(result, detectResult) {
+  const primary = result && result.detail ? String(result.detail) : ('HTTP ' + (result && result.status ? result.status : 0));
+  const detected = detectionDetail(detectResult);
+  return detected ? primary + ' (' + detected + ')' : primary;
+}
+
+function probedEntry(provider, result, now) {
+  return {
+    ...provider,
+    probedModels: result.models || [],
+    probedAt: now(),
+  };
+}
+
+function detectedEntry(provider, result, now) {
+  return {
+    ...provider,
+    dialect: result.dialect,
+    probedModels: result.models || [],
+    probedAt: now(),
+  };
+}
+
+export async function runProviderManagerProbe(provider, {
+  probeProviderModelsImpl = probeProviderModels,
+  detectProviderDialectImpl = detectProviderDialect,
+  now = Date.now,
+} = {}) {
+  const p = provider || {};
+  const canDetect = p.protocol === 'openai-compatible';
+
+  if (p.dialect) {
+    const result = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, dialect: p.dialect });
+    if (result.ok) return { ok: true, entry: probedEntry(p, result, now), result };
+    if (canDetect && isAuthFailure(result)) {
+      const detected = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+      if (detected.ok) return { ok: true, entry: detectedEntry(p, detected, now), result: detected };
+      return { ok: false, detail: probeFailureDetail(result, detected), result, detectResult: detected };
+    }
+    return { ok: false, detail: probeFailureDetail(result), result };
+  }
+
+  let detectResult = null;
+  if (canDetect) {
+    detectResult = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+    if (detectResult.ok) return { ok: true, entry: detectedEntry(p, detectResult, now), result: detectResult };
+  }
+
+  const result = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol });
+  if (result.ok) return { ok: true, entry: probedEntry(p, result, now), result };
+  return { ok: false, detail: probeFailureDetail(result, detectResult), result, detectResult };
+}

--- a/plugin/panel/src/app/providerProbeFlow.js
+++ b/plugin/panel/src/app/providerProbeFlow.js
@@ -39,9 +39,18 @@ export async function runProviderManagerProbe(provider, {
   probeProviderModelsImpl = probeProviderModels,
   detectProviderDialectImpl = detectProviderDialect,
   now = Date.now,
+  forceDetect = false,
 } = {}) {
   const p = provider || {};
   const canDetect = p.protocol === 'openai-compatible';
+
+  if (forceDetect && canDetect) {
+    const detectResult = await detectProviderDialectImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, now });
+    if (detectResult.ok) return { ok: true, entry: detectedEntry(p, detectResult, now), result: detectResult };
+    const result = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, dialect: p.dialect });
+    if (result.ok) return { ok: true, entry: probedEntry(p, result, now), result, detectResult };
+    return { ok: false, detail: probeFailureDetail(result, detectResult), result, detectResult };
+  }
 
   if (p.dialect) {
     const result = await probeProviderModelsImpl({ baseUrl: p.baseUrl, apiKey: p.apiKey, protocol: p.protocol, dialect: p.dialect });

--- a/plugin/panel/src/cep/ccSwitch.js
+++ b/plugin/panel/src/cep/ccSwitch.js
@@ -1,6 +1,10 @@
 // Optional cc-switch inheritance (spec A2): detect-only, never a wizard
 // dependency. Third-party format is unstable -> tolerant field mapping.
 const CONFIG_NAMES = ['config.json', 'providers.json'];
+const API_FORMAT_TO_WIRE_API = {
+  openai_responses: 'responses',
+  openai_chat: 'chat',
+};
 
 function getCepRequire() {
   if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
@@ -31,7 +35,59 @@ function rawProviders(parsed) {
   return [];
 }
 
-export function ccSwitchProviderEntries(list) {
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function wireApiFromApiFormat(value) {
+  return API_FORMAT_TO_WIRE_API[String(value || '').trim().toLowerCase()] || '';
+}
+
+function wireApiFromConfig(config) {
+  if (typeof config !== 'string') return '';
+  const match = config.match(/(?:^|\n)\s*wire_api\s*=\s*["'](responses|chat)["']/i);
+  return match ? match[1].toLowerCase() : '';
+}
+
+function inferWireApi(p, settingsConfig) {
+  const meta = objectValue(p.meta);
+  return wireApiFromApiFormat(meta.apiFormat || meta.api_format)
+    || wireApiFromApiFormat(p.apiFormat || p.api_format)
+    || wireApiFromConfig(settingsConfig.config);
+}
+
+function authSchemeFromApiKeyField(value) {
+  const field = String(value || '').trim();
+  if (field === 'ANTHROPIC_API_KEY') return 'x-api-key';
+  if (/x[-_]?api[-_]?key/i.test(field)) return 'x-api-key';
+  return '';
+}
+
+function inferAuthScheme(p, settingsConfig) {
+  const meta = objectValue(p.meta);
+  const fromApiKeyField = authSchemeFromApiKeyField(meta.apiKeyField || meta.api_key_field);
+  if (fromApiKeyField) return fromApiKeyField;
+  const env = objectValue(settingsConfig.env);
+  const auth = objectValue(settingsConfig.auth);
+  if (hasOwn(env, 'ANTHROPIC_AUTH_TOKEN')) return 'bearer';
+  if (hasOwn(env, 'ANTHROPIC_API_KEY')) return 'x-api-key';
+  if (hasOwn(auth, 'OPENAI_API_KEY') || hasOwn(env, 'OPENAI_API_KEY')) return 'bearer';
+  return '';
+}
+
+function inferDialect(p, now) {
+  const settingsConfig = objectValue(p.settingsConfig || p.settings_config);
+  const wireApi = inferWireApi(p, settingsConfig);
+  const authScheme = inferAuthScheme(p, settingsConfig);
+  if (!wireApi || !authScheme) return null;
+  return { wireApi, authScheme, source: 'ccswitch-import', updatedAt: now() };
+}
+
+export function ccSwitchProviderEntries(list, { now = Date.now } = {}) {
   return (Array.isArray(list) ? list : [])
     .map((p) => {
       if (!p || typeof p !== 'object') return null;
@@ -40,7 +96,10 @@ export function ccSwitchProviderEntries(list) {
       const apiKey = String(p.apiKey || p.api_key || p.key || p.token || '').trim();
       if (!name || !baseUrl) return null;
       const protocol = /anthropic/i.test(String(p.type || p.protocol || p.kind || '')) ? 'anthropic' : 'openai-compatible';
-      return { id: 'ccswitch-' + name.replace(/[^A-Za-z0-9_-]+/g, '-').toLowerCase(), name, protocol, baseUrl, apiKey };
+      const entry = { id: 'ccswitch-' + name.replace(/[^A-Za-z0-9_-]+/g, '-').toLowerCase(), name, protocol, baseUrl, apiKey };
+      const dialect = inferDialect(p, now);
+      if (dialect) entry.dialect = dialect;
+      return entry;
     })
     .filter(Boolean);
 }

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -1,6 +1,7 @@
 import { createNdjsonReader } from '../lib/ndjson.js';
 import { codexAppServerArgs, codexSpawnEnv, ensureUserEnv, normalizeProviderProfile } from '../lib/providerProfile.js';
 import { PANEL_VERSION } from './mcpClient.js';
+import { createCodexResponsesRoute } from './codexResponsesRoute.js';
 import { expertGuidanceEnv } from './externalClients.js';
 
 const RPC_TIMEOUT_MS = 30000;
@@ -246,6 +247,7 @@ export function createCodexBackend({
   // panel only supplies the missing API key env var the provider needs (no
   // `-c model_provider=...` override).
   getCliConfigProvider = () => null,
+  createResponsesRoute = createCodexResponsesRoute,
   resolveCli = resolveCodexCli,
   onEvent,
   lang = 'zh',
@@ -270,8 +272,15 @@ export function createCodexBackend({
   let activeAssistantText = '';
   let toolMeta = { allowedTools: [], annotations: {} };
   let lastCliInfo = null;
+  let providerRoute = null;
   const pendingApprovals = new Map();
   const sessionAllowedTools = new Set();
+
+  function closeProviderRoute() {
+    const route = providerRoute;
+    providerRoute = null;
+    if (route && route.close) Promise.resolve(route.close()).catch(() => {});
+  }
 
   function emit(evt) {
     if (onEvent) onEvent(evt);
@@ -429,6 +438,7 @@ export function createCodexBackend({
     initialized = false;
     threadId = null;
     preambleSent = false;
+    closeProviderRoute();
     if (wasStopping) return;
     if (activeRun) {
       emit({ type: 'error', kind: 'mcp', message: 'codex app-server exited: ' + detail });
@@ -446,6 +456,7 @@ export function createCodexBackend({
     initialized = false;
     threadId = null;
     preambleSent = false;
+    closeProviderRoute();
     if (activeRun) {
       emit({ type: 'error', kind: 'mcp', message: err.message });
       finishActive();
@@ -459,12 +470,28 @@ export function createCodexBackend({
       const spawn = getSpawn();
       const spawnEnv = ensureUserEnv(currentEnv(), { homedir: getHomedir() });
       const providerProfile = normalizeProviderProfile(getProviderProfile ? getProviderProfile() : {}, spawnEnv);
+      let runtimeProviderProfile = providerProfile;
+      if (providerProfile.codexBaseUrl && providerProfile.codexWireApi === 'chat') {
+        closeProviderRoute();
+        providerRoute = createResponsesRoute({
+          upstreamBaseUrl: providerProfile.codexBaseUrl,
+          apiKey: providerProfile.codexApiKey,
+          authScheme: providerProfile.codexAuthScheme,
+        });
+        const routeInfo = await providerRoute.start();
+        runtimeProviderProfile = {
+          ...providerProfile,
+          codexBaseUrl: routeInfo.baseUrl,
+          codexApiKey: routeInfo.apiKey,
+          codexWireApi: 'responses',
+        };
+      }
       stderrTail = '';
       stopping = false;
       const cliOverride = spawnEnv.AE_MCP_CODEX_CLI ? { ok: true, cliPath: String(spawnEnv.AE_MCP_CODEX_CLI), version: '' } : null;
       lastCliInfo = cliOverride || lastCliInfo;
       const command = cliOverride ? cliOverride.cliPath : 'codex';
-      let spawnEnvWithCreds = codexSpawnEnv(providerProfile, spawnEnv);
+      let spawnEnvWithCreds = codexSpawnEnv(runtimeProviderProfile, spawnEnv);
       // Only inherit cli-config's provider env var when the panel has no
       // explicit custom provider (codexBaseUrl) configured — an explicit
       // custom provider always wins.
@@ -475,7 +502,7 @@ export function createCodexBackend({
           spawnEnvWithCreds = Object.assign({}, spawnEnvWithCreds, { [envKey]: cliConfig.apiKey });
         }
       }
-      proc = spawn(command, codexAppServerArgs(providerProfile), {
+      proc = spawn(command, codexAppServerArgs(runtimeProviderProfile), {
         stdio: 'pipe',
         windowsHide: true,
         shell: true,
@@ -630,6 +657,7 @@ export function createCodexBackend({
 
   function reset() {
     stopping = true;
+    closeProviderRoute();
     drainApprovals();
     if (rpc) rpc.close(new Error('Codex backend reset'));
     if (proc) {
@@ -729,3 +757,5 @@ export function createCodexBackend({
     probeAccount,
   };
 }
+
+

--- a/plugin/panel/src/cep/codexResponsesRoute.js
+++ b/plugin/panel/src/cep/codexResponsesRoute.js
@@ -1,0 +1,504 @@
+function getCepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+    return globalThis.window.cep_node.require;
+  }
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  throw new Error('CEP Node require is unavailable');
+}
+
+function normalizeOpenAiRoot(baseUrl) {
+  return String(baseUrl || '').replace(/\/+$/, '').replace(/\/v1$/, '') + '/v1';
+}
+
+function authHeaders(authScheme, apiKey) {
+  if (authScheme === 'x-api-key') return { 'x-api-key': String(apiKey || '') };
+  if (authScheme === 'none') return {};
+  return { Authorization: 'Bearer ' + String(apiKey || '') };
+}
+
+function textFromContent(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map((part) => {
+    if (!part || typeof part !== 'object') return '';
+    if (part.text !== undefined) return String(part.text || '');
+    if (part.content !== undefined) return String(part.content || '');
+    return '';
+  }).join('');
+}
+
+function toolArguments(value) {
+  if (value === undefined || value === null) return '{}';
+  if (typeof value === 'string') return value;
+  try { return JSON.stringify(value); } catch (e) { return '{}'; }
+}
+
+function responsesToolToChatTool(tool) {
+  if (!tool || typeof tool !== 'object') return null;
+  const type = String(tool.type || 'function');
+  if (type !== 'function') return null;
+  if (tool.function && typeof tool.function === 'object') {
+    const fn = {
+      name: String(tool.function.name || tool.name || ''),
+      description: tool.function.description !== undefined ? tool.function.description : tool.description,
+      parameters: tool.function.parameters !== undefined ? tool.function.parameters : (tool.parameters || {}),
+    };
+    if (tool.function.strict !== undefined || tool.strict !== undefined) {
+      fn.strict = tool.function.strict !== undefined ? tool.function.strict : tool.strict;
+    }
+    return { type: 'function', function: fn };
+  }
+  const name = String(tool.name || '');
+  if (!name) return null;
+  const fn = {
+    name,
+    description: tool.description,
+    parameters: tool.parameters || {},
+  };
+  if (tool.strict !== undefined) fn.strict = tool.strict;
+  return { type: 'function', function: fn };
+}
+
+function responsesToolsToChatTools(tools) {
+  if (!Array.isArray(tools)) return [];
+  return tools.map(responsesToolToChatTool).filter(Boolean);
+}
+
+function responsesToolChoiceToChat(toolChoice) {
+  if (!toolChoice || typeof toolChoice !== 'object') return toolChoice;
+  if (toolChoice.type === 'function') {
+    return { type: 'function', function: { name: String(toolChoice.name || (toolChoice.function && toolChoice.function.name) || '') } };
+  }
+  return toolChoice;
+}
+
+function functionCallToChatToolCall(item) {
+  const callId = String(item.call_id || item.id || '');
+  return {
+    id: callId,
+    type: 'function',
+    function: {
+      name: String(item.name || ''),
+      arguments: toolArguments(item.arguments),
+    },
+  };
+}
+
+function inputToMessages(input) {
+  if (typeof input === 'string') return [{ role: 'user', content: input }];
+  if (!Array.isArray(input)) return [{ role: 'user', content: String(input || '') }];
+  const messages = [];
+  let pendingToolCalls = [];
+
+  function flushToolCalls() {
+    if (!pendingToolCalls.length) return;
+    messages.push({ role: 'assistant', content: null, tool_calls: pendingToolCalls });
+    pendingToolCalls = [];
+  }
+
+  for (const item of input) {
+    if (!item || typeof item !== 'object') continue;
+    const type = String(item.type || '');
+    if (type === 'function_call') {
+      pendingToolCalls.push(functionCallToChatToolCall(item));
+      continue;
+    }
+    if (type === 'function_call_output') {
+      flushToolCalls();
+      messages.push({
+        role: 'tool',
+        tool_call_id: String(item.call_id || item.id || ''),
+        content: typeof item.output === 'string' ? item.output : toolArguments(item.output),
+      });
+      continue;
+    }
+    if (type === 'reasoning') continue;
+    flushToolCalls();
+    if (type === 'message' || item.role || item.content !== undefined || item.text !== undefined) {
+      const role = item.role === 'assistant' || item.role === 'system' ? item.role : 'user';
+      const content = textFromContent(item.content !== undefined ? item.content : item.text);
+      if (content || role === 'assistant') messages.push({ role, content: content || '' });
+    }
+  }
+  flushToolCalls();
+  return messages.length ? messages : [{ role: 'user', content: '' }];
+}
+
+export function responsesBodyToChatBody(body = {}) {
+  const messages = [];
+  if (body.instructions) messages.push({ role: 'system', content: String(body.instructions) });
+  messages.push(...inputToMessages(body.input));
+  const chat = {
+    model: body.model,
+    messages,
+    stream: body.stream !== false,
+  };
+  const maxTokens = body.max_output_tokens || body.max_tokens;
+  if (maxTokens !== undefined) chat.max_tokens = maxTokens;
+  if (body.temperature !== undefined) chat.temperature = body.temperature;
+  if (body.top_p !== undefined) chat.top_p = body.top_p;
+  const tools = responsesToolsToChatTools(body.tools);
+  if (tools.length) chat.tools = tools;
+  if (body.tool_choice !== undefined && tools.length) chat.tool_choice = responsesToolChoiceToChat(body.tool_choice);
+  if (body.parallel_tool_calls !== undefined && tools.length) chat.parallel_tool_calls = body.parallel_tool_calls;
+  return chat;
+}
+
+function responseId() {
+  return 'resp_' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+function sse(res, event, data) {
+  res.write('event: ' + event + '\n');
+  res.write('data: ' + JSON.stringify({ type: event, ...data }) + '\n\n');
+}
+
+function chatToolCallsToResponseOutput(message) {
+  const toolCalls = Array.isArray(message && message.tool_calls) ? message.tool_calls : [];
+  return toolCalls.map((toolCall, index) => {
+    const callId = String((toolCall && toolCall.id) || ('call_' + index));
+    const fn = (toolCall && toolCall.function) || {};
+    return {
+      type: 'function_call',
+      id: 'fc_' + callId,
+      call_id: callId,
+      name: String(fn.name || ''),
+      arguments: toolArguments(fn.arguments),
+      status: 'completed',
+    };
+  }).filter((item) => item.name);
+}
+
+function messageOutputItem(id, text) {
+  return {
+    id: 'msg_' + id.slice(5),
+    type: 'message',
+    status: 'completed',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: String(text || '') }],
+  };
+}
+
+function chatMessageToResponseOutput(id, message) {
+  const output = [];
+  const text = message && typeof message.content === 'string' ? message.content : '';
+  if (text) output.push(messageOutputItem(id, text));
+  output.push(...chatToolCallsToResponseOutput(message));
+  if (!output.length) output.push(messageOutputItem(id, ''));
+  return output;
+}
+
+function createStreamState(res, id, model) {
+  let started = false;
+  let nextOutputIndex = 0;
+  let textIndex = null;
+  let text = '';
+  const tools = new Map();
+  const completed = [];
+
+  function ensureStarted() {
+    if (started) return;
+    started = true;
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    sse(res, 'response.created', { response: { id, object: 'response', status: 'in_progress', model, output: [] } });
+  }
+
+  function ensureTextItem() {
+    ensureStarted();
+    if (textIndex !== null) return textIndex;
+    textIndex = nextOutputIndex++;
+    const item = { id: 'msg_' + id.slice(5), type: 'message', status: 'in_progress', role: 'assistant', content: [] };
+    sse(res, 'response.output_item.added', { output_index: textIndex, item });
+    sse(res, 'response.content_part.added', { output_index: textIndex, content_index: 0, part: { type: 'output_text', text: '' } });
+    return textIndex;
+  }
+
+  function pushTextDelta(delta) {
+    if (!delta) return;
+    const outputIndex = ensureTextItem();
+    text += String(delta);
+    sse(res, 'response.output_text.delta', { output_index: outputIndex, content_index: 0, delta: String(delta) });
+  }
+
+  function pushToolCallDelta(toolCall) {
+    ensureStarted();
+    const chatIndex = Number.isFinite(toolCall && toolCall.index) ? toolCall.index : 0;
+    const fn = (toolCall && toolCall.function) || {};
+    let state = tools.get(chatIndex);
+    if (!state) {
+      state = { callId: '', name: '', arguments: '', outputIndex: null, itemId: '', added: false };
+      tools.set(chatIndex, state);
+    }
+    if (toolCall && toolCall.id) state.callId = String(toolCall.id);
+    if (fn.name) state.name = String(fn.name);
+    if (fn.arguments) state.arguments += String(fn.arguments);
+
+    if (!state.added && state.callId && state.name) {
+      state.added = true;
+      state.outputIndex = nextOutputIndex++;
+      state.itemId = 'fc_' + state.callId;
+      const item = {
+        type: 'function_call',
+        id: state.itemId,
+        call_id: state.callId,
+        name: state.name,
+        arguments: '',
+        status: 'in_progress',
+      };
+      sse(res, 'response.output_item.added', { output_index: state.outputIndex, item });
+      if (state.arguments) {
+        sse(res, 'response.function_call_arguments.delta', {
+          item_id: state.itemId,
+          output_index: state.outputIndex,
+          delta: state.arguments,
+        });
+      }
+      return;
+    }
+
+    if (state.added && fn.arguments) {
+      sse(res, 'response.function_call_arguments.delta', {
+        item_id: state.itemId,
+        output_index: state.outputIndex,
+        delta: String(fn.arguments),
+      });
+    }
+  }
+
+  function finish() {
+    ensureStarted();
+    if (textIndex !== null) {
+      const item = messageOutputItem(id, text);
+      sse(res, 'response.output_text.done', { output_index: textIndex, content_index: 0, text });
+      sse(res, 'response.content_part.done', { output_index: textIndex, content_index: 0, part: item.content[0] });
+      sse(res, 'response.output_item.done', { output_index: textIndex, item });
+      completed.push(item);
+    }
+    for (const state of tools.values()) {
+      if (!state.added || !state.name) continue;
+      const item = {
+        type: 'function_call',
+        id: state.itemId || ('fc_' + state.callId),
+        call_id: state.callId || state.itemId,
+        name: state.name,
+        arguments: state.arguments || '{}',
+        status: 'completed',
+      };
+      sse(res, 'response.function_call_arguments.done', {
+        item_id: item.id,
+        output_index: state.outputIndex,
+        arguments: item.arguments,
+      });
+      sse(res, 'response.output_item.done', { output_index: state.outputIndex, item });
+      completed.push(item);
+    }
+    if (!completed.length) completed.push(messageOutputItem(id, ''));
+    sse(res, 'response.completed', {
+      response: { id, object: 'response', status: 'completed', model, output: completed },
+    });
+    res.end();
+  }
+
+  return { pushTextDelta, pushToolCallDelta, finish, ensureStarted };
+}
+
+function sendJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function requestUpstream({ requireImpl, upstreamBaseUrl, apiKey, authScheme, path, method, body, onResponse }) {
+  return new Promise((resolve, reject) => {
+    let endpoint;
+    try {
+      endpoint = new URL(normalizeOpenAiRoot(upstreamBaseUrl) + path);
+    } catch (e) {
+      reject(new Error('Invalid upstream base URL'));
+      return;
+    }
+    const reqImpl = requireImpl(endpoint.protocol === 'http:' ? 'http' : 'https');
+    const payload = body === undefined ? null : JSON.stringify(body);
+    const headers = { ...authHeaders(authScheme, apiKey) };
+    if (payload !== null) headers['Content-Type'] = 'application/json';
+    const req = reqImpl.request({
+      hostname: endpoint.hostname,
+      port: endpoint.port || undefined,
+      protocol: endpoint.protocol,
+      path: endpoint.pathname + endpoint.search,
+      method,
+      headers,
+    }, async (upstream) => {
+      try {
+        await onResponse(upstream);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+    if (payload !== null) req.write(payload);
+    req.end();
+  });
+}
+
+function proxyModels({ req, res, requireImpl, upstreamBaseUrl, apiKey, authScheme }) {
+  return requestUpstream({
+    requireImpl,
+    upstreamBaseUrl,
+    apiKey,
+    authScheme,
+    path: '/models',
+    method: 'GET',
+    onResponse: async (upstream) => {
+      res.writeHead(upstream.statusCode || 502, upstream.headers || {});
+      upstream.on('data', (chunk) => res.write(chunk));
+      upstream.on('end', () => res.end());
+    },
+  }).catch((e) => sendJson(res, 502, { error: { message: e.message || 'Provider route failed' } }));
+}
+
+async function handleResponses({ req, res, requireImpl, upstreamBaseUrl, apiKey, authScheme }) {
+  let body;
+  try {
+    body = JSON.parse(await readBody(req) || '{}');
+  } catch (e) {
+    sendJson(res, 400, { error: { message: 'Invalid JSON request body' } });
+    return;
+  }
+  const chatBody = responsesBodyToChatBody(body);
+  const id = responseId();
+
+  if (chatBody.stream === false) {
+    await requestUpstream({
+      requireImpl,
+      upstreamBaseUrl,
+      apiKey,
+      authScheme,
+      path: '/chat/completions',
+      method: 'POST',
+      body: chatBody,
+      onResponse: async (upstream) => {
+        let text = '';
+        upstream.on('data', (chunk) => { text += chunk; });
+        upstream.on('end', () => {
+          if ((upstream.statusCode || 0) >= 300) {
+            sendJson(res, upstream.statusCode || 502, { error: { message: 'Upstream chat completion failed' } });
+            return;
+          }
+          let message = { content: '' };
+          try {
+            const parsed = JSON.parse(text);
+            message = (parsed.choices && parsed.choices[0] && parsed.choices[0].message) || message;
+          } catch (e) { message = { content: '' }; }
+          sendJson(res, 200, {
+            id,
+            object: 'response',
+            status: 'completed',
+            model: chatBody.model,
+            output: chatMessageToResponseOutput(id, message),
+          });
+        });
+      },
+    }).catch((e) => sendJson(res, 502, { error: { message: e.message || 'Provider route failed' } }));
+    return;
+  }
+
+  const stream = createStreamState(res, id, chatBody.model);
+  await requestUpstream({
+    requireImpl,
+    upstreamBaseUrl,
+    apiKey,
+    authScheme,
+    path: '/chat/completions',
+    method: 'POST',
+    body: chatBody,
+    onResponse: async (upstream) => {
+      if ((upstream.statusCode || 0) >= 300) {
+        let detail = '';
+        upstream.on('data', (chunk) => { detail += chunk; });
+        upstream.on('end', () => sendJson(res, upstream.statusCode || 502, { error: { message: 'Upstream chat completion failed', detail: detail.slice(0, 512) } }));
+        return;
+      }
+      stream.ensureStarted();
+      let buffer = '';
+      upstream.on('data', (chunk) => {
+        buffer += String(chunk || '');
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data:')) continue;
+          const data = trimmed.slice(5).trim();
+          if (!data || data === '[DONE]') continue;
+          try {
+            const json = JSON.parse(data);
+            const delta = json.choices && json.choices[0] && json.choices[0].delta;
+            if (!delta) continue;
+            if (delta.content) stream.pushTextDelta(delta.content);
+            if (Array.isArray(delta.tool_calls)) {
+              for (const toolCall of delta.tool_calls) stream.pushToolCallDelta(toolCall);
+            }
+          } catch (e) { /* ignore malformed upstream SSE frames */ }
+        }
+      });
+      upstream.on('end', () => stream.finish());
+    },
+  }).catch((e) => {
+    if (!res.headersSent) sendJson(res, 502, { error: { message: e.message || 'Provider route failed' } });
+    else res.end();
+  });
+}
+
+export function createCodexResponsesRoute({ upstreamBaseUrl, apiKey, authScheme = 'bearer', requireImpl } = {}) {
+  const reqImpl = requireImpl || getCepRequire();
+  let server = null;
+  let baseUrl = '';
+  const token = 'ae-mcp-route-' + Math.random().toString(36).slice(2);
+
+  return {
+    async start() {
+      if (server && baseUrl) return { baseUrl, apiKey: token };
+      const http = reqImpl('http');
+      server = http.createServer((req, res) => {
+        const path = String(req.url || '').split('?')[0].replace(/^\/v1/, '') || '/';
+        if (req.method === 'GET' && path === '/models') {
+          proxyModels({ req, res, requireImpl: reqImpl, upstreamBaseUrl, apiKey, authScheme });
+          return;
+        }
+        if (req.method === 'POST' && (path === '/responses' || path === '/responses/compact')) {
+          handleResponses({ req, res, requireImpl: reqImpl, upstreamBaseUrl, apiKey, authScheme });
+          return;
+        }
+        sendJson(res, 404, { error: { message: 'Unknown Codex provider route path' } });
+      });
+      await new Promise((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => resolve());
+      });
+      const address = server.address();
+      baseUrl = 'http://127.0.0.1:' + address.port;
+      return { baseUrl, apiKey: token };
+    },
+    async close() {
+      if (!server) return;
+      const closing = server;
+      server = null;
+      baseUrl = '';
+      await new Promise((resolve) => closing.close(resolve));
+    },
+  };
+}

--- a/plugin/panel/src/cep/modelProbe.js
+++ b/plugin/panel/src/cep/modelProbe.js
@@ -11,10 +11,19 @@ function getCepRequire() {
   throw new Error('CEP Node require is unavailable');
 }
 
-export function probeHeaders(protocol, apiKey) {
+function authSchemeFromDialect(dialect) {
+  if (!dialect) return '';
+  if (typeof dialect === 'string') return dialect;
+  return String(dialect.authScheme || '').trim();
+}
+
+export function probeHeaders(protocol, apiKey, dialect) {
   if (protocol === 'anthropic') {
     return { 'x-api-key': String(apiKey || ''), 'anthropic-version': '2023-06-01' };
   }
+  const authScheme = authSchemeFromDialect(dialect);
+  if (authScheme === 'x-api-key') return { 'x-api-key': String(apiKey || '') };
+  if (authScheme === 'none') return {};
   return { Authorization: 'Bearer ' + String(apiKey || '') };
 }
 
@@ -32,7 +41,7 @@ export function parseModelsList(json) {
     .filter(Boolean);
 }
 
-export function probeProviderModels({ baseUrl, apiKey, protocol = 'openai-compatible', httpsImpl, timeoutMs = 8000 } = {}) {
+export function probeProviderModels({ baseUrl, apiKey, protocol = 'openai-compatible', dialect, authScheme, httpsImpl, timeoutMs = 8000 } = {}) {
   let endpoint;
   try {
     const root = String(baseUrl || '').replace(/\/+$/, '').replace(/\/v1$/, '');
@@ -53,7 +62,7 @@ export function probeProviderModels({ baseUrl, apiKey, protocol = 'openai-compat
       protocol: endpoint.protocol,
       path: endpoint.pathname + endpoint.search,
       method: 'GET',
-      headers: probeHeaders(protocol, apiKey),
+      headers: probeHeaders(protocol, apiKey, dialect || authScheme),
     }, (res) => {
       let body = '';
       res.on('data', (chunk) => { body += chunk; });

--- a/plugin/panel/src/cep/providerDetect.js
+++ b/plugin/panel/src/cep/providerDetect.js
@@ -1,0 +1,250 @@
+import { parseModelsList } from './modelProbe.js';
+
+// Detects OpenAI-compatible provider dialects without binding callers to a
+// specific backend: prefer Responses for richer capability, and treat a JSON
+// 400 error as endpoint presence because parameter details vary by provider.
+function getCepRequire() {
+  if (globalThis.window && globalThis.window.cep_node && globalThis.window.cep_node.require) {
+    return globalThis.window.cep_node.require;
+  }
+  if (globalThis.window && globalThis.window.require) return globalThis.window.require;
+  if (globalThis.require) return globalThis.require;
+  throw new Error('CEP Node require is unavailable');
+}
+
+function normalizeRoot(baseUrl) {
+  return String(baseUrl || '').replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
+function authHeaders(authScheme, apiKey) {
+  if (authScheme === 'bearer') return { Authorization: 'Bearer ' + String(apiKey || '') };
+  if (authScheme === 'x-api-key') return { 'x-api-key': String(apiKey || '') };
+  return {};
+}
+
+function authCandidates(apiKey) {
+  return String(apiKey || '') ? ['bearer', 'x-api-key', 'none'] : ['none'];
+}
+
+function safeDetail(message) {
+  return String(message || 'request failed');
+}
+
+function parseJson(value) {
+  try {
+    return { ok: true, value: JSON.parse(value || '') };
+  } catch (e) {
+    return { ok: false, value: null };
+  }
+}
+
+function isJsonErrorObject(body) {
+  const parsed = parseJson(body);
+  return parsed.ok
+    && parsed.value
+    && typeof parsed.value === 'object'
+    && parsed.value.error
+    && typeof parsed.value.error === 'object'
+    && !Array.isArray(parsed.value.error);
+}
+
+function requestProvider({ url, method, headers, body, httpsImpl, timeoutMs }) {
+  return new Promise((resolve) => {
+    let endpoint;
+    try {
+      endpoint = new URL(url);
+    } catch (e) {
+      resolve({ ok: false, network: true, status: 0, body: '', detail: 'Invalid base URL' });
+      return;
+    }
+
+    let https;
+    try {
+      https = httpsImpl || getCepRequire()(endpoint.protocol === 'http:' ? 'http' : 'https');
+    } catch (e) {
+      resolve({ ok: false, network: true, status: 0, body: '', detail: safeDetail(e.message) });
+      return;
+    }
+
+    const payload = body === undefined ? null : JSON.stringify(body);
+    const reqHeaders = Object.assign({}, headers || {});
+    if (payload !== null) {
+      reqHeaders['Content-Type'] = 'application/json';
+    }
+
+    let settled = false;
+    function finish(result) {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    }
+
+    const req = https.request({
+      hostname: endpoint.hostname,
+      port: endpoint.port || undefined,
+      protocol: endpoint.protocol,
+      path: endpoint.pathname + endpoint.search,
+      method,
+      headers: reqHeaders,
+    }, (res) => {
+      let responseBody = '';
+      res.on('data', (chunk) => { responseBody += chunk; });
+      res.on('end', () => finish({
+        ok: true,
+        network: false,
+        status: res.statusCode || 0,
+        body: responseBody,
+        detail: '',
+      }));
+    });
+    req.on('error', (err) => finish({
+      ok: false,
+      network: true,
+      status: 0,
+      body: '',
+      detail: err && err.message ? err.message : 'request failed',
+    }));
+    if (req.setTimeout) {
+      req.setTimeout(timeoutMs, () => {
+        try { req.destroy(); } catch (e) { /* noop */ }
+        finish({ ok: false, network: true, status: 0, body: '', detail: 'timeout' });
+      });
+    }
+    if (payload !== null && req.write) req.write(payload);
+    req.end();
+  });
+}
+
+async function detectAuth({ root, apiKey, httpsImpl, timeoutMs, tried }) {
+  let saw200WithoutModels = false;
+  let sawNonAuthStatus = false;
+  for (const candidate of authCandidates(apiKey)) {
+    const result = await requestProvider({
+      url: root + '/v1/models',
+      method: 'GET',
+      headers: authHeaders(candidate, apiKey),
+      httpsImpl,
+      timeoutMs,
+    });
+    if (result.network) {
+      tried.push({ step: 'auth', candidate, status: 0, outcome: 'network' });
+      return { ok: false, reason: 'network', detail: 'Network error while probing provider models' };
+    }
+    if (result.status === 200) {
+      const parsed = parseJson(result.body);
+      const models = parsed.ok ? parseModelsList(parsed.value) : [];
+      if (models.length) {
+        tried.push({ step: 'auth', candidate, status: 200, outcome: 'accepted' });
+        return { ok: true, authScheme: candidate, models };
+      }
+      saw200WithoutModels = true;
+      tried.push({ step: 'auth', candidate, status: 200, outcome: 'no-models' });
+    } else if (result.status === 401 || result.status === 403) {
+      tried.push({ step: 'auth', candidate, status: result.status, outcome: 'rejected' });
+    } else {
+      sawNonAuthStatus = true;
+      tried.push({ step: 'auth', candidate, status: result.status, outcome: 'rejected' });
+    }
+  }
+
+  if (saw200WithoutModels) {
+    return { ok: false, reason: 'no-models', detail: 'Provider model endpoint did not return a usable model list' };
+  }
+  return {
+    ok: false,
+    reason: 'auth',
+    detail: sawNonAuthStatus
+      ? 'No authentication scheme returned a usable provider model list'
+      : 'Provider rejected all applicable authentication schemes',
+  };
+}
+
+function wireRequest(wireApi, model) {
+  if (wireApi === 'responses') {
+    return {
+      path: '/v1/responses',
+      body: { model, input: 'ping', max_output_tokens: 16, stream: false },
+    };
+  }
+  return {
+    path: '/v1/chat/completions',
+    body: { model, messages: [{ role: 'user', content: 'ping' }], max_tokens: 16, stream: false },
+  };
+}
+
+async function detectWire({ root, apiKey, authScheme, model, httpsImpl, timeoutMs, tried }) {
+  for (const candidate of ['responses', 'chat']) {
+    const wire = wireRequest(candidate, model);
+    const result = await requestProvider({
+      url: root + wire.path,
+      method: 'POST',
+      headers: authHeaders(authScheme, apiKey),
+      body: wire.body,
+      httpsImpl,
+      timeoutMs,
+    });
+    if (result.network) {
+      tried.push({ step: 'wire', candidate, status: 0, outcome: 'network' });
+      return { ok: false, reason: 'network', detail: 'Network error while probing provider wire API' };
+    }
+    if (result.status === 200 || (result.status === 400 && isJsonErrorObject(result.body))) {
+      tried.push({ step: 'wire', candidate, status: result.status, outcome: 'accepted' });
+      return { ok: true, wireApi: candidate };
+    }
+    if (result.status === 401 || result.status === 403) {
+      tried.push({ step: 'wire', candidate, status: result.status, outcome: 'auth-mismatch' });
+      return { ok: false, reason: 'auth-mismatch', detail: 'Provider wire API rejected the authentication scheme accepted by the model endpoint' };
+    }
+    tried.push({ step: 'wire', candidate, status: result.status, outcome: 'rejected' });
+  }
+  return { ok: false, reason: 'wire-undetected', detail: 'Provider did not accept the supported Responses or Chat wire APIs' };
+}
+
+export async function detectProviderDialect({
+  baseUrl,
+  apiKey,
+  protocol = 'openai-compatible',
+  httpsImpl,
+  timeoutMs = 8000,
+  now = Date.now,
+} = {}) {
+  const tried = [];
+  try {
+    if (protocol === 'anthropic') {
+      return { ok: false, reason: 'not-applicable', tried, detail: 'Anthropic providers use a fixed dialect and do not need detection' };
+    }
+
+    let root;
+    try {
+      root = normalizeRoot(baseUrl);
+      new URL(root + '/v1/models');
+    } catch (e) {
+      return { ok: false, reason: 'network', tried, detail: 'Invalid base URL' };
+    }
+
+    const auth = await detectAuth({ root, apiKey, httpsImpl, timeoutMs, tried });
+    if (!auth.ok) return Object.assign({ tried }, auth);
+
+    const model = auth.models[0] && auth.models[0].id;
+    if (!model) {
+      return { ok: false, reason: 'no-models', tried, detail: 'Provider model endpoint did not return a usable model list' };
+    }
+
+    const wire = await detectWire({ root, apiKey, authScheme: auth.authScheme, model, httpsImpl, timeoutMs, tried });
+    if (!wire.ok) return Object.assign({ tried }, wire);
+
+    return {
+      ok: true,
+      dialect: {
+        wireApi: wire.wireApi,
+        authScheme: auth.authScheme,
+        source: 'detected',
+        updatedAt: now(),
+      },
+      models: auth.models,
+      tried,
+    };
+  } catch (e) {
+    return { ok: false, reason: 'network', tried, detail: safeDetail(e && e.message ? e.message : 'Provider detection failed') };
+  }
+}

--- a/plugin/panel/src/cep/providerStore.js
+++ b/plugin/panel/src/cep/providerStore.js
@@ -1,11 +1,14 @@
 // Unified custom-provider store: ~/.ae-mcp/providers.json (spec A2).
 // Entry: {id, name, protocol: 'anthropic'|'openai-compatible', baseUrl,
-// apiKey, probedModels: [{id,label}], probedAt: ms}. Atomic write + chmod
-// 600 mirrors apiKey.js.
+// apiKey, probedModels: [{id,label}], probedAt: ms, dialect?}. Atomic
+// write + chmod 600 mirrors apiKey.js.
 // providers.json consolidates multiple provider keys in one file by design
 // (spec A2); chmod 600 is best-effort on Windows -- the single-file blast
 // radius is accepted in exchange for unified management and migration.
 const PROTOCOLS = new Set(['anthropic', 'openai-compatible']);
+const DIALECT_WIRE_APIS = new Set(['responses', 'chat']);
+const DIALECT_AUTH_SCHEMES = new Set(['bearer', 'x-api-key', 'none']);
+const DIALECT_SOURCES = new Set(['ccswitch-import', 'detected', 'manual']);
 const FILE_NAME = 'providers.json';
 
 function cepRequire() {
@@ -31,7 +34,7 @@ export function normalizeProviderEntry(input = {}) {
   if (!id) throw new Error('Provider entry needs an id');
   const protocol = String(input.protocol || 'openai-compatible');
   if (!PROTOCOLS.has(protocol)) throw new Error('Unsupported provider protocol: ' + protocol);
-  return {
+  const entry = {
     id,
     name: String(input.name || '').trim() || id,
     protocol,
@@ -40,6 +43,19 @@ export function normalizeProviderEntry(input = {}) {
     probedModels: Array.isArray(input.probedModels) ? input.probedModels : [],
     probedAt: Number(input.probedAt) || 0,
   };
+  const dialect = input.dialect && typeof input.dialect === 'object' ? input.dialect : null;
+  const wireApi = dialect ? String(dialect.wireApi || '').trim() : '';
+  const authScheme = dialect ? String(dialect.authScheme || '').trim() : '';
+  if (DIALECT_WIRE_APIS.has(wireApi) && DIALECT_AUTH_SCHEMES.has(authScheme)) {
+    const source = String(dialect.source || '').trim();
+    entry.dialect = {
+      wireApi,
+      authScheme,
+      source: DIALECT_SOURCES.has(source) ? source : 'manual',
+      updatedAt: typeof dialect.updatedAt === 'number' && Number.isFinite(dialect.updatedAt) ? dialect.updatedAt : 0,
+    };
+  }
+  return entry;
 }
 
 export function createProviderStore(deps = defaultDeps()) {

--- a/plugin/panel/src/cep/zcodeBackend.js
+++ b/plugin/panel/src/cep/zcodeBackend.js
@@ -290,6 +290,9 @@ function zcodeProtocolProviderKind(kind) {
 function zcodeProtocolApiFormat(provider, kind) {
   const direct = provider && (provider.apiFormat || provider.api_format);
   if (direct) return direct;
+  const dialect = provider && provider.dialect && typeof provider.dialect === 'object' ? provider.dialect : null;
+  if (kind === 'openai-compatible' && dialect && dialect.wireApi === 'responses') return 'openai-responses';
+  if (kind === 'openai-compatible' && dialect && dialect.wireApi === 'chat') return 'openai-chat-completions';
   if (kind === 'openai') return 'openai-responses';
   if (kind === 'openai-compatible') return 'openai-chat-completions';
   return 'anthropic-messages';

--- a/plugin/panel/src/components/settings/ProviderManagerSection.jsx
+++ b/plugin/panel/src/components/settings/ProviderManagerSection.jsx
@@ -5,10 +5,11 @@ import { Input } from '../forms/Input';
 import { Select } from '../forms/Select';
 import { Field } from '../forms/Field';
 import { emptyDraft, draftFromEntry, validateDraft, draftToEntry } from '../../lib/providerManagerState';
+import { providerDialectBadge } from '../../lib/providerDialectBadge';
 
 const L = {
-  zh: { title: 'Provider 管理', add: '新增', edit: '编辑', del: '删除', probe: '探测模型', probing: '探测中…', save: '保存', cancel: '取消', name: '名称', protocol: '协议', baseUrl: 'Base URL', apiKey: 'API Key', keyCap: '仅保存在本机 ~/.ae-mcp/providers.json', models: (n) => `${n} 个模型`, probeFailed: '探测失败（可手填模型 ID 继续使用）：', importCc: '从 cc-switch 导入' },
-  en: { title: 'Provider manager', add: 'Add', edit: 'Edit', del: 'Delete', probe: 'Probe models', probing: 'Probing…', save: 'Save', cancel: 'Cancel', name: 'Name', protocol: 'Protocol', baseUrl: 'Base URL', apiKey: 'API Key', keyCap: 'Stored locally in ~/.ae-mcp/providers.json', models: (n) => `${n} models`, probeFailed: 'Probe failed (manual model id still works): ', importCc: 'Import from cc-switch' },
+  zh: { title: 'Provider 管理', add: '新增', edit: '编辑', del: '删除', probe: '探测模型', redetect: '重新检测', probing: '探测中…', save: '保存', cancel: '取消', name: '名称', protocol: '协议', baseUrl: 'Base URL', apiKey: 'API Key', keyCap: '仅保存在本机 ~/.ae-mcp/providers.json', models: (n) => `${n} 个模型`, probeFailed: '探测失败（可手填模型 ID 继续使用）：', importCc: '从 cc-switch 导入', dialectSource: { 'ccswitch-import': { zh: '来自 cc-switch' }, detected: { zh: '自动检测' }, manual: { zh: '手动设置' } } },
+  en: { title: 'Provider manager', add: 'Add', edit: 'Edit', del: 'Delete', probe: 'Probe models', redetect: 'Re-detect', probing: 'Probing…', save: 'Save', cancel: 'Cancel', name: 'Name', protocol: 'Protocol', baseUrl: 'Base URL', apiKey: 'API Key', keyCap: 'Stored locally in ~/.ae-mcp/providers.json', models: (n) => `${n} models`, probeFailed: 'Probe failed (manual model id still works): ', importCc: 'Import from cc-switch', dialectSource: { 'ccswitch-import': { en: 'from cc-switch' }, detected: { en: 'auto-detected' }, manual: { en: 'manual' } } },
 };
 
 export function ProviderManagerSection({ lang = 'zh', providers = [], onUpsert, onRemove, onProbe, probing = '', probeErrors = {}, ccSwitch = null, onImportCcSwitch }) {
@@ -32,20 +33,25 @@ export function ProviderManagerSection({ lang = 'zh', providers = [], onUpsert, 
         {ccSwitch && onImportCcSwitch ? (
           <Button variant="secondary" size="sm" icon="download" onClick={onImportCcSwitch}>{t.importCc}</Button>
         ) : null}
-        {providers.map((p) => (
-          <div key={p.id} style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '6px 8px', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)', background: 'var(--bg-panel)' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ flex: 1, minWidth: 0, font: '500 12px/1.35 var(--font-ui)', color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
-              <Badge status="neutral">{p.protocol}</Badge>
-              {p.probedModels.length ? <Badge status="ok">{t.models(p.probedModels.length)}</Badge> : null}
-              <Button variant="ghost" size="sm" disabled={probing === p.id} onClick={() => onProbe(p)}>{probing === p.id ? t.probing : t.probe}</Button>
-              <Button variant="ghost" size="sm" onClick={() => { setDraft(draftFromEntry(p)); setError(''); }}>{t.edit}</Button>
-              <Button variant="ghost" size="sm" onClick={() => onRemove(p.id)}>{t.del}</Button>
+        {providers.map((p) => {
+          const dialectBadge = providerDialectBadge(p.dialect, lang, t.dialectSource);
+          return (
+            <div key={p.id} style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '6px 8px', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)', background: 'var(--bg-panel)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ flex: 1, minWidth: 0, font: '500 12px/1.35 var(--font-ui)', color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
+                <Badge status="neutral">{p.protocol}</Badge>
+                {dialectBadge ? <span title={dialectBadge.title}><Badge status="neutral">{dialectBadge.label}</Badge></span> : null}
+                {p.probedModels.length ? <Badge status="ok">{t.models(p.probedModels.length)}</Badge> : null}
+                <Button variant="ghost" size="sm" disabled={probing === p.id} onClick={() => onProbe(p)}>{probing === p.id ? t.probing : t.probe}</Button>
+                {p.dialect ? <Button variant="ghost" size="sm" disabled={probing === p.id} onClick={() => onProbe(p, { forceDetect: true })}>{probing === p.id ? t.probing : t.redetect}</Button> : null}
+                <Button variant="ghost" size="sm" onClick={() => { setDraft(draftFromEntry(p)); setError(''); }}>{t.edit}</Button>
+                <Button variant="ghost" size="sm" onClick={() => onRemove(p.id)}>{t.del}</Button>
+              </div>
+              <div style={{ font: '400 10px/1.35 var(--font-mono)', color: 'var(--text-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.baseUrl}</div>
+              {probeErrors[p.id] ? <div style={{ font: '400 10px/1.4 var(--font-ui)', color: 'var(--warn)' }}>{t.probeFailed}{probeErrors[p.id]}</div> : null}
             </div>
-            <div style={{ font: '400 10px/1.35 var(--font-mono)', color: 'var(--text-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.baseUrl}</div>
-            {probeErrors[p.id] ? <div style={{ font: '400 10px/1.4 var(--font-ui)', color: 'var(--warn)' }}>{t.probeFailed}{probeErrors[p.id]}</div> : null}
-          </div>
-        ))}
+          );
+        })}
         {draft ? (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '8px', border: '1px solid var(--border-strong)', borderRadius: 'var(--radius-sm)', background: 'var(--bg-panel)' }}>
             <Field label={t.name}><Input value={draft.name} onChange={(v) => setDraft({ ...draft, name: v })} /></Field>

--- a/plugin/panel/src/lib/backendSelect.js
+++ b/plugin/panel/src/lib/backendSelect.js
@@ -4,7 +4,7 @@ import { pickChannel } from './channels.js';
 // Spec D: one selection algorithm for all backends, fed by uniform channel
 // probe arrays. `pref` is the 3-way backend choice (subscription|codex|zcode);
 // channels = { claude: [...], codex: [...], zcode: [...] }.
-export function pickBackend({ pref, channels = {}, lockedChannel = '', nodeOk = true }) {
+export function pickBackend({ pref, channels = {}, lockedChannel = '', nodeOk = true, apiProvider = null }) {
   const group = pref === 'codex' || pref === 'zcode' ? pref : 'claude';
   const list = channels[group] || [];
   if (list.some((c) => c && c.checking)) {
@@ -22,13 +22,23 @@ export function pickBackend({ pref, channels = {}, lockedChannel = '', nodeOk = 
   }
   if (group === 'claude') {
     if (chosen.channel === 'api') {
-      return { backend: nodeOk ? 'claude-api' : 'byok', reason: 'ok', channel: 'api', fixHint: null };
+      const canUseAgentSdk = nodeOk && isOfficialAnthropicProvider(apiProvider);
+      return { backend: canUseAgentSdk ? 'claude-api' : 'byok', reason: 'ok', channel: 'api', fixHint: null };
     }
     return { backend: 'subscription', reason: 'ok', channel: 'subscription', fixHint: null };
   }
   return { backend: group, reason: 'ok', channel: chosen.channel, fixHint: null };
 }
 
+function isOfficialAnthropicProvider(provider) {
+  const baseUrl = provider && provider.baseUrl ? String(provider.baseUrl) : 'https://api.anthropic.com';
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === 'api.anthropic.com';
+  } catch (e) {
+    return /(^|\/)api\.anthropic\.com(\/|$)/i.test(baseUrl);
+  }
+}
 export function deriveToolMeta(tools) {
   const allowedTools = [];
   const annotations = {};
@@ -51,3 +61,4 @@ export function shouldResetOnBackendChange(prevReal, next) {
   if (prevReal === next) return { reset: false, nextReal: prevReal };
   return { reset: true, nextReal: next };
 }
+

--- a/plugin/panel/src/lib/channels.js
+++ b/plugin/panel/src/lib/channels.js
@@ -54,7 +54,13 @@ export function codexChannels({ codexProbe, customProvider, cliConfig, cliConfig
     channel: 'custom',
     source: { zh: '自定义 provider', en: 'Custom provider' },
     checking: false,
-    ok: Boolean(customProvider && customProvider.baseUrl && customProvider.apiKey && (!codexProbe || codexProbe.runtimeOk !== false)),
+    ok: Boolean(
+      customProvider
+      && customProvider.protocol === 'openai-compatible'
+      && customProvider.baseUrl
+      && customProvider.apiKey
+      && (!codexProbe || codexProbe.runtimeOk !== false)
+    ),
     detail: customProvider && customProvider.baseUrl ? customProvider.baseUrl : '',
     fixHint: { zh: '在「Provider 管理」新增/选择一个 OpenAI 兼容 provider（Base URL + Key）。', en: 'Add or pick an OpenAI-compatible provider (base URL + key) in Provider Manager.' },
   };

--- a/plugin/panel/src/lib/providerDialectBadge.js
+++ b/plugin/panel/src/lib/providerDialectBadge.js
@@ -1,0 +1,17 @@
+export const DEFAULT_DIALECT_SOURCE_LABELS = {
+  'ccswitch-import': { zh: '来自 cc-switch', en: 'from cc-switch' },
+  detected: { zh: '自动检测', en: 'auto-detected' },
+  manual: { zh: '手动设置', en: 'manual' },
+};
+
+export function providerDialectBadge(dialect, lang = 'zh', sourceLabels = DEFAULT_DIALECT_SOURCE_LABELS) {
+  if (!dialect || typeof dialect !== 'object') return null;
+  const wireApi = String(dialect.wireApi || '').trim();
+  const authScheme = String(dialect.authScheme || '').trim();
+  if (!wireApi || !authScheme) return null;
+  const source = sourceLabels[dialect.source] || sourceLabels.manual || DEFAULT_DIALECT_SOURCE_LABELS.manual;
+  return {
+    label: wireApi + ' · ' + authScheme,
+    title: source[lang] || source.zh || source.en || '',
+  };
+}

--- a/plugin/panel/src/lib/providerProfile.js
+++ b/plugin/panel/src/lib/providerProfile.js
@@ -21,8 +21,9 @@ function normalizeProviderId(value) {
   return RESERVED_CODEX_PROVIDER_IDS.has(safe) ? safe + '-custom' : safe;
 }
 
-function normalizeCodexWireApi() {
-  return DEFAULT_CODEX_WIRE_API;
+function normalizeCodexWireApi(value) {
+  const text = String(value || '').trim();
+  return text === 'responses' || text === 'chat' ? text : DEFAULT_CODEX_WIRE_API;
 }
 
 function tomlString(value) {
@@ -36,7 +37,7 @@ export function normalizeProviderProfile(input = {}, env = {}) {
     codexApiKey: firstValue(input.codexApiKey, env.AE_MCP_CODEX_API_KEY),
     codexBaseUrl,
     codexProviderId: normalizeProviderId(firstValue(input.codexProviderId, env.AE_MCP_CODEX_PROVIDER_ID)),
-    codexWireApi: normalizeCodexWireApi(),
+    codexWireApi: normalizeCodexWireApi(firstValue(input.codexWireApi, env.AE_MCP_CODEX_WIRE_API)),
     anthropicBaseUrl,
   };
 }

--- a/plugin/panel/src/lib/providerProfile.js
+++ b/plugin/panel/src/lib/providerProfile.js
@@ -26,6 +26,11 @@ function normalizeCodexWireApi(value) {
   return text === 'responses' || text === 'chat' ? text : DEFAULT_CODEX_WIRE_API;
 }
 
+function normalizeCodexAuthScheme(value) {
+  const text = String(value || '').trim();
+  return text === 'x-api-key' || text === 'none' || text === 'bearer' ? text : 'bearer';
+}
+
 function tomlString(value) {
   return JSON.stringify(String(value || ''));
 }
@@ -38,6 +43,7 @@ export function normalizeProviderProfile(input = {}, env = {}) {
     codexBaseUrl,
     codexProviderId: normalizeProviderId(firstValue(input.codexProviderId, env.AE_MCP_CODEX_PROVIDER_ID)),
     codexWireApi: normalizeCodexWireApi(firstValue(input.codexWireApi, env.AE_MCP_CODEX_WIRE_API)),
+    codexAuthScheme: normalizeCodexAuthScheme(firstValue(input.codexAuthScheme, env.AE_MCP_CODEX_AUTH_SCHEME)),
     anthropicBaseUrl,
   };
 }
@@ -91,3 +97,5 @@ export function ensureUserEnv(env = {}, { homedir = '', appData = '' } = {}) {
   if (!next.APPDATA) next.APPDATA = appData || anchor + '\\AppData\\Roaming';
   return next;
 }
+
+

--- a/plugin/panel/test/backendSelect.test.js
+++ b/plugin/panel/test/backendSelect.test.js
@@ -18,6 +18,12 @@ test('pickBackend: claude api channel routes to claude-api with node, byok witho
   assert.equal(pickBackend({ pref: 'subscription', channels, nodeOk: false }).backend, 'byok');
 });
 
+test('pickBackend: third-party claude api providers use byok even when node is available', () => {
+  const channels = { claude: [ch('subscription', false), ch('api', true)] };
+  const apiProvider = { protocol: 'anthropic', baseUrl: 'https://relay.example/v1', apiKey: 'k' };
+  assert.equal(pickBackend({ pref: 'subscription', channels, nodeOk: true, apiProvider }).backend, 'byok');
+});
+
 test('pickBackend: probing and no-channel states carry reason + fixHint', () => {
   const probing = pickBackend({ pref: 'codex', channels: { codex: [ch('cli', false, undefined, true)] } });
   assert.deepEqual(probing, { backend: 'none', reason: 'codex-probing', channel: null, fixHint: null });
@@ -82,3 +88,4 @@ test('shouldResetOnBackendChange ignores none and resets only on real backend ch
   assert.deepEqual(run(['none', 'subscription']), []);
   assert.deepEqual(run(['none', 'byok', 'subscription']), ['subscription']);
 });
+

--- a/plugin/panel/test/ccSwitch.test.js
+++ b/plugin/panel/test/ccSwitch.test.js
@@ -31,9 +31,104 @@ test('ccSwitchProviderEntries maps tolerant fields into normalized entries', () 
   assert.equal(entries[0].protocol, 'openai-compatible');
   assert.equal(entries[0].baseUrl, 'https://example.com');
   assert.equal(entries[0].apiKey, 'sk-abc');
+  assert.equal(entries[0].dialect, undefined);
   assert.equal(entries[1].id, 'ccswitch-anthropic-direct');
   assert.equal(entries[1].protocol, 'anthropic');
   assert.equal(entries[1].apiKey, 'sk-ant');
+  assert.equal(entries[1].dialect, undefined);
+});
+
+test('ccSwitchProviderEntries inherits apiFormat dialect metadata', () => {
+  const entries = ccSwitchProviderEntries([
+    {
+      name: 'Responses Provider',
+      baseUrl: 'https://responses.example.com',
+      meta: { apiFormat: 'openai_responses' },
+      settingsConfig: { auth: { OPENAI_API_KEY: '' } },
+    },
+    {
+      name: 'Chat Provider',
+      baseUrl: 'https://chat.example.com',
+      apiFormat: 'openai_chat',
+      settingsConfig: { auth: { OPENAI_API_KEY: '' } },
+    },
+  ], { now: () => 456 });
+  assert.deepEqual(entries[0].dialect, { wireApi: 'responses', authScheme: 'bearer', source: 'ccswitch-import', updatedAt: 456 });
+  assert.deepEqual(entries[1].dialect, { wireApi: 'chat', authScheme: 'bearer', source: 'ccswitch-import', updatedAt: 456 });
+});
+
+test('ccSwitchProviderEntries extracts wire_api from config TOML', () => {
+  const entries = ccSwitchProviderEntries([{
+    name: 'Toml Provider',
+    baseUrl: 'https://toml.example.com',
+    settingsConfig: {
+      config: `
+model_provider = "custom"
+
+[model_providers.custom]
+wire_api = "chat"
+`,
+      auth: { OPENAI_API_KEY: '' },
+    },
+  }], { now: () => 789 });
+  assert.deepEqual(entries[0].dialect, { wireApi: 'chat', authScheme: 'bearer', source: 'ccswitch-import', updatedAt: 789 });
+});
+
+test('ccSwitchProviderEntries infers auth scheme from apiKeyField, env, and auth', () => {
+  const entries = ccSwitchProviderEntries([
+    {
+      name: 'Anthropic Key Field',
+      baseUrl: 'https://anthropic-key.example.com',
+      meta: { apiFormat: 'openai_responses', apiKeyField: 'ANTHROPIC_API_KEY' },
+      settingsConfig: {},
+    },
+    {
+      name: 'Anthropic Token Env',
+      baseUrl: 'https://anthropic-token.example.com',
+      meta: { apiFormat: 'openai_responses' },
+      settingsConfig: { env: { ANTHROPIC_AUTH_TOKEN: '' } },
+    },
+    {
+      name: 'Anthropic Key Env',
+      baseUrl: 'https://anthropic-env.example.com',
+      meta: { apiFormat: 'openai_responses' },
+      settingsConfig: { env: { ANTHROPIC_API_KEY: '' } },
+    },
+    {
+      name: 'OpenAI Env',
+      baseUrl: 'https://openai-env.example.com',
+      meta: { apiFormat: 'openai_responses' },
+      settingsConfig: { env: { OPENAI_API_KEY: '' } },
+    },
+    {
+      name: 'OpenAI Auth',
+      baseUrl: 'https://openai-auth.example.com',
+      meta: { apiFormat: 'openai_responses' },
+      settingsConfig: { auth: { OPENAI_API_KEY: '' } },
+    },
+  ], { now: () => 1000 });
+  assert.equal(entries[0].dialect.authScheme, 'x-api-key');
+  assert.equal(entries[1].dialect.authScheme, 'bearer');
+  assert.equal(entries[2].dialect.authScheme, 'x-api-key');
+  assert.equal(entries[3].dialect.authScheme, 'bearer');
+  assert.equal(entries[4].dialect.authScheme, 'bearer');
+});
+
+test('ccSwitchProviderEntries omits dialect when either wire or auth signal is missing', () => {
+  const entries = ccSwitchProviderEntries([
+    {
+      name: 'Wire Only',
+      baseUrl: 'https://wire-only.example.com',
+      meta: { apiFormat: 'openai_chat' },
+    },
+    {
+      name: 'Auth Only',
+      baseUrl: 'https://auth-only.example.com',
+      settingsConfig: { auth: { OPENAI_API_KEY: '' } },
+    },
+  ]);
+  assert.equal(entries[0].dialect, undefined);
+  assert.equal(entries[1].dialect, undefined);
 });
 
 test('detectCcSwitch finds config.json in the primary ~/.cc-switch directory', () => {

--- a/plugin/panel/test/channels.test.js
+++ b/plugin/panel/test/channels.test.js
@@ -25,7 +25,11 @@ test('codexChannels: cli login state + custom provider channel', () => {
   assert.equal(list[2].channel, 'custom');
   assert.equal(list[2].ok, false);
   const custom = codexChannels({ codexProbe: { loggedIn: false, runtimeOk: true }, customProvider: { baseUrl: 'https://r', apiKey: 'k' } });
-  assert.equal(custom.find((c) => c.channel === 'custom').ok, true);
+  assert.equal(custom.find((c) => c.channel === 'custom').ok, false);
+  const openAiCustom = codexChannels({ codexProbe: { loggedIn: false, runtimeOk: true }, customProvider: { protocol: 'openai-compatible', baseUrl: 'https://r', apiKey: 'k' } });
+  assert.equal(openAiCustom.find((c) => c.channel === 'custom').ok, true);
+  const anthropicCustom = codexChannels({ codexProbe: { loggedIn: false, runtimeOk: true }, customProvider: { protocol: 'anthropic', baseUrl: 'https://r', apiKey: 'k' } });
+  assert.equal(anthropicCustom.find((c) => c.channel === 'custom').ok, false);
   assert.match(codexChannels({ codexProbe: { loggedIn: false } }).find((c) => c.channel === 'cli').fixHint.zh, /AE_MCP_CODEX_CLI/);
 });
 
@@ -68,7 +72,7 @@ test('codexChannels: cli-config channel is positioned between cli and custom', (
 test('codexChannels: custom provider outranks cli-config in pickChannel when both are ok', () => {
   const list = codexChannels({
     codexProbe: { loggedIn: false, runtimeOk: true },
-    customProvider: { baseUrl: 'https://custom.example/v1', apiKey: 'ck' },
+    customProvider: { protocol: 'openai-compatible', baseUrl: 'https://custom.example/v1', apiKey: 'ck' },
     cliConfig: { model: 'gpt-5.5', providerId: 'mediastorm_glm', provider: { name: 'MediaStorm GLM', baseUrl: 'https://api.example.com/v1', envKey: 'MEDIASTORM_GLM_API_KEY', wireApi: 'responses' } },
     cliConfigApiKey: 'k',
   });

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -222,7 +222,7 @@ test('createCodexBackend starts app-server with custom provider config when supp
       codexBaseUrl: 'https://proxy.example/openai',
       codexApiKey: 'sk-proxy',
       codexProviderId: 'my-provider',
-      codexWireApi: 'chat',
+      codexWireApi: 'responses',
     }),
   });
 
@@ -235,7 +235,7 @@ test('createCodexBackend starts app-server with custom provider config when supp
     '-c', 'model_providers.my-provider.name="AE MCP Custom"',
     '-c', 'model_providers.my-provider.base_url="https://proxy.example/openai"',
     '-c', 'model_providers.my-provider.env_key="AE_MCP_CODEX_API_KEY"',
-    '-c', 'model_providers.my-provider.wire_api="chat"',
+    '-c', 'model_providers.my-provider.wire_api="responses"',
     '-c', 'model_providers.my-provider.requires_openai_auth=false',
   ]);
   assert.equal(spawned.calls[0].options.env.AE_MCP_CODEX_API_KEY, 'sk-proxy');
@@ -244,6 +244,50 @@ test('createCodexBackend starts app-server with custom provider config when supp
   await pending;
 });
 
+test('createCodexBackend routes chat-wire custom providers through a local Responses facade', async () => {
+  const routeCalls = [];
+  let closed = 0;
+  const { backend, spawned } = makeBackend({
+    createResponsesRoute: (input) => {
+      routeCalls.push(input);
+      return {
+        start: async () => ({ baseUrl: 'http://127.0.0.1:49123', apiKey: 'local-route-key' }),
+        close: async () => { closed += 1; },
+      };
+    },
+    getProviderProfile: () => ({
+      codexBaseUrl: 'https://proxy.example/openai',
+      codexApiKey: 'sk-proxy',
+      codexProviderId: 'my-provider',
+      codexWireApi: 'chat',
+      codexAuthScheme: 'bearer',
+    }),
+  });
+
+  const { pending, proc } = await startTurn(backend, spawned, 'custom provider');
+
+  assert.equal(routeCalls.length, 1);
+  assert.deepEqual(routeCalls[0], {
+    upstreamBaseUrl: 'https://proxy.example/openai',
+    apiKey: 'sk-proxy',
+    authScheme: 'bearer',
+  });
+  assert.deepEqual(spawned.calls[0].args, [
+    'app-server',
+    '-c', 'model_provider="my-provider"',
+    '-c', 'model_providers.my-provider.name="AE MCP Custom"',
+    '-c', 'model_providers.my-provider.base_url="http://127.0.0.1:49123"',
+    '-c', 'model_providers.my-provider.env_key="AE_MCP_CODEX_API_KEY"',
+    '-c', 'model_providers.my-provider.wire_api="responses"',
+    '-c', 'model_providers.my-provider.requires_openai_auth=false',
+  ]);
+  assert.equal(spawned.calls[0].options.env.AE_MCP_CODEX_API_KEY, 'local-route-key');
+
+  proc.pushStdout({ jsonrpc: '2.0', method: 'turn/completed', params: {} });
+  await pending;
+  backend.reset();
+  assert.equal(closed, 1);
+});
 test('createCodexBackend injects cli-config provider env var when no custom provider is configured', async () => {
   const { backend, spawned } = makeBackend({
     getCliConfigProvider: () => ({
@@ -763,3 +807,4 @@ test('probeAccount resolves within bounds and kills the process when initialize 
   assert.match(result.detail, /timeout/i);
   assert.equal(proc.killed, true);
 });
+

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -235,7 +235,7 @@ test('createCodexBackend starts app-server with custom provider config when supp
     '-c', 'model_providers.my-provider.name="AE MCP Custom"',
     '-c', 'model_providers.my-provider.base_url="https://proxy.example/openai"',
     '-c', 'model_providers.my-provider.env_key="AE_MCP_CODEX_API_KEY"',
-    '-c', 'model_providers.my-provider.wire_api="responses"',
+    '-c', 'model_providers.my-provider.wire_api="chat"',
     '-c', 'model_providers.my-provider.requires_openai_auth=false',
   ]);
   assert.equal(spawned.calls[0].options.env.AE_MCP_CODEX_API_KEY, 'sk-proxy');

--- a/plugin/panel/test/codexResponsesRoute.test.js
+++ b/plugin/panel/test/codexResponsesRoute.test.js
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createCodexResponsesRoute, responsesBodyToChatBody } from '../src/cep/codexResponsesRoute.js';
+
+function listen(server) {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function requestText(url, { method = 'GET', headers = {}, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const endpoint = new URL(url);
+    const req = http.request({
+      hostname: endpoint.hostname,
+      port: endpoint.port,
+      path: endpoint.pathname + endpoint.search,
+      method,
+      headers,
+    }, (res) => {
+      let text = '';
+      res.on('data', (chunk) => { text += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: text }));
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(typeof body === 'string' ? body : JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('responsesBodyToChatBody maps text-only Responses input to chat completions', () => {
+  assert.deepEqual(responsesBodyToChatBody({
+    model: 'gpt-5.4',
+    instructions: 'system rules',
+    input: [{ role: 'user', content: [{ type: 'input_text', text: 'say ok' }] }],
+    max_output_tokens: 12,
+    stream: true,
+  }), {
+    model: 'gpt-5.4',
+    messages: [
+      { role: 'system', content: 'system rules' },
+      { role: 'user', content: 'say ok' },
+    ],
+    max_tokens: 12,
+    stream: true,
+  });
+});
+
+test('createCodexResponsesRoute adapts streaming Responses requests to chat completions', async () => {
+  const upstreamCalls = [];
+  const upstream = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      upstreamCalls.push({ path: req.url, headers: req.headers, body: JSON.parse(body || '{}') });
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write('data: {"choices":[{"delta":{"content":"CODEX_"}}]}\n\n');
+      res.write('data: {"choices":[{"delta":{"content":"ROUTE_OK"}}]}\n\n');
+      res.end('data: [DONE]\n\n');
+    });
+  });
+  const upstreamPort = await listen(upstream);
+  const route = createCodexResponsesRoute({
+    requireImpl: (name) => { if (name === 'http') return http; throw new Error('unexpected module ' + name); },
+    upstreamBaseUrl: `http://127.0.0.1:${upstreamPort}/v1`,
+    apiKey: 'sk-upstream',
+    authScheme: 'bearer',
+  });
+
+  try {
+    const local = await route.start();
+    const result = await requestText(`${local.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: {
+        model: 'gpt-5.4',
+        input: 'reply ok',
+        max_output_tokens: 16,
+        stream: true,
+      },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(upstreamCalls[0].path, '/v1/chat/completions');
+    assert.equal(upstreamCalls[0].headers.authorization, 'Bearer sk-upstream');
+    assert.equal(upstreamCalls[0].body.stream, true);
+    assert.deepEqual(upstreamCalls[0].body.messages, [{ role: 'user', content: 'reply ok' }]);
+    assert.match(result.body, /event: response.output_text.delta/);
+    assert.match(result.body, /CODEX_ROUTE_OK/);
+    assert.match(result.body, /event: response.completed/);
+  } finally {
+    await route.close();
+    await close(upstream);
+  }
+});
+
+
+test('responsesBodyToChatBody maps function tools and tool history', () => {
+  assert.deepEqual(responsesBodyToChatBody({
+    model: 'gpt-5.4',
+    tools: [{ type: 'function', name: 'ae_status', description: 'status', parameters: { type: 'object', properties: {} } }],
+    tool_choice: { type: 'function', name: 'ae_status' },
+    input: [
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'check' }] },
+      { type: 'function_call', call_id: 'call_1', name: 'ae_status', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'call_1', output: '{"ok":true}' },
+    ],
+    stream: false,
+  }), {
+    model: 'gpt-5.4',
+    messages: [
+      { role: 'user', content: 'check' },
+      { role: 'assistant', content: null, tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'ae_status', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+    ],
+    stream: false,
+    tools: [{ type: 'function', function: { name: 'ae_status', description: 'status', parameters: { type: 'object', properties: {} } } }],
+    tool_choice: { type: 'function', function: { name: 'ae_status' } },
+  });
+});
+
+test('createCodexResponsesRoute adapts streaming tool_calls to Responses function_call events', async () => {
+  const upstreamCalls = [];
+  const upstream = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      upstreamCalls.push({ path: req.url, body: JSON.parse(body || '{}') });
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.write('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_9","function":{"name":"ae_status","arguments":"{"}}]}}]}\n\n');
+      res.write('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}}]}\n\n');
+      res.end('data: [DONE]\n\n');
+    });
+  });
+  const upstreamPort = await listen(upstream);
+  const route = createCodexResponsesRoute({
+    requireImpl: (name) => { if (name === 'http') return http; throw new Error('unexpected module ' + name); },
+    upstreamBaseUrl: `http://127.0.0.1:${upstreamPort}/v1`,
+    apiKey: 'sk-upstream',
+    authScheme: 'bearer',
+  });
+
+  try {
+    const local = await route.start();
+    const result = await requestText(`${local.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: {
+        model: 'gpt-5.4',
+        input: 'use tool',
+        tools: [{ type: 'function', name: 'ae_status', parameters: { type: 'object', properties: {} } }],
+        stream: true,
+      },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(upstreamCalls[0].path, '/v1/chat/completions');
+    assert.equal(upstreamCalls[0].body.tools[0].function.name, 'ae_status');
+    assert.match(result.body, /event: response.output_item.added/);
+    assert.match(result.body, /"type":"function_call"/);
+    assert.match(result.body, /ae_status/);
+    assert.match(result.body, /event: response.function_call_arguments.delta/);
+    assert.match(result.body, /event: response.completed/);
+  } finally {
+    await route.close();
+    await close(upstream);
+  }
+});
+

--- a/plugin/panel/test/modelProbe.test.js
+++ b/plugin/panel/test/modelProbe.test.js
@@ -19,6 +19,9 @@ test('parseModelsList handles Anthropic-style display_name and bare arrays', () 
 
 test('probeHeaders picks auth scheme by protocol', () => {
   assert.deepEqual(probeHeaders('openai-compatible', 'sk-x'), { Authorization: 'Bearer sk-x' });
+  assert.deepEqual(probeHeaders('openai-compatible', 'sk-x', { authScheme: 'bearer' }), { Authorization: 'Bearer sk-x' });
+  assert.deepEqual(probeHeaders('openai-compatible', 'sk-x', { authScheme: 'x-api-key' }), { 'x-api-key': 'sk-x' });
+  assert.deepEqual(probeHeaders('openai-compatible', 'sk-x', { authScheme: 'none' }), {});
   assert.deepEqual(probeHeaders('anthropic', 'sk-a'), { 'x-api-key': 'sk-a', 'anthropic-version': '2023-06-01' });
 });
 
@@ -49,6 +52,26 @@ test('probeProviderModels returns ok with parsed models on 200', async () => {
   const result = await probeProviderModels({ baseUrl: 'https://api.example.com/v1/', apiKey: 'sk-x', protocol: 'openai-compatible', httpsImpl: https });
   assert.equal(result.ok, true);
   assert.deepEqual(result.models, [{ id: 'glm-5.2', label: 'glm-5.2' }]);
+});
+
+test('probeProviderModels respects openai-compatible dialect auth schemes', async () => {
+  const seen = [];
+  const https = makeHttps((options, res, onRes) => {
+    seen.push(options.headers);
+    onRes(Object.assign(res, { statusCode: 200 }));
+    res.handlers.data(JSON.stringify({ data: [{ id: 'm' }] }));
+    res.handlers.end();
+  });
+
+  await probeProviderModels({ baseUrl: 'https://h/v1', apiKey: 'sk', dialect: { authScheme: 'bearer' }, httpsImpl: https });
+  await probeProviderModels({ baseUrl: 'https://h/v1', apiKey: 'sk', dialect: { authScheme: 'x-api-key' }, httpsImpl: https });
+  await probeProviderModels({ baseUrl: 'https://h/v1', apiKey: 'sk', authScheme: 'none', httpsImpl: https });
+
+  assert.deepEqual(seen, [
+    { Authorization: 'Bearer sk' },
+    { 'x-api-key': 'sk' },
+    {},
+  ]);
 });
 
 test('probeProviderModels degrades to ok:false on 401 and network error', async () => {

--- a/plugin/panel/test/noSensitiveDefaults.test.js
+++ b/plugin/panel/test/noSensitiveDefaults.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const forbiddenHost = ['token', 'mediastorm', 'studio'].join('.');
+const scanRoots = [
+  'docs',
+  'plugin/client/dist',
+  'plugin/panel/src',
+  'plugin/panel/test',
+];
+
+async function* walkFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(fullPath);
+    } else if (entry.isFile()) {
+      yield fullPath;
+    }
+  }
+}
+
+test('provider examples and defaults do not expose private hostnames', async () => {
+  const hits = [];
+  for (const root of scanRoots) {
+    for await (const filePath of walkFiles(path.join(repoRoot, root))) {
+      const body = await readFile(filePath, 'utf8');
+      if (body.includes(forbiddenHost)) {
+        hits.push(path.relative(repoRoot, filePath));
+      }
+    }
+  }
+  assert.deepEqual(hits, []);
+});

--- a/plugin/panel/test/providerDetect.test.js
+++ b/plugin/panel/test/providerDetect.test.js
@@ -1,0 +1,228 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectProviderDialect } from '../src/cep/providerDetect.js';
+
+function makeHttps(responses) {
+  const calls = [];
+  return {
+    calls,
+    request(options, onRes) {
+      const req = {
+        handlers: {},
+        body: '',
+        on(ev, fn) { this.handlers[ev] = fn; return this; },
+        setTimeout() {},
+        destroy() {},
+        write(chunk) { this.body += chunk; },
+        end() {
+          const response = responses.shift();
+          calls.push({ options, body: this.body });
+          if (!response) throw new Error('Unexpected request: ' + options.method + ' ' + options.path);
+          if (response.error) {
+            this.handlers.error(new Error(response.error));
+            return;
+          }
+          const res = {
+            handlers: {},
+            on(ev, fn) { this.handlers[ev] = fn; },
+          };
+          onRes(Object.assign(res, { statusCode: response.status }));
+          if (response.body !== undefined) res.handlers.data(response.body);
+          res.handlers.end();
+        },
+      };
+      return req;
+    },
+  };
+}
+
+function modelBody(id = 'glm-5.2') {
+  return JSON.stringify({ data: [{ id }] });
+}
+
+test('detectProviderDialect accepts bearer auth and responses wire API', async () => {
+  const https = makeHttps([
+    { status: 200, body: modelBody('glm-5.2') },
+    { status: 200, body: '{}' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://api.example.com/v1/',
+    apiKey: 'sk-good',
+    httpsImpl: https,
+    now: () => 123,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.dialect, { wireApi: 'responses', authScheme: 'bearer', source: 'detected', updatedAt: 123 });
+  assert.deepEqual(result.models, [{ id: 'glm-5.2', label: 'glm-5.2' }]);
+  assert.deepEqual(result.tried, [
+    { step: 'auth', candidate: 'bearer', status: 200, outcome: 'accepted' },
+    { step: 'wire', candidate: 'responses', status: 200, outcome: 'accepted' },
+  ]);
+  assert.equal(https.calls[0].options.path, '/v1/models');
+  assert.equal(https.calls[0].options.headers.Authorization, 'Bearer sk-good');
+  assert.equal(https.calls[1].options.path, '/v1/responses');
+  assert.deepEqual(JSON.parse(https.calls[1].body), { model: 'glm-5.2', input: 'ping', max_output_tokens: 16, stream: false });
+});
+
+test('detectProviderDialect falls through bearer to x-api-key and chat', async () => {
+  const https = makeHttps([
+    { status: 401, body: 'no' },
+    { status: 200, body: modelBody('chat-model') },
+    { status: 404, body: 'missing' },
+    { status: 200, body: '{}' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://provider.example',
+    apiKey: 'sk-x',
+    httpsImpl: https,
+    now: () => 456,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.dialect, { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 456 });
+  assert.equal(https.calls[1].options.headers['x-api-key'], 'sk-x');
+  assert.equal(https.calls[2].options.path, '/v1/responses');
+  assert.equal(https.calls[3].options.path, '/v1/chat/completions');
+  assert.deepEqual(result.tried, [
+    { step: 'auth', candidate: 'bearer', status: 401, outcome: 'rejected' },
+    { step: 'auth', candidate: 'x-api-key', status: 200, outcome: 'accepted' },
+    { step: 'wire', candidate: 'responses', status: 404, outcome: 'rejected' },
+    { step: 'wire', candidate: 'chat', status: 200, outcome: 'accepted' },
+  ]);
+});
+
+test('detectProviderDialect tries only none auth when apiKey is empty', async () => {
+  const https = makeHttps([
+    { status: 200, body: modelBody('public-model') },
+    { status: 200, body: '{}' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://public.example',
+    apiKey: '',
+    httpsImpl: https,
+    now: () => 789,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.dialect.authScheme, 'none');
+  assert.equal(https.calls.length, 2);
+  assert.deepEqual(https.calls[0].options.headers, {});
+  assert.deepEqual(result.tried.map((t) => t.candidate), ['none', 'responses']);
+});
+
+test('detectProviderDialect reports auth when all model auth attempts are rejected', async () => {
+  const https = makeHttps([
+    { status: 401, body: 'bearer no' },
+    { status: 403, body: 'x no' },
+    { status: 401, body: 'none no' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://locked.example',
+    apiKey: 'sk-bad',
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'auth');
+  assert.equal(https.calls.length, 3);
+  assert.deepEqual(result.tried.map((t) => t.candidate), ['bearer', 'x-api-key', 'none']);
+});
+
+test('detectProviderDialect stops immediately on network error', async () => {
+  const https = makeHttps([
+    { error: 'ECONNREFUSED' },
+    { status: 200, body: modelBody('should-not-run') },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://down.example',
+    apiKey: 'sk-down',
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'network');
+  assert.equal(https.calls.length, 1);
+  assert.deepEqual(result.tried, [{ step: 'auth', candidate: 'bearer', status: 0, outcome: 'network' }]);
+});
+
+test('detectProviderDialect accepts responses on 400 JSON error object', async () => {
+  const https = makeHttps([
+    { status: 200, body: modelBody('strict-model') },
+    { status: 400, body: JSON.stringify({ error: { message: 'unsupported parameter' } }) },
+    { status: 200, body: '{}' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://strict.example',
+    apiKey: 'sk-strict',
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.dialect.wireApi, 'responses');
+  assert.equal(https.calls.length, 2);
+  assert.deepEqual(result.tried.at(-1), { step: 'wire', candidate: 'responses', status: 400, outcome: 'accepted' });
+});
+
+test('detectProviderDialect reports wire-undetected when responses and chat are missing', async () => {
+  const https = makeHttps([
+    { status: 200, body: modelBody('model') },
+    { status: 404, body: 'not found' },
+    { status: 404, body: 'not found' },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://models-only.example',
+    apiKey: 'sk-wire',
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'wire-undetected');
+  assert.deepEqual(result.tried.slice(1), [
+    { step: 'wire', candidate: 'responses', status: 404, outcome: 'rejected' },
+    { step: 'wire', candidate: 'chat', status: 404, outcome: 'rejected' },
+  ]);
+});
+
+test('detectProviderDialect skips anthropic providers', async () => {
+  const https = makeHttps([{ status: 200, body: modelBody('unused') }]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://api.anthropic.com',
+    apiKey: 'sk-a',
+    protocol: 'anthropic',
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'not-applicable');
+  assert.deepEqual(result.tried, []);
+  assert.equal(https.calls.length, 0);
+});
+
+test('detectProviderDialect does not include apiKey in tried or detail', async () => {
+  const apiKey = 'sk-test-secret-1234567890';
+  const https = makeHttps([
+    { status: 401, body: 'Authorization: Bearer ' + apiKey },
+    { status: 403, body: 'x-api-key=' + apiKey },
+    { status: 401, body: 'apiKey=' + apiKey },
+  ]);
+
+  const result = await detectProviderDialect({
+    baseUrl: 'https://secret.example',
+    apiKey,
+    httpsImpl: https,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'auth');
+  assert.doesNotMatch(JSON.stringify(result.tried), new RegExp(apiKey));
+  assert.doesNotMatch(result.detail, new RegExp(apiKey));
+});

--- a/plugin/panel/test/providerDialectBadge.test.js
+++ b/plugin/panel/test/providerDialectBadge.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { providerDialectBadge } from '../src/lib/providerDialectBadge.js';
+
+test('providerDialectBadge formats wire and auth labels', () => {
+  assert.deepEqual(
+    providerDialectBadge({ wireApi: 'chat', authScheme: 'x-api-key', source: 'detected' }, 'zh'),
+    { label: 'chat · x-api-key', title: '自动检测' },
+  );
+});
+
+test('providerDialectBadge maps source titles by language', () => {
+  assert.equal(providerDialectBadge({ wireApi: 'responses', authScheme: 'bearer', source: 'ccswitch-import' }, 'zh').title, '来自 cc-switch');
+  assert.equal(providerDialectBadge({ wireApi: 'responses', authScheme: 'bearer', source: 'ccswitch-import' }, 'en').title, 'from cc-switch');
+  assert.equal(providerDialectBadge({ wireApi: 'responses', authScheme: 'bearer', source: 'manual' }, 'zh').title, '手动设置');
+  assert.equal(providerDialectBadge({ wireApi: 'responses', authScheme: 'bearer', source: 'manual' }, 'en').title, 'manual');
+});
+
+test('providerDialectBadge omits incomplete dialects', () => {
+  assert.equal(providerDialectBadge(null), null);
+  assert.equal(providerDialectBadge({ wireApi: 'chat' }), null);
+  assert.equal(providerDialectBadge({ authScheme: 'bearer' }), null);
+});

--- a/plugin/panel/test/providerProbeFlow.test.js
+++ b/plugin/panel/test/providerProbeFlow.test.js
@@ -84,3 +84,75 @@ test('runProviderManagerProbe re-detects stale dialect after auth failure', asyn
   assert.deepEqual(result.entry.dialect, { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 456 });
   assert.deepEqual(result.entry.probedModels, [{ id: 'm2', label: 'm2' }]);
 });
+
+test('runProviderManagerProbe forceDetect overwrites an existing dialect on success', async () => {
+  const provider = {
+    ...PROVIDER,
+    dialect: { wireApi: 'responses', authScheme: 'bearer', source: 'manual', updatedAt: 1 },
+  };
+  const calls = [];
+  const result = await runProviderManagerProbe(provider, {
+    now: () => 789,
+    forceDetect: true,
+    probeProviderModelsImpl: async () => {
+      calls.push('probe');
+      return { ok: true, status: 200, models: [{ id: 'old', label: 'old' }] };
+    },
+    detectProviderDialectImpl: async () => {
+      calls.push('detect');
+      return {
+        ok: true,
+        dialect: { wireApi: 'chat', authScheme: 'none', source: 'detected', updatedAt: 789 },
+        models: [{ id: 'new', label: 'new' }],
+        tried: [],
+      };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, ['detect']);
+  assert.deepEqual(result.entry.dialect, { wireApi: 'chat', authScheme: 'none', source: 'detected', updatedAt: 789 });
+  assert.deepEqual(result.entry.probedModels, [{ id: 'new', label: 'new' }]);
+});
+
+test('runProviderManagerProbe forceDetect falls back to the existing dialect probe when detection fails', async () => {
+  const provider = {
+    ...PROVIDER,
+    dialect: { wireApi: 'responses', authScheme: 'bearer', source: 'manual', updatedAt: 1 },
+  };
+  const calls = [];
+  const result = await runProviderManagerProbe(provider, {
+    forceDetect: true,
+    probeProviderModelsImpl: async (args) => {
+      calls.push(['probe', args.dialect]);
+      return { ok: true, status: 200, models: [{ id: 'fallback', label: 'fallback' }] };
+    },
+    detectProviderDialectImpl: async () => {
+      calls.push(['detect']);
+      return { ok: false, reason: 'auth-undetected', detail: 'No supported auth scheme worked', tried: [] };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [['detect'], ['probe', provider.dialect]]);
+  assert.deepEqual(result.entry.dialect, provider.dialect);
+  assert.deepEqual(result.entry.probedModels, [{ id: 'fallback', label: 'fallback' }]);
+  assert.match(result.detectResult.detail, /No supported auth scheme worked/);
+});
+
+test('runProviderManagerProbe forceDetect failure detail includes detection reason after fallback probe fails', async () => {
+  const provider = {
+    ...PROVIDER,
+    dialect: { wireApi: 'responses', authScheme: 'bearer', source: 'manual', updatedAt: 1 },
+  };
+  const result = await runProviderManagerProbe(provider, {
+    forceDetect: true,
+    probeProviderModelsImpl: async () => ({ ok: false, status: 401, models: [], detail: 'HTTP 401 from provider' }),
+    detectProviderDialectImpl: async () => ({ ok: false, reason: 'wire-undetected', detail: 'Provider did not accept supported wire APIs', tried: [] }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /HTTP 401 from provider/);
+  assert.match(result.detail, /wire-undetected/);
+  assert.match(result.detail, /Provider did not accept supported wire APIs/);
+});

--- a/plugin/panel/test/providerProbeFlow.test.js
+++ b/plugin/panel/test/providerProbeFlow.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runProviderManagerProbe } from '../src/app/providerProbeFlow.js';
+
+const PROVIDER = {
+  id: 'p1',
+  name: 'Provider',
+  protocol: 'openai-compatible',
+  baseUrl: 'https://provider.example',
+  apiKey: 'sk',
+};
+
+test('runProviderManagerProbe detects and persists dialect before probing openai-compatible providers without dialect', async () => {
+  const calls = [];
+  const result = await runProviderManagerProbe(PROVIDER, {
+    now: () => 123,
+    detectProviderDialectImpl: async (args) => {
+      calls.push(['detect', args.protocol]);
+      return {
+        ok: true,
+        dialect: { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 123 },
+        models: [{ id: 'glm-5.2', label: 'GLM-5.2' }],
+        tried: [],
+      };
+    },
+    probeProviderModelsImpl: async () => {
+      calls.push(['probe']);
+      return { ok: true, status: 200, models: [] };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [['detect', 'openai-compatible']]);
+  assert.deepEqual(result.entry.dialect, { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 123 });
+  assert.deepEqual(result.entry.probedModels, [{ id: 'glm-5.2', label: 'GLM-5.2' }]);
+  assert.equal(result.entry.probedAt, 123);
+});
+
+test('runProviderManagerProbe falls back to bearer probe and reports detection detail when both fail', async () => {
+  const calls = [];
+  const result = await runProviderManagerProbe(PROVIDER, {
+    detectProviderDialectImpl: async () => {
+      calls.push('detect');
+      return { ok: false, reason: 'wire-undetected', detail: 'Provider did not accept supported wire APIs', tried: [] };
+    },
+    probeProviderModelsImpl: async (args) => {
+      calls.push(['probe', args.dialect || null]);
+      return { ok: false, status: 401, models: [], detail: 'HTTP 401 from provider' };
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(calls, ['detect', ['probe', null]]);
+  assert.match(result.detail, /HTTP 401 from provider/);
+  assert.match(result.detail, /wire-undetected/);
+  assert.match(result.detail, /Provider did not accept supported wire APIs/);
+});
+
+test('runProviderManagerProbe re-detects stale dialect after auth failure', async () => {
+  const provider = {
+    ...PROVIDER,
+    dialect: { wireApi: 'responses', authScheme: 'bearer', source: 'manual', updatedAt: 1 },
+  };
+  const calls = [];
+  const result = await runProviderManagerProbe(provider, {
+    now: () => 456,
+    probeProviderModelsImpl: async (args) => {
+      calls.push(['probe', args.dialect]);
+      return { ok: false, status: 403, models: [], detail: 'HTTP 403 from provider' };
+    },
+    detectProviderDialectImpl: async () => {
+      calls.push(['detect']);
+      return {
+        ok: true,
+        dialect: { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 456 },
+        models: [{ id: 'm2', label: 'm2' }],
+        tried: [],
+      };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [['probe', provider.dialect], ['detect']]);
+  assert.deepEqual(result.entry.dialect, { wireApi: 'chat', authScheme: 'x-api-key', source: 'detected', updatedAt: 456 });
+  assert.deepEqual(result.entry.probedModels, [{ id: 'm2', label: 'm2' }]);
+});

--- a/plugin/panel/test/providerProfile.test.js
+++ b/plugin/panel/test/providerProfile.test.js
@@ -26,10 +26,15 @@ test('codexAppServerArgs builds explicit custom provider config for app-server',
     '-c', 'model_providers.my-provider.name="AE MCP Custom"',
     '-c', 'model_providers.my-provider.base_url="https://proxy.example/openai"',
     '-c', 'model_providers.my-provider.env_key="AE_MCP_CODEX_API_KEY"',
-    '-c', 'model_providers.my-provider.wire_api="responses"',
+    '-c', 'model_providers.my-provider.wire_api="chat"',
     '-c', 'model_providers.my-provider.requires_openai_auth=false',
   ]);
   assert.equal(codexSpawnEnv(profile, { PATH: 'C:\\Node' }).AE_MCP_CODEX_API_KEY, 'sk-proxy');
+});
+
+test('normalizeProviderProfile falls back to responses for missing or invalid codex wire API', () => {
+  assert.equal(normalizeProviderProfile({ codexWireApi: 'bogus' }).codexWireApi, 'responses');
+  assert.equal(normalizeProviderProfile({}).codexWireApi, 'responses');
 });
 
 test('anthropicEndpoint appends API paths without dropping a proxy prefix', () => {

--- a/plugin/panel/test/providerStore.test.js
+++ b/plugin/panel/test/providerStore.test.js
@@ -64,6 +64,47 @@ test('normalizeProviderEntry fills defaults and rejects bad protocol', () => {
   assert.throws(() => normalizeProviderEntry({ id: 'y', protocol: 'grpc', baseUrl: 'https://h' }));
 });
 
+test('normalizeProviderEntry preserves a complete dialect', () => {
+  const e = normalizeProviderEntry({
+    id: 'relay',
+    baseUrl: 'https://h/v1',
+    dialect: { wireApi: 'chat', authScheme: 'x-api-key', source: 'ccswitch-import', updatedAt: 123 },
+  });
+  assert.deepEqual(e.dialect, { wireApi: 'chat', authScheme: 'x-api-key', source: 'ccswitch-import', updatedAt: 123 });
+});
+
+test('normalizeProviderEntry drops invalid or partial dialect input', () => {
+  assert.equal(normalizeProviderEntry({
+    id: 'bad-wire',
+    baseUrl: 'https://h/v1',
+    dialect: { wireApi: 'grpc', authScheme: 'bearer', source: 'manual', updatedAt: 1 },
+  }).dialect, undefined);
+  assert.equal(normalizeProviderEntry({
+    id: 'missing-auth',
+    baseUrl: 'https://h/v1',
+    dialect: { wireApi: 'responses', source: 'manual', updatedAt: 1 },
+  }).dialect, undefined);
+});
+
+test('normalizeProviderEntry normalizes dialect source and updatedAt fallbacks', () => {
+  const e = normalizeProviderEntry({
+    id: 'fallbacks',
+    baseUrl: 'https://h/v1',
+    dialect: { wireApi: 'responses', authScheme: 'none', source: 'unknown', updatedAt: '123' },
+  });
+  assert.deepEqual(e.dialect, { wireApi: 'responses', authScheme: 'none', source: 'manual', updatedAt: 0 });
+});
+
+test('old provider entries round-trip without dialect', () => {
+  const deps = makeDeps();
+  const store = createProviderStore(deps);
+  store.upsert({ id: 'old', name: 'Old', protocol: 'openai-compatible', baseUrl: 'https://old.example.com', apiKey: 'k' });
+  const listed = store.list()[0];
+  assert.equal(listed.dialect, undefined);
+  const raw = JSON.parse(deps.files.get('/home/user/.ae-mcp/providers.json'));
+  assert.equal(raw.providers[0].dialect, undefined);
+});
+
 test('migrateLegacy imports anthropic-key/codex-key + base URL prefs once', () => {
   const deps = makeDeps();
   const store = createProviderStore(deps);

--- a/plugin/panel/test/zcodeBackend.test.js
+++ b/plugin/panel/test/zcodeBackend.test.js
@@ -1000,12 +1000,30 @@ test('zcodeRuntimeModelFromDesktopConfig injects the resolved apiKeyEnv key for 
   const config = { provider: { mediastorm_glm: CLI_PROVIDER } };
   const fromEnv = zcodeRuntimeModelFromDesktopConfig({ config, setting: {}, modelRef: 'mediastorm_glm/glm-5.2', env: { MEDIASTORM_GLM_API_KEY: 'sk-env' } });
   assert.equal(fromEnv.model.modelId, 'glm-5.2');
+  assert.equal(fromEnv.provider.apiFormat, 'openai-chat-completions');
   assert.deepEqual(fromEnv.provider.apiKey, { source: 'inline', value: 'sk-env' });
   assert.deepEqual(fromEnv.provider.models, [{ modelId: 'glm-5.2' }]);
   const fromPanel = zcodeRuntimeModelFromDesktopConfig({ config, setting: {}, modelRef: 'mediastorm_glm/glm-5.2', env: {}, storedKey: 'sk-panel' });
   assert.deepEqual(fromPanel.provider.apiKey, { source: 'inline', value: 'sk-panel' });
   const none = zcodeRuntimeModelFromDesktopConfig({ config, setting: {}, modelRef: 'mediastorm_glm/glm-5.2', env: {} });
   assert.equal(none.provider.apiKey, undefined);
+});
+
+test('zcodeRuntimeModelFromDesktopConfig maps openai-compatible dialect responses to openai-responses', () => {
+  const config = {
+    provider: {
+      mediastorm_glm: {
+        ...CLI_PROVIDER,
+        dialect: { wireApi: 'responses', authScheme: 'bearer', source: 'detected', updatedAt: 123 },
+        models: { 'glm-5.2': {} },
+      },
+    },
+  };
+
+  const runtimeModel = zcodeRuntimeModelFromDesktopConfig({ config, setting: {}, modelRef: 'mediastorm_glm/glm-5.2', storedKey: 'sk-panel' });
+
+  assert.equal(runtimeModel.provider.kind, 'openai-compatible');
+  assert.equal(runtimeModel.provider.apiFormat, 'openai-responses');
 });
 
 test('readZcodeDesktopModel merges ~/.zcode/cli/config.json and prefers its top-level model', () => {


### PR DESCRIPTION
## Summary

Closes #49（按 issue 评论中的修订方案：元数据优先、探测兜底，不引入本地翻译代理）。

- **dialect schema**：provider 条目新增可选 `dialect: { wireApi: 'responses'|'chat', authScheme: 'bearer'|'x-api-key'|'none', source, updatedAt }`；缺省 = 旧行为，老 providers.json 零回归
- **cc-switch 方言继承**：从 cc-switch 导入 provider 时解析 `meta.apiFormat` / config TOML `wire_api` / `apiKeyField` / `settingsConfig.env|auth`，双信号齐备才写入 dialect（source=`ccswitch-import`）
- **自动探测梯子**（`providerDetect.js`）：auth 梯子（bearer → x-api-key → none，GET /v1/models）+ wire API 梯子（responses → chat，最小 POST；400+JSON error 视为 endpoint 成立）；错误分类 network/auth/no-models/wire-undetected/auth-mismatch；`tried`/`detail` 不含任何 secret
- **接线**：`probeProviderModels` 按 authScheme 出 header；Codex spawn args 尊重 `dialect.wireApi`（解除固定 `wire_api="responses"`）；ZCode 映射按 dialect 产出 `openai-responses|openai-chat-completions`；Provider Manager probe 流程（`providerProbeFlow.js`）对无 dialect 条目先探测并持久化，已有 dialect 遇 401/403 自动重探测
- **UI**：provider 卡片显示 `wireApi · authScheme` badge（tooltip 标来源），带 dialect 条目提供「重新检测」强制重探测
- **sanitized defaults**：Provider Manager 示例 URL、测试 fixture、计划文档与 bundle 均改为保留 example host，并新增 no-sensitive-defaults 回归测试
- ZCode desktop OAuth runtime-headers 报错路径未改动

## Test plan

- [x] `plugin/panel` `npm test`：379 pass / 0 fail
- [x] `npm run build` bundle 重建成功（dist/app.js 已随 PR 更新）
- [x] 新增覆盖：dialect normalize/round-trip、cc-switch 各推断路径、探测梯子全部分支与 secret 泄漏断言、wire_api chat 透传、probe 流程兜底/重探测/forceDetect、badge 纯函数、provider 示例 URL 不含私有 hostname
- [x] fresh GitHub mirror clone 后搜索公开 heads/tags：敏感 provider URL exact-match 无命中
- [ ] 真机（AE 面板）对一个 chat-only provider（如 DeepSeek 直连）验证：探测出 `chat · bearer` 且 Codex 后端能正常对话
