### PR TITLE
fix(package): stage production host runtime in Windows ZXP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 #### 🐛 修复 / 改进
 
+- **Windows ZXP Host runtime 打包修复（#58）**——生产包现在将 Express 与 Host package anchor 放入面板实际加载的 `runtime/windows-x64/node/host`，并在签名前后验证该契约，避免面板启动时报 `host runtime dependencies are unavailable`。
 - **跨协议角色与流式完成兼容**——向不接受 `developer` 角色的上游安全降级为其支持的等价角色；兼容缺少 `response.completed` 但已正常结束的受限流式实现，同时仍拒绝截断或语义不完整的流。
 - **诊断与错误边界收紧**——最小 token 探测按模型运行，未知错误转为可操作的结构化信息；Provider 响应、凭据、请求头和导出内容均经过脱敏与泄漏回归测试。
 - **双平台不可变 RC 契约更新**——受保护 `main` 的同一个 candidate SHA 生成 `ae-mcp-panel-v0.9.2-macos-arm64.zxp`、`ae-mcp-panel-v0.9.2-macos-arm64.dmg`、`ae-mcp-panel-v0.9.2-windows-x64.zxp`，由 `artifact-manifest-v0.9.2.json` 绑定 artifact ID 与 SHA-256；正式发布只提升已验证字节，禁止重建。
@@ -254,6 +255,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 #### 🐛 Fixed / Improved
 
+- **Windows ZXP Host runtime packaging (#58)** — the production package now places Express and the Host package anchor under the Panel's actual `runtime/windows-x64/node/host` load path and verifies that contract around signing, preventing `host runtime dependencies are unavailable` at Panel startup.
 - **Cross-protocol roles and stream completion** — upstreams that reject the `developer` role receive a safe equivalent supported role. Restricted streaming implementations that finish cleanly without `response.completed` are supported without accepting truncated or semantically incomplete streams.
 - **Tighter diagnostics and error boundaries** — minimal-token probes run per model; unknown failures become actionable structured errors; Provider responses, credentials, headers, and exports are covered by redaction and leak regressions.
 - **Updated immutable dual-platform RC contract** — one protected-`main` candidate SHA produces `ae-mcp-panel-v0.9.2-macos-arm64.zxp`, `ae-mcp-panel-v0.9.2-macos-arm64.dmg`, and `ae-mcp-panel-v0.9.2-windows-x64.zxp`; `artifact-manifest-v0.9.2.json` binds artifact IDs and SHA-256, and release promotion never rebuilds verified bytes.

--- a/docs/release-notes/v0.9.2-zh-CN.md
+++ b/docs/release-notes/v0.9.2-zh-CN.md
@@ -25,7 +25,9 @@
 
 Windows 安装包：`ae-mcp-panel-v0.9.2-windows-x64.zxp`
 
-SHA-256：`60166443cb0c284eb0cce26c60d06588e0dfd1195d28a4293b31a091120d7273`
+SHA-256：`55d1d1bb9a7e77fd56093a6862e75279c324faf4e371274b79f3dea3481c004b`
+
+2026-07-13 已替换最初上传的 Windows ZXP：修复生产面板无法从包内加载 Host runtime 依赖的问题（#58）。
 
 上传前已通过 `ZXPSignCmd -verify` 验证 ZXP 签名。下载后可使用 Release 同页的 `SHA256SUMS-v0.9.2.txt` 校验文件完整性。
 

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -64,18 +64,33 @@ if (Test-Path (Join-Path $stageDir 'sidecar\test')) {
 # local process attach a DevTools/Node client. Strip it before signing.
 Remove-Item -Force (Join-Path $stageDir '.debug') -ErrorAction SilentlyContinue
 
-Write-Host "[2/5] Installing host production dependencies..."
-Push-Location (Join-Path $stageDir 'host')
+Write-Host "[2/5] Installing production host runtime dependencies..."
+$runtimeHostDir = Join-Path $stageDir 'runtime\windows-x64\node\host'
+New-Item -ItemType Directory -Force -Path $runtimeHostDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $stageDir 'host\package.json') -Destination $runtimeHostDir
+Copy-Item -LiteralPath (Join-Path $stageDir 'host\package-lock.json') -Destination $runtimeHostDir
+Push-Location $runtimeHostDir
 try {
     npm ci --omit=dev
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm failed while installing production host runtime dependencies"
+    }
 } finally {
     Pop-Location
+}
+foreach ($requiredHostFile in @('package.json', 'node_modules\express\package.json')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $runtimeHostDir $requiredHostFile) -PathType Leaf)) {
+        throw "Production host runtime file is missing: $requiredHostFile"
+    }
 }
 
 Write-Host "[3/5] Installing sidecar production dependencies..."
 Push-Location (Join-Path $stageDir 'sidecar')
 try {
     npm ci --omit=dev
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm failed while installing sidecar production dependencies"
+    }
 } finally {
     Pop-Location
 }
