### PR TITLE
feat(native-rpc): define bounded AEGP protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  # Stacked native P0 PRs target their dependency branch until real-host
+  # validation is complete, so CI must run for every pull-request base.
+  pull_request: {}
 
 permissions:
   contents: read
@@ -63,6 +64,9 @@ jobs:
       - name: Run native SDK input contract tests
         run: node --test scripts/package/test/ae-sdk-input.test.mjs
 
+      - name: Run native AEGP RPC contract tests
+        run: node --test native/ae-plugin/protocol/protocol.test.mjs
+
       - name: Run host tests
         working-directory: plugin/host
         run: |
@@ -104,6 +108,9 @@ jobs:
 
       - name: Verify the native SDK remains developer-supplied
         run: node scripts/package/ae-sdk-input.mjs verify-repository --repo-root .
+
+      - name: Run native AEGP RPC contract tests
+        run: node --test native/ae-plugin/protocol/protocol.test.mjs
 
       - name: Run packaging contract tests
         run: node --test scripts/package/test/*.test.mjs

--- a/native/ae-plugin/protocol/README.md
+++ b/native/ae-plugin/protocol/README.md
@@ -1,0 +1,196 @@
+# Native AEGP RPC v1
+
+This directory defines the transport-independent contract between the ae-mcp
+Core/broker and the in-process After Effects AEGP plug-in. It is intentionally
+small enough to implement in C++ without a general JSON-RPC framework.
+
+The contract does **not** choose between AEGP and JSX. It only describes native
+capability discovery and invocation when the native execution plane is used.
+Every invocation still passes through approval, audit, compatibility, deadline,
+and side-effect policy in Core.
+
+## Provenance and evidence status
+
+The schema, fixtures, conformance code, and tests in this directory are
+independently designed, product-owned ae-mcp material. They do not contain or
+derive Adobe sample source, headers, PiPL/resource text, SDK documentation, or
+SDK binaries. Public descriptors use product-owned requirement IDs; concrete
+Adobe suite names and versions remain private native-implementation details.
+
+Every checked-in fixture is labelled `synthetic-contract-vector`. Fixtures only
+prove schema, codec, and state-machine behavior. They are **not** evidence of a
+successful SDK build, plug-in installation, AE loading, AEGP execution, runtime
+provenance, or compatibility with any AE/SDK/OS combination. Compatibility stays
+`unverified` until separate real-host evidence is attached.
+
+## Framing
+
+Each message is UTF-8 JSON preceded by one unsigned, four-byte, big-endian
+length. The length covers only the JSON bytes. Version 1 rejects zero-length,
+invalid UTF-8, trailing bytes inside a frame, and frames over 65,536 bytes.
+Transport implementations may apply a lower authenticated-session limit.
+
+Parsers also reject duplicate object keys, unsafe integers, more than 16 JSON
+levels, more than 2,048 JSON nodes, and strings or object keys over 8,192
+Unicode scalar values. Lone UTF-16 surrogates are invalid. C++ implementations
+must count decoded Unicode scalar values—not UTF-8 bytes or UTF-16 code units—so
+astral characters have the same length in Node and native code. These rules
+prevent parser disagreement and bound work before dispatch.
+The same limits apply before canonicalizing or encoding locally constructed
+output; depth 16 is accepted and depth 17 is rejected. Streaming decoders reject
+an unfinished prefix or body from `finalize()` at EOF, and transport adapters
+must split reads into chunks no larger than one maximum frame plus its prefix.
+
+Malformed input closes the connection after a bounded structured error whenever
+the request ID can be recovered safely. Parsing workers may validate and queue a
+message, but they must never call AE suites. Suite calls run only through the
+project-defined host-main-thread/IdleHook dispatcher; that rule is not a claim of
+Adobe approval or completed host validation.
+
+## Lifecycle
+
+1. The broker sends `hello` with its supported wire-version range. The v1
+   length-prefix framing and v1 `hello` envelope are the permanent bootstrap:
+   future clients and plug-ins must parse them before negotiating a later wire
+   version. A version mismatch is therefore still returned in a v1 envelope.
+2. The plug-in selects the highest overlapping version and returns its compiled
+   SDK identity, actual AE host identity, instance/session IDs, limits, and a
+   capability digest. No overlap returns `WIRE_VERSION_MISMATCH`.
+3. The broker requests compact capability summaries by default. It can request
+   full, bounded contracts for selected IDs. Version 1 has one compile-time
+   capability and deliberately does not support pagination: `cursor` is rejected
+   and `nextCursor` must be null. If the effective limit is smaller than the
+   number of matching descriptors, the plug-in fails closed instead of returning
+   an incomplete page. Unknown requested IDs produce an empty, digest-bound page.
+   Responses bind the normalized ids/detail/limit query and session with
+   `queryDigest` and can never be replayed.
+4. `invoke` is a closed `oneOf` over compile-time registered capability-specific
+   input schemas. The v1 seed permits only `ae.project.summary` with an empty
+   argument object. Future capabilities extend that allowlist with closed,
+   bounded schemas; a generic argument bag or field-name blacklist is never a
+   security boundary. Arbitrary C++, JSX, shell text, command lines, pointers,
+   native handles, and unknown nested data are rejected before dispatch.
+5. Zero or more ordered `progress` events may precede exactly one terminal
+   response. Results include `engine=native-aegp` and machine-verifiable evidence.
+6. `cancel` is explicit. A timeout never implies that a dispatched mutation
+   stopped, and an ambiguous mutation failure is never retried through JSX.
+
+Request IDs are unique per session. An in-flight or content-mismatched duplicate
+is rejected with `DUPLICATE_REQUEST`. A bounded terminal-response cache may
+replay only the same RFC 8785-canonical request for an idempotent capability and
+marks the response `replayed=true`. Cache admission requires the active request
+digest to match and a trusted terminal validator to verify the complete exchange;
+callers cannot mint replay authority with a boolean. Replay validation requires
+the ledger-issued receipt, reuses the receipt's original effective deadline when
+the request omitted one, and an expired request is never replayed. Active entries
+that pass their deadline become bounded duplicate-detection tombstones so they do
+not permanently consume capacity. Terminal evidence must complete no later than
+the broker's terminal-observation time, which itself must not exceed the effective
+deadline; no clock tolerance is implicit. Different sessions may reuse an ID.
+Capabilities declared `idempotency-key` must use a capability-specific invoke
+schema that requires the key; non-idempotent mutations are never replayed.
+Failure responses are retained only as duplicate-detection tombstones and are
+never replayed. The reference ledger has hard active/terminal capacities,
+deterministic FIFO terminal eviction, a negotiated TTL, and explicit session
+purge. Clients remain responsible for never reusing request IDs in a live
+session after bounded tombstones expire or are evicted.
+
+## Defaults and bounds
+
+- omitted request deadline: 5,000 ms from broker send time;
+- maximum accepted deadline: 30,000 ms;
+- maximum frame size: 65,536 bytes;
+- omitted capability detail: `summary`;
+- omitted capability page size: 50, maximum 100;
+- maximum in-flight requests: negotiated by `hello`, initially 8;
+- maximum plug-in queue depth: negotiated by `hello`, initially 32;
+- request rate and burst limits: negotiated by `hello`;
+- control-plane request rate and burst limits: independently negotiated by
+  `hello`, initially 20 requests/second with a burst of 4;
+- terminal-response cache entries and TTL: negotiated by `hello`, initially
+  128 entries and 60,000 ms;
+- progress messages are advisory and bounded; terminal evidence is authoritative.
+
+The executable admission reference keys request identities as
+`sessionId:requestId` and uses a deterministic token bucket, then an in-flight
+limit and bounded FIFO queue. Rate or capacity
+saturation returns `QUEUE_FULL` with a bounded `retryAfterMs`; completion either
+releases a slot or promotes exactly one named, unexpired queued request; expired
+entries are terminated with `DEADLINE_EXCEEDED` and skipped. `cancel` uses a
+separately bounded control-plane slot and token bucket so a saturated work queue
+cannot prevent targeted cancellation or allow cancellation floods. Constructor
+limits enforce the same maxima declared by the hello schema. Cancellation state
+is decided atomically by the controller for the target in the cancel request's
+session. It removes an exact queued target or observes running/terminal/unknown
+state and issues a one-use decision receipt; exchange validation rejects copied,
+replayed, or cross-session decisions. Cooperative descriptors map a running
+target to `running-cancel-requested`; the v1 seed's `before-dispatch` descriptor
+maps it to `running-not-cancellable`. This is contract behavior, not a claim that
+the native dispatcher has already been deployed.
+
+All omission behavior is reflected in `aegp-rpc.schema.json` through `default`
+or `x-omissionBehavior` metadata so Core, tests, and generated documentation use
+the same rules.
+
+## Stable locators
+
+Project objects use server-issued UUID locators bound to host instance, native
+session, project, and generation. A locator never contains or encodes an AEGP
+handle, pointer, address, or process-local object. Any host/session/project or
+generation mismatch returns `STALE_LOCATOR` before suite dispatch.
+
+## Error and recovery contract
+
+Every error states whether it is retryable and whether a side effect is known not
+to have started, may have occurred, or completed. Recovery is one small enum plus
+a short hint; models do not need SDK knowledge to choose the next action.
+
+Error code, retryability, side-effect state, and recovery action are a bound
+schema tuple. In particular, `POSSIBLY_SIDE_EFFECTING_FAILURE` is never retryable
+and always requires state inspection. Queue saturation includes a bounded retry
+delay; no other error may include `retryAfterMs`. Capability-specific failures
+carry the matching product capability ID, while wire-version mismatch carries
+the supported range. Deadline expiry is reported as safe-to-retry only before dispatch; an
+expiry after mutation acceptance uses the possibly-side-effecting error.
+
+Capability, request, and postcondition digests use SHA-256 over RFC 8785 JSON
+Canonicalization Scheme bytes. Object property names are sorted by UTF-16 code
+units as RFC 8785 requires; this is distinct from the Unicode-scalar counting
+used for string length limits. The digest scopes are machine-declared in the
+schema. A transcript is valid only when outer envelopes, hello nonce/session,
+host instance, descriptor, request/method, capability ID/version, effective
+deadline, read/write effect and undo semantics, evidence, monotonic progress,
+and terminal count agree; shape validation alone is insufficient. For a fresh
+success, broker-send time must be no later than native start, completion must be
+no earlier than start, and completion must not exceed the effective deadline.
+A replayed success has no progress events and must carry the trusted ledger
+receipt for the originally validated response. Cancel
+validation likewise binds the requested target ID and, when promised, its one
+later terminal response; a queued cancellation must end in typed `CANCELLED`.
+
+Full capability descriptors use product-owned requirement references shaped as
+`{id, contractVersion}`. They disclose neither Adobe suite names nor SDK text,
+but the versioned requirement is machine-readable by the private native
+implementation. Full descriptors embed normalized, self-contained input and
+result JSON Schemas so Core or a direct-run UI can validate a call without an
+agent or an unverifiable lookup. The empty input explicitly has `required: []`,
+`additionalProperties: false`, and no defaults. Full descriptors also carry
+bounded positive and negative examples with actual arguments and expected
+result/error shapes.
+
+The product-owned Draft 2020-12 subset validator covers every keyword used by
+this schema, including deep JSON equality for `const`/`uniqueItems`, Unicode
+scalar string bounds, conditionals, combinators, and closed object shapes.
+Response and event frames use decode-plus-root-shape entry points before any
+exchange semantics or ledger terminal validation. Cross-field rules represented by
+`x-invariant` (for example `minimum <= maximum`), session/nonce/digest bindings,
+deadline materialization, and transcript state are enforced by the composite
+validators after decoding. Transport adapters must use the composite
+decode/shape/semantic entry point and return its typed error; accepting a message
+because a schema-only validator passed is not sufficient.
+
+The synthetic vectors and negative corpus are executable protocol-conformance
+tests for schema binding, defaults, bidirectional version mismatch, duplicate IDs, malformed
+messages, fixed-seed property fuzz, exact codec bounds, wrong enums, stale
+locators, cancellation, admission saturation/recovery, and digest verification.
+They deliberately make no claim about a real After Effects process.

--- a/native/ae-plugin/protocol/aegp-rpc.schema.json
+++ b/native/ae-plugin/protocol/aegp-rpc.schema.json
@@ -1,0 +1,1083 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-mcp.invalid/schemas/aegp-rpc-v1.json",
+  "title": "AeMcpNativeAegpRpcV1",
+  "x-framing": {
+    "lengthPrefixBytes": 4,
+    "byteOrder": "big-endian",
+    "encoding": "utf-8",
+    "maxFrameBytes": 65536,
+    "maxJsonDepth": 16,
+    "maxJsonNodes": 2048,
+    "maxStringLength": 8192,
+    "stringLengthUnit": "unicode-scalar-values",
+    "duplicateObjectKeys": "reject"
+  },
+  "x-bootstrap": {
+    "framingVersion": 1,
+    "helloEnvelopeVersion": 1,
+    "permanent": true,
+    "futureImplementations": "must-parse-v1-framing-and-hello-before-negotiation"
+  },
+  "x-lifecycle": {
+    "defaultDeadlineMs": 5000,
+    "maximumDeadlineMs": 30000,
+    "duplicateRequest": "reject-in-flight-or-nonidentical",
+    "terminalResponsesPerRequest": 1,
+    "pagination": "unsupported-in-v1",
+    "defaultTerminalCacheEntries": 128,
+    "defaultTerminalCacheTtlMs": 60000,
+    "terminalObservationClockToleranceMs": 0,
+    "cancelDecision": "atomic-one-use-controller-receipt"
+  },
+  "x-digests": {
+    "algorithm": "sha256",
+    "canonicalization": "rfc8785-jcs",
+    "propertyNameSort": "utf-16-code-units",
+    "contractScope": "normalized-self-contained-input-and-result-schemas",
+    "capabilitiesScope": "ordered-full-capability-descriptors",
+    "requestScope": "complete-request-envelope",
+    "postconditionScope": "capability-id-version-and-result-value"
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/request" },
+    { "$ref": "#/$defs/response" },
+    { "$ref": "#/$defs/progressEvent" }
+  ],
+  "$defs": {
+    "wireVersion": { "const": 1 },
+    "safePositiveInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "safeNonnegativeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "requestId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "capabilityId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 96,
+      "pattern": "^ae(?:\\.[a-z][a-z0-9_-]*)+$"
+    },
+    "platform": {
+      "enum": ["macos-arm64", "windows-x64"]
+    },
+    "method": {
+      "enum": ["hello", "capabilities", "invoke", "cancel"]
+    },
+    "wireRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum"],
+      "properties": {
+        "minimum": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "maximum": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "x-invariant": "minimum-must-not-exceed-maximum"
+    },
+    "clientIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "version", "instanceId"],
+      "properties": {
+        "component": { "enum": ["core-broker", "development-smoke"] },
+        "version": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "instanceId": { "$ref": "#/$defs/uuid" }
+      }
+    },
+    "helloParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supportedWireVersions", "client", "nonce"],
+      "properties": {
+        "supportedWireVersions": { "$ref": "#/$defs/wireRange" },
+        "client": { "$ref": "#/$defs/clientIdentity" },
+        "nonce": { "type": "string", "minLength": 32, "maxLength": 128, "pattern": "^[A-Za-z0-9_-]+$" }
+      }
+    },
+    "capabilitiesParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ids": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capabilityId" }
+        },
+        "detail": {
+          "enum": ["summary", "full"],
+          "default": "summary",
+          "x-omissionBehavior": "summary"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 50,
+          "x-omissionBehavior": 50
+        }
+      }
+    },
+    "projectSummaryArguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {}
+    },
+    "projectSummaryInputSchemaContract": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [],
+        "properties": {}
+      }
+    },
+    "projectSummaryResultSchemaContract": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["projectOpen", "projectName", "itemCount"],
+        "properties": {
+          "projectOpen": { "type": "boolean" },
+          "projectName": { "type": "string", "maxLength": 1024 },
+          "itemCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        }
+      }
+    },
+    "projectSummaryInvokeParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capabilityId", "capabilityVersion", "arguments"],
+      "properties": {
+        "capabilityId": { "const": "ae.project.summary" },
+        "capabilityVersion": { "const": 1 },
+        "arguments": { "$ref": "#/$defs/projectSummaryArguments" }
+      }
+    },
+    "invokeParams": {
+      "oneOf": [
+        { "$ref": "#/$defs/projectSummaryInvokeParams" }
+      ],
+      "x-invariant": "every-invoke-variant-is-compile-time-allowlisted-and-closed"
+    },
+    "cancelParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetRequestId"],
+      "properties": {
+        "targetRequestId": { "$ref": "#/$defs/requestId" }
+      }
+    },
+    "requestBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "requestId", "method", "params"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "request" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "$ref": "#/$defs/method" },
+        "deadlineUnixMs": {
+          "$ref": "#/$defs/safePositiveInteger",
+          "x-omissionBehavior": "broker-send-time-plus-5000ms"
+        },
+        "params": { "type": "object" }
+      }
+    },
+    "helloRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/requestBase" },
+        {
+          "type": "object",
+          "not": { "required": ["sessionId"] },
+          "properties": {
+            "method": { "const": "hello" },
+            "params": { "$ref": "#/$defs/helloParams" }
+          }
+        }
+      ]
+    },
+    "capabilitiesRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/requestBase" },
+        {
+          "type": "object",
+          "required": ["sessionId"],
+          "properties": {
+            "method": { "const": "capabilities" },
+            "params": { "$ref": "#/$defs/capabilitiesParams" }
+          }
+        }
+      ]
+    },
+    "invokeRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/requestBase" },
+        {
+          "type": "object",
+          "required": ["sessionId"],
+          "properties": {
+            "method": { "const": "invoke" },
+            "params": { "$ref": "#/$defs/invokeParams" }
+          }
+        }
+      ]
+    },
+    "cancelRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/requestBase" },
+        {
+          "type": "object",
+          "required": ["sessionId"],
+          "properties": {
+            "method": { "const": "cancel" },
+            "params": { "$ref": "#/$defs/cancelParams" }
+          }
+        }
+      ]
+    },
+    "request": {
+      "oneOf": [
+        { "$ref": "#/$defs/helloRequest" },
+        { "$ref": "#/$defs/capabilitiesRequest" },
+        { "$ref": "#/$defs/invokeRequest" },
+        { "$ref": "#/$defs/cancelRequest" }
+      ]
+    },
+    "compiledSdk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "build", "architecture"],
+      "properties": {
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(?:\\.[0-9]+)?$" },
+        "build": { "$ref": "#/$defs/safePositiveInteger" },
+        "architecture": { "enum": ["arm64", "x86_64"] }
+      }
+    },
+    "hostIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["application", "version", "build", "platform", "instanceId"],
+      "properties": {
+        "application": { "const": "after-effects" },
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(?:\\.[0-9]+)?$" },
+        "build": { "$ref": "#/$defs/safePositiveInteger" },
+        "platform": { "$ref": "#/$defs/platform" },
+        "instanceId": { "$ref": "#/$defs/uuid" }
+      }
+    },
+    "negotiatedLimits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maxFrameBytes",
+        "maxInFlight",
+        "maxQueueDepth",
+        "maxDeadlineMs",
+        "maxRequestsPerSecond",
+        "maxBurst",
+        "maxControlInFlight",
+        "maxControlRequestsPerSecond",
+        "maxControlBurst",
+        "maxTerminalCacheEntries",
+        "terminalCacheTtlMs"
+      ],
+      "properties": {
+        "maxFrameBytes": { "type": "integer", "minimum": 4096, "maximum": 65536 },
+        "maxInFlight": { "type": "integer", "minimum": 1, "maximum": 64 },
+        "maxQueueDepth": { "type": "integer", "minimum": 1, "maximum": 256 },
+        "maxDeadlineMs": { "type": "integer", "minimum": 100, "maximum": 30000 },
+        "maxRequestsPerSecond": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "maxBurst": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "maxControlInFlight": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "maxControlRequestsPerSecond": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "maxControlBurst": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "maxTerminalCacheEntries": { "type": "integer", "minimum": 1, "maximum": 4096 },
+        "terminalCacheTtlMs": { "type": "integer", "minimum": 1000, "maximum": 300000 }
+      }
+    },
+    "helloResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selectedWireVersion",
+        "pluginVersion",
+        "compiledSdk",
+        "host",
+        "sessionId",
+        "sessionGeneration",
+        "limits",
+        "capabilitiesDigest",
+        "clientNonce"
+      ],
+      "properties": {
+        "selectedWireVersion": { "$ref": "#/$defs/wireVersion" },
+        "pluginVersion": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "compiledSdk": { "$ref": "#/$defs/compiledSdk" },
+        "host": { "$ref": "#/$defs/hostIdentity" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "sessionGeneration": { "$ref": "#/$defs/safePositiveInteger" },
+        "limits": { "$ref": "#/$defs/negotiatedLimits" },
+        "capabilitiesDigest": { "$ref": "#/$defs/sha256" },
+        "clientNonce": { "type": "string", "minLength": 32, "maxLength": 128, "pattern": "^[A-Za-z0-9_-]+$" }
+      },
+      "x-invariant": "selected-version-must-overlap-offer; outer-and-result-session-and-nonce-must-match; platform-and-architecture-must-agree"
+    },
+    "contractId": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128,
+      "pattern": "^aemcp\\.contract(?:\\.[a-z][a-z0-9_-]*)+\\.v[1-9][0-9]*$"
+    },
+    "requirementId": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128,
+      "pattern": "^aemcp\\.requirement(?:\\.[a-z][a-z0-9_-]*)+$"
+    },
+    "requirementRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "contractVersion"],
+      "properties": {
+        "id": { "$ref": "#/$defs/requirementId" },
+        "contractVersion": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "compatibilityUnverified": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "intendedPlatforms"],
+      "properties": {
+        "status": { "const": "unverified" },
+        "intendedPlatforms": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/platform" }
+        }
+      }
+    },
+    "compatibilityVerified": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "intendedPlatforms", "minimumHostMajor", "maximumHostMajor"],
+      "properties": {
+        "status": { "const": "verified" },
+        "intendedPlatforms": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/platform" }
+        },
+        "minimumHostMajor": { "type": "integer", "minimum": 1 },
+        "maximumHostMajor": { "type": "integer", "minimum": 1 }
+      },
+      "x-invariant": "minimumHostMajor-must-not-exceed-maximumHostMajor"
+    },
+    "compatibility": {
+      "oneOf": [
+        { "$ref": "#/$defs/compatibilityUnverified" },
+        { "$ref": "#/$defs/compatibilityVerified" }
+      ]
+    },
+    "positiveCapabilityExample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "summary", "arguments", "expected"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^aemcp-example-[a-z0-9-]+$", "maxLength": 96 },
+        "kind": { "const": "positive" },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "arguments": { "$ref": "#/$defs/projectSummaryArguments" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["outcome", "value"],
+          "properties": {
+            "outcome": { "const": "succeeded" },
+            "value": { "$ref": "#/$defs/projectSummaryValue" }
+          }
+        }
+      }
+    },
+    "negativeCapabilityExample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "summary", "arguments", "expected"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^aemcp-example-[a-z0-9-]+$", "maxLength": 96 },
+        "kind": { "const": "negative" },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "arguments": { "$ref": "#/$defs/projectSummaryArguments" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["errorCode", "recoveryAction"],
+          "properties": {
+            "errorCode": { "$ref": "#/$defs/errorCode" },
+            "recoveryAction": {
+              "enum": [
+                "retry",
+                "refresh-capabilities",
+                "refresh-locator",
+                "reconnect",
+                "open-project",
+                "change-arguments",
+                "inspect-state",
+                "none"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "capabilityExample": {
+      "oneOf": [
+        { "$ref": "#/$defs/positiveCapabilityExample" },
+        { "$ref": "#/$defs/negativeCapabilityExample" }
+      ]
+    },
+    "capabilityDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "detail",
+        "id",
+        "version",
+        "schemaVersion",
+        "summary",
+        "risk",
+        "mutability",
+        "idempotency",
+        "cancellation",
+        "undo",
+        "sideEffectSummary",
+        "preconditions",
+        "compatibility"
+      ],
+      "properties": {
+        "detail": { "enum": ["summary", "full"] },
+        "id": { "$ref": "#/$defs/capabilityId" },
+        "version": { "type": "integer", "minimum": 1 },
+        "schemaVersion": { "type": "integer", "minimum": 1 },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "risk": { "enum": ["read", "write"] },
+        "mutability": { "enum": ["read-only", "mutating"] },
+        "idempotency": { "enum": ["idempotent", "idempotency-key", "non-idempotent"] },
+        "cancellation": { "enum": ["before-dispatch", "cooperative", "none"] },
+        "undo": { "enum": ["not-applicable", "ae-undo-group", "checkpoint-required", "none"] },
+        "sideEffectSummary": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "preconditions": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 96 }
+        },
+        "compatibility": { "$ref": "#/$defs/compatibility" },
+        "inputContractId": { "$ref": "#/$defs/contractId" },
+        "resultContractId": { "$ref": "#/$defs/contractId" },
+        "contractDigest": { "$ref": "#/$defs/sha256" },
+        "inputSchema": { "$ref": "#/$defs/projectSummaryInputSchemaContract" },
+        "resultSchema": { "$ref": "#/$defs/projectSummaryResultSchemaContract" },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/requirementRef" }
+        },
+        "examples": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "items": { "$ref": "#/$defs/capabilityExample" }
+        }
+      }
+    },
+    "capabilitySummary": {
+      "allOf": [
+        { "$ref": "#/$defs/capabilityDescriptor" },
+        {
+          "type": "object",
+          "properties": { "detail": { "const": "summary" } },
+          "not": {
+            "anyOf": [
+              { "required": ["inputContractId"] },
+              { "required": ["resultContractId"] },
+              { "required": ["contractDigest"] },
+              { "required": ["inputSchema"] },
+              { "required": ["resultSchema"] },
+              { "required": ["requirements"] },
+              { "required": ["examples"] }
+            ]
+          }
+        }
+      ]
+    },
+    "capabilityFull": {
+      "allOf": [
+        { "$ref": "#/$defs/capabilityDescriptor" },
+        {
+          "type": "object",
+          "required": [
+            "inputContractId",
+            "resultContractId",
+            "contractDigest",
+            "inputSchema",
+            "resultSchema",
+            "requirements",
+            "examples"
+          ],
+          "properties": { "detail": { "const": "full" } }
+        }
+      ]
+    },
+    "capabilityResultItem": {
+      "oneOf": [
+        { "$ref": "#/$defs/capabilitySummary" },
+        { "$ref": "#/$defs/capabilityFull" }
+      ]
+    },
+    "capabilitiesResultBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["detail", "items", "nextCursor", "queryDigest", "capabilitiesDigest"],
+      "properties": {
+        "detail": { "enum": ["summary", "full"] },
+        "items": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/capabilityResultItem" }
+        },
+        "nextCursor": { "type": "null" },
+        "queryDigest": { "$ref": "#/$defs/sha256" },
+        "capabilitiesDigest": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "capabilitiesSummaryResult": {
+      "allOf": [
+        { "$ref": "#/$defs/capabilitiesResultBase" },
+        {
+          "type": "object",
+          "properties": {
+            "detail": { "const": "summary" },
+            "items": {
+              "type": "array",
+              "maxItems": 100,
+              "items": { "$ref": "#/$defs/capabilitySummary" }
+            }
+          }
+        }
+      ]
+    },
+    "capabilitiesFullResult": {
+      "allOf": [
+        { "$ref": "#/$defs/capabilitiesResultBase" },
+        {
+          "type": "object",
+          "properties": {
+            "detail": { "const": "full" },
+            "items": {
+              "type": "array",
+              "maxItems": 100,
+              "items": { "$ref": "#/$defs/capabilityFull" }
+            }
+          }
+        }
+      ]
+    },
+    "capabilitiesResult": {
+      "oneOf": [
+        { "$ref": "#/$defs/capabilitiesSummaryResult" },
+        { "$ref": "#/$defs/capabilitiesFullResult" }
+      ]
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "hostInstanceId", "sessionId", "projectId", "generation", "objectId"],
+      "properties": {
+        "kind": { "enum": ["project", "item", "composition", "layer", "stream"] },
+        "hostInstanceId": { "$ref": "#/$defs/uuid" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "projectId": { "$ref": "#/$defs/uuid" },
+        "generation": { "$ref": "#/$defs/safePositiveInteger" },
+        "objectId": { "$ref": "#/$defs/uuid" }
+      },
+      "x-invariant": "server-issued-opaque-identifiers-bound-to-host-session-project-generation"
+    },
+    "postconditionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verified", "kind", "algorithm", "digest"],
+      "properties": {
+        "verified": { "const": true },
+        "kind": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z][a-z0-9_-]*$" },
+        "algorithm": { "const": "sha256-rfc8785-jcs-v1" },
+        "digest": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "undoEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "verified"],
+      "properties": {
+        "available": { "type": "boolean" },
+        "verified": { "type": "boolean" },
+        "groupId": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    },
+    "executionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "engine",
+        "hostInstanceId",
+        "sessionId",
+        "requestId",
+        "capabilityId",
+        "capabilityVersion",
+        "startedAtUnixMs",
+        "completedAtUnixMs",
+        "effect",
+        "postcondition",
+        "requestDigest"
+      ],
+      "properties": {
+        "engine": { "const": "native-aegp" },
+        "hostInstanceId": { "$ref": "#/$defs/uuid" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "capabilityId": { "$ref": "#/$defs/capabilityId" },
+        "capabilityVersion": { "type": "integer", "minimum": 1 },
+        "startedAtUnixMs": { "$ref": "#/$defs/safePositiveInteger" },
+        "completedAtUnixMs": { "$ref": "#/$defs/safePositiveInteger" },
+        "effect": { "enum": ["none", "committed"] },
+        "postcondition": { "$ref": "#/$defs/postconditionEvidence" },
+        "requestDigest": { "$ref": "#/$defs/sha256" },
+        "undo": { "$ref": "#/$defs/undoEvidence" }
+      },
+      "x-invariant": "outer-session-request-capability-must-match-and-completed-time-must-not-precede-started-time"
+    },
+    "projectSummaryValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["projectOpen", "projectName", "itemCount"],
+      "properties": {
+        "projectOpen": { "type": "boolean" },
+        "projectName": { "type": "string", "maxLength": 1024 },
+        "itemCount": { "$ref": "#/$defs/safeNonnegativeInteger" }
+      }
+    },
+    "invokeResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capabilityId", "capabilityVersion", "engine", "outcome", "value", "evidence"],
+      "properties": {
+        "capabilityId": { "const": "ae.project.summary" },
+        "capabilityVersion": { "const": 1 },
+        "engine": { "const": "native-aegp" },
+        "outcome": { "const": "succeeded" },
+        "value": { "$ref": "#/$defs/projectSummaryValue" },
+        "evidence": { "$ref": "#/$defs/executionEvidence" }
+      }
+    },
+    "cancelResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetRequestId", "state", "terminalResponseExpected"],
+      "properties": {
+        "targetRequestId": { "$ref": "#/$defs/requestId" },
+        "state": {
+          "enum": [
+            "queued-cancelled",
+            "running-cancel-requested",
+            "running-not-cancellable",
+            "already-terminal",
+            "not-found"
+          ]
+        },
+        "terminalResponseExpected": { "type": "boolean" }
+      }
+    },
+    "errorCode": {
+      "enum": [
+        "NATIVE_UNAVAILABLE",
+        "NATIVE_UNSUPPORTED",
+        "WIRE_VERSION_MISMATCH",
+        "INVALID_REQUEST",
+        "INVALID_ARGUMENT",
+        "DUPLICATE_REQUEST",
+        "PRECONDITION_FAILED",
+        "STALE_LOCATOR",
+        "DEADLINE_EXCEEDED",
+        "CANCELLED",
+        "QUEUE_FULL",
+        "AE_SHUTTING_DOWN",
+        "SESSION_STALE",
+        "CAPABILITY_FAILED",
+        "POSSIBLY_SIDE_EFFECTING_FAILURE"
+      ]
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "hint"],
+      "properties": {
+        "action": {
+          "enum": [
+            "retry",
+            "refresh-capabilities",
+            "refresh-locator",
+            "reconnect",
+            "open-project",
+            "change-arguments",
+            "inspect-state",
+            "none"
+          ]
+        },
+        "hint": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "retryAfterMs": { "type": "integer", "minimum": 1, "maximum": 30000 }
+      }
+    },
+    "errorDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "field": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "capabilityId": { "$ref": "#/$defs/capabilityId" },
+        "supportedWireVersions": { "$ref": "#/$defs/wireRange" },
+        "currentGeneration": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "errorPolicy": {
+      "oneOf": [
+        {
+          "properties": {
+            "code": { "enum": ["NATIVE_UNAVAILABLE", "AE_SHUTTING_DOWN", "SESSION_STALE"] },
+            "retryable": { "const": true },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "reconnect" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "NATIVE_UNSUPPORTED" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "refresh-capabilities" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "WIRE_VERSION_MISMATCH" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "reconnect" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "INVALID_REQUEST" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "none" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "INVALID_ARGUMENT" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "change-arguments" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "DUPLICATE_REQUEST" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "inspect-state" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "PRECONDITION_FAILED" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "open-project" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "STALE_LOCATOR" },
+            "retryable": { "const": true },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "refresh-locator" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "DEADLINE_EXCEEDED" },
+            "retryable": { "const": true },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "retry" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "CANCELLED" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "none" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "QUEUE_FULL" },
+            "retryable": { "const": true },
+            "sideEffect": { "const": "not-started" },
+            "recovery": {
+              "required": ["retryAfterMs"],
+              "properties": { "action": { "const": "retry" } }
+            }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "CAPABILITY_FAILED" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "not-started" },
+            "recovery": { "properties": { "action": { "const": "inspect-state" } } }
+          }
+        },
+        {
+          "properties": {
+            "code": { "const": "POSSIBLY_SIDE_EFFECTING_FAILURE" },
+            "retryable": { "const": false },
+            "sideEffect": { "const": "may-have-occurred" },
+            "recovery": { "properties": { "action": { "const": "inspect-state" } } }
+          }
+        }
+      ]
+    },
+    "rpcError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable", "sideEffect", "recovery"],
+      "properties": {
+        "code": { "$ref": "#/$defs/errorCode" },
+        "message": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "retryable": { "type": "boolean" },
+        "sideEffect": { "enum": ["not-started", "may-have-occurred", "completed"] },
+        "recovery": { "$ref": "#/$defs/recovery" },
+        "details": { "$ref": "#/$defs/errorDetails" }
+      },
+      "allOf": [
+        { "$ref": "#/$defs/errorPolicy" },
+        {
+          "if": { "properties": { "code": { "const": "QUEUE_FULL" } } },
+          "then": { "properties": { "recovery": { "required": ["retryAfterMs"] } } },
+          "else": { "properties": { "recovery": { "not": { "required": ["retryAfterMs"] } } } }
+        },
+        {
+          "if": { "properties": { "code": { "const": "WIRE_VERSION_MISMATCH" } } },
+          "then": {
+            "required": ["details"],
+            "properties": { "details": { "required": ["supportedWireVersions"] } }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "code": {
+                "enum": [
+                  "NATIVE_UNSUPPORTED",
+                  "PRECONDITION_FAILED",
+                  "STALE_LOCATOR",
+                  "CAPABILITY_FAILED",
+                  "POSSIBLY_SIDE_EFFECTING_FAILURE"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": ["details"],
+            "properties": { "details": { "required": ["capabilityId"] } }
+          }
+        }
+      ]
+    },
+    "helloSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "method", "ok", "replayed", "result"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "const": "hello" },
+        "ok": { "const": true },
+        "replayed": { "const": false },
+        "result": { "$ref": "#/$defs/helloResult" }
+      }
+    },
+    "capabilitiesSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "method", "ok", "replayed", "result"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "const": "capabilities" },
+        "ok": { "const": true },
+        "replayed": { "const": false },
+        "result": { "$ref": "#/$defs/capabilitiesResult" }
+      }
+    },
+    "invokeSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "method", "ok", "replayed", "result"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "const": "invoke" },
+        "ok": { "const": true },
+        "replayed": { "type": "boolean" },
+        "result": { "$ref": "#/$defs/invokeResult" }
+      }
+    },
+    "cancelSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "method", "ok", "replayed", "result"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "const": "cancel" },
+        "ok": { "const": true },
+        "replayed": { "const": false },
+        "result": { "$ref": "#/$defs/cancelResult" }
+      }
+    },
+    "failureBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "requestId", "method", "ok", "replayed", "error"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "$ref": "#/$defs/method" },
+        "ok": { "const": false },
+        "replayed": { "const": false },
+        "error": { "$ref": "#/$defs/rpcError" }
+      }
+    },
+    "helloFailure": {
+      "allOf": [
+        { "$ref": "#/$defs/failureBase" },
+        {
+          "type": "object",
+          "not": { "required": ["sessionId"] },
+          "properties": {
+            "method": { "const": "hello" },
+            "error": {
+              "properties": {
+                "code": {
+                  "enum": ["NATIVE_UNAVAILABLE", "WIRE_VERSION_MISMATCH", "INVALID_REQUEST", "INVALID_ARGUMENT"]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "sessionFailure": {
+      "allOf": [
+        { "$ref": "#/$defs/failureBase" },
+        {
+          "type": "object",
+          "required": ["sessionId"],
+          "properties": {
+            "method": { "enum": ["capabilities", "invoke", "cancel"] },
+            "error": {
+              "properties": {
+                "code": { "not": { "const": "WIRE_VERSION_MISMATCH" } }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "response": {
+      "oneOf": [
+        { "$ref": "#/$defs/helloSuccess" },
+        { "$ref": "#/$defs/capabilitiesSuccess" },
+        { "$ref": "#/$defs/invokeSuccess" },
+        { "$ref": "#/$defs/cancelSuccess" },
+        { "$ref": "#/$defs/helloFailure" },
+        { "$ref": "#/$defs/sessionFailure" }
+      ]
+    },
+    "progressEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "event", "sequence", "progress"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "event" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "event": { "const": "progress" },
+        "sequence": { "$ref": "#/$defs/safePositiveInteger" },
+        "progress": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["phase", "fraction", "message"],
+          "properties": {
+            "phase": { "enum": ["queued", "dispatched", "running", "validating"] },
+            "fraction": { "type": "number", "minimum": 0, "maximum": 1 },
+            "message": { "type": "string", "minLength": 1, "maxLength": 160 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/native/ae-plugin/protocol/conformance.mjs
+++ b/native/ae-plugin/protocol/conformance.mjs
@@ -1,0 +1,1579 @@
+import crypto from 'node:crypto';
+
+export const LIMITS = Object.freeze({
+  maxFrameBytes: 65536,
+  maxJsonDepth: 16,
+  maxJsonNodes: 2048,
+  maxStringLength: 8192,
+  defaultDeadlineMs: 5000,
+  maximumDeadlineMs: 30000,
+  defaultTerminalCacheEntries: 128,
+  defaultTerminalCacheTtlMs: 60000,
+});
+
+export const ERROR_POLICIES = Object.freeze({
+  NATIVE_UNAVAILABLE: [true, 'not-started', 'reconnect'],
+  NATIVE_UNSUPPORTED: [false, 'not-started', 'refresh-capabilities'],
+  WIRE_VERSION_MISMATCH: [false, 'not-started', 'reconnect'],
+  INVALID_REQUEST: [false, 'not-started', 'none'],
+  INVALID_ARGUMENT: [false, 'not-started', 'change-arguments'],
+  DUPLICATE_REQUEST: [false, 'not-started', 'inspect-state'],
+  PRECONDITION_FAILED: [false, 'not-started', 'open-project'],
+  STALE_LOCATOR: [true, 'not-started', 'refresh-locator'],
+  DEADLINE_EXCEEDED: [true, 'not-started', 'retry'],
+  CANCELLED: [false, 'not-started', 'none'],
+  QUEUE_FULL: [true, 'not-started', 'retry'],
+  AE_SHUTTING_DOWN: [true, 'not-started', 'reconnect'],
+  SESSION_STALE: [true, 'not-started', 'reconnect'],
+  CAPABILITY_FAILED: [false, 'not-started', 'inspect-state'],
+  POSSIBLY_SIDE_EFFECTING_FAILURE: [false, 'may-have-occurred', 'inspect-state'],
+});
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/u;
+const METHODS = new Set(['hello', 'capabilities', 'invoke', 'cancel']);
+const PROGRESS_PHASE = Object.freeze({ queued: 0, dispatched: 1, running: 2, validating: 3 });
+const VALID_REPLAY_RECEIPTS = new WeakSet();
+const VALID_CANCEL_DECISIONS = new WeakSet();
+const CONSUMED_CANCEL_DECISIONS = new WeakSet();
+export const INVOKE_REGISTRY = Object.freeze([
+  Object.freeze({
+    id: 'ae.project.summary',
+    version: 1,
+    inputContractId: 'aemcp.contract.ae.project.summary.input.v1',
+    resultContractId: 'aemcp.contract.ae.project.summary.result.v1',
+  }),
+]);
+const ENVELOPE_KEYS = new Set([
+  'wireVersion', 'kind', 'sessionId', 'requestId', 'method', 'deadlineUnixMs', 'params',
+]);
+
+function fail(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  throw error;
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasLoneSurrogate(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function unicodeScalarLength(value) {
+  if (typeof value !== 'string' || hasLoneSurrogate(value)) {
+    fail('INVALID_REQUEST', 'string is not valid Unicode scalar data');
+  }
+  return Array.from(value).length;
+}
+
+function exactKeys(value, allowed, required = []) {
+  return isPlainObject(value)
+    && Object.keys(value).every((key) => allowed.has(key))
+    && required.every((key) => Object.hasOwn(value, key));
+}
+
+function isBoundedScalarString(value, minimum, maximum) {
+  if (typeof value !== 'string') return false;
+  try {
+    const length = unicodeScalarLength(value);
+    return length >= minimum && length <= maximum;
+  } catch {
+    return false;
+  }
+}
+
+function resolveSchemaRef(root, reference) {
+  if (typeof reference !== 'string' || !reference.startsWith('#/')) {
+    fail('INVALID_ARGUMENT', 'only local schema references are supported');
+  }
+  return reference.slice(2).split('/').reduce((value, segment) => {
+    if (!isPlainObject(value)) fail('INVALID_ARGUMENT', 'invalid local schema reference');
+    const key = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (!Object.hasOwn(value, key)) fail('INVALID_ARGUMENT', 'unresolved local schema reference');
+    return value[key];
+  }, root);
+}
+
+function jsonDeepEqual(left, right) {
+  if (left === right) return true;
+  if (typeof left === 'number' && typeof right === 'number') {
+    return Number.isNaN(left) && Number.isNaN(right);
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) && Array.isArray(right)
+      && left.length === right.length
+      && left.every((item, index) => jsonDeepEqual(item, right[index]));
+  }
+  if (!isPlainObject(left) || !isPlainObject(right)) return false;
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((key) => Object.hasOwn(right, key) && jsonDeepEqual(left[key], right[key]));
+}
+
+function schemaTypeMatches(type, value) {
+  if (type === 'object') return isPlainObject(value);
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'integer') return Number.isInteger(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'null') return value === null;
+  return typeof value === type;
+}
+
+function schemaAcceptsUnchecked(candidate, value, root) {
+  if (candidate === true) return true;
+  if (candidate === false || !isPlainObject(candidate)) return false;
+  if (candidate.$ref !== undefined
+      && !schemaAcceptsUnchecked(resolveSchemaRef(root, candidate.$ref), value, root)) return false;
+  if (Object.hasOwn(candidate, 'const') && !jsonDeepEqual(candidate.const, value)) return false;
+  if (candidate.enum && !candidate.enum.some((item) => jsonDeepEqual(item, value))) return false;
+  if (candidate.not && schemaAcceptsUnchecked(candidate.not, value, root)) return false;
+  if (candidate.if) {
+    const branch = schemaAcceptsUnchecked(candidate.if, value, root) ? candidate.then : candidate.else;
+    if (branch !== undefined && !schemaAcceptsUnchecked(branch, value, root)) return false;
+  }
+  if (candidate.oneOf
+      && candidate.oneOf.filter((part) => schemaAcceptsUnchecked(part, value, root)).length !== 1) {
+    return false;
+  }
+  if (candidate.anyOf
+      && !candidate.anyOf.some((part) => schemaAcceptsUnchecked(part, value, root))) return false;
+  if (candidate.allOf
+      && !candidate.allOf.every((part) => schemaAcceptsUnchecked(part, value, root))) return false;
+  if (candidate.type && !schemaTypeMatches(candidate.type, value)) return false;
+
+  if (typeof value === 'number') {
+    if (candidate.minimum !== undefined && value < candidate.minimum) return false;
+    if (candidate.maximum !== undefined && value > candidate.maximum) return false;
+  }
+  if (typeof value === 'string') {
+    const length = unicodeScalarLength(value);
+    if (candidate.minLength !== undefined && length < candidate.minLength) return false;
+    if (candidate.maxLength !== undefined && length > candidate.maxLength) return false;
+    if (candidate.pattern && !(new RegExp(candidate.pattern, 'u')).test(value)) return false;
+  }
+  if (Array.isArray(value)) {
+    if (candidate.minItems !== undefined && value.length < candidate.minItems) return false;
+    if (candidate.maxItems !== undefined && value.length > candidate.maxItems) return false;
+    if (candidate.uniqueItems && value.some((item, index) => (
+      value.slice(index + 1).some((other) => jsonDeepEqual(item, other))
+    ))) return false;
+    if (candidate.items
+        && !value.every((item) => schemaAcceptsUnchecked(candidate.items, item, root))) return false;
+  }
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value);
+    if (candidate.required && !candidate.required.every((key) => Object.hasOwn(value, key))) return false;
+    if (candidate.properties) {
+      for (const [key, member] of Object.entries(candidate.properties)) {
+        if (Object.hasOwn(value, key) && !schemaAcceptsUnchecked(member, value[key], root)) return false;
+      }
+    }
+    if (candidate.additionalProperties === false
+        && keys.some((key) => !Object.hasOwn(candidate.properties ?? {}, key))) return false;
+  }
+  return true;
+}
+
+export function schemaAccepts(candidate, value, root = candidate) {
+  try {
+    assertJsonLimits(value);
+    return schemaAcceptsUnchecked(candidate, value, root);
+  } catch {
+    return false;
+  }
+}
+
+export function assertJsonLimits(value, limits = LIMITS) {
+  const stack = [{ value, depth: 1 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    nodes += 1;
+    if (nodes > limits.maxJsonNodes) fail('INVALID_REQUEST', 'JSON node limit exceeded');
+    if (current.depth > limits.maxJsonDepth) fail('INVALID_REQUEST', 'JSON depth exceeded');
+    if (current.value === null || typeof current.value === 'boolean') continue;
+    if (typeof current.value === 'string') {
+      if (unicodeScalarLength(current.value) > limits.maxStringLength) {
+        fail('INVALID_REQUEST', 'JSON string limit exceeded');
+      }
+      continue;
+    }
+    if (typeof current.value === 'number') {
+      if (!Number.isFinite(current.value)) fail('INVALID_REQUEST', 'non-finite JSON number');
+      if (Number.isInteger(current.value) && !Number.isSafeInteger(current.value)) {
+        fail('INVALID_REQUEST', 'unsafe JSON integer');
+      }
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      for (let index = current.value.length - 1; index >= 0; index -= 1) {
+        stack.push({ value: current.value[index], depth: current.depth + 1 });
+      }
+      continue;
+    }
+    if (!isPlainObject(current.value)) fail('INVALID_REQUEST', 'unsupported JSON value');
+    for (const [key, member] of Object.entries(current.value).reverse()) {
+      if (unicodeScalarLength(key) > limits.maxStringLength) {
+        fail('INVALID_REQUEST', 'JSON key limit exceeded');
+      }
+      if (member === undefined || typeof member === 'bigint' || typeof member === 'function'
+          || typeof member === 'symbol') fail('INVALID_REQUEST', 'unsupported JSON member');
+      stack.push({ value: member, depth: current.depth + 1 });
+    }
+  }
+  return true;
+}
+
+function canonicalizeUnchecked(value) {
+  if (value === null) return 'null';
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  if (typeof value === 'string') {
+    if (hasLoneSurrogate(value)) fail('INVALID_ARGUMENT', 'lone unicode surrogate');
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('INVALID_ARGUMENT', 'non-finite JSON number');
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      fail('INVALID_ARGUMENT', 'unsafe JSON integer');
+    }
+    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+  }
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalizeUnchecked(item)).join(',')}]`;
+  if (!isPlainObject(value)) fail('INVALID_ARGUMENT', 'unsupported canonical JSON value');
+  const members = Object.keys(value).sort().map((key) => (
+    `${JSON.stringify(key)}:${canonicalizeUnchecked(value[key])}`
+  ));
+  return `{${members.join(',')}}`;
+}
+
+export function canonicalize(value) {
+  assertJsonLimits(value);
+  return canonicalizeUnchecked(value);
+}
+
+export function sha256Jcs(value) {
+  return crypto.createHash('sha256').update(canonicalize(value), 'utf8').digest('hex');
+}
+
+class StrictJsonParser {
+  constructor(text, limits = LIMITS) {
+    this.text = text;
+    this.index = 0;
+    this.nodes = 0;
+    this.limits = limits;
+  }
+
+  parse() {
+    this.skipWhitespace();
+    const value = this.parseValue(1);
+    this.skipWhitespace();
+    if (this.index !== this.text.length) fail('INVALID_REQUEST', 'trailing JSON bytes');
+    return value;
+  }
+
+  countNode(depth) {
+    if (depth > this.limits.maxJsonDepth) fail('INVALID_REQUEST', 'JSON depth exceeded');
+    this.nodes += 1;
+    if (this.nodes > this.limits.maxJsonNodes) fail('INVALID_REQUEST', 'JSON node limit exceeded');
+  }
+
+  parseValue(depth) {
+    this.countNode(depth);
+    const char = this.text[this.index];
+    if (char === '{') return this.parseObject(depth);
+    if (char === '[') return this.parseArray(depth);
+    if (char === '"') return this.parseString();
+    if (char === 't') return this.parseLiteral('true', true);
+    if (char === 'f') return this.parseLiteral('false', false);
+    if (char === 'n') return this.parseLiteral('null', null);
+    return this.parseNumber();
+  }
+
+  parseObject(depth) {
+    this.index += 1;
+    this.skipWhitespace();
+    const result = Object.create(null);
+    const keys = new Set();
+    if (this.text[this.index] === '}') {
+      this.index += 1;
+      return result;
+    }
+    while (this.index < this.text.length) {
+      if (this.text[this.index] !== '"') fail('INVALID_REQUEST', 'object key must be a string');
+      const key = this.parseString();
+      if (keys.has(key)) fail('INVALID_REQUEST', 'duplicate JSON object key');
+      keys.add(key);
+      this.skipWhitespace();
+      if (this.text[this.index] !== ':') fail('INVALID_REQUEST', 'missing object colon');
+      this.index += 1;
+      this.skipWhitespace();
+      result[key] = this.parseValue(depth + 1);
+      this.skipWhitespace();
+      const separator = this.text[this.index];
+      this.index += 1;
+      if (separator === '}') return result;
+      if (separator !== ',') fail('INVALID_REQUEST', 'invalid object separator');
+      this.skipWhitespace();
+    }
+    fail('INVALID_REQUEST', 'unterminated object');
+  }
+
+  parseArray(depth) {
+    this.index += 1;
+    this.skipWhitespace();
+    const result = [];
+    if (this.text[this.index] === ']') {
+      this.index += 1;
+      return result;
+    }
+    while (this.index < this.text.length) {
+      result.push(this.parseValue(depth + 1));
+      this.skipWhitespace();
+      const separator = this.text[this.index];
+      this.index += 1;
+      if (separator === ']') return result;
+      if (separator !== ',') fail('INVALID_REQUEST', 'invalid array separator');
+      this.skipWhitespace();
+    }
+    fail('INVALID_REQUEST', 'unterminated array');
+  }
+
+  parseString() {
+    const start = this.index;
+    this.index += 1;
+    while (this.index < this.text.length) {
+      const code = this.text.charCodeAt(this.index);
+      if (code === 0x22) {
+        this.index += 1;
+        let value;
+        try {
+          value = JSON.parse(this.text.slice(start, this.index));
+        } catch {
+          fail('INVALID_REQUEST', 'invalid JSON string');
+        }
+        if (unicodeScalarLength(value) > this.limits.maxStringLength) {
+          fail('INVALID_REQUEST', 'JSON string limit exceeded');
+        }
+        return value;
+      }
+      if (code < 0x20) fail('INVALID_REQUEST', 'unescaped string control character');
+      if (code === 0x5c) {
+        this.index += 1;
+        const escaped = this.text[this.index];
+        if (escaped === 'u') {
+          const hex = this.text.slice(this.index + 1, this.index + 5);
+          if (!/^[0-9a-fA-F]{4}$/u.test(hex)) fail('INVALID_REQUEST', 'invalid unicode escape');
+          this.index += 4;
+        } else if (!'"\\/bfnrt'.includes(escaped)) {
+          fail('INVALID_REQUEST', 'invalid string escape');
+        }
+      }
+      this.index += 1;
+    }
+    fail('INVALID_REQUEST', 'unterminated string');
+  }
+
+  parseLiteral(literal, value) {
+    if (this.text.slice(this.index, this.index + literal.length) !== literal) {
+      fail('INVALID_REQUEST', 'invalid JSON literal');
+    }
+    this.index += literal.length;
+    return value;
+  }
+
+  parseNumber() {
+    const match = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/u.exec(
+      this.text.slice(this.index),
+    );
+    if (!match) fail('INVALID_REQUEST', 'invalid JSON value');
+    this.index += match[0].length;
+    const value = Number(match[0]);
+    if (!Number.isFinite(value)) fail('INVALID_REQUEST', 'non-finite JSON number');
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      fail('INVALID_REQUEST', 'unsafe JSON integer');
+    }
+    return value;
+  }
+
+  skipWhitespace() {
+    while (' \t\r\n'.includes(this.text[this.index] ?? '\0')) this.index += 1;
+  }
+}
+
+export function strictParseJson(text, limits = LIMITS) {
+  return new StrictJsonParser(text, limits).parse();
+}
+
+export function encodeFrame(message) {
+  const body = Buffer.from(canonicalize(message), 'utf8');
+  if (body.length === 0 || body.length > LIMITS.maxFrameBytes) fail('INVALID_REQUEST', 'frame size rejected');
+  const frame = Buffer.allocUnsafe(body.length + 4);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+export function decodeFrame(frame) {
+  if (frame.length < 4) fail('INVALID_REQUEST', 'incomplete frame prefix');
+  const length = frame.readUInt32BE(0);
+  if (length === 0 || length > LIMITS.maxFrameBytes) fail('INVALID_REQUEST', 'frame size rejected');
+  if (frame.length !== length + 4) fail('INVALID_REQUEST', 'incomplete or trailing frame bytes');
+  let text;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(frame.subarray(4));
+  } catch {
+    fail('INVALID_REQUEST', 'invalid UTF-8');
+  }
+  return strictParseJson(text);
+}
+
+export class FrameDecoder {
+  constructor() {
+    this.pending = Buffer.alloc(0);
+  }
+
+  push(chunk) {
+    if (!Buffer.isBuffer(chunk) && !(chunk instanceof Uint8Array)) {
+      fail('INVALID_REQUEST', 'frame chunk must be bytes');
+    }
+    if (chunk.length > LIMITS.maxFrameBytes + 4) {
+      fail('INVALID_REQUEST', 'transport chunk exceeds bounded decoder input');
+    }
+    this.pending = Buffer.concat([this.pending, chunk]);
+    const messages = [];
+    while (this.pending.length >= 4) {
+      const length = this.pending.readUInt32BE(0);
+      if (length === 0 || length > LIMITS.maxFrameBytes) fail('INVALID_REQUEST', 'frame size rejected');
+      if (this.pending.length < length + 4) break;
+      const frame = this.pending.subarray(0, length + 4);
+      messages.push(decodeFrame(frame));
+      this.pending = this.pending.subarray(length + 4);
+    }
+    return messages;
+  }
+
+  finalize() {
+    if (this.pending.length !== 0) fail('INVALID_REQUEST', 'incomplete frame at end of stream');
+    return [];
+  }
+}
+
+export function selectWireVersion(clientRange, pluginRange) {
+  for (const range of [clientRange, pluginRange]) {
+    if (!Number.isInteger(range?.minimum) || !Number.isInteger(range?.maximum)
+        || range.minimum < 1 || range.maximum > 65535 || range.maximum < range.minimum) {
+      fail('INVALID_ARGUMENT', 'invalid wire-version range');
+    }
+  }
+  const minimum = Math.max(clientRange.minimum, pluginRange.minimum);
+  const maximum = Math.min(clientRange.maximum, pluginRange.maximum);
+  return minimum <= maximum ? maximum : null;
+}
+
+export function materializeDeadline(request, nowUnixMs, maxDeadlineMs = LIMITS.maximumDeadlineMs) {
+  if (!Number.isSafeInteger(nowUnixMs) || nowUnixMs < 1) fail('INVALID_ARGUMENT', 'invalid current time');
+  const deadline = request.deadlineUnixMs ?? (nowUnixMs + LIMITS.defaultDeadlineMs);
+  if (!Number.isSafeInteger(deadline) || deadline < 1) fail('INVALID_ARGUMENT', 'invalid deadline');
+  if (deadline <= nowUnixMs) fail('DEADLINE_EXCEEDED', 'deadline expired before dispatch');
+  if (deadline > nowUnixMs + maxDeadlineMs) fail('INVALID_ARGUMENT', 'deadline exceeds negotiated maximum');
+  return deadline;
+}
+
+export function classifyRequest(message) {
+  if (!exactKeys(message, ENVELOPE_KEYS, ['wireVersion', 'kind', 'requestId', 'method', 'params'])) {
+    return { ok: false, errorCode: 'INVALID_REQUEST' };
+  }
+  if (message.wireVersion !== 1 || message.kind !== 'request'
+      || !REQUEST_ID.test(message.requestId) || !METHODS.has(message.method)) {
+    return { ok: false, errorCode: 'INVALID_REQUEST' };
+  }
+  if (message.deadlineUnixMs !== undefined
+      && (!Number.isSafeInteger(message.deadlineUnixMs) || message.deadlineUnixMs < 1)) {
+    return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+  }
+  if (message.method === 'hello') {
+    if (message.sessionId !== undefined) return { ok: false, errorCode: 'INVALID_REQUEST' };
+    const params = message.params;
+    if (!exactKeys(params, new Set(['supportedWireVersions', 'client', 'nonce']),
+      ['supportedWireVersions', 'client', 'nonce'])) return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    try {
+      selectWireVersion(params.supportedWireVersions, { minimum: 1, maximum: 1 });
+    } catch {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    }
+    if (!exactKeys(params.client, new Set(['component', 'version', 'instanceId']),
+      ['component', 'version', 'instanceId'])
+      || !['core-broker', 'development-smoke'].includes(params.client.component)
+      || !isBoundedScalarString(params.client.version, 1, 64) || !UUID.test(params.client.instanceId)
+      || typeof params.nonce !== 'string' || !/^[A-Za-z0-9_-]{32,128}$/u.test(params.nonce)) {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    }
+    return { ok: true };
+  }
+  if (!UUID.test(message.sessionId ?? '')) return { ok: false, errorCode: 'SESSION_STALE' };
+  if (message.method === 'capabilities') {
+    const params = message.params;
+    const allowed = new Set(['ids', 'detail', 'limit']);
+    if (!exactKeys(params, allowed)) return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    if (params.detail !== undefined && !['summary', 'full'].includes(params.detail)) {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    }
+    if (params.limit !== undefined
+        && (!Number.isInteger(params.limit) || params.limit < 1 || params.limit > 100)) {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    }
+    if (params.ids !== undefined
+        && (!Array.isArray(params.ids) || params.ids.length < 1 || params.ids.length > 32
+          || new Set(params.ids).size !== params.ids.length
+          || params.ids.some((id) => typeof id !== 'string' || id.length > 96
+            || !/^ae(?:\.[a-z][a-z0-9_-]*)+$/u.test(id)))) {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    }
+    return { ok: true };
+  }
+  if (message.method === 'invoke') {
+    const params = message.params;
+    if (!exactKeys(params, new Set(['capabilityId', 'capabilityVersion', 'arguments']),
+      ['capabilityId', 'capabilityVersion', 'arguments'])) return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    const registration = INVOKE_REGISTRY.find((item) => item.id === params.capabilityId
+      && item.version === params.capabilityVersion);
+    if (!registration
+        || !exactKeys(params.arguments, new Set())) return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+    return { ok: true };
+  }
+  const params = message.params;
+  if (!exactKeys(params, new Set(['targetRequestId']), ['targetRequestId'])
+      || !REQUEST_ID.test(params.targetRequestId)) return { ok: false, errorCode: 'INVALID_ARGUMENT' };
+  return { ok: true };
+}
+
+export function validateRequestComposite(message, schema) {
+  try {
+    if (!schemaAccepts(schema?.$defs?.request, message, schema)) {
+      return { ok: false, errorCode: 'INVALID_REQUEST' };
+    }
+    return classifyRequest(message);
+  } catch (error) {
+    return { ok: false, errorCode: error.code ?? 'INVALID_REQUEST' };
+  }
+}
+
+export function decodeAndClassifyRequest(frame, schema) {
+  try {
+    const message = decodeFrame(frame);
+    const classification = validateRequestComposite(message, schema);
+    return classification.ok === true ? { ok: true, message } : classification;
+  } catch (error) {
+    return { ok: false, errorCode: error.code ?? 'INVALID_REQUEST' };
+  }
+}
+
+export function validateResponseShape(message, schema) {
+  return schemaAccepts(schema?.$defs?.response, message, schema);
+}
+
+export function validateProgressEventShape(message, schema) {
+  return schemaAccepts(schema?.$defs?.progressEvent, message, schema);
+}
+
+function decodeAndValidateShape(frame, schema, definition) {
+  try {
+    const message = decodeFrame(frame);
+    if (!schemaAccepts(schema?.$defs?.[definition], message, schema)) {
+      return { ok: false, errorCode: 'INVALID_REQUEST' };
+    }
+    return { ok: true, message };
+  } catch (error) {
+    return { ok: false, errorCode: error.code ?? 'INVALID_REQUEST' };
+  }
+}
+
+export function decodeAndValidateResponse(frame, schema) {
+  return decodeAndValidateShape(frame, schema, 'response');
+}
+
+export function decodeAndValidateProgressEvent(frame, schema) {
+  return decodeAndValidateShape(frame, schema, 'progressEvent');
+}
+
+export function validateErrorPolicy(error, schema) {
+  if (!schemaAccepts(schema?.$defs?.rpcError, error, schema)) return false;
+  const expected = ERROR_POLICIES[error?.code];
+  if (!expected) return false;
+  const [retryable, sideEffect, action] = expected;
+  if (error.retryable !== retryable || error.sideEffect !== sideEffect
+      || error.recovery?.action !== action) return false;
+  if (error.code === 'QUEUE_FULL'
+      && (!Number.isInteger(error.recovery.retryAfterMs) || error.recovery.retryAfterMs < 1)) return false;
+  if (error.code !== 'QUEUE_FULL' && error.recovery.retryAfterMs !== undefined) return false;
+  return true;
+}
+
+const CAPABILITY_DETAIL_ERRORS = new Set([
+  'NATIVE_UNSUPPORTED',
+  'PRECONDITION_FAILED',
+  'STALE_LOCATOR',
+  'CAPABILITY_FAILED',
+  'POSSIBLY_SIDE_EFFECTING_FAILURE',
+]);
+
+export function validateFailureExchange(
+  helloContext,
+  request,
+  response,
+  descriptor = null,
+  schema = helloContext?.schema,
+) {
+  if (request?.method === 'hello') return validateHelloFailure(request, response, schema);
+  if (!validateHelloContext(helloContext, schema)
+      || validateRequestComposite(request, schema).ok !== true
+      || !validateResponseShape(response, schema)
+      || response?.ok !== false || response.kind !== 'response' || response.replayed !== false
+      || response.requestId !== request.requestId || response.method !== request.method
+      || response.sessionId !== request.sessionId
+      || request.sessionId !== helloContext.response.sessionId
+      || response.wireVersion !== request.wireVersion || !validateErrorPolicy(response.error, schema)
+      || response.error.code === 'WIRE_VERSION_MISMATCH') return false;
+  const capabilityId = request.method === 'invoke' ? request.params.capabilityId : null;
+  if (CAPABILITY_DETAIL_ERRORS.has(response.error.code)) {
+    if (capabilityId === null || response.error.details?.capabilityId !== capabilityId) return false;
+  } else if (response.error.details?.capabilityId !== undefined
+      && response.error.details.capabilityId !== capabilityId) return false;
+  if (descriptor !== null && (descriptor.id !== capabilityId
+      || descriptor.version !== request.params.capabilityVersion)) return false;
+  return true;
+}
+
+export function validateHelloExchange(request, response, schema) {
+  if (validateRequestComposite(request, schema).ok !== true || request.method !== 'hello'
+      || !validateResponseShape(response, schema)) return false;
+  if (!response?.ok || !isPlainObject(response.result) || !isPlainObject(response.result.host)
+      || !isPlainObject(response.result.compiledSdk)
+      || response.kind !== 'response' || response.method !== 'hello'
+      || response.requestId !== request.requestId || response.replayed !== false) return false;
+  if (response.sessionId !== response.result?.sessionId
+      || response.result.clientNonce !== request.params.nonce) return false;
+  const selected = selectWireVersion(request.params.supportedWireVersions, { minimum: 1, maximum: 1 });
+  if (selected === null || response.result.selectedWireVersion !== selected
+      || response.wireVersion !== selected) return false;
+  const { platform } = response.result.host;
+  const { architecture } = response.result.compiledSdk;
+  return (platform === 'macos-arm64' && architecture === 'arm64')
+    || (platform === 'windows-x64' && architecture === 'x86_64');
+}
+
+export function validateHelloFailure(request, response, schema) {
+  if (validateRequestComposite(request, schema).ok !== true || request.method !== 'hello'
+      || !validateResponseShape(response, schema)) return false;
+  if (response?.ok !== false || response.kind !== 'response' || response.method !== 'hello'
+      || response.requestId !== request.requestId || response.sessionId !== undefined
+      || response.wireVersion !== request.wireVersion || response.replayed !== false
+      || !validateErrorPolicy(response.error, schema)) return false;
+  if (response.error.code === 'WIRE_VERSION_MISMATCH') {
+    const supported = response.error.details?.supportedWireVersions;
+    if (!supported) return false;
+    try {
+      return selectWireVersion(request.params.supportedWireVersions, supported) === null;
+    } catch {
+      return false;
+    }
+  }
+  return ['NATIVE_UNAVAILABLE', 'INVALID_REQUEST', 'INVALID_ARGUMENT'].includes(response.error.code);
+}
+
+function validateHelloContext(context, schemaOverride = undefined) {
+  const schema = schemaOverride ?? context?.schema;
+  return isPlainObject(context) && isPlainObject(context.request) && isPlainObject(context.response)
+    && validateHelloExchange(context.request, context.response, schema);
+}
+
+export function projectSummaryContractDigest(schema) {
+  const inputSchema = structuredClone(schema.$defs.projectSummaryInputSchemaContract.const);
+  const resultSchema = structuredClone(schema.$defs.projectSummaryResultSchemaContract.const);
+  return sha256Jcs({
+    inputSchema,
+    resultSchema,
+  });
+}
+
+export function capabilityDigest(items) {
+  return sha256Jcs(items);
+}
+
+export function projectSummaryDescriptor(schema) {
+  const registration = INVOKE_REGISTRY[0];
+  return {
+    detail: 'full',
+    id: registration.id,
+    version: registration.version,
+    schemaVersion: 1,
+    summary: 'Read bounded facts about the active After Effects project.',
+    risk: 'read',
+    mutability: 'read-only',
+    idempotency: 'idempotent',
+    cancellation: 'before-dispatch',
+    undo: 'not-applicable',
+    sideEffectSummary: 'Reads project state without modifying it.',
+    preconditions: [],
+    compatibility: {
+      status: 'unverified',
+      intendedPlatforms: ['macos-arm64', 'windows-x64'],
+    },
+    inputContractId: registration.inputContractId,
+    resultContractId: registration.resultContractId,
+    contractDigest: projectSummaryContractDigest(schema),
+    inputSchema: structuredClone(schema.$defs.projectSummaryInputSchemaContract.const),
+    resultSchema: structuredClone(schema.$defs.projectSummaryResultSchemaContract.const),
+    requirements: [{
+      id: 'aemcp.requirement.native.project-read',
+      contractVersion: 1,
+    }],
+    examples: [
+      {
+        id: 'aemcp-example-project-summary-empty',
+        kind: 'positive',
+        summary: 'Read a bounded summary when no project content exists.',
+        arguments: {},
+        expected: {
+          outcome: 'succeeded',
+          value: { projectOpen: false, projectName: 'SYNTHETIC_EXAMPLE', itemCount: 0 },
+        },
+      },
+      {
+        id: 'aemcp-example-project-summary-unavailable',
+        kind: 'negative',
+        summary: 'Return a typed unavailable error before native dispatch.',
+        arguments: {},
+        expected: { errorCode: 'NATIVE_UNAVAILABLE', recoveryAction: 'reconnect' },
+      },
+    ],
+  };
+}
+
+export function capabilityQueryDigest(request) {
+  if (classifyRequest(request).ok !== true || request.method !== 'capabilities') {
+    fail('INVALID_ARGUMENT', 'invalid capabilities request');
+  }
+  return sha256Jcs({
+    sessionId: request.sessionId,
+    ids: request.params.ids ?? null,
+    detail: request.params.detail ?? 'summary',
+    limit: request.params.limit ?? 50,
+  });
+}
+
+function summarizeDescriptor(descriptor) {
+  const summary = structuredClone(descriptor);
+  summary.detail = 'summary';
+  for (const key of [
+    'inputContractId', 'resultContractId', 'contractDigest', 'inputSchema', 'resultSchema',
+    'requirements', 'examples',
+  ]) delete summary[key];
+  return summary;
+}
+
+export function postconditionDigest(result) {
+  return sha256Jcs({
+    capabilityId: result.capabilityId,
+    capabilityVersion: result.capabilityVersion,
+    value: result.value,
+  });
+}
+
+export function validateCapabilitiesExchange(
+  helloContext,
+  request,
+  response,
+  schema,
+  registryOverride = undefined,
+) {
+  if (!validateHelloContext(helloContext, schema)
+      || validateRequestComposite(request, schema).ok !== true
+      || !validateResponseShape(response, schema)
+      || request.method !== 'capabilities' || !response?.ok || response.kind !== 'response'
+      || response.method !== 'capabilities' || response.requestId !== request.requestId
+      || response.replayed !== false
+      || request.sessionId !== helloContext.response.sessionId
+      || response.sessionId !== request.sessionId || response.wireVersion !== request.wireVersion) return false;
+  if (!isPlainObject(response.result) || !Array.isArray(response.result.items)) return false;
+  const detail = request.params.detail ?? 'summary';
+  let registry;
+  try {
+    registry = registryOverride ?? [projectSummaryDescriptor(schema)];
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(registry)
+      || registry.some((item) => !validateCapabilityDescriptor(item, schema))) {
+    return false;
+  }
+  const requestedIds = request.params.ids ? new Set(request.params.ids) : null;
+  const selected = registry.filter((item) => !requestedIds || requestedIds.has(item.id));
+  if (selected.length > (request.params.limit ?? 50)) return false;
+  const expectedItems = detail === 'full' ? selected : selected.map(summarizeDescriptor);
+  const result = response.result;
+  if (result.detail !== detail || result.nextCursor !== null
+      || result.items.length > (request.params.limit ?? 50)
+      || result.queryDigest !== capabilityQueryDigest(request)) return false;
+  try {
+    if (canonicalize(result.items) !== canonicalize(expectedItems)) return false;
+  } catch {
+    return false;
+  }
+  if (result.items.some((item) => !validateCapabilityDescriptor(item, schema))) return false;
+  let digest;
+  try {
+    digest = capabilityDigest(registry);
+  } catch {
+    return false;
+  }
+  return result.capabilitiesDigest === digest
+    && helloContext.response.result.capabilitiesDigest === digest;
+}
+
+export function validateCapabilityDescriptor(descriptor, schema) {
+  if (!schemaAccepts(schema?.$defs?.capabilityResultItem, descriptor, schema)
+      || !isPlainObject(descriptor) || !isPlainObject(descriptor.compatibility)) return false;
+  if (descriptor.risk === 'read'
+      && (descriptor.mutability !== 'read-only' || descriptor.undo !== 'not-applicable'
+        || descriptor.idempotency !== 'idempotent')) return false;
+  if (descriptor.risk === 'write' && descriptor.mutability !== 'mutating') return false;
+  if (descriptor.detail === 'full') {
+    if (!Array.isArray(descriptor.requirements) || descriptor.requirements.length === 0
+        || descriptor.requirements.some((requirement) => !isPlainObject(requirement)
+          || typeof requirement.id !== 'string'
+          || !Number.isInteger(requirement.contractVersion) || requirement.contractVersion < 1)) return false;
+    if (!Array.isArray(descriptor.examples)) return false;
+    const kinds = new Set(descriptor.examples.map((example) => example?.kind));
+    if (!kinds.has('positive') || !kinds.has('negative')) return false;
+    if (descriptor.examples.some((example) => !isPlainObject(example.arguments)
+        || !isPlainObject(example.expected))) return false;
+  }
+  const compatibility = descriptor.compatibility;
+  if (compatibility.status === 'unverified') {
+    return compatibility.minimumHostMajor === undefined && compatibility.maximumHostMajor === undefined;
+  }
+  return compatibility.status === 'verified'
+    && Number.isInteger(compatibility.minimumHostMajor)
+    && Number.isInteger(compatibility.maximumHostMajor)
+    && compatibility.minimumHostMajor <= compatibility.maximumHostMajor;
+}
+
+export function validateIdempotencyContract(descriptor, invokeParams) {
+  if (descriptor.idempotency === 'idempotency-key') {
+    return typeof invokeParams.idempotencyKey === 'string'
+      && /^[A-Za-z0-9._:-]{16,128}$/u.test(invokeParams.idempotencyKey);
+  }
+  return invokeParams.idempotencyKey === undefined;
+}
+
+export function validateCancelResult(result, schema) {
+  if (!schemaAccepts(schema?.$defs?.cancelResult, result, schema)) return false;
+  const expected = {
+    'queued-cancelled': true,
+    'running-cancel-requested': true,
+    'running-not-cancellable': true,
+    'already-terminal': false,
+    'not-found': false,
+  }[result?.state];
+  return expected !== undefined && result.terminalResponseExpected === expected;
+}
+
+export function validateProgressEvent(message, request, schema) {
+  return validateProgressEventShape(message, schema)
+    && validateRequestComposite(request, schema).ok === true
+    && isPlainObject(request) && isPlainObject(message) && isPlainObject(message.progress)
+    && exactKeys(message, new Set([
+    'wireVersion', 'kind', 'sessionId', 'requestId', 'event', 'sequence', 'progress',
+  ]), ['wireVersion', 'kind', 'sessionId', 'requestId', 'event', 'sequence', 'progress'])
+    && message.wireVersion === request.wireVersion
+    && message.kind === 'event'
+    && message.sessionId === request.sessionId
+    && message.requestId === request.requestId
+    && message.event === 'progress'
+    && Number.isSafeInteger(message.sequence) && message.sequence >= 1
+    && exactKeys(message.progress, new Set(['phase', 'fraction', 'message']), [
+      'phase', 'fraction', 'message',
+    ])
+    && PROGRESS_PHASE[message.progress.phase] !== undefined
+    && typeof message.progress.fraction === 'number'
+    && Number.isFinite(message.progress.fraction)
+    && message.progress.fraction >= 0 && message.progress.fraction <= 1
+    && isBoundedScalarString(message.progress.message, 1, 160);
+}
+
+export function validateCancelExchange(
+  context,
+  cancelRequest,
+  cancelResponse,
+  targetRequest,
+  targetMessages,
+) {
+  const helloContext = context?.hello;
+  const descriptor = context?.descriptor;
+  const schema = context?.schema;
+  const decision = context?.cancelDecision;
+  if (!validateHelloContext(helloContext, schema)
+      || validateRequestComposite(cancelRequest, schema).ok !== true
+      || cancelRequest.method !== 'cancel' || !validateResponseShape(cancelResponse, schema)
+      || cancelRequest.sessionId !== helloContext.response.sessionId
+      || cancelResponse?.ok !== true || cancelResponse.kind !== 'response'
+      || cancelResponse.method !== 'cancel' || cancelResponse.requestId !== cancelRequest.requestId
+      || cancelResponse.sessionId !== cancelRequest.sessionId
+      || cancelResponse.wireVersion !== cancelRequest.wireVersion
+      || cancelResponse.replayed !== false
+      || cancelResponse.result?.targetRequestId !== cancelRequest.params.targetRequestId
+      || !validateCancelResult(cancelResponse.result, schema) || !Array.isArray(targetMessages)
+      || !validateCapabilityDescriptor(descriptor, schema)
+      || !isPlainObject(decision) || !VALID_CANCEL_DECISIONS.has(decision)
+      || CONSUMED_CANCEL_DECISIONS.has(decision)
+      || decision.cancelKey !== `${cancelRequest.sessionId}:${cancelRequest.requestId}`
+      || decision.cancelRequestId !== cancelRequest.requestId
+      || decision.sessionId !== cancelRequest.sessionId
+      || decision.targetKey !== `${cancelRequest.sessionId}:${cancelRequest.params.targetRequestId}`
+      || decision.targetRequestId !== cancelRequest.params.targetRequestId
+      || decision.capabilityId !== descriptor.id
+      || decision.capabilityVersion !== descriptor.version
+      || decision.cancellation !== descriptor.cancellation
+      || decision.state !== cancelResponse.result.state
+      || decision.terminalResponseExpected !== cancelResponse.result.terminalResponseExpected) return false;
+
+  const { state, terminalResponseExpected } = cancelResponse.result;
+  const knownTarget = state !== 'not-found';
+  if (!knownTarget) {
+    if (targetRequest !== null || decision.targetRequestDigest !== null
+        || decision.targetEffectiveDeadlineUnixMs !== null || targetMessages.length !== 0) return false;
+    CONSUMED_CANCEL_DECISIONS.add(decision);
+    return true;
+  }
+  if (validateRequestComposite(targetRequest, schema).ok !== true
+      || targetRequest.method !== 'invoke' || targetRequest.requestId === cancelRequest.requestId
+      || targetRequest.requestId !== cancelRequest.params.targetRequestId
+      || targetRequest.sessionId !== cancelRequest.sessionId
+      || descriptor.id !== targetRequest.params.capabilityId
+      || descriptor.version !== targetRequest.params.capabilityVersion
+      || decision.targetRequestDigest !== sha256Jcs(targetRequest)
+      || decision.targetEffectiveDeadlineUnixMs !== context?.targetTranscriptContext?.effectiveDeadlineUnixMs) {
+    return false;
+  }
+  if (!terminalResponseExpected) {
+    if (state !== 'already-terminal' || targetMessages.length !== 0) return false;
+    CONSUMED_CANCEL_DECISIONS.add(decision);
+    return true;
+  }
+  const transcriptContext = {
+    ...context.targetTranscriptContext,
+    hello: helloContext,
+    descriptor,
+    schema,
+  };
+  if (!validateTranscript(transcriptContext, targetRequest, targetMessages)) return false;
+  const terminal = targetMessages.at(-1);
+  let validTerminal = true;
+  if (state === 'queued-cancelled') {
+    validTerminal = terminal.ok === false && terminal.error?.code === 'CANCELLED';
+  } else if (state === 'running-not-cancellable') {
+    validTerminal = !(terminal.ok === false && terminal.error?.code === 'CANCELLED');
+  } else if (state !== 'running-cancel-requested') {
+    validTerminal = false;
+  }
+  if (!validTerminal) return false;
+  CONSUMED_CANCEL_DECISIONS.add(decision);
+  return true;
+}
+
+export function validateTranscript(context, request, messages) {
+  const helloContext = context?.hello;
+  const descriptor = context?.descriptor;
+  const schema = context?.schema;
+  const deadline = context?.effectiveDeadlineUnixMs;
+  const brokerSendUnixMs = context?.brokerSendUnixMs;
+  const terminalObservedUnixMs = context?.terminalObservedUnixMs;
+  let expectedDeadline;
+  try {
+    expectedDeadline = request?.deadlineUnixMs === undefined
+        && VALID_REPLAY_RECEIPTS.has(context?.replayReceipt)
+      ? context.replayReceipt.effectiveDeadlineUnixMs
+      : materializeDeadline(
+        request,
+        brokerSendUnixMs,
+        helloContext?.response?.result?.limits?.maxDeadlineMs,
+      );
+  } catch {
+    return false;
+  }
+  let descriptorDigest;
+  let requestDigest;
+  try {
+    descriptorDigest = capabilityDigest([descriptor]);
+    requestDigest = sha256Jcs(request);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(messages) || !validateHelloContext(helloContext, schema)
+      || validateRequestComposite(request, schema).ok !== true
+      || request.method !== 'invoke' || !validateCapabilityDescriptor(descriptor, schema)
+      || descriptor.id !== request.params.capabilityId
+      || descriptor.version !== request.params.capabilityVersion
+      || descriptorDigest !== helloContext.response.result.capabilitiesDigest
+      || request.sessionId !== helloContext.response.sessionId
+      || request.wireVersion !== helloContext.response.result.selectedWireVersion
+      || !Number.isSafeInteger(deadline) || deadline < 1 || deadline !== expectedDeadline) return false;
+  let expectedSequence = 1;
+  let terminal = null;
+  let previousPhase = -1;
+  let previousFraction = -1;
+  for (const message of messages) {
+    if (terminal) return false;
+    if (message.kind === 'event') {
+      if (!validateProgressEvent(message, request, schema) || message.sequence !== expectedSequence
+          || PROGRESS_PHASE[message.progress.phase] < previousPhase
+          || message.progress.fraction < previousFraction
+      ) return false;
+      previousPhase = PROGRESS_PHASE[message.progress.phase];
+      previousFraction = message.progress.fraction;
+      expectedSequence += 1;
+    } else if (message.kind === 'response') {
+      if (!validateResponseShape(message, schema)) return false;
+      terminal = message;
+    } else {
+      return false;
+    }
+  }
+  if (!terminal || terminal.requestId !== request.requestId || terminal.sessionId !== request.sessionId
+      || terminal.method !== request.method || terminal.wireVersion !== request.wireVersion) return false;
+  if (terminal.replayed !== false && terminal.replayed !== true) return false;
+  if (!terminal.ok) {
+    return terminal.replayed === false
+      && validateFailureExchange(helloContext, request, terminal, descriptor, schema);
+  }
+  const replayed = terminal.replayed === true;
+  if (replayed) {
+    const receipt = context.replayReceipt;
+    const original = structuredClone(terminal);
+    original.replayed = false;
+    if (!isPlainObject(receipt) || !VALID_REPLAY_RECEIPTS.has(receipt)
+        || expectedSequence !== 1
+        || receipt.sessionId !== request.sessionId || receipt.requestId !== request.requestId
+        || receipt.requestDigest !== requestDigest
+        || (() => {
+          try {
+            return receipt.responseDigest !== sha256Jcs(original);
+          } catch {
+            return true;
+          }
+        })()
+        || receipt.effectiveDeadlineUnixMs !== deadline
+        || !Number.isSafeInteger(receipt.terminalObservedUnixMs)
+        || !Number.isSafeInteger(original.result?.evidence?.completedAtUnixMs)
+        || original.result.evidence.completedAtUnixMs > receipt.terminalObservedUnixMs
+        || receipt.terminalObservedUnixMs > deadline) return false;
+  } else if (context.replayReceipt !== undefined) return false;
+  const result = terminal.result;
+  if (!isPlainObject(result) || !isPlainObject(result.evidence)
+      || !isPlainObject(result.evidence.postcondition)
+      || !schemaAccepts(descriptor.resultSchema, result.value, descriptor.resultSchema)) return false;
+  const evidence = result.evidence;
+  let resultDigest;
+  try {
+    resultDigest = postconditionDigest(result);
+  } catch {
+    return false;
+  }
+  return result.capabilityId === request.params.capabilityId
+    && result.capabilityVersion === request.params.capabilityVersion
+    && result.engine === 'native-aegp'
+    && evidence.engine === result.engine
+    && evidence.hostInstanceId === helloContext.response.result.host.instanceId
+    && evidence.sessionId === request.sessionId
+    && evidence.requestId === request.requestId
+    && evidence.capabilityId === result.capabilityId
+    && evidence.capabilityVersion === result.capabilityVersion
+    && (replayed || evidence.startedAtUnixMs >= brokerSendUnixMs)
+    && evidence.completedAtUnixMs >= evidence.startedAtUnixMs
+    && evidence.completedAtUnixMs <= deadline
+    && (replayed || (Number.isSafeInteger(terminalObservedUnixMs)
+      && evidence.completedAtUnixMs <= terminalObservedUnixMs
+      && terminalObservedUnixMs <= deadline))
+    && (descriptor.mutability !== 'read-only'
+      || (evidence.effect === 'none' && evidence.undo === undefined))
+    && (descriptor.mutability !== 'mutating'
+      || (evidence.effect === 'committed'
+        && (descriptor.undo !== 'ae-undo-group'
+          || (evidence.undo?.available === true && evidence.undo?.verified === true))))
+    && evidence.postcondition.verified === true
+    && evidence.requestDigest === requestDigest
+    && evidence.postcondition.digest === resultDigest;
+}
+
+export function validateLocator(locator, context, schema) {
+  const ids = ['hostInstanceId', 'sessionId', 'projectId', 'objectId'];
+  if (!schemaAccepts(schema?.$defs?.locator, locator, schema)
+      || !isPlainObject(locator) || !isPlainObject(context)
+      || !ids.every((key) => UUID.test(locator[key] ?? ''))
+      || !Number.isSafeInteger(locator.generation) || locator.generation < 1) return false;
+  return ids.slice(0, 3).every((key) => locator[key] === context[key])
+    && locator.generation === context.generation;
+}
+
+function requireSafeTime(nowUnixMs) {
+  if (!Number.isSafeInteger(nowUnixMs) || nowUnixMs < 0) {
+    fail('INVALID_ARGUMENT', 'invalid monotonic reference time');
+  }
+}
+
+const ADMISSION_MAXIMA = Object.freeze({
+  maxInFlight: 64,
+  maxQueueDepth: 256,
+  maxDeadlineMs: LIMITS.maximumDeadlineMs,
+  maxRequestsPerSecond: 100,
+  maxBurst: 100,
+  maxControlInFlight: 8,
+  maxControlRequestsPerSecond: 100,
+  maxControlBurst: 100,
+  maxTerminalCacheEntries: 4096,
+});
+
+export class AdmissionController {
+  constructor(limits) {
+    for (const [key, maximum] of Object.entries(ADMISSION_MAXIMA)) {
+      const minimum = key === 'maxDeadlineMs' ? 100 : 1;
+      if (!Number.isSafeInteger(limits?.[key])
+          || limits[key] < minimum || limits[key] > maximum) {
+        fail('INVALID_ARGUMENT', `invalid admission limit ${key}`);
+      }
+    }
+    this.limits = Object.freeze(Object.fromEntries(
+      Object.keys(ADMISSION_MAXIMA).map((key) => [key, limits[key]]),
+    ));
+    this.inFlight = new Map();
+    this.queue = [];
+    this.controlInFlight = new Map();
+    this.terminal = new Map();
+    this.cancelRequested = new Set();
+    this.decidedControls = new Set();
+    this.tokens = limits.maxBurst;
+    this.controlTokens = limits.maxControlBurst;
+    this.lastRefillMs = null;
+    this.lastControlRefillMs = null;
+  }
+
+  refill(nowUnixMs, control = false) {
+    requireSafeTime(nowUnixMs);
+    const lastKey = control ? 'lastControlRefillMs' : 'lastRefillMs';
+    const tokenKey = control ? 'controlTokens' : 'tokens';
+    const burstKey = control ? 'maxControlBurst' : 'maxBurst';
+    const rateKey = control ? 'maxControlRequestsPerSecond' : 'maxRequestsPerSecond';
+    if (this[lastKey] === null) {
+      this[lastKey] = nowUnixMs;
+      return;
+    }
+    if (nowUnixMs < this[lastKey]) fail('INVALID_ARGUMENT', 'admission clock moved backwards');
+    const elapsed = nowUnixMs - this[lastKey];
+    this[tokenKey] = Math.min(
+      this.limits[burstKey],
+      this[tokenKey] + ((elapsed * this.limits[rateKey]) / 1000),
+    );
+    this[lastKey] = nowUnixMs;
+  }
+
+  static key(request) {
+    if (!isPlainObject(request) || !UUID.test(request.sessionId ?? '')
+        || !REQUEST_ID.test(request.requestId ?? '')) {
+      fail('INVALID_ARGUMENT', 'request identity requires session and request IDs');
+    }
+    return `${request.sessionId}:${request.requestId}`;
+  }
+
+  static identity(request, effectiveDeadlineUnixMs) {
+    return Object.freeze({
+      key: AdmissionController.key(request),
+      sessionId: request.sessionId,
+      requestId: request.requestId,
+      method: request.method,
+      effectiveDeadlineUnixMs,
+      requestDigest: sha256Jcs(request),
+      ...(request.method === 'invoke' ? {
+        capabilityId: request.params.capabilityId,
+        capabilityVersion: request.params.capabilityVersion,
+      } : {}),
+    });
+  }
+
+  contains(request) {
+    const key = AdmissionController.key(request);
+    return this.inFlight.has(key) || this.controlInFlight.has(key) || this.terminal.has(key)
+      || this.queue.some((item) => item.key === key);
+  }
+
+  rememberTerminal(identity) {
+    this.terminal.delete(identity.key);
+    while (this.terminal.size >= this.limits.maxTerminalCacheEntries) {
+      this.terminal.delete(this.terminal.keys().next().value);
+    }
+    this.terminal.set(identity.key, identity);
+  }
+
+  rateLimit(nowUnixMs, control) {
+    this.refill(nowUnixMs, control);
+    const tokenKey = control ? 'controlTokens' : 'tokens';
+    const rateKey = control ? 'maxControlRequestsPerSecond' : 'maxRequestsPerSecond';
+    if (this[tokenKey] < 1) {
+      return Math.max(1, Math.ceil(
+        ((1 - this[tokenKey]) * 1000) / this.limits[rateKey],
+      ));
+    }
+    this[tokenKey] -= 1;
+    return null;
+  }
+
+  admit(request, nowUnixMs) {
+    if (classifyRequest(request).ok !== true || request.method === 'hello') {
+      return { state: 'rejected', errorCode: 'INVALID_REQUEST' };
+    }
+    let effectiveDeadlineUnixMs;
+    try {
+      effectiveDeadlineUnixMs = materializeDeadline(request, nowUnixMs, this.limits.maxDeadlineMs);
+      if (this.contains(request)) {
+        return { state: 'rejected', errorCode: 'DUPLICATE_REQUEST' };
+      }
+    } catch (error) {
+      return { state: 'rejected', errorCode: error.code ?? 'INVALID_ARGUMENT' };
+    }
+    const identity = AdmissionController.identity(request, effectiveDeadlineUnixMs);
+    if (request.method === 'cancel') {
+      const retryAfterMs = this.rateLimit(nowUnixMs, true);
+      if (retryAfterMs !== null) {
+        return {
+          state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'control-rate-limit', retryAfterMs,
+        };
+      }
+      if (this.controlInFlight.size >= this.limits.maxControlInFlight) {
+        return {
+          state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'control-capacity', retryAfterMs: 1,
+        };
+      }
+      this.controlInFlight.set(identity.key, identity);
+      return { state: 'control-dispatched', request: identity };
+    }
+    const retryAfterMs = this.rateLimit(nowUnixMs, false);
+    if (retryAfterMs !== null) {
+      return { state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'rate-limit', retryAfterMs };
+    }
+    if (this.inFlight.size < this.limits.maxInFlight) {
+      this.inFlight.set(identity.key, identity);
+      return { state: 'dispatched', request: identity };
+    }
+    if (this.queue.length < this.limits.maxQueueDepth) {
+      this.queue.push(identity);
+      return { state: 'queued', request: identity };
+    }
+    return { state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'queue-capacity', retryAfterMs: 1 };
+  }
+
+  complete(request, nowUnixMs) {
+    requireSafeTime(nowUnixMs);
+    const key = AdmissionController.key(request);
+    if (this.controlInFlight.has(key)) {
+      const completed = this.controlInFlight.get(key);
+      this.controlInFlight.delete(key);
+      this.decidedControls.delete(key);
+      this.rememberTerminal(completed);
+      return { state: 'control-released', completed };
+    }
+    if (!this.inFlight.has(key)) fail('INVALID_REQUEST', 'request is not in flight');
+    const completed = this.inFlight.get(key);
+    this.inFlight.delete(key);
+    this.cancelRequested.delete(key);
+    this.rememberTerminal(completed);
+    const expired = [];
+    while (this.queue.length > 0) {
+      const candidate = this.queue.shift();
+      if (candidate.effectiveDeadlineUnixMs <= nowUnixMs) {
+        this.rememberTerminal(candidate);
+        expired.push({ request: candidate, errorCode: 'DEADLINE_EXCEEDED' });
+        continue;
+      }
+      this.inFlight.set(candidate.key, candidate);
+      return { state: 'promoted', completed, promoted: candidate, expired };
+    }
+    return { state: 'released', completed, expired };
+  }
+
+  decideCancel(cancelRequest, descriptor) {
+    if (classifyRequest(cancelRequest).ok !== true || cancelRequest.method !== 'cancel'
+        || !isPlainObject(descriptor)
+        || !['before-dispatch', 'cooperative', 'none'].includes(descriptor.cancellation)) {
+      fail('INVALID_ARGUMENT', 'invalid atomic cancellation decision input');
+    }
+    const cancelKey = AdmissionController.key(cancelRequest);
+    if (!this.controlInFlight.has(cancelKey) || this.decidedControls.has(cancelKey)) {
+      fail('INVALID_REQUEST', 'cancel request is not an undecided control operation');
+    }
+    const targetKey = `${cancelRequest.sessionId}:${cancelRequest.params.targetRequestId}`;
+    const runningTarget = this.inFlight.get(targetKey) ?? null;
+    const queueIndex = runningTarget
+      ? -1 : this.queue.findIndex((item) => item.key === targetKey);
+    const queuedTarget = queueIndex >= 0 ? this.queue[queueIndex] : null;
+    const terminalTarget = runningTarget || queuedTarget
+      ? null : this.terminal.get(targetKey) ?? null;
+    const target = runningTarget ?? queuedTarget ?? terminalTarget;
+    if (target && (target.method !== 'invoke' || target.sessionId !== cancelRequest.sessionId
+        || target.capabilityId !== descriptor.id
+        || target.capabilityVersion !== descriptor.version)) {
+      fail('INVALID_ARGUMENT', 'cancel target does not match capability descriptor');
+    }
+
+    let state;
+    if (runningTarget) {
+      state = descriptor.cancellation === 'cooperative'
+        ? 'running-cancel-requested' : 'running-not-cancellable';
+      if (state === 'running-cancel-requested') this.cancelRequested.add(targetKey);
+    } else if (queuedTarget) {
+      this.queue.splice(queueIndex, 1);
+      this.rememberTerminal(queuedTarget);
+      state = 'queued-cancelled';
+    } else if (terminalTarget) {
+      state = 'already-terminal';
+    } else {
+      state = 'not-found';
+    }
+    const terminalResponseExpected = [
+      'queued-cancelled', 'running-cancel-requested', 'running-not-cancellable',
+    ].includes(state);
+    const decisionReceipt = Object.freeze({
+      cancelKey,
+      cancelRequestId: cancelRequest.requestId,
+      sessionId: cancelRequest.sessionId,
+      targetKey,
+      targetRequestId: cancelRequest.params.targetRequestId,
+      capabilityId: descriptor.id,
+      capabilityVersion: descriptor.version,
+      cancellation: descriptor.cancellation,
+      state,
+      terminalResponseExpected,
+      targetRequestDigest: target?.requestDigest ?? null,
+      targetEffectiveDeadlineUnixMs: target?.effectiveDeadlineUnixMs ?? null,
+    });
+    this.decidedControls.add(cancelKey);
+    VALID_CANCEL_DECISIONS.add(decisionReceipt);
+    return { state, terminalResponseExpected, target, decisionReceipt };
+  }
+
+  snapshot() {
+    return {
+      inFlight: [...this.inFlight.values()],
+      queued: [...this.queue],
+      controlInFlight: [...this.controlInFlight.values()],
+      terminal: [...this.terminal.values()],
+      tokens: this.tokens,
+      controlTokens: this.controlTokens,
+    };
+  }
+}
+
+export class RequestLedger {
+  constructor({
+    maxActiveEntries = 40,
+    maxTerminalEntries = LIMITS.defaultTerminalCacheEntries,
+    terminalTtlMs = LIMITS.defaultTerminalCacheTtlMs,
+    maxDeadlineMs = LIMITS.maximumDeadlineMs,
+    terminalValidator = null,
+  } = {}) {
+    for (const [key, value] of Object.entries({
+      maxActiveEntries, maxTerminalEntries, terminalTtlMs, maxDeadlineMs,
+    })) {
+      if (!Number.isSafeInteger(value) || value < 1) fail('INVALID_ARGUMENT', `invalid ledger ${key}`);
+    }
+    if (maxActiveEntries > 320 || maxTerminalEntries > 4096 || terminalTtlMs > 300000
+        || maxDeadlineMs > LIMITS.maximumDeadlineMs) {
+      fail('INVALID_ARGUMENT', 'ledger limit exceeds protocol maximum');
+    }
+    if (terminalValidator !== null && typeof terminalValidator !== 'function') {
+      fail('INVALID_ARGUMENT', 'terminal validator must be a function');
+    }
+    this.maxActiveEntries = maxActiveEntries;
+    this.maxTerminalEntries = maxTerminalEntries;
+    this.terminalTtlMs = terminalTtlMs;
+    this.maxDeadlineMs = maxDeadlineMs;
+    this.terminalValidator = terminalValidator;
+    this.active = new Map();
+    this.terminal = new Map();
+  }
+
+  static key(request) {
+    return `${request.sessionId}:${request.requestId}`;
+  }
+
+  storeTerminal(key, entry) {
+    this.terminal.delete(key);
+    while (this.terminal.size >= this.maxTerminalEntries) {
+      this.terminal.delete(this.terminal.keys().next().value);
+    }
+    this.terminal.set(key, entry);
+  }
+
+  purgeExpired(nowUnixMs, preserveActiveKey = null) {
+    requireSafeTime(nowUnixMs);
+    for (const [key, entry] of this.terminal) {
+      if (entry.expiresAtUnixMs <= nowUnixMs) this.terminal.delete(key);
+    }
+    if (!Number.isSafeInteger(nowUnixMs + this.terminalTtlMs)) {
+      fail('INVALID_ARGUMENT', 'terminal expiry exceeds safe integer range');
+    }
+    for (const [key, entry] of this.active) {
+      if (key !== preserveActiveKey && entry.effectiveDeadlineUnixMs <= nowUnixMs) {
+        this.active.delete(key);
+        this.storeTerminal(key, {
+          digest: entry.digest,
+          effectiveDeadlineUnixMs: entry.effectiveDeadlineUnixMs,
+          response: null,
+          replayable: false,
+          replayReceipt: null,
+          expired: true,
+          expiresAtUnixMs: nowUnixMs + this.terminalTtlMs,
+        });
+      }
+    }
+  }
+
+  accept(request, nowUnixMs = 0) {
+    requireSafeTime(nowUnixMs);
+    if (classifyRequest(request).ok !== true || request.method === 'hello') {
+      return { state: 'rejected', errorCode: 'INVALID_REQUEST' };
+    }
+    this.purgeExpired(nowUnixMs);
+    const key = RequestLedger.key(request);
+    const digest = sha256Jcs(request);
+    if (this.active.has(key)) return { state: 'rejected', errorCode: 'DUPLICATE_REQUEST' };
+    const previous = this.terminal.get(key);
+    if (previous) {
+      if (nowUnixMs >= previous.effectiveDeadlineUnixMs) {
+        return { state: 'rejected', errorCode: 'DEADLINE_EXCEEDED' };
+      }
+      if (previous.digest === digest && previous.replayable && previous.response.ok === true) {
+        return {
+          state: 'replayed',
+          effectiveDeadlineUnixMs: previous.effectiveDeadlineUnixMs,
+          response: { ...structuredClone(previous.response), replayed: true },
+          replayReceipt: previous.replayReceipt,
+        };
+      }
+      return { state: 'rejected', errorCode: 'DUPLICATE_REQUEST' };
+    }
+    let effectiveDeadlineUnixMs;
+    try {
+      effectiveDeadlineUnixMs = materializeDeadline(request, nowUnixMs, this.maxDeadlineMs);
+    } catch (error) {
+      return { state: 'rejected', errorCode: error.code ?? 'INVALID_ARGUMENT' };
+    }
+    if (this.active.size >= this.maxActiveEntries) {
+      return { state: 'rejected', errorCode: 'QUEUE_FULL' };
+    }
+    this.active.set(key, {
+      digest,
+      request: structuredClone(request),
+      brokerSendUnixMs: nowUnixMs,
+      effectiveDeadlineUnixMs,
+    });
+    return { state: 'accepted', effectiveDeadlineUnixMs };
+  }
+
+  complete(request, response, terminalObservedUnixMs = 0) {
+    requireSafeTime(terminalObservedUnixMs);
+    const key = RequestLedger.key(request);
+    let current = this.active.get(key);
+    if (current && terminalObservedUnixMs > current.effectiveDeadlineUnixMs) {
+      this.purgeExpired(terminalObservedUnixMs);
+      fail('DEADLINE_EXCEEDED', 'terminal was observed after the effective deadline');
+    }
+    this.purgeExpired(terminalObservedUnixMs, key);
+    current = this.active.get(key);
+    if (!current) fail('INVALID_REQUEST', 'request is not active');
+    if (sha256Jcs(request) !== current.digest) {
+      fail('INVALID_REQUEST', 'completion request does not match stored active request');
+    }
+    const storedRequest = current.request;
+    if (response?.requestId !== storedRequest.requestId
+        || response.sessionId !== storedRequest.sessionId
+        || response.method !== storedRequest.method || response.kind !== 'response'
+        || response.replayed !== false) {
+      fail('INVALID_REQUEST', 'terminal response does not match active request');
+    }
+    if (storedRequest.method === 'invoke' && response.ok === true
+        && (!Number.isSafeInteger(response.result?.evidence?.completedAtUnixMs)
+          || response.result.evidence.completedAtUnixMs > terminalObservedUnixMs)) {
+      fail('INVALID_REQUEST', 'terminal evidence is later than broker observation');
+    }
+    let validation;
+    try {
+      validation = this.terminalValidator?.(storedRequest, response, {
+        brokerSendUnixMs: current.brokerSendUnixMs,
+        effectiveDeadlineUnixMs: current.effectiveDeadlineUnixMs,
+        terminalObservedUnixMs,
+      });
+    } catch {
+      fail('INVALID_REQUEST', 'terminal validator rejected response');
+    }
+    if (validation !== true && validation?.valid !== true) {
+      fail('INVALID_REQUEST', 'terminal response was not independently validated');
+    }
+    if (!Number.isSafeInteger(terminalObservedUnixMs + this.terminalTtlMs)) {
+      fail('INVALID_ARGUMENT', 'terminal expiry exceeds safe integer range');
+    }
+    const responseDigest = sha256Jcs(response);
+    const replayable = response.ok === true && storedRequest.method === 'invoke'
+      && storedRequest.params.capabilityId === 'ae.project.summary';
+    let replayReceipt = null;
+    if (replayable) {
+      replayReceipt = Object.freeze({
+        sessionId: storedRequest.sessionId,
+        requestId: storedRequest.requestId,
+        requestDigest: current.digest,
+        responseDigest,
+        effectiveDeadlineUnixMs: current.effectiveDeadlineUnixMs,
+        terminalObservedUnixMs,
+      });
+      VALID_REPLAY_RECEIPTS.add(replayReceipt);
+    }
+    this.active.delete(key);
+    this.storeTerminal(key, {
+      digest: current.digest,
+      effectiveDeadlineUnixMs: current.effectiveDeadlineUnixMs,
+      response: structuredClone(response),
+      replayable,
+      replayReceipt,
+      expiresAtUnixMs: terminalObservedUnixMs + this.terminalTtlMs,
+    });
+  }
+
+  purgeSession(sessionId) {
+    for (const store of [this.active, this.terminal]) {
+      for (const [key, entry] of store) {
+        const request = entry.request;
+        if (request?.sessionId === sessionId || key.startsWith(`${sessionId}:`)) store.delete(key);
+      }
+    }
+  }
+
+  snapshot() {
+    return { active: this.active.size, terminal: this.terminal.size };
+  }
+}

--- a/native/ae-plugin/protocol/fixtures/cancel.json
+++ b/native/ae-plugin/protocol/fixtures/cancel.json
@@ -1,0 +1,63 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "targetRequest": {
+    "wireVersion": 1,
+    "kind": "request",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "invoke-summary-cancelled",
+    "method": "invoke",
+    "deadlineUnixMs": 1900000005000,
+    "params": {
+      "capabilityId": "ae.project.summary",
+      "capabilityVersion": 1,
+      "arguments": {}
+    }
+  },
+  "request": {
+    "wireVersion": 1,
+    "kind": "request",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "cancel-1",
+    "method": "cancel",
+    "params": { "targetRequestId": "invoke-summary-cancelled" }
+  },
+  "response": {
+    "wireVersion": 1,
+    "kind": "response",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "cancel-1",
+    "method": "cancel",
+    "ok": true,
+    "replayed": false,
+    "result": {
+      "targetRequestId": "invoke-summary-cancelled",
+      "state": "queued-cancelled",
+      "terminalResponseExpected": true
+    }
+  },
+  "targetMessages": [
+    {
+      "wireVersion": 1,
+      "kind": "response",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-summary-cancelled",
+      "method": "invoke",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "CANCELLED",
+        "message": "The queued synthetic request was cancelled before dispatch.",
+        "retryable": false,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "none",
+          "hint": "Issue a new request only if the result is still needed."
+        }
+      }
+    }
+  ]
+}

--- a/native/ae-plugin/protocol/fixtures/capabilities.json
+++ b/native/ae-plugin/protocol/fixtures/capabilities.json
@@ -1,0 +1,109 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "request": {
+    "wireVersion": 1,
+    "kind": "request",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "capabilities-1",
+    "method": "capabilities",
+    "params": {
+      "ids": ["ae.project.summary"],
+      "detail": "full",
+      "limit": 1
+    }
+  },
+  "response": {
+    "wireVersion": 1,
+    "kind": "response",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "capabilities-1",
+    "method": "capabilities",
+    "ok": true,
+    "replayed": false,
+    "result": {
+      "detail": "full",
+      "items": [
+        {
+          "detail": "full",
+          "id": "ae.project.summary",
+          "version": 1,
+          "schemaVersion": 1,
+          "summary": "Read bounded facts about the active After Effects project.",
+          "risk": "read",
+          "mutability": "read-only",
+          "idempotency": "idempotent",
+          "cancellation": "before-dispatch",
+          "undo": "not-applicable",
+          "sideEffectSummary": "Reads project state without modifying it.",
+          "preconditions": [],
+          "compatibility": {
+            "status": "unverified",
+            "intendedPlatforms": ["macos-arm64", "windows-x64"]
+          },
+          "inputContractId": "aemcp.contract.ae.project.summary.input.v1",
+          "resultContractId": "aemcp.contract.ae.project.summary.result.v1",
+          "contractDigest": "baecd602479045f71288b2a7e0df645d4a5313453a34b89ced07178867ccaf9a",
+          "inputSchema": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [],
+            "properties": {}
+          },
+          "resultSchema": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["projectOpen", "projectName", "itemCount"],
+            "properties": {
+              "projectOpen": { "type": "boolean" },
+              "projectName": { "type": "string", "maxLength": 1024 },
+              "itemCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            }
+          },
+          "requirements": [
+            {
+              "id": "aemcp.requirement.native.project-read",
+              "contractVersion": 1
+            }
+          ],
+          "examples": [
+            {
+              "id": "aemcp-example-project-summary-empty",
+              "kind": "positive",
+              "summary": "Read a bounded summary when no project content exists.",
+              "arguments": {},
+              "expected": {
+                "outcome": "succeeded",
+                "value": {
+                  "projectOpen": false,
+                  "projectName": "SYNTHETIC_EXAMPLE",
+                  "itemCount": 0
+                }
+              }
+            },
+            {
+              "id": "aemcp-example-project-summary-unavailable",
+              "kind": "negative",
+              "summary": "Return a typed unavailable error before native dispatch.",
+              "arguments": {},
+              "expected": {
+                "errorCode": "NATIVE_UNAVAILABLE",
+                "recoveryAction": "reconnect"
+              }
+            }
+          ]
+        }
+      ],
+      "nextCursor": null,
+      "queryDigest": "aa3c66bc21e50b6a35db9c3cb12fcb1627694cd8f9fc411f21f7e3de46b3e56a",
+      "capabilitiesDigest": "778a01733fcf37510f56894a46ec5bd87c7429de2e06d2d5eafb4cdbbae88557"
+    }
+  }
+}

--- a/native/ae-plugin/protocol/fixtures/errors.json
+++ b/native/ae-plugin/protocol/fixtures/errors.json
@@ -1,0 +1,115 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "responses": {
+    "wireVersionMismatch": {
+      "wireVersion": 1,
+      "kind": "response",
+      "requestId": "hello-2",
+      "method": "hello",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "WIRE_VERSION_MISMATCH",
+        "message": "No supported native wire version overlaps the client range.",
+        "retryable": false,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "reconnect",
+          "hint": "Upgrade Core or the native plug-in, then reconnect."
+        },
+        "details": {
+          "supportedWireVersions": { "minimum": 1, "maximum": 1 }
+        }
+      }
+    },
+    "staleLocator": {
+      "wireVersion": 1,
+      "kind": "response",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-stale-1",
+      "method": "invoke",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "STALE_LOCATOR",
+        "message": "The locator generation does not match current state.",
+        "retryable": true,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "refresh-locator",
+          "hint": "Read the parent object again and retry with its new locator."
+        },
+        "details": {
+          "field": "arguments.layer",
+          "capabilityId": "ae.layer.inspect",
+          "currentGeneration": 8
+        }
+      }
+    },
+    "possiblySideEffecting": {
+      "wireVersion": 1,
+      "kind": "response",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-mutation-1",
+      "method": "invoke",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "POSSIBLY_SIDE_EFFECTING_FAILURE",
+        "message": "The host stopped responding after accepting the mutation.",
+        "retryable": false,
+        "sideEffect": "may-have-occurred",
+        "recovery": {
+          "action": "inspect-state",
+          "hint": "Read the affected object before deciding whether to retry."
+        },
+        "details": {
+          "capabilityId": "ae.project.set_current_time"
+        }
+      }
+    },
+    "queueFull": {
+      "wireVersion": 1,
+      "kind": "response",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-queue-full-1",
+      "method": "invoke",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "QUEUE_FULL",
+        "message": "The bounded native dispatch queue is full.",
+        "retryable": true,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "retry",
+          "hint": "Retry after the bounded delay.",
+          "retryAfterMs": 250
+        }
+      }
+    },
+    "duplicateRequest": {
+      "wireVersion": 1,
+      "kind": "response",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-summary-1",
+      "method": "invoke",
+      "ok": false,
+      "replayed": false,
+      "error": {
+        "code": "DUPLICATE_REQUEST",
+        "message": "The request ID is in flight or has different content.",
+        "retryable": false,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "inspect-state",
+          "hint": "Inspect the original result before issuing a new request ID."
+        }
+      }
+    }
+  }
+}

--- a/native/ae-plugin/protocol/fixtures/framing-corpus.json
+++ b/native/ae-plugin/protocol/fixtures/framing-corpus.json
@@ -1,0 +1,29 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "vectors": [
+  {
+    "name": "zero-length",
+    "hex": "00000000",
+    "expectedErrorCode": "INVALID_REQUEST"
+  },
+  {
+    "name": "over-maximum",
+    "hex": "00010001",
+    "expectedErrorCode": "INVALID_REQUEST"
+  },
+  {
+    "name": "truncated-json",
+    "hex": "000000087b226f6b22",
+    "expectedErrorCode": "INVALID_REQUEST"
+  },
+  {
+    "name": "invalid-utf8",
+    "hex": "00000002c328",
+    "expectedErrorCode": "INVALID_REQUEST"
+  }
+  ]
+}

--- a/native/ae-plugin/protocol/fixtures/hello.json
+++ b/native/ae-plugin/protocol/fixtures/hello.json
@@ -1,0 +1,64 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "request": {
+    "wireVersion": 1,
+    "kind": "request",
+    "requestId": "hello-1",
+    "method": "hello",
+    "params": {
+      "supportedWireVersions": { "minimum": 1, "maximum": 1 },
+      "client": {
+        "component": "core-broker",
+        "version": "0.9.2",
+        "instanceId": "33333333-3333-4333-8333-333333333333"
+      },
+      "nonce": "abcdefghijklmnopqrstuvwxyzABCDEF"
+    }
+  },
+  "response": {
+    "wireVersion": 1,
+    "kind": "response",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "hello-1",
+    "method": "hello",
+    "ok": true,
+    "replayed": false,
+    "result": {
+      "selectedWireVersion": 1,
+      "pluginVersion": "0.0.0-synthetic",
+      "compiledSdk": {
+        "version": "0.0.0",
+        "build": 1,
+        "architecture": "arm64"
+      },
+      "host": {
+        "application": "after-effects",
+        "version": "0.0.0",
+        "build": 1,
+        "platform": "macos-arm64",
+        "instanceId": "22222222-2222-4222-8222-222222222222"
+      },
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "sessionGeneration": 1,
+      "limits": {
+        "maxFrameBytes": 65536,
+        "maxInFlight": 8,
+        "maxQueueDepth": 32,
+        "maxDeadlineMs": 30000,
+        "maxRequestsPerSecond": 10,
+        "maxBurst": 4,
+        "maxControlInFlight": 1,
+        "maxControlRequestsPerSecond": 20,
+        "maxControlBurst": 4,
+        "maxTerminalCacheEntries": 128,
+        "terminalCacheTtlMs": 60000
+      },
+      "capabilitiesDigest": "778a01733fcf37510f56894a46ec5bd87c7429de2e06d2d5eafb4cdbbae88557",
+      "clientNonce": "abcdefghijklmnopqrstuvwxyzABCDEF"
+    }
+  }
+}

--- a/native/ae-plugin/protocol/fixtures/invoke-project-summary.json
+++ b/native/ae-plugin/protocol/fixtures/invoke-project-summary.json
@@ -1,0 +1,99 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "request": {
+    "wireVersion": 1,
+    "kind": "request",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "invoke-summary-1",
+    "method": "invoke",
+    "deadlineUnixMs": 1900000005000,
+    "params": {
+      "capabilityId": "ae.project.summary",
+      "capabilityVersion": 1,
+      "arguments": {}
+    }
+  },
+  "events": [
+    {
+      "wireVersion": 1,
+      "kind": "event",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-summary-1",
+      "event": "progress",
+      "sequence": 1,
+      "progress": {
+        "phase": "queued",
+        "fraction": 0,
+        "message": "Queued for the bounded main-thread dispatcher."
+      }
+    },
+    {
+      "wireVersion": 1,
+      "kind": "event",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-summary-1",
+      "event": "progress",
+      "sequence": 2,
+      "progress": {
+        "phase": "dispatched",
+        "fraction": 0.5,
+        "message": "Entered the synthetic host-thread dispatch phase."
+      }
+    },
+    {
+      "wireVersion": 1,
+      "kind": "event",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "invoke-summary-1",
+      "event": "progress",
+      "sequence": 3,
+      "progress": {
+        "phase": "validating",
+        "fraction": 0.9,
+        "message": "Validating the bounded synthetic result."
+      }
+    }
+  ],
+  "response": {
+    "wireVersion": 1,
+    "kind": "response",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "invoke-summary-1",
+    "method": "invoke",
+    "ok": true,
+    "replayed": false,
+    "result": {
+      "capabilityId": "ae.project.summary",
+      "capabilityVersion": 1,
+      "engine": "native-aegp",
+      "outcome": "succeeded",
+      "value": {
+        "projectOpen": false,
+        "projectName": "SYNTHETIC_CONTRACT_VECTOR",
+        "itemCount": 0
+      },
+      "evidence": {
+        "engine": "native-aegp",
+        "hostInstanceId": "22222222-2222-4222-8222-222222222222",
+        "sessionId": "11111111-1111-4111-8111-111111111111",
+        "requestId": "invoke-summary-1",
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "startedAtUnixMs": 1900000000000,
+        "completedAtUnixMs": 1900000000025,
+        "effect": "none",
+        "requestDigest": "9df120d0b016b1313035b94329245474a0dc31bad5c0383a9ecde11db5fbdc8f",
+        "postcondition": {
+          "verified": true,
+          "kind": "project-summary",
+          "algorithm": "sha256-rfc8785-jcs-v1",
+          "digest": "64a69b209d2948d0766fe54b07a34af20e007a1c9884315b109e3019d5f6f433"
+        }
+      }
+    }
+  }
+}

--- a/native/ae-plugin/protocol/fixtures/negative-corpus.json
+++ b/native/ae-plugin/protocol/fixtures/negative-corpus.json
@@ -1,0 +1,138 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "vectors": [
+  {
+    "name": "unknown-method",
+    "expectedErrorCode": "INVALID_REQUEST",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-1",
+      "method": "execute",
+      "params": {}
+    }
+  },
+  {
+    "name": "invoke-missing-session",
+    "expectedErrorCode": "SESSION_STALE",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "requestId": "bad-2",
+      "method": "invoke",
+      "deadlineUnixMs": 1900000005000,
+      "params": {
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "arguments": {}
+      }
+    }
+  },
+  {
+    "name": "wrong-capability-detail-enum",
+    "expectedErrorCode": "INVALID_ARGUMENT",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-3",
+      "method": "capabilities",
+      "params": { "detail": "everything" }
+    }
+  },
+  {
+    "name": "unexpected-envelope-field",
+    "expectedErrorCode": "INVALID_REQUEST",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "requestId": "bad-4",
+      "method": "hello",
+      "unexpected": true,
+      "params": {
+        "supportedWireVersions": { "minimum": 1, "maximum": 1 },
+        "client": {
+          "component": "core-broker",
+          "version": "0.9.2",
+          "instanceId": "33333333-3333-4333-8333-333333333333"
+        },
+        "nonce": "abcdefghijklmnopqrstuvwxyzABCDEF"
+      }
+    }
+  },
+  {
+    "name": "invoke-missing-capability-version",
+    "expectedErrorCode": "INVALID_ARGUMENT",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-5",
+      "method": "invoke",
+      "deadlineUnixMs": 1900000005000,
+      "params": {
+        "capabilityId": "ae.project.summary",
+        "arguments": {}
+      }
+    }
+  },
+  {
+    "name": "raw-jsx-argument",
+    "expectedErrorCode": "INVALID_ARGUMENT",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-6",
+      "method": "invoke",
+      "deadlineUnixMs": 1900000005000,
+      "params": {
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "arguments": { "jsx": "alert('not allowed')" }
+      }
+    }
+  },
+  {
+    "name": "nested-executable-alias",
+    "expectedErrorCode": "INVALID_ARGUMENT",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-7",
+      "method": "invoke",
+      "deadlineUnixMs": 1900000005000,
+      "params": {
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "arguments": {
+          "payload": { "code": "synthetic executable input" }
+        }
+      }
+    }
+  },
+  {
+    "name": "unsafe-integer-deadline",
+    "expectedErrorCode": "INVALID_ARGUMENT",
+    "message": {
+      "wireVersion": 1,
+      "kind": "request",
+      "sessionId": "11111111-1111-4111-8111-111111111111",
+      "requestId": "bad-8",
+      "method": "invoke",
+      "deadlineUnixMs": 9007199254740992,
+      "params": {
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "arguments": {}
+      }
+    }
+  }
+  ]
+}

--- a/native/ae-plugin/protocol/fixtures/version-negotiation.json
+++ b/native/ae-plugin/protocol/fixtures/version-negotiation.json
@@ -1,0 +1,87 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "vectors": [
+    {
+      "name": "future-client-to-v1-plugin",
+      "request": {
+        "wireVersion": 1,
+        "kind": "request",
+        "requestId": "hello-future-client",
+        "method": "hello",
+        "params": {
+          "supportedWireVersions": { "minimum": 2, "maximum": 3 },
+          "client": {
+            "component": "core-broker",
+            "version": "2.0.0-synthetic",
+            "instanceId": "33333333-3333-4333-8333-333333333333"
+          },
+          "nonce": "futureClientUsesPermanentV1BootX"
+        }
+      },
+      "response": {
+        "wireVersion": 1,
+        "kind": "response",
+        "requestId": "hello-future-client",
+        "method": "hello",
+        "ok": false,
+        "replayed": false,
+        "error": {
+          "code": "WIRE_VERSION_MISMATCH",
+          "message": "The future client does not support the v1 plug-in range.",
+          "retryable": false,
+          "sideEffect": "not-started",
+          "recovery": {
+            "action": "reconnect",
+            "hint": "Install a plug-in supporting the client range."
+          },
+          "details": {
+            "supportedWireVersions": { "minimum": 1, "maximum": 1 }
+          }
+        }
+      }
+    },
+    {
+      "name": "v1-client-to-future-plugin",
+      "request": {
+        "wireVersion": 1,
+        "kind": "request",
+        "requestId": "hello-future-plugin",
+        "method": "hello",
+        "params": {
+          "supportedWireVersions": { "minimum": 1, "maximum": 1 },
+          "client": {
+            "component": "core-broker",
+            "version": "1.0.0-synthetic",
+            "instanceId": "33333333-3333-4333-8333-333333333333"
+          },
+          "nonce": "v1ClientUsesPermanentBootstrapXX"
+        }
+      },
+      "response": {
+        "wireVersion": 1,
+        "kind": "response",
+        "requestId": "hello-future-plugin",
+        "method": "hello",
+        "ok": false,
+        "replayed": false,
+        "error": {
+          "code": "WIRE_VERSION_MISMATCH",
+          "message": "The future plug-in does not support the v1 client range.",
+          "retryable": false,
+          "sideEffect": "not-started",
+          "recovery": {
+            "action": "reconnect",
+            "hint": "Upgrade Core to a supported negotiated wire version."
+          },
+          "details": {
+            "supportedWireVersions": { "minimum": 2, "maximum": 3 }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/native/ae-plugin/protocol/protocol.test.mjs
+++ b/native/ae-plugin/protocol/protocol.test.mjs
@@ -1,0 +1,1341 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AdmissionController,
+  ERROR_POLICIES,
+  FrameDecoder,
+  LIMITS,
+  RequestLedger,
+  assertJsonLimits,
+  canonicalize,
+  capabilityDigest,
+  capabilityQueryDigest,
+  classifyRequest,
+  decodeAndClassifyRequest,
+  decodeAndValidateProgressEvent,
+  decodeAndValidateResponse,
+  decodeFrame,
+  encodeFrame,
+  materializeDeadline,
+  postconditionDigest,
+  projectSummaryContractDigest,
+  projectSummaryDescriptor,
+  schemaAccepts as productSchemaAccepts,
+  selectWireVersion,
+  sha256Jcs,
+  strictParseJson,
+  unicodeScalarLength,
+  validateCancelResult,
+  validateCancelExchange,
+  validateCapabilitiesExchange,
+  validateCapabilityDescriptor,
+  validateErrorPolicy,
+  validateFailureExchange,
+  validateHelloFailure,
+  validateHelloExchange,
+  validateIdempotencyContract,
+  validateLocator,
+  validateProgressEvent,
+  validateRequestComposite,
+  validateResponseShape,
+  validateTranscript,
+} from './conformance.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixtures = path.join(here, 'fixtures');
+const schema = readJson(path.join(here, 'aegp-rpc.schema.json'));
+const SESSION = '11111111-1111-4111-8111-111111111111';
+const HOST = '22222222-2222-4222-8222-222222222222';
+const PROJECT = '44444444-4444-4444-8444-444444444444';
+const OBJECT = '55555555-5555-4555-8555-555555555555';
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function schemaAccepts(candidate, value, root = schema) {
+  return productSchemaAccepts(candidate, value, root);
+}
+
+function frameFromText(text) {
+  const body = Buffer.from(text, 'utf8');
+  const frame = Buffer.allocUnsafe(body.length + 4);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+function golden(name) {
+  return readJson(path.join(fixtures, name));
+}
+
+function errorVector(code) {
+  const [retryable, sideEffect, action] = ERROR_POLICIES[code];
+  const vector = {
+    code,
+    message: `Synthetic ${code} vector.`,
+    retryable,
+    sideEffect,
+    recovery: {
+      action,
+      hint: 'Synthetic bounded recovery guidance.',
+      ...(code === 'QUEUE_FULL' ? { retryAfterMs: 250 } : {}),
+    },
+  };
+  if (code === 'WIRE_VERSION_MISMATCH') {
+    vector.details = { supportedWireVersions: { minimum: 1, maximum: 1 } };
+  }
+  if (['NATIVE_UNSUPPORTED', 'PRECONDITION_FAILED', 'STALE_LOCATOR', 'CAPABILITY_FAILED',
+    'POSSIBLY_SIDE_EFFECTING_FAILURE'].includes(code)) {
+    vector.details = { capabilityId: 'ae.project.summary' };
+  }
+  return vector;
+}
+
+function seededRandom(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomJson(random, depth = 0) {
+  const variant = depth >= 4 ? Math.floor(random() * 4) : Math.floor(random() * 6);
+  if (variant === 0) return null;
+  if (variant === 1) return random() >= 0.5;
+  if (variant === 2) return Math.floor(random() * 2000000) - 1000000;
+  if (variant === 3) return `s-${Math.floor(random() * 1000000)}-合成`;
+  if (variant === 4) {
+    return Array.from({ length: Math.floor(random() * 5) }, () => randomJson(random, depth + 1));
+  }
+  const result = {};
+  for (let index = 0; index < Math.floor(random() * 5); index += 1) {
+    result[`k${depth}-${index}`] = randomJson(random, depth + 1);
+  }
+  return result;
+}
+
+function successForRequest(request, startedAtUnixMs) {
+  const response = structuredClone(golden('invoke-project-summary.json').response);
+  response.requestId = request.requestId;
+  response.sessionId = request.sessionId;
+  response.replayed = false;
+  response.result.evidence.sessionId = request.sessionId;
+  response.result.evidence.requestId = request.requestId;
+  response.result.evidence.startedAtUnixMs = startedAtUnixMs;
+  response.result.evidence.completedAtUnixMs = startedAtUnixMs + 25;
+  response.result.evidence.requestDigest = sha256Jcs(request);
+  return response;
+}
+
+function strictTerminalValidator(request, response, timing) {
+  const hello = golden('hello.json');
+  const descriptor = projectSummaryDescriptor(schema);
+  if (response.ok === false) {
+    return validateFailureExchange(hello, request, response, descriptor, schema);
+  }
+  return validateTranscript({
+    hello,
+    descriptor,
+    schema,
+    brokerSendUnixMs: timing.brokerSendUnixMs,
+    effectiveDeadlineUnixMs: timing.effectiveDeadlineUnixMs,
+    terminalObservedUnixMs: timing.terminalObservedUnixMs,
+  }, request, [response]);
+}
+
+test('schema locks strict framing, bounded defaults, rate limits, and native provenance', () => {
+  assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  assert.deepEqual(schema['x-framing'], {
+    lengthPrefixBytes: 4,
+    byteOrder: 'big-endian',
+    encoding: 'utf-8',
+    maxFrameBytes: 65536,
+    maxJsonDepth: 16,
+    maxJsonNodes: 2048,
+    maxStringLength: 8192,
+    stringLengthUnit: 'unicode-scalar-values',
+    duplicateObjectKeys: 'reject',
+  });
+  assert.equal(schema['x-lifecycle'].defaultDeadlineMs, 5000);
+  assert.equal(schema['x-lifecycle'].maximumDeadlineMs, 30000);
+  assert.equal(schema['x-lifecycle'].pagination, 'unsupported-in-v1');
+  assert.equal(schema['x-lifecycle'].terminalObservationClockToleranceMs, 0);
+  assert.equal(schema['x-digests'].propertyNameSort, 'utf-16-code-units');
+  assert.deepEqual(schema.$defs.method.enum, ['hello', 'capabilities', 'invoke', 'cancel']);
+  assert.equal(schema.$defs.executionEvidence.properties.engine.const, 'native-aegp');
+  assert.equal(schema.$defs.negotiatedLimits.required.includes('maxRequestsPerSecond'), true);
+  assert.equal(schema.$defs.negotiatedLimits.required.includes('maxBurst'), true);
+  assert.equal(schema.$defs.negotiatedLimits.required.includes('maxControlRequestsPerSecond'), true);
+  assert.equal(schema.$defs.negotiatedLimits.required.includes('maxControlBurst'), true);
+  assert.equal(schema.$defs.negotiatedLimits.required.includes('maxTerminalCacheEntries'), true);
+  assert.equal(schema.$defs.capabilitiesParams.properties.detail.default, 'summary');
+  assert.equal(schema.$defs.capabilitiesParams.properties.limit.default, 50);
+  assert.equal(schema.$defs.capabilitiesParams.properties.cursor, undefined);
+  assert.deepEqual(schema.$defs.capabilitiesResultBase.properties.nextCursor, { type: 'null' });
+});
+
+test('repository CI executes this contract on Windows, Linux, and stacked PR bases', () => {
+  const ci = fs.readFileSync(path.join(here, '..', '..', '..', '.github', 'workflows', 'ci.yml'), 'utf8');
+  assert.match(ci, /\n  pull_request: \{\}\n/);
+  const command = 'node --test native/ae-plugin/protocol/protocol.test.mjs';
+  assert.equal(ci.split(command).length - 1, 2);
+  assert.match(ci, /runs-on: windows-2022/);
+  assert.match(ci, /runs-on: ubuntu-24\.04/);
+});
+
+test('all checked-in vectors are synthetic and contain no host or Adobe suite claim', () => {
+  for (const name of [
+    'hello.json',
+    'capabilities.json',
+    'invoke-project-summary.json',
+    'cancel.json',
+    'errors.json',
+    'negative-corpus.json',
+    'framing-corpus.json',
+    'version-negotiation.json',
+  ]) {
+    const fixture = golden(name);
+    assert.deepEqual(fixture._fixture, {
+      classification: 'synthetic-contract-vector',
+      runtimeEvidence: false,
+      compatibilityEvidence: false,
+    });
+  }
+  const publicText = [
+    fs.readFileSync(path.join(here, 'README.md'), 'utf8'),
+    fs.readFileSync(path.join(here, 'aegp-rpc.schema.json'), 'utf8'),
+    fs.readFileSync(path.join(fixtures, 'capabilities.json'), 'utf8'),
+  ].join('\n');
+  assert.doesNotMatch(publicText, /25\.6\.61|26\.3\.0|AEGP_[A-Za-z0-9_]*Suite/u);
+  assert.match(publicText, /product-owned/);
+  assert.match(publicText, /not.*evidence/isu);
+});
+
+test('golden requests, events, responses, and bound error policies validate', () => {
+  for (const name of ['hello.json', 'capabilities.json', 'invoke-project-summary.json', 'cancel.json']) {
+    const fixture = golden(name);
+    assert.equal(schemaAccepts(schema.$defs.request, fixture.request), true, `${name} request`);
+    for (const event of fixture.events ?? []) {
+      assert.equal(schemaAccepts(schema.$defs.progressEvent, event), true, `${name} event`);
+    }
+    assert.equal(schemaAccepts(schema.$defs.response, fixture.response), true, `${name} response`);
+    assert.equal(fixture.response.requestId, fixture.request.requestId);
+    assert.equal(fixture.response.method, fixture.request.method);
+  }
+  for (const [name, response] of Object.entries(golden('errors.json').responses)) {
+    assert.equal(schemaAccepts(schema.$defs.response, response), true, name);
+    assert.equal(validateErrorPolicy(response.error, schema), true, name);
+  }
+});
+
+test('invalid requests are rejected with their exact bounded error classification', () => {
+  for (const seed of golden('negative-corpus.json').vectors) {
+    assert.equal(schemaAccepts(schema.$defs.request, seed.message), false, seed.name);
+    assert.deepEqual(classifyRequest(seed.message), {
+      ok: false,
+      errorCode: seed.expectedErrorCode,
+    }, seed.name);
+  }
+});
+
+test('strict framing handles UTF-8, fragments, multiple frames, and malformed JSON safely', () => {
+  const first = { message: '合成向量', value: 1 };
+  const second = { message: 'second', value: 2 };
+  const firstFrame = encodeFrame(first);
+  assert.equal(firstFrame.readUInt32BE(0), firstFrame.length - 4);
+  assert.equal(canonicalize(decodeFrame(firstFrame)), canonicalize(first));
+
+  const decoder = new FrameDecoder();
+  assert.deepEqual(decoder.push(firstFrame.subarray(0, 2)), []);
+  assert.deepEqual(decoder.push(firstFrame.subarray(2, 7)), []);
+  assert.equal(canonicalize(decoder.push(firstFrame.subarray(7))[0]), canonicalize(first));
+  assert.deepEqual(decoder.finalize(), []);
+  const combined = Buffer.concat([firstFrame, encodeFrame(second)]);
+  assert.deepEqual(new FrameDecoder().push(combined).map(canonicalize), [
+    canonicalize(first), canonicalize(second),
+  ]);
+
+  const boundedItems = Array.from({ length: 1000 }, () => 'x'.repeat(58));
+  const emptyPadLength = Buffer.byteLength(canonicalize({ items: boundedItems, pad: '' }), 'utf8');
+  const exactMaximum = { items: boundedItems, pad: 'x'.repeat(LIMITS.maxFrameBytes - emptyPadLength) };
+  const maximumFrame = encodeFrame(exactMaximum);
+  assert.equal(maximumFrame.readUInt32BE(0), LIMITS.maxFrameBytes);
+  assert.equal(canonicalize(decodeFrame(maximumFrame)), canonicalize(exactMaximum));
+  assert.throws(() => encodeFrame({ ...exactMaximum, pad: `${exactMaximum.pad}x` }), {
+    code: 'INVALID_REQUEST',
+  });
+
+  for (let length = 0; length < firstFrame.length; length += 1) {
+    assert.throws(() => decodeFrame(firstFrame.subarray(0, length)), { code: 'INVALID_REQUEST' });
+  }
+
+  for (const seed of golden('framing-corpus.json').vectors) {
+    assert.throws(() => decodeFrame(Buffer.from(seed.hex, 'hex')), { code: seed.expectedErrorCode }, seed.name);
+  }
+  assert.throws(() => decodeFrame(frameFromText('{"a":1,"a":2}')), { code: 'INVALID_REQUEST' });
+  assert.throws(() => strictParseJson(`${'['.repeat(17)}0${']'.repeat(17)}`), { code: 'INVALID_REQUEST' });
+  assert.throws(() => strictParseJson(`[${'0,'.repeat(2048)}0]`), { code: 'INVALID_REQUEST' });
+  assert.throws(() => strictParseJson(JSON.stringify('x'.repeat(8193))), { code: 'INVALID_REQUEST' });
+  assert.throws(() => strictParseJson('{"n":9007199254740993}'), { code: 'INVALID_REQUEST' });
+});
+
+test('input and output codecs enforce the same exact JSON limits', () => {
+  const depth16 = Array.from({ length: 15 }).reduce((value) => [value], 0);
+  const depth17 = [depth16];
+  assert.equal(assertJsonLimits(depth16), true);
+  assert.doesNotThrow(() => encodeFrame(depth16));
+  assert.throws(() => assertJsonLimits(depth17), { code: 'INVALID_REQUEST' });
+  assert.throws(() => encodeFrame(depth17), { code: 'INVALID_REQUEST' });
+
+  const nodes2048 = Array.from({ length: 2047 }, () => 0);
+  assert.equal(assertJsonLimits(nodes2048), true);
+  assert.throws(() => assertJsonLimits([...nodes2048, 0]), { code: 'INVALID_REQUEST' });
+  assert.doesNotThrow(() => encodeFrame('x'.repeat(8192)));
+  assert.throws(() => encodeFrame('x'.repeat(8193)), { code: 'INVALID_REQUEST' });
+  assert.throws(() => encodeFrame({ ['x'.repeat(8193)]: true }), { code: 'INVALID_REQUEST' });
+  assert.throws(() => encodeFrame('\ud800'), { code: 'INVALID_REQUEST' });
+});
+
+test('Unicode bounds count scalar values and reject lone surrogates symmetrically', () => {
+  const atLimit = '😀'.repeat(LIMITS.maxStringLength);
+  const overLimit = `${atLimit}😀`;
+  assert.equal(unicodeScalarLength('😀'), 1);
+  assert.equal(unicodeScalarLength(atLimit), LIMITS.maxStringLength);
+  assert.equal(strictParseJson(JSON.stringify(atLimit)), atLimit);
+  assert.doesNotThrow(() => encodeFrame(atLimit));
+  assert.throws(() => strictParseJson(JSON.stringify(overLimit)), { code: 'INVALID_REQUEST' });
+  assert.throws(() => encodeFrame(overLimit), { code: 'INVALID_REQUEST' });
+  assert.doesNotThrow(() => encodeFrame({ [atLimit]: true }));
+  assert.throws(() => encodeFrame({ [overLimit]: true }), { code: 'INVALID_REQUEST' });
+  for (const value of ['\ud800', '\udc00', `valid😀\ud800`]) {
+    assert.throws(() => unicodeScalarLength(value), { code: 'INVALID_REQUEST' });
+    assert.throws(() => strictParseJson(JSON.stringify(value)), { code: 'INVALID_REQUEST' });
+    assert.throws(() => canonicalize(value), { code: 'INVALID_REQUEST' });
+  }
+
+  const resultSchema = projectSummaryDescriptor(schema).resultSchema;
+  assert.equal(schemaAccepts(resultSchema, {
+    projectOpen: true,
+    projectName: '😀'.repeat(1024),
+    itemCount: 1,
+  }, resultSchema), true);
+  assert.equal(schemaAccepts(resultSchema, {
+    projectOpen: true,
+    projectName: '😀'.repeat(1025),
+    itemCount: 1,
+  }, resultSchema), false);
+});
+
+test('RFC 8785 canonicalization covers Unicode and the safe numeric subset', () => {
+  assert.equal(canonicalize(-0), '0');
+  assert.equal(canonicalize(333333333.33333329), '333333333.3333333');
+  assert.equal(JSON.stringify(1e30), '1e+30',
+    'RFC 8785 delegates numeric spelling to ECMAScript');
+  assert.throws(() => canonicalize(1e30), { code: 'INVALID_REQUEST' },
+    'the wire contract deliberately rejects unsafe integral doubles before JCS');
+  assert.equal(canonicalize(4.5), '4.5');
+  assert.equal(canonicalize(2e-3), '0.002');
+  assert.equal(canonicalize(1e-27), '1e-27');
+  assert.equal(canonicalize({ accent: 'é', emoji: '😀' }), '{"accent":"é","emoji":"😀"}');
+  assert.equal(canonicalize({ '\ue000': 1, '😀': 2 }), '{"😀":2,"\ue000":1}',
+    'RFC 8785 sorts property names by UTF-16 code units, not Unicode code points');
+});
+
+test('fixed-seed framing property fuzz round-trips chunks and rejects EOF truncation', () => {
+  const random = seededRandom(0xaee07201);
+  for (let iteration = 0; iteration < 384; iteration += 1) {
+    const value = randomJson(random);
+    const frame = encodeFrame(value);
+    const decoder = new FrameDecoder();
+    const decoded = [];
+    for (let offset = 0; offset < frame.length;) {
+      const width = 1 + Math.floor(random() * Math.min(31, frame.length - offset));
+      decoded.push(...decoder.push(frame.subarray(offset, offset + width)));
+      offset += width;
+    }
+    decoder.finalize();
+    assert.equal(decoded.length, 1, `iteration ${iteration}`);
+    assert.equal(canonicalize(decoded[0]), canonicalize(value), `iteration ${iteration}`);
+
+    const cut = 1 + Math.floor(random() * (frame.length - 1));
+    const truncated = new FrameDecoder();
+    truncated.push(frame.subarray(0, cut));
+    assert.throws(() => truncated.finalize(), { code: 'INVALID_REQUEST' }, `iteration ${iteration}`);
+  }
+});
+
+test('wire negotiation, hello nonce/session, and platform architecture are cross-bound', () => {
+  assert.equal(selectWireVersion({ minimum: 1, maximum: 3 }, { minimum: 1, maximum: 2 }), 2);
+  assert.equal(selectWireVersion({ minimum: 1, maximum: 1 }, { minimum: 2, maximum: 4 }), null);
+  assert.throws(() => selectWireVersion({ minimum: 2, maximum: 1 }, { minimum: 1, maximum: 1 }), {
+    code: 'INVALID_ARGUMENT',
+  });
+  const fixture = golden('hello.json');
+  assert.equal(validateHelloExchange(fixture.request, fixture.response, schema), true);
+  assert.equal(validateHelloExchange(fixture.request, {
+    ...fixture.response,
+    sessionId: '44444444-4444-4444-8444-444444444444',
+  }, schema), false);
+  assert.equal(validateHelloExchange(fixture.request, {
+    ...fixture.response,
+    result: { ...fixture.response.result, clientNonce: 'Z'.repeat(32) },
+  }, schema), false);
+  assert.equal(validateHelloExchange(fixture.request, {
+    ...fixture.response,
+    result: {
+      ...fixture.response.result,
+      compiledSdk: { ...fixture.response.result.compiledSdk, architecture: 'x86_64' },
+    },
+  }, schema), false);
+
+  const mismatchRequest = {
+    ...fixture.request,
+    requestId: 'hello-2',
+    params: {
+      ...fixture.request.params,
+      supportedWireVersions: { minimum: 2, maximum: 3 },
+    },
+  };
+  const mismatch = golden('errors.json').responses.wireVersionMismatch;
+  assert.equal(validateHelloFailure(mismatchRequest, mismatch, schema), true);
+  assert.equal(validateHelloFailure(
+    mismatchRequest, { ...mismatch, sessionId: SESSION }, schema,
+  ), false);
+});
+
+test('schema shape and composite request validation have an explicit differential boundary', () => {
+  const validRequests = [
+    golden('hello.json').request,
+    golden('capabilities.json').request,
+    golden('invoke-project-summary.json').request,
+    golden('cancel.json').request,
+  ];
+  for (const request of validRequests) {
+    assert.equal(schemaAccepts(schema.$defs.request, request), true);
+    assert.deepEqual(validateRequestComposite(request, schema), { ok: true });
+    const decoded = decodeAndClassifyRequest(encodeFrame(request), schema);
+    assert.equal(decoded.ok, true);
+    assert.equal(canonicalize(decoded.message), canonicalize(request));
+  }
+
+  const hello = golden('hello.json').request;
+  const tooHighWire = structuredClone(hello);
+  tooHighWire.params.supportedWireVersions.maximum = 65536;
+  const missingNonce = structuredClone(hello);
+  delete missingNonce.params.nonce;
+  const capabilities = golden('capabilities.json').request;
+  const longCapabilityId = structuredClone(capabilities);
+  longCapabilityId.params.ids = [`ae.${'a'.repeat(94)}`];
+  const duplicateIds = structuredClone(capabilities);
+  duplicateIds.params.ids = ['ae.project.summary', 'ae.project.summary'];
+  for (const candidate of [tooHighWire, missingNonce, longCapabilityId, duplicateIds]) {
+    assert.equal(schemaAccepts(schema.$defs.request, candidate), false);
+    assert.equal(validateRequestComposite(candidate, schema).ok, false);
+  }
+
+  const reversedRange = structuredClone(hello);
+  reversedRange.params.supportedWireVersions = { minimum: 2, maximum: 1 };
+  assert.equal(schemaAccepts(schema.$defs.request, reversedRange), true,
+    'Draft 2020-12 intentionally ignores the documented x-invariant');
+  assert.deepEqual(validateRequestComposite(reversedRange, schema), {
+    ok: false, errorCode: 'INVALID_ARGUMENT',
+  });
+  assert.deepEqual(decodeAndClassifyRequest(encodeFrame(reversedRange), schema), {
+    ok: false, errorCode: 'INVALID_ARGUMENT',
+  });
+  assert.deepEqual(decodeAndClassifyRequest(Buffer.from([0]), schema), {
+    ok: false, errorCode: 'INVALID_REQUEST',
+  });
+
+  const invoke = golden('invoke-project-summary.json');
+  for (const event of invoke.events) {
+    assert.equal(schemaAccepts(schema.$defs.progressEvent, event), true);
+    assert.equal(validateProgressEvent(event, invoke.request, schema), true);
+  }
+  const missingMessage = structuredClone(invoke.events[0]);
+  delete missingMessage.progress.message;
+  const longMessage = structuredClone(invoke.events[0]);
+  longMessage.progress.message = '😀'.repeat(161);
+  const wrongKind = structuredClone(invoke.events[0]);
+  wrongKind.kind = 'response';
+  for (const event of [missingMessage, longMessage, wrongKind]) {
+    assert.equal(schemaAccepts(schema.$defs.progressEvent, event), false);
+    assert.equal(validateProgressEvent(event, invoke.request, schema), false);
+  }
+  const wrongSession = structuredClone(invoke.events[0]);
+  wrongSession.sessionId = '77777777-7777-4777-8777-777777777777';
+  assert.equal(schemaAccepts(schema.$defs.progressEvent, wrongSession), true);
+  assert.equal(validateProgressEvent(wrongSession, invoke.request, schema), false,
+    'composite validation adds request/session binding');
+});
+
+test('response and event decode composites enforce closed root shapes before semantics', () => {
+  const hello = golden('hello.json');
+  const invoke = golden('invoke-project-summary.json');
+  const decodedResponse = decodeAndValidateResponse(encodeFrame(hello.response), schema);
+  assert.equal(decodedResponse.ok, true);
+  assert.equal(validateResponseShape(decodedResponse.message, schema), true);
+  const decodedEvent = decodeAndValidateProgressEvent(encodeFrame(invoke.events[0]), schema);
+  assert.equal(decodedEvent.ok, true);
+
+  const extraEnvelope = { ...hello.response, unexpected: true };
+  const missingHelloField = structuredClone(hello.response);
+  delete missingHelloField.result.pluginVersion;
+  const overBoundLimit = structuredClone(hello.response);
+  overBoundLimit.result.limits.maxInFlight = 65;
+  for (const candidate of [extraEnvelope, missingHelloField, overBoundLimit]) {
+    assert.equal(validateResponseShape(candidate, schema), false);
+    assert.deepEqual(decodeAndValidateResponse(encodeFrame(candidate), schema), {
+      ok: false, errorCode: 'INVALID_REQUEST',
+    });
+    assert.equal(validateHelloExchange(hello.request, candidate, schema), false);
+  }
+
+  const capabilities = golden('capabilities.json');
+  const extraResult = structuredClone(capabilities.response);
+  extraResult.result.unexpected = true;
+  const missingDigest = structuredClone(capabilities.response);
+  delete missingDigest.result.queryDigest;
+  const invalidDetail = structuredClone(capabilities.response);
+  invalidDetail.result.detail = 'verbose';
+  for (const candidate of [extraResult, missingDigest, invalidDetail]) {
+    assert.equal(validateResponseShape(candidate, schema), false);
+    assert.equal(validateCapabilitiesExchange(
+      hello, capabilities.request, candidate, schema,
+    ), false);
+  }
+
+  const malformedFailure = structuredClone(golden('errors.json').responses.wireVersionMismatch);
+  delete malformedFailure.error.message;
+  assert.equal(validateHelloFailure({
+    ...hello.request,
+    requestId: malformedFailure.requestId,
+    params: {
+      ...hello.request.params,
+      supportedWireVersions: { minimum: 2, maximum: 3 },
+    },
+  }, malformedFailure, schema), false);
+
+  const malformedEvent = structuredClone(invoke.events[0]);
+  malformedEvent.progress.extra = true;
+  assert.deepEqual(decodeAndValidateProgressEvent(encodeFrame(malformedEvent), schema), {
+    ok: false, errorCode: 'INVALID_REQUEST',
+  });
+  assert.equal(productSchemaAccepts({
+    type: 'array', uniqueItems: true,
+  }, [{ id: 'same', version: 1 }, { version: 1, id: 'same' }]), false,
+  'uniqueItems uses JSON deep equality rather than property insertion order');
+});
+
+test('v1 framing and hello remain the permanent negotiation bootstrap in both directions', () => {
+  assert.deepEqual(schema['x-bootstrap'], {
+    framingVersion: 1,
+    helloEnvelopeVersion: 1,
+    permanent: true,
+    futureImplementations: 'must-parse-v1-framing-and-hello-before-negotiation',
+  });
+  for (const vector of golden('version-negotiation.json').vectors) {
+    assert.equal(schemaAccepts(schema.$defs.request, vector.request), true, vector.name);
+    assert.equal(schemaAccepts(schema.$defs.response, vector.response), true, vector.name);
+    assert.equal(validateHelloFailure(vector.request, vector.response, schema), true, vector.name);
+    assert.equal(selectWireVersion(
+      vector.request.params.supportedWireVersions,
+      vector.response.error.details.supportedWireVersions,
+    ), null, vector.name);
+  }
+  const malformed = structuredClone(golden('version-negotiation.json').vectors[0].response);
+  malformed.error.details.supportedWireVersions = { minimum: 3, maximum: 2 };
+  assert.equal(schemaAccepts(schema.$defs.response, malformed), true,
+    'range order is a composite invariant, not expressible by this Draft schema');
+  assert.doesNotThrow(() => validateHelloFailure(
+    golden('version-negotiation.json').vectors[0].request, malformed, schema,
+  ));
+  assert.equal(validateHelloFailure(
+    golden('version-negotiation.json').vectors[0].request, malformed, schema,
+  ), false);
+});
+
+test('session failures bind method, session, request, and capability-specific details', () => {
+  const request = {
+    ...golden('invoke-project-summary.json').request,
+    requestId: 'invoke-stale-1',
+  };
+  const response = structuredClone(golden('errors.json').responses.staleLocator);
+  response.error.details.capabilityId = request.params.capabilityId;
+  assert.equal(validateFailureExchange(
+    golden('hello.json'), request, response, projectSummaryDescriptor(schema), schema,
+  ), true);
+  response.error.details.capabilityId = 'ae.layer.inspect';
+  assert.equal(validateFailureExchange(
+    golden('hello.json'), request, response, projectSummaryDescriptor(schema), schema,
+  ), false);
+  assert.equal(validateFailureExchange(
+    golden('hello.json'), request, { ...response, requestId: 'wrong' },
+    projectSummaryDescriptor(schema), schema,
+  ), false);
+});
+
+test('deadline omission materializes to 5 seconds and invalid windows fail before dispatch', () => {
+  const request = structuredClone(golden('invoke-project-summary.json').request);
+  delete request.deadlineUnixMs;
+  const now = 1900000000000;
+  assert.equal(schemaAccepts(schema.$defs.request, request), true);
+  assert.equal(materializeDeadline(request, now), now + LIMITS.defaultDeadlineMs);
+  assert.throws(() => materializeDeadline({ ...request, deadlineUnixMs: now }, now), {
+    code: 'DEADLINE_EXCEEDED',
+  });
+  assert.throws(() => materializeDeadline({ ...request, deadlineUnixMs: now + 30001 }, now), {
+    code: 'INVALID_ARGUMENT',
+  });
+  assert.deepEqual(classifyRequest({ ...request, deadlineUnixMs: Number.MAX_SAFE_INTEGER + 1 }), {
+    ok: false, errorCode: 'INVALID_ARGUMENT',
+  });
+});
+
+test('capability discovery uses real canonical digests and keeps compatibility unverified', () => {
+  const hello = golden('hello.json');
+  const exchange = golden('capabilities.json');
+  const capabilities = exchange.response;
+  const descriptor = capabilities.result.items[0];
+  assert.equal(descriptor.contractDigest, projectSummaryContractDigest(schema));
+  assert.deepEqual(descriptor, projectSummaryDescriptor(schema));
+  assert.equal(capabilities.result.capabilitiesDigest, capabilityDigest([projectSummaryDescriptor(schema)]));
+  assert.equal(capabilities.result.queryDigest, capabilityQueryDigest(exchange.request));
+  assert.equal(validateCapabilitiesExchange(hello, exchange.request, capabilities, schema), true);
+  assert.equal(validateCapabilityDescriptor(descriptor, schema), true);
+  assert.equal(descriptor.compatibility.status, 'unverified');
+  assert.equal(validateCapabilitiesExchange(hello, exchange.request, {
+    ...capabilities,
+    result: { ...capabilities.result, capabilitiesDigest: '0'.repeat(64) },
+  }, schema), false);
+  assert.equal(validateCapabilitiesExchange(hello, exchange.request, {
+    ...capabilities,
+    requestId: 'wrong-request',
+  }, schema), false);
+  assert.equal(validateCapabilitiesExchange(hello, {
+    ...exchange.request,
+    params: { ...exchange.request.params, ids: ['ae.layer.inspect'] },
+  }, capabilities, schema), false);
+  assert.deepEqual(classifyRequest({
+    ...exchange.request,
+    params: { ...exchange.request.params, cursor: 'unsupported-v1-cursor' },
+  }), { ok: false, errorCode: 'INVALID_ARGUMENT' });
+  assert.equal(validateCapabilityDescriptor({ ...descriptor, mutability: 'mutating' }, schema), false);
+  assert.equal(validateCapabilityDescriptor({
+    ...descriptor,
+    examples: descriptor.examples.filter((example) => example.kind === 'positive'),
+  }, schema), false);
+  assert.equal(validateCapabilityDescriptor({
+    ...descriptor,
+    compatibility: {
+      status: 'verified', intendedPlatforms: ['macos-arm64'], minimumHostMajor: 27, maximumHostMajor: 26,
+    },
+  }, schema), false);
+});
+
+test('full descriptors are bounded, self-contained direct-run contracts', () => {
+  const descriptor = projectSummaryDescriptor(schema);
+  const containsRef = (value) => {
+    if (Array.isArray(value)) return value.some(containsRef);
+    if (value === null || typeof value !== 'object') return false;
+    return Object.hasOwn(value, '$ref') || Object.values(value).some(containsRef);
+  };
+  assert.equal(schemaAccepts(schema.$defs.capabilityFull, descriptor), true);
+  assert.equal(containsRef(descriptor.inputSchema), false);
+  assert.equal(containsRef(descriptor.resultSchema), false);
+  assert.deepEqual(descriptor.inputSchema, {
+    type: 'object', additionalProperties: false, required: [], properties: {},
+  });
+  assert.equal(schemaAccepts(descriptor.inputSchema, {}, descriptor.inputSchema), true);
+  assert.equal(schemaAccepts(descriptor.inputSchema, { jsx: 'forbidden' }, descriptor.inputSchema), false);
+  const value = { projectOpen: true, projectName: 'SYNTHETIC_PROJECT', itemCount: 2 };
+  assert.equal(schemaAccepts(descriptor.resultSchema, value, descriptor.resultSchema), true);
+  assert.equal(schemaAccepts(descriptor.resultSchema, { projectOpen: true }, descriptor.resultSchema), false);
+  assert.equal(descriptor.contractDigest, sha256Jcs({
+    inputSchema: descriptor.inputSchema,
+    resultSchema: descriptor.resultSchema,
+  }));
+  assert.ok(Buffer.byteLength(canonicalize(descriptor), 'utf8') < LIMITS.maxFrameBytes);
+});
+
+test('v1 capability discovery is single-page, fail-closed, and never replayed', () => {
+  const hello = golden('hello.json');
+  const exchange = golden('capabilities.json');
+  assert.equal(exchange.request.params.limit, 1);
+  assert.equal(validateCapabilitiesExchange(hello, exchange.request, exchange.response, schema), true);
+
+  const zeroLimit = structuredClone(exchange.request);
+  zeroLimit.params.limit = 0;
+  assert.equal(schemaAccepts(schema.$defs.request, zeroLimit), false);
+  assert.equal(validateCapabilitiesExchange(hello, zeroLimit, exchange.response, schema), false);
+
+  const unknownRequest = structuredClone(exchange.request);
+  unknownRequest.requestId = 'capabilities-unknown';
+  unknownRequest.params.ids = ['ae.project.unknown'];
+  const unknownResponse = structuredClone(exchange.response);
+  unknownResponse.requestId = unknownRequest.requestId;
+  unknownResponse.result.items = [];
+  unknownResponse.result.queryDigest = capabilityQueryDigest(unknownRequest);
+  assert.equal(validateCapabilitiesExchange(hello, unknownRequest, unknownResponse, schema), true,
+    'an unknown explicit ID yields an empty, digest-bound single page');
+
+  const secondDescriptor = {
+    ...projectSummaryDescriptor(schema),
+    id: 'ae.project.second',
+    inputContractId: 'aemcp.contract.ae.project.second.input.v1',
+    resultContractId: 'aemcp.contract.ae.project.second.result.v1',
+  };
+  const multiRequest = structuredClone(exchange.request);
+  delete multiRequest.params.ids;
+  assert.equal(validateCapabilitiesExchange(
+    hello,
+    multiRequest,
+    exchange.response,
+    schema,
+    [projectSummaryDescriptor(schema), secondDescriptor],
+  ), false, 'v1 refuses truncation when the requested limit is smaller than matching entries');
+
+  const replayed = { ...exchange.response, replayed: true };
+  assert.equal(schemaAccepts(schema.$defs.response, replayed), false);
+  assert.equal(validateCapabilitiesExchange(hello, exchange.request, replayed, schema), false);
+  const replayedCancel = { ...golden('cancel.json').response, replayed: true };
+  assert.equal(schemaAccepts(schema.$defs.response, replayedCancel), false);
+});
+
+test('invoke is a closed capability-specific allowlist, including nested executable aliases', () => {
+  const request = golden('invoke-project-summary.json').request;
+  assert.equal(schemaAccepts(schema.$defs.request, request), true);
+  for (const argumentsValue of [
+    { jsx: 'synthetic' },
+    { Code: 'synthetic' },
+    { payload: { commandLine: 'synthetic', jsx: 'synthetic' } },
+    { source: 'synthetic' },
+  ]) {
+    const candidate = { ...request, params: { ...request.params, arguments: argumentsValue } };
+    assert.equal(schemaAccepts(schema.$defs.request, candidate), false);
+    assert.deepEqual(classifyRequest(candidate), { ok: false, errorCode: 'INVALID_ARGUMENT' });
+  }
+  assert.equal(validateIdempotencyContract({ idempotency: 'idempotency-key' }, {
+    idempotencyKey: 'synthetic-key-0001',
+  }), true);
+  assert.equal(validateIdempotencyContract({ idempotency: 'idempotency-key' }, {}), false);
+  assert.equal(validateIdempotencyContract({ idempotency: 'idempotent' }, {
+    idempotencyKey: 'synthetic-key-0001',
+  }), false);
+});
+
+test('every error code has one safe retry/side-effect/recovery tuple', () => {
+  for (const code of Object.keys(ERROR_POLICIES)) {
+    const valid = errorVector(code);
+    assert.equal(schemaAccepts(schema.$defs.rpcError, valid), true, code);
+    assert.equal(validateErrorPolicy(valid, schema), true, code);
+    assert.equal(schemaAccepts(schema.$defs.rpcError, { ...valid, retryable: !valid.retryable }), false, code);
+    assert.equal(schemaAccepts(schema.$defs.rpcError, {
+      ...valid,
+      recovery: { ...valid.recovery, action: valid.recovery.action === 'retry' ? 'none' : 'retry' },
+    }), false, code);
+  }
+  const queue = errorVector('QUEUE_FULL');
+  delete queue.recovery.retryAfterMs;
+  assert.equal(schemaAccepts(schema.$defs.rpcError, queue), false);
+  const cancelled = errorVector('CANCELLED');
+  cancelled.recovery.retryAfterMs = 250;
+  assert.equal(schemaAccepts(schema.$defs.rpcError, cancelled), false);
+  assert.equal(validateErrorPolicy(cancelled, schema), false);
+});
+
+test('request ledger resists poisoning and only replays verified, live, identical reads', () => {
+  const now = 1900000000000;
+  const request = golden('invoke-project-summary.json').request;
+  const response = successForRequest(request, now);
+  const ledger = new RequestLedger({
+    maxActiveEntries: 2,
+    maxTerminalEntries: 2,
+    terminalTtlMs: 1000,
+    terminalValidator: strictTerminalValidator,
+  });
+  assert.deepEqual(ledger.accept(request, now), {
+    state: 'accepted', effectiveDeadlineUnixMs: request.deadlineUnixMs,
+  });
+  assert.deepEqual(ledger.accept(request, now), {
+    state: 'rejected', errorCode: 'DUPLICATE_REQUEST',
+  });
+  const poisonedRequest = { ...request, deadlineUnixMs: request.deadlineUnixMs - 1 };
+  assert.throws(() => ledger.complete(poisonedRequest, response, now + 30), {
+    code: 'INVALID_REQUEST',
+  });
+  assert.deepEqual(ledger.snapshot(), { active: 1, terminal: 0 });
+  ledger.complete(request, response, now + 30);
+  const replay = ledger.accept(request, now + 40);
+  assert.equal(replay.state, 'replayed');
+  assert.equal(replay.response.replayed, true);
+  assert.equal(validateTranscript({
+    hello: golden('hello.json'),
+    descriptor: projectSummaryDescriptor(schema),
+    schema,
+    brokerSendUnixMs: now + 40,
+    effectiveDeadlineUnixMs: request.deadlineUnixMs,
+    replayReceipt: replay.replayReceipt,
+  }, request, [replay.response]), true);
+  assert.equal(validateTranscript({
+    hello: golden('hello.json'),
+    descriptor: projectSummaryDescriptor(schema),
+    schema,
+    brokerSendUnixMs: now + 40,
+    effectiveDeadlineUnixMs: request.deadlineUnixMs,
+    replayReceipt: { ...replay.replayReceipt },
+  }, request, [replay.response]), false, 'forged replay receipt is rejected');
+  assert.deepEqual(ledger.accept(request, request.deadlineUnixMs), {
+    state: 'rejected', errorCode: 'DEADLINE_EXCEEDED',
+  });
+
+  const unverified = new RequestLedger({ maxActiveEntries: 1, maxTerminalEntries: 1 });
+  unverified.accept(request, now);
+  assert.throws(() => unverified.complete(request, response, now + 30), {
+    code: 'INVALID_REQUEST',
+  });
+  assert.deepEqual(unverified.snapshot(), { active: 1, terminal: 0 });
+
+  const shapeFirst = new RequestLedger({
+    maxActiveEntries: 1, maxTerminalEntries: 1, terminalValidator: strictTerminalValidator,
+  });
+  shapeFirst.accept(request, now);
+  const malformedTerminal = { ...response, unexpected: true };
+  assert.equal(validateResponseShape(malformedTerminal, schema), false);
+  assert.throws(() => shapeFirst.complete(request, malformedTerminal, now + 30), {
+    code: 'INVALID_REQUEST',
+  });
+  assert.deepEqual(shapeFirst.snapshot(), { active: 1, terminal: 0 });
+
+  const capacity = new RequestLedger({
+    maxActiveEntries: 1, maxTerminalEntries: 1, terminalValidator: strictTerminalValidator,
+  });
+  assert.equal(capacity.accept(request, now).state, 'accepted');
+  assert.deepEqual(capacity.accept({ ...request, requestId: 'capacity-full' }, now), {
+    state: 'rejected', errorCode: 'QUEUE_FULL',
+  });
+
+  const failureLedger = new RequestLedger({
+    maxActiveEntries: 2, maxTerminalEntries: 2, terminalValidator: strictTerminalValidator,
+  });
+  const failed = { ...request, requestId: 'failed-1' };
+  const failedResponse = {
+    ...golden('errors.json').responses.duplicateRequest,
+    requestId: failed.requestId,
+  };
+  assert.equal(failureLedger.accept(failed, now).state, 'accepted');
+  failureLedger.complete(failed, failedResponse, now + 1);
+  assert.deepEqual(failureLedger.accept(failed, now + 2), {
+    state: 'rejected', errorCode: 'DUPLICATE_REQUEST',
+  });
+
+  const ttl = new RequestLedger({
+    maxActiveEntries: 2,
+    maxTerminalEntries: 1,
+    terminalTtlMs: 100,
+    terminalValidator: strictTerminalValidator,
+  });
+  assert.equal(ttl.accept(request, now).state, 'accepted');
+  ttl.complete(request, response, now + 30);
+  assert.equal(ttl.accept(request, now + 129).state, 'replayed');
+  assert.equal(ttl.accept(request, now + 131).state, 'accepted', 'expired tombstone is not replayed');
+  ttl.purgeSession(request.sessionId);
+  assert.deepEqual(ttl.snapshot(), { active: 0, terminal: 0 });
+
+  const futureEvidence = new RequestLedger({
+    maxActiveEntries: 1, maxTerminalEntries: 1, terminalValidator: strictTerminalValidator,
+  });
+  futureEvidence.accept(request, now);
+  assert.throws(() => futureEvidence.complete(request, response, now + 20), {
+    code: 'INVALID_REQUEST',
+  });
+  assert.deepEqual(futureEvidence.snapshot(), { active: 1, terminal: 0 });
+
+  const expiryCapacity = new RequestLedger({
+    maxActiveEntries: 1, maxTerminalEntries: 2, terminalValidator: strictTerminalValidator,
+  });
+  const short = { ...request, requestId: 'short-active', deadlineUnixMs: now + 10 };
+  assert.equal(expiryCapacity.accept(short, now).state, 'accepted');
+  assert.equal(expiryCapacity.accept({ ...request, requestId: 'after-expiry' }, now + 10).state,
+    'accepted', 'expired active entries release capacity and leave a tombstone');
+  assert.deepEqual(expiryCapacity.accept(short, now + 10), {
+    state: 'rejected', errorCode: 'DEADLINE_EXCEEDED',
+  });
+
+  const omitted = structuredClone(request);
+  omitted.requestId = 'omitted-deadline';
+  delete omitted.deadlineUnixMs;
+  const omittedResponse = successForRequest(omitted, now);
+  const omittedLedger = new RequestLedger({
+    maxActiveEntries: 1, maxTerminalEntries: 1, terminalValidator: strictTerminalValidator,
+  });
+  const omittedAccepted = omittedLedger.accept(omitted, now);
+  omittedLedger.complete(omitted, omittedResponse, now + 30);
+  const omittedReplay = omittedLedger.accept(omitted, now + 40);
+  assert.equal(omittedReplay.effectiveDeadlineUnixMs, omittedAccepted.effectiveDeadlineUnixMs);
+  assert.equal(validateTranscript({
+    hello: golden('hello.json'),
+    descriptor: projectSummaryDescriptor(schema),
+    schema,
+    brokerSendUnixMs: now + 40,
+    effectiveDeadlineUnixMs: omittedReplay.effectiveDeadlineUnixMs,
+    replayReceipt: omittedReplay.replayReceipt,
+  }, omitted, [omittedReplay.response]), true);
+
+  const otherSession = { ...request, sessionId: '44444444-4444-4444-8444-444444444444' };
+  const sessions = new RequestLedger({
+    maxActiveEntries: 2, maxTerminalEntries: 1, terminalValidator: strictTerminalValidator,
+  });
+  assert.equal(sessions.accept(request, now).state, 'accepted');
+  assert.equal(sessions.accept(otherSession, now).state, 'accepted');
+  sessions.purgeSession(otherSession.sessionId);
+  assert.deepEqual(sessions.snapshot(), { active: 1, terminal: 0 });
+  assert.equal(golden('errors.json').responses.duplicateRequest.error.code, 'DUPLICATE_REQUEST');
+});
+
+test('admission controller enforces burst, rate, in-flight, queue, and recovery', () => {
+  const now = 1900000000000;
+  const base = golden('invoke-project-summary.json').request;
+  const request = (requestId, extra = {}) => ({ ...base, requestId, ...extra });
+  const limits = (overrides = {}) => ({
+    maxInFlight: 8,
+    maxQueueDepth: 8,
+    maxDeadlineMs: 30000,
+    maxRequestsPerSecond: 100,
+    maxBurst: 100,
+    maxControlInFlight: 1,
+    maxControlRequestsPerSecond: 20,
+    maxControlBurst: 4,
+    maxTerminalCacheEntries: 128,
+    ...overrides,
+  });
+  const rate = new AdmissionController(limits({
+    maxInFlight: 8, maxQueueDepth: 8, maxRequestsPerSecond: 2, maxBurst: 2,
+  }));
+  assert.equal(rate.admit(request('rate-1'), now).state, 'dispatched');
+  assert.equal(rate.admit(request('rate-2'), now).state, 'dispatched');
+  assert.deepEqual(rate.admit(request('rate-3'), now), {
+    state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'rate-limit', retryAfterMs: 500,
+  });
+  assert.equal(rate.admit(request('rate-4'), now + 500).state, 'dispatched');
+
+  const capacity = new AdmissionController(limits({
+    maxInFlight: 1, maxQueueDepth: 2, maxRequestsPerSecond: 100, maxBurst: 10,
+  }));
+  const work1 = request('work-1');
+  const work2 = request('work-2');
+  const work3 = request('work-3');
+  assert.equal(capacity.admit(work1, now).state, 'dispatched');
+  assert.equal(capacity.admit(work2, now).state, 'queued');
+  assert.equal(capacity.admit(work3, now).state, 'queued');
+  assert.deepEqual(capacity.admit(request('work-4'), now), {
+    state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'queue-capacity', retryAfterMs: 1,
+  });
+
+  const cancel = {
+    ...golden('cancel.json').request,
+    requestId: 'cancel-control-1',
+    params: { targetRequestId: 'work-2' },
+  };
+  assert.equal(capacity.admit(cancel, now).state, 'control-dispatched');
+  assert.deepEqual(capacity.admit({ ...cancel, requestId: 'cancel-control-2' }, now), {
+    state: 'rejected', errorCode: 'QUEUE_FULL', reason: 'control-capacity', retryAfterMs: 1,
+  });
+  const promotion = capacity.complete(work1, now + 1);
+  assert.equal(promotion.state, 'promoted');
+  assert.equal(promotion.completed.requestId, 'work-1');
+  assert.equal(promotion.promoted.requestId, 'work-2');
+  assert.equal(capacity.complete(cancel, now + 1).state, 'control-released');
+  assert.equal(capacity.complete(work2, now + 2).state, 'promoted');
+  assert.equal(capacity.complete(work3, now + 3).state, 'released');
+
+  const sessions = new AdmissionController(limits());
+  const sameIdOtherSession = request('shared-id', {
+    sessionId: '44444444-4444-4444-8444-444444444444',
+  });
+  assert.equal(sessions.admit(request('shared-id'), now).state, 'dispatched');
+  assert.equal(sessions.admit(sameIdOtherSession, now).state, 'dispatched');
+
+  const expiry = new AdmissionController(limits({ maxInFlight: 1, maxQueueDepth: 3 }));
+  const active = request('expiry-active');
+  const expiredQueued = request('expiry-queued', { deadlineUnixMs: now + 10 });
+  const liveQueued = request('expiry-live', { deadlineUnixMs: now + 100 });
+  expiry.admit(active, now);
+  expiry.admit(expiredQueued, now);
+  expiry.admit(liveQueued, now);
+  const expiryPromotion = expiry.complete(active, now + 20);
+  assert.equal(expiryPromotion.promoted.requestId, 'expiry-live');
+  assert.deepEqual(expiryPromotion.expired.map((item) => item.request.requestId), ['expiry-queued']);
+
+  const controlRate = new AdmissionController(limits({
+    maxControlRequestsPerSecond: 1, maxControlBurst: 4,
+  }));
+  let controlAccepted = 0;
+  let controlLimited = 0;
+  for (let index = 0; index < 100; index += 1) {
+    const candidate = { ...cancel, requestId: `cancel-burst-${index}` };
+    const result = controlRate.admit(candidate, now);
+    if (result.state === 'control-dispatched') {
+      controlAccepted += 1;
+      controlRate.complete(candidate, now);
+    } else if (result.reason === 'control-rate-limit') {
+      controlLimited += 1;
+    }
+  }
+  assert.equal(controlAccepted, 4);
+  assert.equal(controlLimited, 96);
+});
+
+test('admission constructor enforces every negotiated schema maximum', () => {
+  const valid = {
+    maxInFlight: 64,
+    maxQueueDepth: 256,
+    maxDeadlineMs: 30000,
+    maxRequestsPerSecond: 100,
+    maxBurst: 100,
+    maxControlInFlight: 8,
+    maxControlRequestsPerSecond: 100,
+    maxControlBurst: 100,
+    maxTerminalCacheEntries: 4096,
+  };
+  assert.doesNotThrow(() => new AdmissionController(valid));
+  for (const [key, value] of Object.entries({
+    maxInFlight: 65,
+    maxQueueDepth: 257,
+    maxDeadlineMs: 30001,
+    maxRequestsPerSecond: 101,
+    maxBurst: 101,
+    maxControlInFlight: 9,
+    maxControlRequestsPerSecond: 101,
+    maxControlBurst: 101,
+    maxTerminalCacheEntries: 4097,
+  })) {
+    assert.throws(() => new AdmissionController({ ...valid, [key]: value }), {
+      code: 'INVALID_ARGUMENT',
+    }, key);
+  }
+});
+
+test('invoke transcript binds progress order, one terminal result, identities, time, and digests', () => {
+  const fixture = golden('invoke-project-summary.json');
+  const context = {
+    hello: golden('hello.json'),
+    descriptor: projectSummaryDescriptor(schema),
+    schema,
+    brokerSendUnixMs: 1900000000000,
+    effectiveDeadlineUnixMs: fixture.request.deadlineUnixMs,
+    terminalObservedUnixMs: 1900000000030,
+  };
+  const messages = [...fixture.events, fixture.response];
+  assert.equal(fixture.response.result.evidence.requestDigest, sha256Jcs(fixture.request));
+  assert.equal(fixture.response.result.evidence.postcondition.digest, postconditionDigest(fixture.response.result));
+  assert.equal(validateTranscript(context, fixture.request, messages), true);
+
+  const badSequence = structuredClone(messages);
+  badSequence[1].sequence = 4;
+  assert.equal(validateTranscript(context, fixture.request, badSequence), false);
+  assert.equal(validateTranscript(context, fixture.request, [...messages, fixture.response]), false);
+  assert.equal(validateTranscript(context, fixture.request, [fixture.response, fixture.events[0]]), false);
+  const wrongIdentity = structuredClone(messages);
+  wrongIdentity.at(-1).result.evidence.sessionId = '44444444-4444-4444-8444-444444444444';
+  assert.equal(validateTranscript(context, fixture.request, wrongIdentity), false);
+  const wrongHost = structuredClone(messages);
+  wrongHost.at(-1).result.evidence.hostInstanceId = '77777777-7777-4777-8777-777777777777';
+  assert.equal(validateTranscript(context, fixture.request, wrongHost), false);
+  const reversedTime = structuredClone(messages);
+  reversedTime.at(-1).result.evidence.completedAtUnixMs = 1;
+  assert.equal(validateTranscript(context, fixture.request, reversedTime), false);
+  const beforeBrokerSend = structuredClone(messages);
+  beforeBrokerSend.at(-1).result.evidence.startedAtUnixMs = context.brokerSendUnixMs - 1;
+  assert.equal(validateTranscript(context, fixture.request, beforeBrokerSend), false);
+  const afterDeadline = structuredClone(messages);
+  afterDeadline.at(-1).result.evidence.completedAtUnixMs = fixture.request.deadlineUnixMs + 1;
+  assert.equal(validateTranscript(context, fixture.request, afterDeadline), false);
+  const wrongDigest = structuredClone(messages);
+  wrongDigest.at(-1).result.evidence.postcondition.digest = '0'.repeat(64);
+  assert.equal(validateTranscript(context, fixture.request, wrongDigest), false);
+  for (const mutate of [
+    (terminal) => { terminal.result.extra = true; },
+    (terminal) => { terminal.result.evidence.extra = true; },
+    (terminal) => { terminal.result.evidence.postcondition.extra = true; },
+    (terminal) => { delete terminal.result.value.projectName; },
+    (terminal) => { terminal.result.value.extra = true; },
+  ]) {
+    const malformedShape = structuredClone(messages);
+    mutate(malformedShape.at(-1));
+    assert.equal(validateResponseShape(malformedShape.at(-1), schema), false);
+    assert.equal(validateTranscript(context, fixture.request, malformedShape), false);
+  }
+  const decreasingProgress = structuredClone(messages);
+  decreasingProgress[0].progress.fraction = 0.4;
+  decreasingProgress[1].progress.fraction = 0.3;
+  assert.equal(validateTranscript(context, fixture.request, decreasingProgress), false);
+  const backwardsPhase = structuredClone(messages);
+  backwardsPhase[1].progress.phase = 'running';
+  backwardsPhase[2].progress.phase = 'dispatched';
+  assert.equal(validateTranscript(context, fixture.request, backwardsPhase), false);
+  const readEffect = structuredClone(messages);
+  readEffect.at(-1).result.evidence.effect = 'committed';
+  assert.equal(validateTranscript(context, fixture.request, readEffect), false);
+  const readUndo = structuredClone(messages);
+  readUndo.at(-1).result.evidence.undo = { available: true, verified: true, groupId: 'synthetic' };
+  assert.equal(validateTranscript(context, fixture.request, readUndo), false);
+  assert.equal(validateTranscript({ ...context, descriptor: { ...context.descriptor, version: 2 } },
+    fixture.request, messages), false);
+  const unverified = structuredClone(fixture.response);
+  unverified.result.evidence.postcondition.verified = false;
+  assert.equal(schemaAccepts(schema.$defs.response, unverified), false);
+});
+
+test('server-issued locators reject pointer shapes and stale host/session/project/generation', () => {
+  const locator = {
+    kind: 'layer',
+    hostInstanceId: HOST,
+    sessionId: SESSION,
+    projectId: PROJECT,
+    generation: 8,
+    objectId: OBJECT,
+  };
+  const context = {
+    hostInstanceId: HOST, sessionId: SESSION, projectId: PROJECT, generation: 8,
+  };
+  assert.equal(schemaAccepts(schema.$defs.locator, locator), true);
+  assert.equal(validateLocator(locator, context, schema), true);
+  assert.equal(schemaAccepts(schema.$defs.locator, { ...locator, objectId: '0x0000000100abcdef' }), false);
+  assert.equal(validateLocator(locator, { ...context, generation: 9 }, schema), false);
+  assert.equal(validateLocator(locator, {
+    ...context, sessionId: '66666666-6666-4666-8666-666666666666',
+  }, schema), false);
+});
+
+test('cancel states distinguish queued, running, terminal, and missing targets', () => {
+  const fixture = golden('cancel.json');
+  assert.equal(schemaAccepts(schema.$defs.response, fixture.response), true);
+  assert.equal(validateCancelResult(fixture.response.result, schema), true);
+  for (const [state, terminalResponseExpected] of Object.entries({
+    'queued-cancelled': true,
+    'running-cancel-requested': true,
+    'running-not-cancellable': true,
+    'already-terminal': false,
+    'not-found': false,
+  })) {
+    assert.equal(validateCancelResult({
+      targetRequestId: 'target-1', state, terminalResponseExpected,
+    }, schema), true);
+    assert.equal(validateCancelResult({
+      targetRequestId: 'target-1', state, terminalResponseExpected: !terminalResponseExpected,
+    }, schema), false);
+  }
+  const now = 1900000000000;
+  const limits = {
+    maxInFlight: 1,
+    maxQueueDepth: 2,
+    maxDeadlineMs: 30000,
+    maxRequestsPerSecond: 100,
+    maxBurst: 10,
+    maxControlInFlight: 1,
+    maxControlRequestsPerSecond: 20,
+    maxControlBurst: 4,
+    maxTerminalCacheEntries: 128,
+  };
+  const descriptor = projectSummaryDescriptor(schema);
+  const helloFor = (capabilityDescriptor) => {
+    const hello = structuredClone(golden('hello.json'));
+    hello.response.result.capabilitiesDigest = capabilityDigest([capabilityDescriptor]);
+    return hello;
+  };
+  const responseFor = (request, state, terminalResponseExpected) => ({
+    ...fixture.response,
+    requestId: request.requestId,
+    result: {
+      targetRequestId: request.params.targetRequestId,
+      state,
+      terminalResponseExpected,
+    },
+  });
+  const contextFor = (decision, capabilityDescriptor, targetRequest, hello = helloFor(capabilityDescriptor)) => ({
+    hello,
+    descriptor: capabilityDescriptor,
+    schema,
+    cancelDecision: decision.decisionReceipt,
+    targetTranscriptContext: targetRequest ? {
+      brokerSendUnixMs: now,
+      effectiveDeadlineUnixMs: targetRequest.deadlineUnixMs ?? now + LIMITS.defaultDeadlineMs,
+      terminalObservedUnixMs: now + 30,
+    } : undefined,
+  });
+
+  const queuedAdmission = new AdmissionController(limits);
+  queuedAdmission.admit(golden('invoke-project-summary.json').request, now);
+  queuedAdmission.admit(fixture.targetRequest, now);
+  queuedAdmission.admit(fixture.request, now);
+  const beforeRejectedCancel = structuredClone(queuedAdmission.snapshot());
+  assert.throws(() => queuedAdmission.decideCancel(
+    fixture.request, { ...descriptor, id: 'ae.project.wrong' },
+  ), { code: 'INVALID_ARGUMENT' });
+  assert.deepEqual(queuedAdmission.snapshot(), beforeRejectedCancel,
+    'a rejected cancellation decision must preserve all admission state');
+  const queuedDecision = queuedAdmission.decideCancel(fixture.request, descriptor);
+  const queuedContext = contextFor(queuedDecision, descriptor, fixture.targetRequest);
+  assert.equal(queuedDecision.state, 'queued-cancelled');
+  assert.equal(validateCancelExchange(
+    queuedContext, fixture.request, fixture.response, fixture.targetRequest, [],
+  ), false);
+  assert.equal(validateCancelExchange(
+    queuedContext,
+    fixture.request,
+    { ...fixture.response, replayed: true },
+    fixture.targetRequest,
+    fixture.targetMessages,
+  ), false);
+  assert.equal(validateCancelExchange(
+    queuedContext, fixture.request, fixture.response, fixture.targetRequest, fixture.targetMessages,
+  ), true);
+  assert.equal(validateCancelExchange(
+    queuedContext, fixture.request, fixture.response, fixture.targetRequest, fixture.targetMessages,
+  ), false, 'an atomic cancellation decision is consumed exactly once');
+  assert.equal(validateCancelExchange(
+    { ...queuedContext, cancelDecision: { ...queuedDecision.decisionReceipt } },
+    fixture.request,
+    fixture.response,
+    fixture.targetRequest,
+    fixture.targetMessages,
+  ), false, 'a copied decision receipt has no authority');
+
+  const runningFixture = golden('invoke-project-summary.json');
+  const runningAdmission = new AdmissionController(limits);
+  runningAdmission.admit(runningFixture.request, now);
+  const runningRequest = {
+    ...fixture.request,
+    requestId: 'cancel-running',
+    params: { targetRequestId: runningFixture.request.requestId },
+  };
+  const runningResponse = {
+    ...fixture.response,
+    requestId: runningRequest.requestId,
+    result: {
+      targetRequestId: runningFixture.request.requestId,
+      state: 'running-not-cancellable',
+      terminalResponseExpected: true,
+    },
+  };
+  runningAdmission.admit(runningRequest, now);
+  const runningDecision = runningAdmission.decideCancel(runningRequest, descriptor);
+  const runningContext = contextFor(runningDecision, descriptor, runningFixture.request);
+  assert.equal(validateCancelExchange(
+    runningContext,
+    runningRequest,
+    {
+      ...runningResponse,
+      result: { ...runningResponse.result, state: 'running-cancel-requested' },
+    },
+    runningFixture.request,
+    [...runningFixture.events, runningFixture.response],
+  ), false, 'before-dispatch capability cannot request running cancellation');
+  assert.equal(validateCancelExchange(
+    runningContext,
+    runningRequest,
+    runningResponse,
+    runningFixture.request,
+    [...runningFixture.events, runningFixture.response],
+  ), true);
+
+  const terminalAdmission = new AdmissionController(limits);
+  terminalAdmission.admit(runningFixture.request, now);
+  terminalAdmission.complete(runningFixture.request, now + 1);
+  const terminalCancel = { ...runningRequest, requestId: 'cancel-terminal' };
+  terminalAdmission.admit(terminalCancel, now + 1);
+  const terminalDecision = terminalAdmission.decideCancel(terminalCancel, descriptor);
+  const alreadyTerminal = {
+    ...runningResponse,
+    requestId: terminalCancel.requestId,
+    result: {
+      ...runningResponse.result,
+      state: 'already-terminal',
+      terminalResponseExpected: false,
+    },
+  };
+  assert.equal(validateCancelExchange(
+    contextFor(terminalDecision, descriptor, runningFixture.request),
+    terminalCancel,
+    alreadyTerminal,
+    runningFixture.request,
+    [],
+  ), true);
+
+  const unknownAdmission = new AdmissionController(limits);
+  const unknownRequest = { ...runningRequest, requestId: 'cancel-unknown' };
+  unknownAdmission.admit(unknownRequest, now);
+  const unknownDecision = unknownAdmission.decideCancel(unknownRequest, descriptor);
+  const unknownResponse = responseFor(unknownRequest, 'not-found', false);
+  assert.equal(validateCancelExchange(
+    contextFor(unknownDecision, descriptor, null), unknownRequest, unknownResponse,
+    runningFixture.request, [],
+  ), false, 'a not-found decision cannot be rebound to a supplied target request');
+  assert.equal(validateCancelExchange(
+    contextFor(unknownDecision, descriptor, null), unknownRequest, unknownResponse, null, [],
+  ), true);
+
+  const otherSessionAdmission = new AdmissionController(limits);
+  const otherSessionTarget = {
+    ...runningFixture.request,
+    sessionId: '44444444-4444-4444-8444-444444444444',
+  };
+  otherSessionAdmission.admit(otherSessionTarget, now);
+  const crossSessionCancel = { ...runningRequest, requestId: 'cancel-cross-session' };
+  otherSessionAdmission.admit(crossSessionCancel, now);
+  const crossSessionDecision = otherSessionAdmission.decideCancel(crossSessionCancel, descriptor);
+  assert.equal(crossSessionDecision.state, 'not-found',
+    'target identity is scoped by the cancel request session');
+
+  const cooperativeDescriptor = { ...descriptor, cancellation: 'cooperative' };
+  const cooperativeAdmission = new AdmissionController(limits);
+  cooperativeAdmission.admit(runningFixture.request, now);
+  const cooperativeCancel = { ...runningRequest, requestId: 'cancel-cooperative' };
+  cooperativeAdmission.admit(cooperativeCancel, now);
+  const cooperativeDecision = cooperativeAdmission.decideCancel(
+    cooperativeCancel, cooperativeDescriptor,
+  );
+  assert.equal(cooperativeDecision.state, 'running-cancel-requested');
+  const cooperativeResponse = responseFor(cooperativeCancel, 'running-cancel-requested', true);
+  const cancelledTerminal = structuredClone(fixture.targetMessages[0]);
+  cancelledTerminal.requestId = runningFixture.request.requestId;
+  assert.equal(validateCancelExchange(
+    contextFor(cooperativeDecision, cooperativeDescriptor, runningFixture.request),
+    cooperativeCancel,
+    cooperativeResponse,
+    runningFixture.request,
+    [cancelledTerminal],
+  ), true, 'cooperative running cancellation permits a fully validated CANCELLED terminal');
+});
+
+test('public semantic validators fail closed without throwing on malformed values', () => {
+  const validators = [
+    () => validateCapabilitiesExchange(golden('hello.json'), golden('capabilities.json').request, {}, schema),
+    () => validateCapabilitiesExchange({}, {}, {}, {}),
+    () => validateTranscript({}, {}, []),
+    () => validateTranscript({ hello: golden('hello.json') }, null, [{}]),
+    () => validateCancelExchange({}, {}, {}, {}, []),
+    () => validateCapabilityDescriptor({ detail: 'full', compatibility: {}, examples: {} }, schema),
+    () => validateHelloFailure(golden('hello.json').request, {
+      ...golden('errors.json').responses.wireVersionMismatch,
+      error: {
+        ...golden('errors.json').responses.wireVersionMismatch.error,
+        details: { supportedWireVersions: { minimum: 3, maximum: 2 } },
+      },
+    }, schema),
+  ];
+  for (const validate of validators) {
+    assert.doesNotThrow(validate);
+    assert.equal(validate(), false);
+  }
+});

--- a/packages/core/tests/test_native_rpc_protocol.py
+++ b/packages/core/tests/test_native_rpc_protocol.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROTOCOL_ROOT = REPO_ROOT / "native" / "ae-plugin" / "protocol"
+SCHEMA_PATH = PROTOCOL_ROOT / "aegp-rpc.schema.json"
+FIXTURE_ROOT = PROTOCOL_ROOT / "fixtures"
+
+
+def _json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jcs_subset(value) -> bytes:
+    """Independent JCS encoder for the fixture's integer/string JSON subset."""
+
+    def encode(item) -> str:
+        if item is None:
+            return "null"
+        if item is True:
+            return "true"
+        if item is False:
+            return "false"
+        if isinstance(item, int):
+            return str(item)
+        if isinstance(item, str):
+            return json.dumps(item, ensure_ascii=False, separators=(",", ":"))
+        if isinstance(item, list):
+            return "[" + ",".join(encode(member) for member in item) + "]"
+        if isinstance(item, dict):
+            members = sorted(
+                item.items(),
+                key=lambda member: member[0].encode("utf-16-be"),
+            )
+            return "{" + ",".join(
+                f"{encode(key)}:{encode(member)}" for key, member in members
+            ) + "}"
+        raise TypeError(f"unsupported independent JCS fixture value: {type(item)!r}")
+
+    return encode(value).encode("utf-8")
+
+
+def test_native_rpc_schema_and_golden_vectors_are_draft_2020_12_valid():
+    schema = _json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    for name in (
+        "hello.json",
+        "capabilities.json",
+        "invoke-project-summary.json",
+        "cancel.json",
+    ):
+        fixture = _json(FIXTURE_ROOT / name)
+        validator.validate(fixture["request"])
+        for event in fixture.get("events", []):
+            validator.validate(event)
+        validator.validate(fixture["response"])
+
+    for response in _json(FIXTURE_ROOT / "errors.json")["responses"].values():
+        validator.validate(response)
+
+    for vector in _json(FIXTURE_ROOT / "version-negotiation.json")["vectors"]:
+        validator.validate(vector["request"])
+        validator.validate(vector["response"])
+
+    for name in (
+        "hello.json",
+        "capabilities.json",
+        "invoke-project-summary.json",
+        "cancel.json",
+        "errors.json",
+        "negative-corpus.json",
+        "framing-corpus.json",
+        "version-negotiation.json",
+    ):
+        fixture = _json(FIXTURE_ROOT / name)
+        assert fixture["_fixture"] == {
+            "classification": "synthetic-contract-vector",
+            "runtimeEvidence": False,
+            "compatibilityEvidence": False,
+        }
+
+    descriptor = _json(FIXTURE_ROOT / "capabilities.json")["response"]["result"][
+        "items"
+    ][0]
+    assert descriptor["requirements"] == [
+        {
+            "id": "aemcp.requirement.native.project-read",
+            "contractVersion": 1,
+        }
+    ]
+    assert {example["kind"] for example in descriptor["examples"]} == {
+        "positive",
+        "negative",
+    }
+    assert all("arguments" in example and "expected" in example for example in descriptor["examples"])
+
+    input_schema = descriptor["inputSchema"]
+    result_schema = descriptor["resultSchema"]
+    Draft202012Validator.check_schema(input_schema)
+    Draft202012Validator.check_schema(result_schema)
+    Draft202012Validator(input_schema).validate({})
+    with pytest.raises(ValidationError):
+        Draft202012Validator(input_schema).validate({"jsx": "forbidden"})
+    Draft202012Validator(result_schema).validate(
+        {"projectOpen": True, "projectName": "😀" * 1024, "itemCount": 1}
+    )
+    with pytest.raises(ValidationError):
+        Draft202012Validator(result_schema).validate(
+            {"projectOpen": True, "projectName": "😀" * 1025, "itemCount": 1}
+        )
+
+    contract = {"inputSchema": input_schema, "resultSchema": result_schema}
+    assert hashlib.sha256(_jcs_subset(contract)).hexdigest() == descriptor[
+        "contractDigest"
+    ]
+    descriptors = _json(FIXTURE_ROOT / "capabilities.json")["response"]["result"][
+        "items"
+    ]
+    assert hashlib.sha256(_jcs_subset(descriptors)).hexdigest() == _json(
+        FIXTURE_ROOT / "capabilities.json"
+    )["response"]["result"]["capabilitiesDigest"]
+    assert _jcs_subset({"\ue000": 1, "😀": 2}).decode("utf-8") == (
+        '{"😀":2,"\ue000":1}'
+    )
+
+
+def test_native_rpc_negative_corpus_is_rejected_by_the_public_envelope():
+    schema = _json(SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    for seed in _json(FIXTURE_ROOT / "negative-corpus.json")["vectors"]:
+        with pytest.raises(ValidationError):
+            validator.validate(seed["message"])
+
+    capabilities = _json(FIXTURE_ROOT / "capabilities.json")["request"]
+    capabilities["params"]["cursor"] = "pagination-is-fail-closed-in-v1"
+    with pytest.raises(ValidationError):
+        validator.validate(capabilities)
+
+    capabilities = _json(FIXTURE_ROOT / "capabilities.json")
+    replayed_capabilities = deepcopy(capabilities["response"])
+    replayed_capabilities["replayed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(replayed_capabilities)
+
+    replayed_cancel = deepcopy(_json(FIXTURE_ROOT / "cancel.json")["response"])
+    replayed_cancel["replayed"] = True
+    with pytest.raises(ValidationError):
+        validator.validate(replayed_cancel)
+
+    reversed_range = deepcopy(_json(FIXTURE_ROOT / "hello.json")["request"])
+    reversed_range["params"]["supportedWireVersions"] = {
+        "minimum": 2,
+        "maximum": 1,
+    }
+    validator.validate(reversed_range)
+    assert (
+        schema["$defs"]["wireRange"]["x-invariant"]
+        == "minimum-must-not-exceed-maximum"
+    )
+
+
+def test_native_rpc_error_policy_rejects_unsafe_retry_combinations():
+    schema = _json(SCHEMA_PATH)
+    valid = _json(FIXTURE_ROOT / "errors.json")["responses"][
+        "possiblySideEffecting"
+    ]["error"]
+
+    # Resolve local refs by validating through the root response schema.
+    response = _json(FIXTURE_ROOT / "errors.json")["responses"][
+        "possiblySideEffecting"
+    ]
+    Draft202012Validator(schema).validate(response)
+
+    unsafe = deepcopy(response)
+    unsafe["error"]["retryable"] = True
+    unsafe["error"]["sideEffect"] = "not-started"
+    unsafe["error"]["recovery"]["action"] = "retry"
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(unsafe)
+
+    delayed_non_queue = deepcopy(response)
+    delayed_non_queue["error"]["recovery"]["retryAfterMs"] = 250
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(delayed_non_queue)
+
+    queue_full = deepcopy(
+        _json(FIXTURE_ROOT / "errors.json")["responses"]["queueFull"]
+    )
+    del queue_full["error"]["recovery"]["retryAfterMs"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(queue_full)
+
+    assert valid["retryable"] is False


### PR DESCRIPTION
## Summary

- define a versioned, transport-independent RPC contract for the native AEGP execution plane
- add strict length-prefixed framing, bounded JSON/JCS codecs, admission control, deadlines, replay rules, cancellation, and typed failures
- add concise capability discovery plus a closed `ae.project.summary` v1 read contract with structured evidence
- add synthetic golden/negative/fuzz fixtures and independent Python Draft 2020-12 validation
- run the protocol contract on Windows and Linux CI, including stacked PR bases

## Why

The native plug-in, Core transport, and public MCP surface need one bounded contract before implementation can begin. This contract is deliberately AI-facing: it minimizes ambiguous inputs, declares side effects and recovery behavior, and makes results automatically verifiable without exposing arbitrary JSX, C++, shell commands, command lines, pointers, or AEGP handles.

## Stack and scope

- Tracks #72; depends on #71 / PR #84.
- Base: `codex/issue-71-sdk-intake`.
- This PR defines the native RPC contract only. It does **not** implement the AEGP plug-in, IPC, Core routing, public MCP invocation, or AEGP/JSX route selection.
- All checked-in fixtures are synthetic contract vectors. Compatibility and runtime evidence remain explicitly false.
- The Adobe SDK remains developer-supplied and is not committed or distributed.

## Validation

- Node protocol suite: 28/28 passed.
- Independent Python/jsonschema suite: 3/3 passed.
- Packaging and release contract suites: passed.
- Repository SDK anti-vendoring check: passed (`no-tracked-sdk-material`).
- JSON parse, Node syntax, staged diff, secret/path scan: passed.
- Independent security re-review: queued and running cancellation failures are state-preserving; correct retry remains possible; previous protocol blockers did not regress.
- Independent license/provenance delta review: passed; zero Adobe SDK line or 10-token similarity hits.

The complete local Python suite still has one pre-existing macOS-only failure in `test_tool_audit.py::test_audit_generations_are_owner_only` (`audit record exceeds generation size`); the same failure reproduces on the #71 base and is unrelated to this diff.

## Real-host evidence and merge gate

This PR provides **no** `.plugin` build, After Effects installation/load, native dispatcher, public MCP-to-AEGP call, audit, Undo, restart, or reconnect evidence. A compile, mock, or ping would not satisfy that gate either.

**DO NOT MERGE this stacked Draft independently.** Keep #71-#78 unmerged until the top of the P0 stack completes the real macOS vertical slice through the public MCP surface:

`MCP -> Core -> native RPC -> AEGP -> After Effects -> typed result/audit`

That gate requires at least one real read and one undoable, verified write in a disposable AE fixture, plus unload/restart/reconnect and diagnostic evidence. After the top-stack gate passes, rebase/retest and merge the dependency chain in order without administrator bypass.
