### PR TITLE
Add Chinese release notes for v0.9.2

### DIFF
--- a/docs/release-notes/v0.9.2-zh-CN.md
+++ b/docs/release-notes/v0.9.2-zh-CN.md
@@ -1,0 +1,39 @@
+# ae-mcp v0.9.2 中文说明
+
+[English release →](https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.9.2)
+
+这是面向 After Effects 的 **Windows x64 正式版本**。macOS 兼容、包内离线 RuntimeManager、正式跨平台签名链以及完整 AE 25/26 实机矩阵转入 v0.9.3。
+
+## 主要更新
+
+- 自定义 Provider 升级为按模型探测和缓存协议能力，同一个 Provider 可同时承载 OpenAI Responses、Chat Completions 与 Anthropic Messages 模型。
+- 原生支持 Responses 的模型直连 `/responses`；仅支持 Chat Completions 的模型通过本地 Responses facade 安全转换。只有无法等价转换的特性才返回结构化 compact 501，不会静默丢字段。
+- Platform Helper 接管 Provider 凭据边界，系统凭据存取保持 fail-closed；Helper 生命周期跟随已认证的 AE 主进程。
+- Tool Library 完整闭环：支持搜索、查看、创建、编辑、复制、固定、归档、删除、安全导入/导出，以及 Search → Inspect → Use 渐进执行流程。
+- Codex 官方登录态模型列表加入 GPT-5.6 系列。
+- 修复跨协议 `developer` 角色、流式完成、逐模型探测、脱敏和未知错误提示等兼容问题。
+
+## 本次支持范围
+
+- Windows 11 24H2 或更高版本，x64 架构；不支持 Windows ARM。
+- 已完成 After Effects 2025（25.x）实机验证。
+- CEP manifest 仍为 `[25.0,26.9]`；AE 26 完整验收转入 v0.9.3。
+- 本版继续使用现有外部 runtime/launcher 配置；包内离线 RuntimeManager 转入 v0.9.3。
+- macOS 安装资产将在 v0.9.3 提供，本 Release 不包含 macOS ZXP 或 DMG。
+
+## 下载与校验
+
+Windows 安装包：`ae-mcp-panel-v0.9.2-windows-x64.zxp`
+
+SHA-256：`60166443cb0c284eb0cce26c60d06588e0dfd1195d28a4293b31a091120d7273`
+
+上传前已通过 `ZXPSignCmd -verify` 验证 ZXP 签名。下载后可使用 Release 同页的 `SHA256SUMS-v0.9.2.txt` 校验文件完整性。
+
+## 签名边界说明
+
+- ZXP 使用自签名 `CN=ae-mcp` 证书，有效期为 2026-07-04 至 2037-09-20。
+- 该证书默认不受操作系统信任，安装器可能显示未受信任发布者提示。
+- ZXPSignCmd 无法通过本机代理连接 TSA，因此本次资产没有 TSA 时间戳。
+- 包内原生 Helper、launcher 和 N-API transport 二进制尚未进行 Authenticode 签名。
+
+请使用受支持的 ZXP installer 安装，重启 After Effects，然后打开 `Window → Extensions → ae-mcp`。


### PR DESCRIPTION
Adds a standalone Simplified Chinese release-notes page so the v0.9.2 Release language switch uses a reliable page link instead of an in-page Unicode anchor. Validation: Markdown diff check passed; only the new release-notes file is included.