@@ -91,9 +106,18 @@ Write-Host "[5/5] Signing package..."
 if (Test-Path $OutputPath) {
     Remove-Item -Force $OutputPath
 }
-# -tsa adds a trusted timestamp so the signature stays valid after the cert
-# expires.
-& $ZxpSignCmd -sign $stageDir $OutputPath $CertPath $CertPassword -tsa $Tsa
+if ([string]::IsNullOrWhiteSpace($Tsa)) {
+    & $ZxpSignCmd -sign $stageDir $OutputPath $CertPath $CertPassword
+} else {
+    & $ZxpSignCmd -sign $stageDir $OutputPath $CertPath $CertPassword -tsa $Tsa
+}
+if ($LASTEXITCODE -ne 0) {
+    throw "ZXP signing failed"
+}
+& $ZxpSignCmd -verify $OutputPath
+if ($LASTEXITCODE -ne 0) {
+    throw "ZXP signature verification failed"
+}
 
 Write-Host ""
 Write-Host "Wrote $OutputPath"

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -126,6 +126,17 @@ async function writeRuntime(repoRoot, platform) {
     await writeFixtureFile(root, 'node/node.exe', nativeBytes, 0o644);
     await writeFixtureFile(root, 'python/python.exe', nativeBytes, 0o644);
   }
+  await writeFixtureFile(root, 'node/host/package.json', `${JSON.stringify({
+    name: 'ae-mcp-host',
+    version: '0.9.2',
+    dependencies: { express: '4.22.1' },
+  })}\n`);
+  await writeFixtureFile(root, 'node/host/package-lock.json', '{}\n');
+  await writeFixtureFile(root, 'node/host/node_modules/express/package.json', `${JSON.stringify({
+    name: 'express',
+    version: '4.22.1',
+    main: 'index.js',
+  })}\n`);
   await writeFixtureFile(root, 'node/host/node_modules/express/index.js', 'module.exports = () => {};\n');
   await writeFixtureFile(root, 'node/sidecar/node_modules/sdk/index.js', 'export default {};\n');
   const claudePackage = platform === 'macos-arm64'

--- a/scripts/package/test/legacy-zxp.test.mjs
+++ b/scripts/package/test/legacy-zxp.test.mjs
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('self-signed Windows ZXP stages Express at the production host runtime path', async () => {
+  const source = await fs.promises.readFile('scripts/package-zxp.ps1', 'utf8');
+
+  assert.match(
+    source,
+    /\$runtimeHostDir\s*=\s*Join-Path \$stageDir 'runtime\\windows-x64\\node\\host'/,
+  );
+  assert.match(source, /Copy-Item[^\r\n]+host\\package\.json[^\r\n]+\$runtimeHostDir/);
+  assert.match(source, /Copy-Item[^\r\n]+host\\package-lock\.json[^\r\n]+\$runtimeHostDir/);
+  assert.match(source, /Push-Location \$runtimeHostDir[\s\S]+?npm ci --omit=dev/);
+  assert.match(source, /node_modules\\express\\package\.json/);
+  assert.match(source, /IsNullOrWhiteSpace\(\$Tsa\)/);
+  assert.match(source, /& \$ZxpSignCmd -verify \$OutputPath/);
+  assert.doesNotMatch(
+    source,
+    /Push-Location \(Join-Path \$stageDir 'host'\)[\s\S]+?npm ci --omit=dev/,
+  );
+});

--- a/scripts/package/test/verify-platform-bundle.test.mjs
+++ b/scripts/package/test/verify-platform-bundle.test.mjs
@@ -37,6 +37,21 @@ test('verification rejects one changed runtime byte', async (t) => {
   );
 });
 
+test('verification requires the production host package anchor used by the CEP panel', async (t) => {
+  const h = await makeStageHarness(t, 'windows-x64');
+  await stagePlatformBundle(h.input);
+  await fs.promises.rm(path.join(
+    h.outDir,
+    'runtime/windows-x64/node/host/package.json',
+  ));
+  await rewriteStageManifests(h);
+
+  await assert.rejects(
+    verifyPlatformBundle(h.verifyInput),
+    { code: 'BUNDLE_HOST_RUNTIME_INVALID' },
+  );
+});
+
 test('verification rejects the wrong expected platform and version', async (t) => {
   const h = await makeStageHarness(t, 'windows-x64');
   await stagePlatformBundle(h.input);

--- a/scripts/package/verify-platform-bundle.mjs
+++ b/scripts/package/verify-platform-bundle.mjs
@@ -154,6 +154,48 @@ async function verifyRuntimeEvidence(root, platform, runtimeManifest, bundleMani
   });
 }
 
+async function verifyHostRuntime(root, platform, entries) {
+  const relativeHostRoot = `runtime/${platform}/node/host`;
+  const hostRoot = path.join(root, 'runtime', platform, 'node', 'host');
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  const requireFile = (relative) => {
+    const entry = entriesByPath.get(`${relativeHostRoot}/${relative}`);
+    if (!entry || entry.type !== 'file') {
+      throw bundleError(
+        'BUNDLE_HOST_RUNTIME_INVALID',
+        `required production host runtime file is missing: ${relative}`,
+      );
+    }
+  };
+  requireFile('package.json');
+  requireFile('node_modules/express/package.json');
+
+  const hostPackage = await readJsonFile(
+    path.join(hostRoot, 'package.json'),
+    'BUNDLE_HOST_RUNTIME_INVALID',
+  );
+  const expressPackage = await readJsonFile(
+    path.join(hostRoot, 'node_modules', 'express', 'package.json'),
+    'BUNDLE_HOST_RUNTIME_INVALID',
+  );
+  if (hostPackage.name !== 'ae-mcp-host'
+      || typeof hostPackage.dependencies?.express !== 'string'
+      || expressPackage.name !== 'express') {
+    throw bundleError('BUNDLE_HOST_RUNTIME_INVALID', 'production host package identity is invalid');
+  }
+  const mainEntry = expressPackage.main === undefined ? 'index.js' : expressPackage.main;
+  if (typeof mainEntry !== 'string' || !mainEntry.trim() || mainEntry.includes('\0')) {
+    throw bundleError('BUNDLE_HOST_RUNTIME_INVALID', 'Express package main is invalid');
+  }
+  const expressRoot = path.join(hostRoot, 'node_modules', 'express');
+  const resolvedEntry = path.resolve(expressRoot, mainEntry);
+  const entryRelative = path.relative(expressRoot, resolvedEntry);
+  if (!entryRelative || entryRelative.startsWith('..') || path.isAbsolute(entryRelative)) {
+    throw bundleError('BUNDLE_HOST_RUNTIME_INVALID', 'Express package main escapes its package root');
+  }
+  requireFile(`node_modules/express/${entryRelative.split(path.sep).join('/')}`);
+}
+
 async function verifyHelper(root, platform, manifest) {
   const helperRoot = path.join(root, 'platform', platform);
   const helperManifestPath = path.join(helperRoot, 'helper-manifest.json');
@@ -293,6 +335,7 @@ export async function verifyPlatformBundle({ root, platform, version, sourceComm
   const runtimeManifest = validateRuntimeManifest(await readJsonFile(runtimeManifestPath), platform);
   await verifyRuntimeInventory(resolvedRoot, platform, runtimeManifest);
   await verifyRuntimeEvidence(resolvedRoot, platform, runtimeManifest, manifest);
+  await verifyHostRuntime(resolvedRoot, platform, actual);
   await verifySupportContract(resolvedRoot, platform);
   await verifyHelper(resolvedRoot, platform, manifest);
   assertProductionFileSet(actual, platform);


### PR DESCRIPTION
## What changed

- stage Host production dependencies under `runtime/windows-x64/node/host` in the self-signed Windows ZXP path
- verify the signed ZXP and fail when the Host package anchor or Express entrypoint is missing
- add regression coverage and update the v0.9.2 checksum documentation

## Root cause

The v0.9.2 ZXP installed Express under `host/node_modules`, but production Panel startup only loads Host dependencies from `runtime/windows-x64/node/host`. Because signed packages omit `.debug`, the development fallback was unavailable and Panel startup failed with `host runtime dependencies are unavailable`.

## Validation

- focused package regressions: 4/4 passed
- PowerShell parser validation passed
- `git diff --check` passed
- rebuilt ZXP signature verified with Adobe ZXPSignCmd
- rebuilt payload contains the production Host anchor and 779 runtime entries, with no `.debug` or development Host `node_modules`

Closes #58