### PR TITLE
feat(native): add authenticated macOS AEGP read transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Run native AEGP RPC contract tests
         run: node --test native/ae-plugin/protocol/protocol.test.mjs
 
+      - name: Run Unix native AEGP client transport tests
+        run: node --test plugin/host/native-aegp-client.test.js
+
       - name: Build and run the portable native host dispatcher test
         run: >-
           c++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -pthread
@@ -120,6 +123,41 @@ jobs:
           native/ae-plugin/tests/host_dispatcher_test.cpp
           -o /tmp/ae-mcp-host-dispatcher-test
           && /tmp/ae-mcp-host-dispatcher-test
+
+      - name: Build and run the portable native RPC codec test
+        run: >-
+          c++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -pthread
+          -I native/ae-plugin/include
+          native/ae-plugin/src/core/rpc_codec.cpp
+          native/ae-plugin/tests/rpc_codec_test.cpp
+          -o /tmp/ae-mcp-rpc-codec-test
+          && /tmp/ae-mcp-rpc-codec-test
+
+      - name: Build and run the portable native RPC connection test
+        run: >-
+          c++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -pthread
+          -I native/ae-plugin/include
+          native/ae-plugin/src/core/host_dispatcher.cpp
+          native/ae-plugin/src/core/rpc_codec.cpp
+          native/ae-plugin/src/core/native_rpc_connection.cpp
+          native/ae-plugin/tests/native_rpc_connection_test.cpp
+          -o /tmp/ae-mcp-native-rpc-connection-test
+          && /tmp/ae-mcp-native-rpc-connection-test
+
+      - name: Build and run the portable native pairing and transport tests
+        run: |
+          c++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -pthread \
+            -I native/ae-plugin/include \
+            native/ae-plugin/src/core/pairing_gate.cpp \
+            native/ae-plugin/tests/pairing_gate_test.cpp \
+            -o /tmp/ae-mcp-pairing-gate-test
+          /tmp/ae-mcp-pairing-gate-test
+          c++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -pthread \
+            -I native/ae-plugin/include \
+            native/ae-plugin/src/core/transport_auth.cpp \
+            native/ae-plugin/tests/transport_auth_test.cpp \
+            -o /tmp/ae-mcp-transport-auth-test
+          /tmp/ae-mcp-transport-auth-test
 
       - name: Run packaging contract tests
         run: node --test scripts/package/test/*.test.mjs

--- a/native/ae-plugin/build-macos.mjs
+++ b/native/ae-plugin/build-macos.mjs
@@ -338,8 +338,27 @@ async function buildMacPluginInternal({
     await fs.promises.mkdir(stage, { mode: 0o700 });
     stageOwned = true;
     const productInputPaths = [
+      'native/ae-plugin/include/aemcp_native/endpoint_registry_macos.hpp',
       'native/ae-plugin/include/aemcp_native/host_dispatcher.hpp',
+      'native/ae-plugin/include/aemcp_native/mac_ipc_server.hpp',
+      'native/ae-plugin/include/aemcp_native/native_rpc_connection.hpp',
+      'native/ae-plugin/include/aemcp_native/pairing_gate.hpp',
+      'native/ae-plugin/include/aemcp_native/pairing_ui_macos.hpp',
+      'native/ae-plugin/include/aemcp_native/peer_identity.hpp',
+      'native/ae-plugin/include/aemcp_native/peer_identity_macos.hpp',
+      'native/ae-plugin/include/aemcp_native/rpc_codec.hpp',
+      'native/ae-plugin/include/aemcp_native/secure_random_macos.hpp',
+      'native/ae-plugin/include/aemcp_native/transport_auth.hpp',
       'native/ae-plugin/src/core/host_dispatcher.cpp',
+      'native/ae-plugin/src/core/native_rpc_connection.cpp',
+      'native/ae-plugin/src/core/pairing_gate.cpp',
+      'native/ae-plugin/src/core/rpc_codec.cpp',
+      'native/ae-plugin/src/core/transport_auth.cpp',
+      'native/ae-plugin/src/platform/macos/endpoint_registry_macos.cpp',
+      'native/ae-plugin/src/platform/macos/mac_ipc_server.cpp',
+      'native/ae-plugin/src/platform/macos/pairing_ui_macos.mm',
+      'native/ae-plugin/src/platform/macos/peer_identity_macos.cpp',
+      'native/ae-plugin/src/platform/macos/secure_random_macos.cpp',
       'native/ae-plugin/src/aegp/plugin_entry.cpp',
       'native/ae-plugin/resources/Info.plist',
       'native/ae-plugin/resources/AeMcpNative_PiPL.r',
@@ -438,20 +457,38 @@ async function buildMacPluginInternal({
       ...includes,
     ];
     const sourceFiles = [
-      productInputs.get('native/ae-plugin/src/core/host_dispatcher.cpp'),
-      productInputs.get('native/ae-plugin/src/aegp/plugin_entry.cpp'),
+      'native/ae-plugin/src/core/host_dispatcher.cpp',
+      'native/ae-plugin/src/core/native_rpc_connection.cpp',
+      'native/ae-plugin/src/core/pairing_gate.cpp',
+      'native/ae-plugin/src/core/rpc_codec.cpp',
+      'native/ae-plugin/src/core/transport_auth.cpp',
+      'native/ae-plugin/src/platform/macos/endpoint_registry_macos.cpp',
+      'native/ae-plugin/src/platform/macos/mac_ipc_server.cpp',
+      'native/ae-plugin/src/platform/macos/pairing_ui_macos.mm',
+      'native/ae-plugin/src/platform/macos/peer_identity_macos.cpp',
+      'native/ae-plugin/src/platform/macos/secure_random_macos.cpp',
+      'native/ae-plugin/src/aegp/plugin_entry.cpp',
     ];
     const objectFiles = [];
-    for (const [index, source] of sourceFiles.entries()) {
+    for (const [index, relativePath] of sourceFiles.entries()) {
+      const source = productInputs.get(relativePath);
       const object = path.join(objects, `${index}.o`);
-      command(clang, [...compileFlags, '-c', source, '-o', object], redactions);
+      const languageFlags = relativePath.endsWith('.mm') ? ['-fobjc-arc'] : [];
+      command(clang, [
+        ...compileFlags, ...languageFlags, '-c', source, '-o', object,
+      ], redactions);
       objectFiles.push(object);
     }
     command(clang, [
       '-bundle', '-arch', 'arm64', '-mmacosx-version-min=14.0', '-pthread',
       '-isysroot', sysroot,
       '-Wl,-dead_strip', '-Wl,-exported_symbol,_AeMcpNativeMain',
-      ...objectFiles, '-framework', 'CoreFoundation', '-o', executable,
+      ...objectFiles,
+      '-framework', 'AppKit',
+      '-framework', 'CoreFoundation',
+      '-framework', 'Security',
+      '-lbsm',
+      '-o', executable,
     ], redactions);
     command(rez, [
       '-useDF', '-arch', 'arm64', '-isysroot', sysroot,

--- a/native/ae-plugin/include/aemcp_native/endpoint_registry_macos.hpp
+++ b/native/ae-plugin/include/aemcp_native/endpoint_registry_macos.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "aemcp_native/peer_identity.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace aemcp::native {
+
+struct NativeEndpointDescriptor {
+  std::uint32_t schema_version{1};
+  std::string host_instance_id;
+  ExpectedProcess host_process;
+  std::string socket_name;
+  std::uint32_t wire_version{1};
+  std::string source_commit;
+};
+
+enum class EndpointCode {
+  kOk,
+  kInvalidArgument,
+  kRuntimeRootUnavailable,
+  kRuntimeRootUnsafe,
+  kDirectoryLimitExceeded,
+  kStaleEntryUnsafe,
+  kSocketCreateFailed,
+  kSocketPublishFailed,
+  kDescriptorPublishFailed,
+  kEndpointReplaced,
+  kAlreadyStarted,
+};
+
+struct EndpointResult {
+  EndpointCode code{EndpointCode::kInvalidArgument};
+  std::string diagnostic;
+
+  [[nodiscard]] bool ok() const noexcept { return code == EndpointCode::kOk; }
+};
+
+struct EndpointRegistryConfig {
+  // Empty selects confstr(_CS_DARWIN_USER_TEMP_DIR). Tests may inject a
+  // private, already-created 0700 directory; product code must leave it empty.
+  std::string runtime_root;
+  std::string endpoint_nonce;
+  int listen_backlog{2};
+  std::size_t maximum_directory_entries{128};
+};
+
+// Owns one per-AE AF_UNIX listener and its untrusted discovery descriptor.
+// Secrets are deliberately absent from the descriptor. All filesystem work is
+// anchored to validated directory descriptors and cleanup is inode-checked.
+class MacEndpointRegistry final {
+ public:
+  MacEndpointRegistry(PeerIdentityBackend& process_backend, EndpointRegistryConfig config);
+  MacEndpointRegistry(const MacEndpointRegistry&) = delete;
+  MacEndpointRegistry& operator=(const MacEndpointRegistry&) = delete;
+  ~MacEndpointRegistry();
+
+  [[nodiscard]] EndpointResult start(NativeEndpointDescriptor descriptor);
+  [[nodiscard]] EndpointResult verify() const;
+  void stop() noexcept;
+
+  [[nodiscard]] int listener_fd() const noexcept { return listener_fd_; }
+  [[nodiscard]] const NativeEndpointDescriptor& descriptor() const noexcept {
+    return descriptor_;
+  }
+  [[nodiscard]] const std::string& descriptor_path() const noexcept {
+    return descriptor_path_;
+  }
+  [[nodiscard]] const std::string& socket_path() const noexcept { return socket_path_; }
+
+  [[nodiscard]] static bool parse_descriptor(
+      const std::string& text,
+      NativeEndpointDescriptor& output) noexcept;
+  [[nodiscard]] static std::string serialize_descriptor(
+      const NativeEndpointDescriptor& descriptor);
+
+ private:
+  struct PublishedEntry {
+    std::string name;
+    std::uint64_t device{0};
+    std::uint64_t inode{0};
+  };
+
+  [[nodiscard]] EndpointResult open_directories();
+  [[nodiscard]] EndpointResult cleanup_stale();
+  [[nodiscard]] EndpointResult create_listener();
+  [[nodiscard]] EndpointResult publish_descriptor();
+  [[nodiscard]] bool safe_unlink(const PublishedEntry& entry, bool socket) const noexcept;
+
+  PeerIdentityBackend& process_backend_;
+  const EndpointRegistryConfig config_;
+  NativeEndpointDescriptor descriptor_;
+  int root_fd_{-1};
+  int directory_fd_{-1};
+  int listener_fd_{-1};
+  std::string runtime_root_;
+  std::string directory_path_;
+  std::string descriptor_path_;
+  std::string socket_path_;
+  PublishedEntry descriptor_entry_;
+  PublishedEntry socket_entry_;
+  bool started_{false};
+};
+
+[[nodiscard]] const char* endpoint_code_name(EndpointCode code) noexcept;
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/host_dispatcher.hpp
+++ b/native/ae-plugin/include/aemcp_native/host_dispatcher.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -20,6 +21,8 @@ using TimePoint = std::chrono::steady_clock::time_point;
 class Clock {
  public:
   virtual ~Clock() = default;
+  // Dispatch admission and transport workers may call this concurrently.
+  // Implementations must be thread-safe and monotonic.
   [[nodiscard]] virtual TimePoint now() const noexcept = 0;
 };
 
@@ -54,6 +57,11 @@ struct Request {
   std::string request_id;
   std::string capability_id;
   TimePoint deadline;
+  // Opaque transport ownership. Authenticated IPC callers must supply a
+  // non-empty route and monotonically increase the generation whenever that
+  // route is re-bound.
+  std::string route_id{};
+  std::uint64_t session_generation{0};
 };
 
 enum class EnqueueCode {
@@ -63,6 +71,7 @@ enum class EnqueueCode {
   kDuplicateRequest,
   kDeadlineExceeded,
   kQueueFull,
+  kStaleRoute,
   kShuttingDown,
 };
 
@@ -74,11 +83,39 @@ struct EnqueueResult {
 struct Completion {
   std::string request_id;
   std::string capability_id;
+  std::string route_id;
+  std::uint64_t session_generation{0};
   bool ok{false};
   ProjectSummary result;
   std::string error_code;
   std::string message;
   bool late_result_discarded{false};
+  // This is a snapshot for audit/filtering, not a send authorization. A
+  // transport must exact-match route+generation under the same connection lock
+  // used by close/revoke immediately before writing to a socket.
+  bool route_revoked{false};
+};
+
+enum class CancelCode {
+  kQueuedCancelled,
+  kRunningNotCancellable,
+  kAlreadyTerminal,
+  kNotFound,
+  kInvalidRequest,
+  kStaleRoute,
+};
+
+struct CancelResult {
+  CancelCode code{CancelCode::kInvalidRequest};
+  bool terminal_response_expected{false};
+};
+
+struct RouteRevocationResult {
+  bool fence_recorded{false};
+  bool fence_saturated{false};
+  std::size_t queued_cancelled{0};
+  std::size_t running_detached{0};
+  std::size_t pending_outbound_marked{0};
 };
 
 struct DrainBatch {
@@ -92,6 +129,10 @@ struct DispatcherConfig {
   std::size_t max_queue_depth{32};
   std::size_t max_tasks_per_idle{4};
   std::chrono::milliseconds idle_budget{4};
+  std::size_t max_outbound_depth{64};
+  std::size_t max_terminal_tombstones{128};
+  std::chrono::milliseconds terminal_ttl{60000};
+  std::size_t max_route_fences{128};
 };
 
 class HostDispatcher final {
@@ -101,16 +142,62 @@ class HostDispatcher final {
   HostDispatcher& operator=(const HostDispatcher&) = delete;
 
   [[nodiscard]] EnqueueResult enqueue(Request request);
+  [[nodiscard]] CancelResult cancel(
+      std::string_view route_id,
+      std::uint64_t session_generation,
+      std::string_view target_request_id);
+  [[nodiscard]] RouteRevocationResult revoke_route(
+      std::string_view route_id, std::uint64_t session_generation);
   [[nodiscard]] DrainBatch drain(HostApi& host);
+  // Worker-side transfer only. Host suite calls and socket I/O intentionally
+  // live on opposite sides of this bounded queue. Returned generations remain
+  // immutable, but the transport owns the final synchronized send decision.
+  [[nodiscard]] std::vector<Completion> take_outbound(std::size_t max_items = 64);
+  // Lifecycle shutdown is owner-thread-only, keeping destruction serialized
+  // with drain/HostApi execution. Wrong-thread calls throw std::logic_error.
   [[nodiscard]] std::vector<Completion> shutdown();
   [[nodiscard]] std::size_t queued() const;
+  [[nodiscard]] std::size_t outbound() const;
+  [[nodiscard]] std::size_t terminal_count();
+  [[nodiscard]] bool has_terminal(
+      std::string_view route_id,
+      std::uint64_t session_generation,
+      std::string_view request_id);
   [[nodiscard]] bool running() const;
 
  private:
   enum class State { kRunning, kStopping, kStopped };
 
+  struct RequestKey {
+    std::string route_id;
+    std::uint64_t session_generation{0};
+    std::string request_id;
+
+    [[nodiscard]] bool operator==(const RequestKey&) const = default;
+  };
+
+  struct RequestKeyHash {
+    [[nodiscard]] std::size_t operator()(const RequestKey& key) const noexcept;
+  };
+
+  struct TerminalTombstone {
+    RequestKey key;
+    TimePoint expires_at;
+  };
+
   [[nodiscard]] Completion expired(const Request& request, bool late) const;
-  void finish_request(const std::string& request_id);
+  [[nodiscard]] static RequestKey key_for(const Request& request);
+  [[nodiscard]] bool route_revoked_locked(
+      std::string_view route_id, std::uint64_t session_generation) const;
+  [[nodiscard]] bool route_stale_locked(
+      std::string_view route_id, std::uint64_t session_generation) const;
+  [[nodiscard]] bool pending_outbound_locked(const RequestKey& key) const;
+  [[nodiscard]] bool terminal_locked(const RequestKey& key) const;
+  void purge_terminal_locked(TimePoint now);
+  void remember_terminal_locked(RequestKey key, TimePoint now);
+  [[nodiscard]] bool fence_route_locked(
+      std::string route_id, std::uint64_t session_generation);
+  void finish_request_locked(const RequestKey& key, Completion& completion, TimePoint now);
 
   const std::thread::id owner_thread_;
   Clock& clock_;
@@ -118,7 +205,12 @@ class HostDispatcher final {
   mutable std::mutex mutex_;
   State state_{State::kRunning};
   std::deque<Request> queue_;
-  std::unordered_set<std::string> active_request_ids_;
+  std::deque<Completion> outbound_;
+  std::deque<TerminalTombstone> terminal_tombstones_;
+  std::unordered_set<RequestKey, RequestKeyHash> active_requests_;
+  std::unordered_set<RequestKey, RequestKeyHash> detached_requests_;
+  std::unordered_map<std::string, std::uint64_t> route_fences_;
+  bool route_fences_saturated_{false};
 };
 
 }  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/mac_ipc_server.hpp
+++ b/native/ae-plugin/include/aemcp_native/mac_ipc_server.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "aemcp_native/endpoint_registry_macos.hpp"
+#include "aemcp_native/pairing_gate.hpp"
+#include "aemcp_native/peer_identity.hpp"
+#include "aemcp_native/transport_auth.hpp"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace aemcp::native {
+
+struct AuthenticatedConnection {
+  int socket_fd{-1};
+  PeerBinding peer;
+  std::array<std::uint8_t, 16> client_nonce{};
+  std::string session_id;
+  std::uint32_t session_generation{0};
+};
+
+class AuthenticatedConnectionHandler {
+ public:
+  virtual ~AuthenticatedConnectionHandler() = default;
+  // Runs on the single IPC worker. The server retains fd ownership and closes
+  // it after serve() returns. AE suite calls are forbidden here.
+  virtual void serve(const AuthenticatedConnection& connection) noexcept = 0;
+};
+
+class NativeIpcObserver {
+ public:
+  virtual ~NativeIpcObserver() = default;
+  // event and decision are closed, non-sensitive identifiers. Implementations
+  // must not log endpoint paths, fingerprints, nonces, tokens, or payloads.
+  virtual void on_ipc_event(
+      std::string_view event,
+      std::string_view decision) noexcept = 0;
+};
+
+struct MacIpcServerConfig {
+  std::chrono::milliseconds handshake_timeout{1500};
+  std::chrono::milliseconds pairing_poll_interval{100};
+  std::size_t maximum_ancestor_depth{16};
+  std::int32_t expected_cpu_type{0};
+};
+
+// Minimum P0 authenticated transport. It deliberately does not claim the
+// strict Adobe signing/client-attestation hardening tracked in #89. Admission
+// requires same UID, exact current AE ancestry, and an AEGP-owned explicit
+// pairing decision before the handler sees the connection.
+class MacIpcServer final {
+ public:
+  MacIpcServer(
+      MacEndpointRegistry& endpoint,
+      PeerIdentityBackend& peer_backend,
+      PairingGate& pairing_gate,
+      AuthenticatedConnectionHandler& handler,
+      NativeIpcObserver& observer,
+      MacIpcServerConfig config);
+  MacIpcServer(const MacIpcServer&) = delete;
+  MacIpcServer& operator=(const MacIpcServer&) = delete;
+  ~MacIpcServer();
+
+  [[nodiscard]] bool start();
+  void stop() noexcept;
+
+  [[nodiscard]] std::optional<PendingPairingSnapshot> pending_pairing();
+  [[nodiscard]] bool confirm_pending(
+      const std::string& connection_id,
+      const std::string& fingerprint);
+  [[nodiscard]] bool reject_pending(
+      const std::string& connection_id,
+      const std::string& fingerprint);
+  [[nodiscard]] bool running() const noexcept { return running_.load(); }
+
+ private:
+  void run() noexcept;
+  void handle_connection(int socket_fd) noexcept;
+  [[nodiscard]] std::optional<PeerBinding> admit_peer(
+      int socket_fd,
+      const std::string& connection_id) noexcept;
+  [[nodiscard]] bool same_peer(
+      int socket_fd,
+      const PeerBinding& binding) noexcept;
+  [[nodiscard]] bool read_exact(
+      int socket_fd,
+      std::uint8_t* output,
+      std::size_t size,
+      std::chrono::steady_clock::time_point deadline) noexcept;
+  [[nodiscard]] bool write_exact(
+      int socket_fd,
+      const std::uint8_t* input,
+      std::size_t size,
+      std::chrono::steady_clock::time_point deadline) noexcept;
+  void close_active(int socket_fd) noexcept;
+
+  MacEndpointRegistry& endpoint_;
+  PeerIdentityBackend& peer_backend_;
+  PairingGate& pairing_gate_;
+  AuthenticatedConnectionHandler& handler_;
+  NativeIpcObserver& observer_;
+  const MacIpcServerConfig config_;
+  std::atomic<bool> stop_requested_{false};
+  std::atomic<bool> running_{false};
+  std::thread worker_;
+  std::mutex active_mutex_;
+  int active_fd_{-1};
+  std::atomic<std::uint32_t> next_session_generation_{1};
+};
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/native_rpc_connection.hpp
+++ b/native/ae-plugin/include/aemcp_native/native_rpc_connection.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "aemcp_native/host_dispatcher.hpp"
+#include "aemcp_native/mac_ipc_server.hpp"
+#include "aemcp_native/rpc_codec.hpp"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace aemcp::native {
+
+struct NativeRpcRuntimeInfo {
+  std::string plugin_version;
+  std::string compiled_sdk_version;
+  std::uint64_t compiled_sdk_build{0};
+  std::string host_version;
+  std::uint64_t host_build{0};
+  std::string host_instance_id;
+  std::string capabilities_digest;
+  std::string project_summary_contract_digest;
+};
+
+class NativeRpcObserver {
+ public:
+  virtual ~NativeRpcObserver() = default;
+  virtual void on_rpc_event(
+      std::string_view event,
+      std::string_view request_id,
+      std::string_view decision) noexcept = 0;
+  virtual void on_rpc_terminal(
+      const Completion& completion,
+      std::string_view request_digest,
+      std::string_view postcondition_digest,
+      std::uint64_t started_at_unix_ms,
+      std::uint64_t completed_at_unix_ms) noexcept = 0;
+};
+
+// Owns #72 framing/session state on the single IPC worker and bridges only
+// admitted invoke/cancel requests to HostDispatcher. It never calls HostApi.
+class NativeRpcConnectionHandler final : public AuthenticatedConnectionHandler {
+ public:
+  NativeRpcConnectionHandler(
+      HostDispatcher& dispatcher,
+      Clock& dispatcher_clock,
+      rpc::SessionClock& session_clock,
+      NativeRpcRuntimeInfo runtime,
+      NativeRpcObserver& observer);
+
+  void serve(const AuthenticatedConnection& connection) noexcept override;
+
+ private:
+  HostDispatcher& dispatcher_;
+  Clock& dispatcher_clock_;
+  rpc::SessionClock& session_clock_;
+  const NativeRpcRuntimeInfo runtime_;
+  NativeRpcObserver& observer_;
+};
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/pairing_gate.hpp
+++ b/native/ae-plugin/include/aemcp_native/pairing_gate.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace aemcp::native {
+
+using PairingTimePoint = std::chrono::steady_clock::time_point;
+
+struct PeerBinding {
+  std::int32_t pid{0};
+  std::uint32_t pid_version{0};
+  std::uint32_t uid{0};
+  std::uint32_t audit_session{0};
+  std::string connection_id;
+  std::string host_instance_id;
+
+  [[nodiscard]] bool valid() const noexcept;
+  friend bool operator==(const PeerBinding&, const PeerBinding&) = default;
+};
+
+struct PairingMaterial {
+  std::array<std::uint8_t, 32> capability{};
+  std::string fingerprint;
+};
+
+class PairingMaterialSource {
+ public:
+  virtual ~PairingMaterialSource() = default;
+  [[nodiscard]] virtual PairingMaterial create() = 0;
+};
+
+class PairingGateClock {
+ public:
+  virtual ~PairingGateClock() = default;
+  [[nodiscard]] virtual PairingTimePoint now() const noexcept = 0;
+};
+
+class SystemPairingGateClock final : public PairingGateClock {
+ public:
+  [[nodiscard]] PairingTimePoint now() const noexcept override;
+};
+
+enum class BeginPairingCode {
+  kPending,
+  kBusy,
+  kInvalidBinding,
+  kMaterialFailure,
+  kShuttingDown,
+};
+
+struct BeginPairingResult {
+  BeginPairingCode code{BeginPairingCode::kInvalidBinding};
+  std::string fingerprint;
+  std::chrono::milliseconds expires_in{0};
+};
+
+enum class PairingDecision {
+  kAuthorized,
+  kRejected,
+  kExpired,
+  kRevoked,
+  kUnknown,
+  kShuttingDown,
+};
+
+struct PendingPairingSnapshot {
+  PeerBinding binding;
+  std::string fingerprint;
+  std::chrono::milliseconds expires_in{0};
+};
+
+struct PairingGateConfig {
+  std::chrono::milliseconds pending_ttl{30000};
+};
+
+// PairingGate is the in-memory user-presence boundary. A peer must already have
+// passed OS/process authentication before begin() is called. The 256-bit
+// capability never leaves this object; only its short display fingerprint is
+// exposed. Authorization is bound to the exact PeerBinding and is revoked on
+// disconnect, expiry, peer generation change, or shutdown.
+class PairingGate final {
+ public:
+  PairingGate(
+      PairingGateClock& clock,
+      PairingMaterialSource& material_source,
+      PairingGateConfig config = {});
+  PairingGate(const PairingGate&) = delete;
+  PairingGate& operator=(const PairingGate&) = delete;
+  ~PairingGate();
+
+  [[nodiscard]] BeginPairingResult begin(const PeerBinding& binding);
+  [[nodiscard]] std::optional<PendingPairingSnapshot> pending();
+
+  // Called only from the AEGP-owned menu/UI after the user has compared the
+  // displayed fingerprint with the ae-mcp panel.
+  [[nodiscard]] bool confirm(
+      const std::string& connection_id,
+      const std::string& fingerprint);
+  [[nodiscard]] bool reject(
+      const std::string& connection_id,
+      const std::string& fingerprint);
+
+  [[nodiscard]] PairingDecision wait_for_decision(
+      const PeerBinding& binding,
+      PairingTimePoint deadline);
+  [[nodiscard]] bool authorized(const PeerBinding& binding);
+
+  void revoke(const PeerBinding& binding);
+  void revoke_connection(const std::string& connection_id);
+  void shutdown();
+
+ private:
+  enum class State { kPending, kAuthorized, kRejected, kRevoked };
+
+  struct Entry {
+    PeerBinding binding;
+    std::array<std::uint8_t, 32> capability{};
+    std::string fingerprint;
+    PairingTimePoint expires_at{};
+    State state{State::kPending};
+  };
+
+  void expire_locked(PairingTimePoint now);
+  void clear_locked() noexcept;
+  [[nodiscard]] static bool valid_fingerprint(const std::string& value) noexcept;
+
+  PairingGateClock& clock_;
+  PairingMaterialSource& material_source_;
+  const PairingGateConfig config_;
+  std::mutex mutex_;
+  std::condition_variable changed_;
+  std::optional<Entry> entry_;
+  bool shutting_down_{false};
+};
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/pairing_ui_macos.hpp
+++ b/native/ae-plugin/include/aemcp_native/pairing_ui_macos.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <chrono>
+#include <string_view>
+
+namespace aemcp::native {
+
+enum class PairingUiDecision { kAuthorize, kReject, kUnavailable };
+
+[[nodiscard]] PairingUiDecision show_pairing_confirmation(
+    std::string_view fingerprint,
+    std::chrono::milliseconds expires_in) noexcept;
+void show_no_pending_pairing() noexcept;
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/peer_identity.hpp
+++ b/native/ae-plugin/include/aemcp_native/peer_identity.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace aemcp::native {
+
+struct ProcessGeneration {
+  std::uint64_t start_seconds{0};
+  std::uint64_t start_microseconds{0};
+
+  [[nodiscard]] bool valid() const noexcept { return start_seconds != 0; }
+  friend bool operator==(const ProcessGeneration&, const ProcessGeneration&) = default;
+};
+
+struct ExpectedProcess {
+  std::int32_t pid{0};
+  ProcessGeneration generation;
+
+  [[nodiscard]] bool valid() const noexcept { return pid > 1 && generation.valid(); }
+};
+
+struct SocketPeerEvidence {
+  std::int32_t pid{0};
+  std::uint32_t euid{0};
+  std::uint32_t egid{0};
+  std::uint32_t audit_session{0};
+  std::uint32_t pid_version{0};
+
+  friend bool operator==(const SocketPeerEvidence&, const SocketPeerEvidence&) = default;
+};
+
+struct ProcessSnapshot {
+  std::int32_t pid{0};
+  std::int32_t parent_pid{0};
+  std::uint32_t uid{0};
+  ProcessGeneration generation;
+  std::int32_t cpu_type{0};
+  bool traced{false};
+  bool exiting{false};
+
+  friend bool operator==(const ProcessSnapshot&, const ProcessSnapshot&) = default;
+};
+
+class PeerIdentityBackend {
+ public:
+  virtual ~PeerIdentityBackend() = default;
+  [[nodiscard]] virtual bool socket_peer(int socket_fd, SocketPeerEvidence& output) = 0;
+  [[nodiscard]] virtual bool process_snapshot(std::int32_t pid, ProcessSnapshot& output) = 0;
+};
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/peer_identity_macos.hpp
+++ b/native/ae-plugin/include/aemcp_native/peer_identity_macos.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "aemcp_native/peer_identity.hpp"
+
+#include <memory>
+
+namespace aemcp::native {
+
+[[nodiscard]] std::unique_ptr<PeerIdentityBackend> create_macos_peer_identity_backend();
+[[nodiscard]] ExpectedProcess current_macos_process(PeerIdentityBackend& backend);
+[[nodiscard]] std::int32_t macos_native_cpu_type() noexcept;
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
+++ b/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
@@ -1,0 +1,344 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace aemcp::native::rpc {
+
+inline constexpr std::size_t kFramePrefixBytes = 4;
+inline constexpr std::size_t kMaxFrameBytes = 65'536;
+inline constexpr std::size_t kMaxJsonDepth = 16;
+inline constexpr std::size_t kMaxJsonNodes = 2'048;
+inline constexpr std::size_t kMaxStringScalars = 8'192;
+inline constexpr std::uint64_t kMaxSafeInteger = 9'007'199'254'740'991ULL;
+
+enum class CodecErrorKind {
+  kInvalidRequest,
+  kInvalidArgument,
+  kSessionStale,
+};
+
+class CodecError final : public std::runtime_error {
+ public:
+  CodecError(CodecErrorKind kind, std::string message);
+  [[nodiscard]] CodecErrorKind kind() const noexcept { return kind_; }
+  [[nodiscard]] std::string_view error_code() const noexcept;
+
+ private:
+  CodecErrorKind kind_;
+};
+
+enum class RpcMethod { kHello, kCapabilities, kInvoke, kCancel };
+enum class ClientComponent { kCoreBroker, kDevelopmentSmoke };
+enum class CapabilityDetail { kSummary, kFull };
+
+struct HelloParams {
+  std::uint16_t minimum_wire_version{0};
+  std::uint16_t maximum_wire_version{0};
+  ClientComponent component{ClientComponent::kCoreBroker};
+  std::string client_version;
+  std::string client_instance_id;
+  std::string nonce;
+};
+
+struct CapabilitiesParams {
+  std::optional<std::vector<std::string>> ids;
+  CapabilityDetail detail{CapabilityDetail::kSummary};
+  bool detail_was_provided{false};
+  std::uint16_t limit{50};
+  bool limit_was_provided{false};
+};
+
+struct InvokeParams {
+  std::string capability_id{"ae.project.summary"};
+  std::uint16_t capability_version{1};
+};
+
+struct CancelParams {
+  std::string target_request_id;
+};
+
+using RequestParams = std::variant<HelloParams, CapabilitiesParams, InvokeParams, CancelParams>;
+
+struct ParsedRequest {
+  RpcMethod method{RpcMethod::kHello};
+  std::string request_id;
+  std::optional<std::string> session_id;
+  std::optional<std::uint64_t> deadline_unix_ms;
+  RequestParams params{HelloParams{}};
+
+  // SHA-256 over the normalized, closed request envelope. Raw untrusted JSON is
+  // deliberately not retained by the public API.
+  std::string request_fingerprint_sha256;
+};
+
+[[nodiscard]] ParsedRequest decode_request_frame(std::span<const std::uint8_t> frame);
+[[nodiscard]] std::string digest_capabilities_query(
+    std::string_view session_id,
+    const CapabilitiesParams& params);
+[[nodiscard]] std::string digest_project_summary_postcondition(
+    bool project_open,
+    std::string_view project_name,
+    std::uint64_t item_count);
+
+class FrameDecoder final {
+ public:
+  // A transport adapter must pass chunks no larger than one maximum frame and
+  // its prefix. One push can still yield multiple small frames.
+  [[nodiscard]] std::vector<ParsedRequest> push(std::span<const std::uint8_t> chunk);
+  void finalize();
+  [[nodiscard]] bool failed() const noexcept { return failed_; }
+  [[nodiscard]] std::size_t pending_bytes() const noexcept { return pending_.size(); }
+
+ private:
+  std::vector<std::uint8_t> pending_;
+  bool failed_{false};
+};
+
+class SessionClock {
+ public:
+  virtual ~SessionClock() = default;
+  [[nodiscard]] virtual std::uint64_t now_unix_ms() const noexcept = 0;
+};
+
+class SystemSessionClock final : public SessionClock {
+ public:
+  [[nodiscard]] std::uint64_t now_unix_ms() const noexcept override;
+};
+
+struct SessionFrontDoorConfig {
+  std::size_t max_active_requests{64};
+  std::size_t max_terminal_tombstones{128};
+  std::uint64_t tombstone_ttl_ms{60'000};
+  std::uint64_t default_deadline_ms{5'000};
+  std::uint64_t maximum_deadline_ms{30'000};
+};
+
+enum class SessionIngressCode {
+  kAcceptedHello,
+  kAcceptedRequest,
+  kPairingRequired,
+  kAuthorizationRequired,
+  kHelloRequired,
+  kWireVersionMismatch,
+  kInvalidRequest,
+  kSessionStale,
+  kDuplicateRequest,
+  kDeadlineExceeded,
+  kInvalidDeadline,
+  kLedgerFull,
+  kClosed,
+};
+
+struct SessionIngressResult {
+  SessionIngressCode code{SessionIngressCode::kClosed};
+  std::string error_code;
+  std::optional<std::uint64_t> effective_deadline_unix_ms;
+  bool duplicate_content_matches{false};
+
+  [[nodiscard]] bool accepted() const noexcept {
+    return code == SessionIngressCode::kAcceptedHello
+        || code == SessionIngressCode::kAcceptedRequest;
+  }
+  [[nodiscard]] bool dispatchable() const noexcept {
+    return code == SessionIngressCode::kAcceptedRequest;
+  }
+};
+
+// Transport authentication happens outside this class. The front door binds
+// the resulting connection to trusted host/session identifiers and cannot mint
+// identifiers or inspect OS identity itself. It is intentionally single-owner:
+// every method (including complete_request) must run on one connection worker.
+// The AE owner thread publishes dispatcher completions to an outbound queue and
+// never calls this object. Concurrent use is unsupported.
+class RpcSessionFrontDoor final {
+ public:
+  RpcSessionFrontDoor(
+      std::string connection_id,
+      std::string host_instance_id,
+      std::string session_id,
+      SessionClock& clock,
+      SessionFrontDoorConfig config = {});
+
+  [[nodiscard]] bool authorize_pairing() noexcept;
+  void revoke_pairing() noexcept;
+  [[nodiscard]] SessionIngressResult admit(const ParsedRequest& request);
+  [[nodiscard]] bool complete_request(std::string_view request_id);
+  void close() noexcept;
+
+  [[nodiscard]] bool paired() const noexcept { return paired_; }
+  [[nodiscard]] bool hello_complete() const noexcept { return hello_complete_; }
+  [[nodiscard]] bool closed() const noexcept { return closed_; }
+  [[nodiscard]] std::string_view connection_id() const noexcept { return connection_id_; }
+  [[nodiscard]] std::string_view host_instance_id() const noexcept { return host_instance_id_; }
+  [[nodiscard]] std::string_view session_id() const noexcept { return session_id_; }
+  [[nodiscard]] std::size_t active_request_count() const noexcept { return active_.size(); }
+  [[nodiscard]] std::size_t tombstone_count() const noexcept { return tombstones_.size(); }
+
+ private:
+  struct ActiveEntry {
+    std::string fingerprint;
+    std::uint64_t effective_deadline_unix_ms{0};
+  };
+  struct Tombstone {
+    std::string request_id;
+    std::string fingerprint;
+    std::uint64_t expires_at_unix_ms{0};
+  };
+
+  void cleanup(std::uint64_t now);
+  void add_tombstone(
+      std::string request_id, std::string fingerprint, std::uint64_t now);
+
+  std::string connection_id_;
+  std::string host_instance_id_;
+  std::string session_id_;
+  SessionClock& clock_;
+  SessionFrontDoorConfig config_;
+  bool paired_{false};
+  bool hello_complete_{false};
+  bool closed_{false};
+  std::unordered_map<std::string, ActiveEntry> active_;
+  std::deque<Tombstone> tombstones_;
+};
+
+struct NegotiatedLimits {
+  std::uint32_t max_frame_bytes{65'536};
+  std::uint16_t max_in_flight{8};
+  std::uint16_t max_queue_depth{32};
+  std::uint32_t max_deadline_ms{30'000};
+  std::uint16_t max_requests_per_second{10};
+  std::uint16_t max_burst{4};
+  std::uint16_t max_control_in_flight{1};
+  std::uint16_t max_control_requests_per_second{20};
+  std::uint16_t max_control_burst{4};
+  std::uint16_t max_terminal_cache_entries{128};
+  std::uint32_t terminal_cache_ttl_ms{60'000};
+};
+
+struct HelloSuccess {
+  std::string request_id;
+  std::string session_id;
+  std::string client_nonce;
+  std::string plugin_version;
+  std::string compiled_sdk_version;
+  std::uint64_t compiled_sdk_build{0};
+  std::string architecture;
+  std::string host_version;
+  std::uint64_t host_build{0};
+  std::string platform;
+  std::string host_instance_id;
+  std::uint64_t session_generation{0};
+  NegotiatedLimits limits;
+  std::string capabilities_digest;
+};
+
+struct CapabilitiesSuccess {
+  std::string request_id;
+  std::string session_id;
+  CapabilityDetail detail{CapabilityDetail::kSummary};
+  bool include_project_summary{true};
+  std::string query_digest;
+  std::string capabilities_digest;
+  // Required only for detail=full when the descriptor is included.
+  std::string project_summary_contract_digest;
+};
+
+enum class ProgressPhase { kQueued, kDispatched, kRunning, kValidating };
+
+struct ProgressEvent {
+  std::string request_id;
+  std::string session_id;
+  std::uint64_t sequence{0};
+  ProgressPhase phase{ProgressPhase::kQueued};
+  double fraction{0.0};
+  std::string message;
+};
+
+struct ProjectSummarySuccess {
+  std::string request_id;
+  std::string session_id;
+  std::string host_instance_id;
+  bool project_open{false};
+  std::string project_name;
+  std::uint64_t item_count{0};
+  std::uint64_t started_at_unix_ms{0};
+  std::uint64_t completed_at_unix_ms{0};
+  std::string request_digest;
+  std::string postcondition_digest;
+  bool replayed{false};
+};
+
+enum class CancelState {
+  kQueuedCancelled,
+  kRunningCancelRequested,
+  kRunningNotCancellable,
+  kAlreadyTerminal,
+  kNotFound,
+};
+
+struct CancelSuccess {
+  std::string request_id;
+  std::string session_id;
+  std::string target_request_id;
+  CancelState state{CancelState::kNotFound};
+  bool terminal_response_expected{false};
+};
+
+enum class RpcErrorCode {
+  kNativeUnavailable,
+  kNativeUnsupported,
+  kWireVersionMismatch,
+  kInvalidRequest,
+  kInvalidArgument,
+  kDuplicateRequest,
+  kPreconditionFailed,
+  kStaleLocator,
+  kDeadlineExceeded,
+  kCancelled,
+  kQueueFull,
+  kAeShuttingDown,
+  kSessionStale,
+  kCapabilityFailed,
+  kPossiblySideEffectingFailure,
+};
+
+struct ErrorDetails {
+  std::optional<std::string> field;
+  std::optional<std::string> capability_id;
+  std::optional<std::uint16_t> supported_wire_minimum;
+  std::optional<std::uint16_t> supported_wire_maximum;
+  std::optional<std::uint64_t> current_generation;
+};
+
+struct ErrorResponse {
+  RpcMethod method{RpcMethod::kHello};
+  std::string request_id;
+  std::optional<std::string> session_id;
+  RpcErrorCode code{RpcErrorCode::kInvalidRequest};
+  std::string message;
+  std::string recovery_hint;
+  std::optional<std::uint32_t> retry_after_ms;
+  std::optional<ErrorDetails> details;
+};
+
+[[nodiscard]] std::vector<std::uint8_t> encode_hello_success(const HelloSuccess& response);
+[[nodiscard]] std::vector<std::uint8_t> encode_capabilities_success(
+    const CapabilitiesSuccess& response);
+[[nodiscard]] std::vector<std::uint8_t> encode_progress_event(const ProgressEvent& event);
+[[nodiscard]] std::vector<std::uint8_t> encode_project_summary_success(
+    const ProjectSummarySuccess& response);
+[[nodiscard]] std::vector<std::uint8_t> encode_cancel_success(
+    const CancelSuccess& response);
+[[nodiscard]] std::vector<std::uint8_t> encode_error_response(const ErrorResponse& response);
+
+}  // namespace aemcp::native::rpc

--- a/native/ae-plugin/include/aemcp_native/secure_random_macos.hpp
+++ b/native/ae-plugin/include/aemcp_native/secure_random_macos.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "aemcp_native/pairing_gate.hpp"
+
+#include <string>
+
+namespace aemcp::native {
+
+class MacPairingMaterialSource final : public PairingMaterialSource {
+ public:
+  [[nodiscard]] PairingMaterial create() override;
+};
+
+// Returns a lower-case RFC 4122 version-4 UUID using SecRandomCopyBytes.
+// Failure throws; callers must fail closed rather than substituting time/PID.
+[[nodiscard]] std::string secure_uuid_v4();
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/include/aemcp_native/transport_auth.hpp
+++ b/native/ae-plugin/include/aemcp_native/transport_auth.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace aemcp::native {
+
+inline constexpr std::size_t kTransportAuthPrefaceBytes = 24;
+inline constexpr std::size_t kTransportAuthPendingBytes = 57;
+inline constexpr std::size_t kTransportAuthDecisionBytes = 49;
+
+struct TransportAuthPreface {
+  std::array<std::uint8_t, 16> client_nonce{};
+};
+
+struct TransportAuthPending {
+  std::string fingerprint;
+  std::chrono::milliseconds expires_in{0};
+  std::string host_instance_id;
+};
+
+enum class TransportAuthDecisionCode : std::uint8_t {
+  kAuthorized = 1,
+  kRejected = 2,
+  kExpired = 3,
+  kRevoked = 4,
+  kShuttingDown = 5,
+};
+
+struct TransportAuthDecision {
+  TransportAuthDecisionCode code{TransportAuthDecisionCode::kRejected};
+  std::string session_id;
+  std::uint32_t session_generation{0};
+};
+
+[[nodiscard]] std::array<std::uint8_t, kTransportAuthPrefaceBytes>
+serialize_auth_preface(const TransportAuthPreface& value);
+[[nodiscard]] bool parse_auth_preface(
+    const std::array<std::uint8_t, kTransportAuthPrefaceBytes>& bytes,
+    TransportAuthPreface& output) noexcept;
+
+[[nodiscard]] std::array<std::uint8_t, kTransportAuthPendingBytes>
+serialize_auth_pending(const TransportAuthPending& value);
+[[nodiscard]] bool parse_auth_pending(
+    const std::array<std::uint8_t, kTransportAuthPendingBytes>& bytes,
+    TransportAuthPending& output) noexcept;
+
+[[nodiscard]] std::array<std::uint8_t, kTransportAuthDecisionBytes>
+serialize_auth_decision(const TransportAuthDecision& value);
+[[nodiscard]] bool parse_auth_decision(
+    const std::array<std::uint8_t, kTransportAuthDecisionBytes>& bytes,
+    TransportAuthDecision& output) noexcept;
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/aegp/plugin_entry.cpp
+++ b/native/ae-plugin/src/aegp/plugin_entry.cpp
@@ -615,6 +615,33 @@ A_Err command_hook(
   }
 }
 
+A_Err update_menu_hook(
+    AEGP_GlobalRefcon global_refcon,
+    AEGP_UpdateMenuRefcon,
+    AEGP_WindowType) noexcept {
+  try {
+    auto* state = reinterpret_cast<PluginState*>(global_refcon);
+    if (state == nullptr || state->pairing_command == 0) return A_Err_GENERIC;
+
+    const AEGP_CommandSuite1* command_suite = nullptr;
+    const SPErr acquire_error = state->basic->AcquireSuite(
+        kAEGPCommandSuite,
+        kAEGPCommandSuiteVersion1,
+        reinterpret_cast<const void**>(&command_suite));
+    if (acquire_error != 0 || command_suite == nullptr) return A_Err_GENERIC;
+
+    const A_Err enable_error = command_suite->AEGP_EnableCommand(
+        state->pairing_command);
+    const SPErr release_error = state->basic->ReleaseSuite(
+        kAEGPCommandSuite, kAEGPCommandSuiteVersion1);
+    return enable_error == A_Err_NONE && release_error == 0
+        ? A_Err_NONE
+        : A_Err_GENERIC;
+  } catch (...) {
+    return A_Err_GENERIC;
+  }
+}
+
 }  // namespace
 
 extern "C" __attribute__((visibility("default"))) A_Err AeMcpNativeMain(
@@ -682,6 +709,10 @@ extern "C" __attribute__((visibility("default"))) A_Err AeMcpNativeMain(
             AEGP_Command_ALL,
             command_hook,
             0);
+      }
+      if (menu_error == A_Err_NONE) {
+        menu_error = register_suite->AEGP_RegisterUpdateMenuHook(
+            plugin_id, update_menu_hook, 0);
       }
       const SPErr command_release_error = pica_basic->ReleaseSuite(
           kAEGPCommandSuite, kAEGPCommandSuiteVersion1);

--- a/native/ae-plugin/src/aegp/plugin_entry.cpp
+++ b/native/ae-plugin/src/aegp/plugin_entry.cpp
@@ -1,10 +1,19 @@
 #include "aemcp_native/host_dispatcher.hpp"
+#include "aemcp_native/endpoint_registry_macos.hpp"
+#include "aemcp_native/mac_ipc_server.hpp"
+#include "aemcp_native/native_rpc_connection.hpp"
+#include "aemcp_native/pairing_gate.hpp"
+#include "aemcp_native/pairing_ui_macos.hpp"
+#include "aemcp_native/peer_identity_macos.hpp"
+#include "aemcp_native/rpc_codec.hpp"
+#include "aemcp_native/secure_random_macos.hpp"
 
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <charconv>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -13,7 +22,9 @@
 #include <memory>
 #include <mutex>
 #include <new>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -40,6 +51,15 @@ using aemcp::native::DrainBatch;
 using aemcp::native::HostApi;
 using aemcp::native::HostDispatcher;
 using aemcp::native::HostReadResult;
+using aemcp::native::MacEndpointRegistry;
+using aemcp::native::MacIpcServer;
+using aemcp::native::NativeEndpointDescriptor;
+using aemcp::native::NativeIpcObserver;
+using aemcp::native::NativeRpcConnectionHandler;
+using aemcp::native::NativeRpcObserver;
+using aemcp::native::NativeRpcRuntimeInfo;
+using aemcp::native::PairingGate;
+using aemcp::native::PairingUiDecision;
 using aemcp::native::ProjectSummary;
 using aemcp::native::Request;
 using aemcp::native::SystemClock;
@@ -48,7 +68,12 @@ using aemcp::native::kProjectSummaryCapability;
 
 constexpr std::string_view kPluginVersion = "0.1.0-dev";
 constexpr std::string_view kSdkVersion = "25.6.61";
+constexpr std::uint64_t kSdkBuild = 61;
 constexpr std::string_view kSourceCommit = AE_MCP_SOURCE_COMMIT;
+constexpr std::string_view kCapabilitiesDigest =
+    "778a01733fcf37510f56894a46ec5bd87c7429de2e06d2d5eafb4cdbbae88557";
+constexpr std::string_view kProjectSummaryContractDigest =
+    "baecd602479045f71288b2a7e0df645d4a5313453a34b89ced07178867ccaf9a";
 constexpr std::int64_t kMaximumProjectItems = 100000;
 static_assert(kSourceCommit.size() == 40);
 
@@ -95,15 +120,27 @@ std::string cf_string(CFTypeRef value) {
 struct HostIdentity {
   std::string version;
   std::string build;
+  std::uint64_t build_number{0};
 };
+
+std::uint64_t positive_integer(std::string_view value) {
+  std::uint64_t parsed = 0;
+  const auto [end, error] = std::from_chars(
+      value.data(), value.data() + value.size(), parsed);
+  return error == std::errc{} && end == value.data() + value.size() && parsed > 0
+      ? parsed : 0;
+}
 
 HostIdentity read_host_identity() {
   const CFBundleRef bundle = CFBundleGetMainBundle();
   if (bundle == nullptr) return {};
-  return {
-      cf_string(CFBundleGetValueForInfoDictionaryKey(bundle, CFSTR("CFBundleShortVersionString"))),
-      cf_string(CFBundleGetValueForInfoDictionaryKey(bundle, CFSTR("Adobe Product Build"))),
-  };
+  HostIdentity identity;
+  identity.version = cf_string(
+      CFBundleGetValueForInfoDictionaryKey(bundle, CFSTR("CFBundleShortVersionString")));
+  identity.build = cf_string(
+      CFBundleGetValueForInfoDictionaryKey(bundle, CFSTR("Adobe Product Build")));
+  identity.build_number = positive_integer(identity.build);
+  return identity;
 }
 
 class DiagnosticLog final {
@@ -294,18 +331,65 @@ class AegpHostApi final : public HostApi {
   SPBasicSuite* basic_{nullptr};
 };
 
-struct PluginState final {
+struct PluginState final : NativeIpcObserver, NativeRpcObserver {
   PluginState(SPBasicSuite* basic_suite, AEGP_PluginID plugin_id_value,
       A_long driver_major_value, A_long driver_minor_value)
       : basic(basic_suite),
         plugin_id(plugin_id_value),
         driver_major(driver_major_value),
         driver_minor(driver_minor_value),
-        dispatcher(std::this_thread::get_id(), clock) {
-    const auto timestamp = unix_time_ms();
-    instance_id = std::to_string(static_cast<long long>(getpid())) + "-"
-        + std::to_string(static_cast<long long>(timestamp));
+        dispatcher(std::this_thread::get_id(), clock),
+        pairing_gate(pairing_clock, pairing_material) {
+    instance_id = aemcp::native::secure_uuid_v4();
+    peer_backend = aemcp::native::create_macos_peer_identity_backend();
+    const auto host_process = aemcp::native::current_macos_process(*peer_backend);
+    if (!host_process.valid()) throw std::runtime_error("native host identity unavailable");
+    std::string endpoint_nonce;
+    for (const char character : instance_id) {
+      if (character != '-' && endpoint_nonce.size() < 12) endpoint_nonce.push_back(character);
+    }
+    endpoint = std::make_unique<MacEndpointRegistry>(
+        *peer_backend,
+        aemcp::native::EndpointRegistryConfig{{}, endpoint_nonce, 2, 128});
+    rpc_handler = std::make_unique<NativeRpcConnectionHandler>(
+        dispatcher,
+        clock,
+        session_clock,
+        NativeRpcRuntimeInfo{
+            std::string(kPluginVersion),
+            std::string(kSdkVersion),
+            kSdkBuild,
+            host_identity.version,
+            host_identity.build_number,
+            instance_id,
+            std::string(kCapabilitiesDigest),
+            std::string(kProjectSummaryContractDigest),
+        },
+        *this);
+    ipc_server = std::make_unique<MacIpcServer>(
+        *endpoint,
+        *peer_backend,
+        pairing_gate,
+        *rpc_handler,
+        *this,
+        aemcp::native::MacIpcServerConfig{
+            1500ms, 100ms, 16, aemcp::native::macos_native_cpu_type()});
   }
+
+  [[nodiscard]] bool start_ipc() noexcept;
+  void stop_ipc() noexcept;
+  void on_ipc_event(
+      std::string_view event, std::string_view decision) noexcept override;
+  void on_rpc_event(
+      std::string_view event,
+      std::string_view request_id,
+      std::string_view decision) noexcept override;
+  void on_rpc_terminal(
+      const Completion& completion,
+      std::string_view request_digest,
+      std::string_view postcondition_digest,
+      std::uint64_t started_at_unix_ms,
+      std::uint64_t completed_at_unix_ms) noexcept override;
 
   SPBasicSuite* basic;
   AEGP_PluginID plugin_id;
@@ -316,7 +400,15 @@ struct PluginState final {
   DiagnosticLog log;
   SystemClock clock;
   HostDispatcher dispatcher;
-  bool boot_probe_submitted{false};
+  aemcp::native::rpc::SystemSessionClock session_clock;
+  aemcp::native::SystemPairingGateClock pairing_clock;
+  aemcp::native::MacPairingMaterialSource pairing_material;
+  PairingGate pairing_gate;
+  std::unique_ptr<aemcp::native::PeerIdentityBackend> peer_backend;
+  std::unique_ptr<MacEndpointRegistry> endpoint;
+  std::unique_ptr<NativeRpcConnectionHandler> rpc_handler;
+  std::unique_ptr<MacIpcServer> ipc_server;
+  AEGP_Command pairing_command{0};
 };
 
 std::string event_prefix(const PluginState& state, std::string_view event) {
@@ -343,18 +435,37 @@ void log_load(PluginState& state) {
   state.log.append(output.str());
 }
 
-void log_completion(PluginState& state, const Completion& completion) {
+void log_completion(
+    PluginState& state,
+    const Completion& completion,
+    std::string_view request_digest = {},
+    std::string_view postcondition_digest = {},
+    std::uint64_t started_at_unix_ms = 0,
+    std::uint64_t completed_at_unix_ms = 0) {
   std::ostringstream output;
   output << event_prefix(state, "invoke.terminal")
          << ",\"requestId\":\"" << json_escape(completion.request_id)
          << "\",\"capabilityId\":\"" << json_escape(completion.capability_id)
-         << "\",\"ok\":" << (completion.ok ? "true" : "false");
+         << "\",\"ok\":" << (completion.ok ? "true" : "false")
+         << ",\"routeRevoked\":" << (completion.route_revoked ? "true" : "false");
+  if (!request_digest.empty()) {
+    output << ",\"requestDigest\":\"" << json_escape(request_digest) << "\"";
+  }
+  if (started_at_unix_ms > 0 && completed_at_unix_ms >= started_at_unix_ms) {
+    output << ",\"startedAtUnixMs\":" << started_at_unix_ms
+           << ",\"completedAtUnixMs\":" << completed_at_unix_ms;
+  }
   if (completion.ok) {
     output << ",\"result\":{\"projectOpen\":"
            << (completion.result.project_open ? "true" : "false")
            << ",\"projectNameRedacted\":"
            << (completion.result.project_name.empty() ? "false" : "true")
-           << ",\"itemCount\":" << completion.result.item_count << "}";
+           << ",\"itemCount\":" << completion.result.item_count;
+    if (!postcondition_digest.empty()) {
+      output << ",\"postconditionDigest\":\""
+             << json_escape(postcondition_digest) << "\"";
+    }
+    output << "}";
   } else {
     output << ",\"error\":{\"code\":\"" << json_escape(completion.error_code)
            << "\",\"message\":\"" << json_escape(completion.message)
@@ -365,6 +476,69 @@ void log_completion(PluginState& state, const Completion& completion) {
   state.log.append(output.str());
 }
 
+bool PluginState::start_ipc() noexcept {
+  try {
+    const auto host_process = aemcp::native::current_macos_process(*peer_backend);
+    const auto result = endpoint->start(NativeEndpointDescriptor{
+        1,
+        instance_id,
+        host_process,
+        {},
+        1,
+        std::string(kSourceCommit),
+    });
+    if (!result.ok()) {
+      log.append(event_prefix(*this, "ipc.start-failed")
+          + ",\"decision\":\"" + json_escape(result.diagnostic) + "\"}");
+      return false;
+    }
+    if (!ipc_server->start()) {
+      endpoint->stop();
+      log.append(event_prefix(*this, "ipc.start-failed")
+          + ",\"decision\":\"worker-start-failed\"}");
+      return false;
+    }
+    return true;
+  } catch (...) {
+    if (endpoint) endpoint->stop();
+    return false;
+  }
+}
+
+void PluginState::stop_ipc() noexcept {
+  if (ipc_server) ipc_server->stop();
+}
+
+void PluginState::on_ipc_event(
+    std::string_view event, std::string_view decision) noexcept {
+  log.append(event_prefix(*this, std::string("ipc.") + std::string(event))
+      + ",\"decision\":\"" + json_escape(decision) + "\"}");
+}
+
+void PluginState::on_rpc_event(
+    std::string_view event,
+    std::string_view request_id,
+    std::string_view decision) noexcept {
+  log.append(event_prefix(*this, std::string("rpc.") + std::string(event))
+      + ",\"requestId\":\"" + json_escape(request_id)
+      + "\",\"decision\":\"" + json_escape(decision) + "\"}");
+}
+
+void PluginState::on_rpc_terminal(
+    const Completion& completion,
+    std::string_view request_digest,
+    std::string_view postcondition_digest,
+    std::uint64_t started_at_unix_ms,
+    std::uint64_t completed_at_unix_ms) noexcept {
+  log_completion(
+      *this,
+      completion,
+      request_digest,
+      postcondition_digest,
+      started_at_unix_ms,
+      completed_at_unix_ms);
+}
+
 A_Err death_hook(
     AEGP_GlobalRefcon global_refcon, AEGP_DeathRefcon death_refcon) noexcept {
   try {
@@ -372,6 +546,7 @@ A_Err death_hook(
     if (state == nullptr) state = reinterpret_cast<PluginState*>(global_refcon);
     if (state == nullptr) return A_Err_GENERIC;
     std::unique_ptr<PluginState> state_owner(state);
+    state->stop_ipc();
     for (const Completion& completion : state->dispatcher.shutdown()) {
       log_completion(*state, completion);
     }
@@ -382,39 +557,58 @@ A_Err death_hook(
   }
 }
 
-void submit_boot_probe_once(PluginState& state) noexcept {
-  if (state.boot_probe_submitted) return;
-  state.boot_probe_submitted = true;
-  try {
-    const auto admission = state.dispatcher.enqueue({
-        "boot-project-summary",
-        std::string(kProjectSummaryCapability),
-        state.clock.now() + 60s,
-    });
-    if (admission.code != aemcp::native::EnqueueCode::kAccepted) {
-      state.log.append(event_prefix(state, "boot-probe.rejected")
-          + ",\"errorCode\":\"" + json_escape(admission.error_code) + "\"}");
-    }
-  } catch (...) {
-    // This at-most-once boot diagnostic must never fail AE's idle callback.
-  }
-}
-
 A_Err idle_hook(
     AEGP_GlobalRefcon global_refcon, AEGP_IdleRefcon idle_refcon, A_long* max_sleep) noexcept {
   try {
     auto* state = reinterpret_cast<PluginState*>(idle_refcon);
     if (state == nullptr) state = reinterpret_cast<PluginState*>(global_refcon);
     if (state == nullptr) return A_Err_GENERIC;
-    submit_boot_probe_once(*state);
     AegpHostApi host(state->basic);
     const DrainBatch batch = state->dispatcher.drain(host);
     if (batch.wrong_thread) {
       state->log.append(event_prefix(*state, "dispatch.wrong-thread") + "}");
       return A_Err_GENERIC;
     }
-    for (const Completion& completion : batch.completions) log_completion(*state, completion);
     if (max_sleep != nullptr && batch.remaining > 0) *max_sleep = 1;
+    return A_Err_NONE;
+  } catch (...) {
+    return A_Err_GENERIC;
+  }
+}
+
+A_Err command_hook(
+    AEGP_GlobalRefcon global_refcon,
+    AEGP_CommandRefcon,
+    AEGP_Command command,
+    AEGP_HookPriority,
+    A_Boolean,
+    A_Boolean* handled) noexcept {
+  try {
+    auto* state = reinterpret_cast<PluginState*>(global_refcon);
+    if (state == nullptr || handled == nullptr || command != state->pairing_command) {
+      return A_Err_NONE;
+    }
+    *handled = TRUE;
+    const auto pending = state->ipc_server
+        ? state->ipc_server->pending_pairing() : std::nullopt;
+    if (!pending.has_value()) {
+      aemcp::native::show_no_pending_pairing();
+      return A_Err_NONE;
+    }
+    const PairingUiDecision decision = aemcp::native::show_pairing_confirmation(
+        pending->fingerprint, pending->expires_in);
+    bool applied = false;
+    if (decision == PairingUiDecision::kAuthorize) {
+      applied = state->ipc_server->confirm_pending(
+          pending->binding.connection_id, pending->fingerprint);
+    } else {
+      applied = state->ipc_server->reject_pending(
+          pending->binding.connection_id, pending->fingerprint);
+    }
+    state->log.append(event_prefix(*state, "pairing.user-decision")
+        + ",\"decision\":\""
+        + (decision == PairingUiDecision::kAuthorize ? "authorize" : "reject")
+        + "\",\"applied\":" + (applied ? "true" : "false") + "}");
     return A_Err_NONE;
   } catch (...) {
     return A_Err_GENERIC;
@@ -462,6 +656,39 @@ extern "C" __attribute__((visibility("default"))) A_Err AeMcpNativeMain(
         ? register_suite->AEGP_RegisterIdleHook(
             plugin_id, idle_hook, reinterpret_cast<AEGP_IdleRefcon>(lifecycle_state))
         : death_error;
+
+    A_Err menu_error = A_Err_GENERIC;
+    const AEGP_CommandSuite1* command_suite = nullptr;
+    const SPErr command_acquire_error = idle_error == A_Err_NONE
+        ? pica_basic->AcquireSuite(
+            kAEGPCommandSuite,
+            kAEGPCommandSuiteVersion1,
+            reinterpret_cast<const void**>(&command_suite))
+        : A_Err_GENERIC;
+    if (command_acquire_error == 0 && command_suite != nullptr) {
+      menu_error = command_suite->AEGP_GetUniqueCommand(
+          &lifecycle_state->pairing_command);
+      if (menu_error == A_Err_NONE) {
+        menu_error = command_suite->AEGP_InsertMenuCommand(
+            lifecycle_state->pairing_command,
+            "AE MCP: Pair native connection...",
+            AEGP_Menu_WINDOW,
+            AEGP_MENU_INSERT_SORTED);
+      }
+      if (menu_error == A_Err_NONE) {
+        menu_error = register_suite->AEGP_RegisterCommandHook(
+            plugin_id,
+            AEGP_HP_BeforeAE,
+            AEGP_Command_ALL,
+            command_hook,
+            0);
+      }
+      const SPErr command_release_error = pica_basic->ReleaseSuite(
+          kAEGPCommandSuite, kAEGPCommandSuiteVersion1);
+      if (command_release_error != 0 && menu_error == A_Err_NONE) {
+        menu_error = A_Err_GENERIC;
+      }
+    }
     const SPErr release_error = pica_basic->ReleaseSuite(
         kAEGPRegisterSuite, kAEGPRegisterSuiteVersion5);
 
@@ -475,6 +702,12 @@ extern "C" __attribute__((visibility("default"))) A_Err AeMcpNativeMain(
 
     try {
       log_load(*lifecycle_state);
+      if (menu_error != A_Err_NONE) {
+        lifecycle_state->log.append(
+            event_prefix(*lifecycle_state, "pairing.menu-unavailable") + "}");
+      } else {
+        (void)lifecycle_state->start_ipc();
+      }
     } catch (...) {
       // Hook registration is authoritative; optional boot diagnostics cannot
       // turn a live AE-owned state into a failed initialization.

--- a/native/ae-plugin/src/core/host_dispatcher.cpp
+++ b/native/ae-plugin/src/core/host_dispatcher.cpp
@@ -1,6 +1,7 @@
 #include "aemcp_native/host_dispatcher.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <stdexcept>
 #include <utility>
 
@@ -21,13 +22,27 @@ bool valid_request_id(std::string_view value) {
   });
 }
 
+bool valid_route(std::string_view route_id, std::uint64_t session_generation) {
+  // Empty/zero is the one legacy in-process route. The authenticated transport
+  // supplies an opaque, bounded route; its syntax is deliberately not parsed.
+  if (route_id.empty()) return session_generation == 0;
+  return session_generation > 0 && route_id.size() <= 128
+      && route_id.find('\0') == std::string_view::npos;
+}
+
 Completion failure_for(const Request& request, std::string code, std::string message) {
   Completion completion;
   completion.request_id = request.request_id;
   completion.capability_id = request.capability_id;
+  completion.route_id = request.route_id;
+  completion.session_generation = request.session_generation;
   completion.error_code = std::move(code);
   completion.message = std::move(message);
   return completion;
+}
+
+void hash_combine(std::size_t& seed, std::size_t value) noexcept {
+  seed ^= value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
 }
 
 }  // namespace
@@ -50,25 +65,40 @@ HostReadResult HostReadResult::failure(std::string code, std::string detail) {
   return result;
 }
 
+std::size_t HostDispatcher::RequestKeyHash::operator()(const RequestKey& key) const noexcept {
+  std::size_t value = std::hash<std::string>{}(key.route_id);
+  hash_combine(value, std::hash<std::uint64_t>{}(key.session_generation));
+  hash_combine(value, std::hash<std::string>{}(key.request_id));
+  return value;
+}
+
 HostDispatcher::HostDispatcher(
     std::thread::id owner_thread, Clock& clock, DispatcherConfig config)
     : owner_thread_(owner_thread), clock_(clock), config_(config) {
   if (owner_thread_ == std::thread::id{} || config_.max_queue_depth == 0
       || config_.max_queue_depth > 256 || config_.max_tasks_per_idle == 0
       || config_.max_tasks_per_idle > 64 || config_.idle_budget.count() <= 0
-      || config_.idle_budget > std::chrono::milliseconds(16)) {
+      || config_.idle_budget > std::chrono::milliseconds(16)
+      || config_.max_outbound_depth == 0 || config_.max_outbound_depth > 512
+      || config_.max_terminal_tombstones == 0
+      || config_.max_terminal_tombstones > 4096
+      || config_.terminal_ttl.count() <= 0
+      || config_.terminal_ttl > std::chrono::milliseconds(300000)
+      || config_.max_route_fences == 0 || config_.max_route_fences > 4096) {
     throw std::invalid_argument("invalid native host dispatcher configuration");
   }
 }
 
 EnqueueResult HostDispatcher::enqueue(Request request) {
-  if (!valid_request_id(request.request_id) || request.capability_id.empty()) {
+  if (!valid_request_id(request.request_id) || request.capability_id.empty()
+      || !valid_route(request.route_id, request.session_generation)) {
     return {EnqueueCode::kInvalidRequest, "INVALID_REQUEST"};
   }
   if (request.capability_id != kProjectSummaryCapability) {
     return {EnqueueCode::kUnsupportedCapability, "NATIVE_UNSUPPORTED"};
   }
-  if (request.deadline <= clock_.now()) {
+  const TimePoint now = clock_.now();
+  if (request.deadline <= now) {
     return {EnqueueCode::kDeadlineExceeded, "DEADLINE_EXCEEDED"};
   }
 
@@ -76,23 +106,112 @@ EnqueueResult HostDispatcher::enqueue(Request request) {
   if (state_ != State::kRunning) {
     return {EnqueueCode::kShuttingDown, "AE_SHUTTING_DOWN"};
   }
-  if (active_request_ids_.contains(request.request_id)) {
+  purge_terminal_locked(now);
+  const RequestKey key = key_for(request);
+  if (route_stale_locked(key.route_id, key.session_generation)) {
+    return {EnqueueCode::kStaleRoute, "SESSION_STALE"};
+  }
+  if (active_requests_.contains(key) || terminal_locked(key)
+      || pending_outbound_locked(key)) {
     return {EnqueueCode::kDuplicateRequest, "DUPLICATE_REQUEST"};
   }
-  if (queue_.size() >= config_.max_queue_depth) {
+  if (queue_.size() >= config_.max_queue_depth
+      || outbound_.size() + active_requests_.size() >= config_.max_outbound_depth) {
     return {EnqueueCode::kQueueFull, "QUEUE_FULL"};
   }
-  const auto [active, inserted] = active_request_ids_.insert(request.request_id);
+  const auto [active, inserted] = active_requests_.insert(key);
   if (!inserted) {
     return {EnqueueCode::kDuplicateRequest, "DUPLICATE_REQUEST"};
   }
   try {
     queue_.push_back(std::move(request));
   } catch (...) {
-    active_request_ids_.erase(active);
+    active_requests_.erase(active);
     throw;
   }
   return {EnqueueCode::kAccepted, {}};
+}
+
+CancelResult HostDispatcher::cancel(
+    std::string_view route_id,
+    std::uint64_t session_generation,
+    std::string_view target_request_id) {
+  if (!valid_route(route_id, session_generation) || !valid_request_id(target_request_id)) {
+    return {CancelCode::kInvalidRequest, false};
+  }
+
+  const TimePoint now = clock_.now();
+  std::lock_guard lock(mutex_);
+  purge_terminal_locked(now);
+  RequestKey key{std::string(route_id), session_generation, std::string(target_request_id)};
+  if (terminal_locked(key) || pending_outbound_locked(key)) {
+    return {CancelCode::kAlreadyTerminal, false};
+  }
+  if (route_revoked_locked(route_id, session_generation)) {
+    return {CancelCode::kStaleRoute, false};
+  }
+
+  const auto queued = std::find_if(queue_.begin(), queue_.end(), [&](const Request& request) {
+    return request.route_id == route_id && request.session_generation == session_generation
+        && request.request_id == target_request_id;
+  });
+  if (queued != queue_.end()) {
+    Completion completion = failure_for(
+        *queued, "CANCELLED", "native request was cancelled before host dispatch");
+    queue_.erase(queued);
+    finish_request_locked(key, completion, now);
+    return {CancelCode::kQueuedCancelled, true};
+  }
+  if (active_requests_.contains(key)) {
+    return {CancelCode::kRunningNotCancellable, true};
+  }
+  if (route_stale_locked(route_id, session_generation)) {
+    return {CancelCode::kStaleRoute, false};
+  }
+  return {CancelCode::kNotFound, false};
+}
+
+RouteRevocationResult HostDispatcher::revoke_route(
+    std::string_view route_id, std::uint64_t session_generation) {
+  RouteRevocationResult result;
+  if (!valid_route(route_id, session_generation)) return result;
+
+  const TimePoint now = clock_.now();
+  std::lock_guard lock(mutex_);
+  purge_terminal_locked(now);
+  result.fence_recorded = fence_route_locked(std::string(route_id), session_generation);
+  result.fence_saturated = route_fences_saturated_;
+
+  for (Completion& completion : outbound_) {
+    if (completion.route_id == route_id
+        && completion.session_generation <= session_generation
+        && !completion.route_revoked) {
+      completion.route_revoked = true;
+      ++result.pending_outbound_marked;
+    }
+  }
+
+  auto queued = queue_.begin();
+  while (queued != queue_.end()) {
+    if (queued->route_id != route_id || queued->session_generation > session_generation) {
+      ++queued;
+      continue;
+    }
+    const RequestKey key = key_for(*queued);
+    Completion completion = failure_for(
+        *queued, "CANCELLED", "native request route was revoked before host dispatch");
+    completion.route_revoked = true;
+    queued = queue_.erase(queued);
+    finish_request_locked(key, completion, now);
+    ++result.queued_cancelled;
+  }
+
+  for (const RequestKey& key : active_requests_) {
+    if (key.route_id == route_id && key.session_generation <= session_generation) {
+      if (detached_requests_.insert(key).second) ++result.running_detached;
+    }
+  }
+  return result;
 }
 
 DrainBatch HostDispatcher::drain(HostApi& host) {
@@ -136,6 +255,8 @@ DrainBatch HostDispatcher::drain(HostApi& host) {
         } else {
           completion.request_id = request.request_id;
           completion.capability_id = request.capability_id;
+          completion.route_id = request.route_id;
+          completion.session_generation = request.session_generation;
           completion.ok = true;
           completion.result = std::move(host_result.value);
         }
@@ -144,7 +265,10 @@ DrainBatch HostDispatcher::drain(HostApi& host) {
             request, "CAPABILITY_FAILED", "native host adapter raised an exception");
       }
     }
-    finish_request(request.request_id);
+    {
+      std::lock_guard lock(mutex_);
+      finish_request_locked(key_for(request), completion, clock_.now());
+    }
     batch.completions.push_back(std::move(completion));
   }
 
@@ -155,18 +279,36 @@ DrainBatch HostDispatcher::drain(HostApi& host) {
   return batch;
 }
 
-std::vector<Completion> HostDispatcher::shutdown() {
+std::vector<Completion> HostDispatcher::take_outbound(std::size_t max_items) {
   std::vector<Completion> completions;
+  if (max_items == 0) return completions;
+  std::lock_guard lock(mutex_);
+  const std::size_t count = std::min(max_items, outbound_.size());
+  completions.reserve(count);
+  for (std::size_t index = 0; index < count; ++index) {
+    completions.push_back(std::move(outbound_.front()));
+    outbound_.pop_front();
+  }
+  return completions;
+}
+
+std::vector<Completion> HostDispatcher::shutdown() {
+  if (std::this_thread::get_id() != owner_thread_) {
+    throw std::logic_error("native host dispatcher shutdown must run on its owner thread");
+  }
+  std::vector<Completion> completions;
+  const TimePoint now = clock_.now();
   std::lock_guard lock(mutex_);
   if (state_ == State::kStopped) return completions;
   state_ = State::kStopping;
   completions.reserve(queue_.size());
   while (!queue_.empty()) {
-    const Request& request = queue_.front();
-    completions.push_back(failure_for(
-        request, "AE_SHUTTING_DOWN", "After Effects is shutting down"));
-    active_request_ids_.erase(request.request_id);
+    Request request = std::move(queue_.front());
     queue_.pop_front();
+    Completion completion = failure_for(
+        request, "AE_SHUTTING_DOWN", "After Effects is shutting down");
+    finish_request_locked(key_for(request), completion, now);
+    completions.push_back(std::move(completion));
   }
   state_ = State::kStopped;
   return completions;
@@ -175,6 +317,28 @@ std::vector<Completion> HostDispatcher::shutdown() {
 std::size_t HostDispatcher::queued() const {
   std::lock_guard lock(mutex_);
   return queue_.size();
+}
+
+std::size_t HostDispatcher::outbound() const {
+  std::lock_guard lock(mutex_);
+  return outbound_.size();
+}
+
+std::size_t HostDispatcher::terminal_count() {
+  std::lock_guard lock(mutex_);
+  purge_terminal_locked(clock_.now());
+  return terminal_tombstones_.size();
+}
+
+bool HostDispatcher::has_terminal(
+    std::string_view route_id,
+    std::uint64_t session_generation,
+    std::string_view request_id) {
+  if (!valid_route(route_id, session_generation) || !valid_request_id(request_id)) return false;
+  std::lock_guard lock(mutex_);
+  purge_terminal_locked(clock_.now());
+  return terminal_locked(
+      {std::string(route_id), session_generation, std::string(request_id)});
 }
 
 bool HostDispatcher::running() const {
@@ -189,9 +353,79 @@ Completion HostDispatcher::expired(const Request& request, bool late) const {
   return completion;
 }
 
-void HostDispatcher::finish_request(const std::string& request_id) {
-  std::lock_guard lock(mutex_);
-  active_request_ids_.erase(request_id);
+HostDispatcher::RequestKey HostDispatcher::key_for(const Request& request) {
+  return {request.route_id, request.session_generation, request.request_id};
+}
+
+bool HostDispatcher::route_revoked_locked(
+    std::string_view route_id, std::uint64_t session_generation) const {
+  const auto fence = route_fences_.find(std::string(route_id));
+  return fence != route_fences_.end() && session_generation <= fence->second;
+}
+
+bool HostDispatcher::route_stale_locked(
+    std::string_view route_id, std::uint64_t session_generation) const {
+  if (route_revoked_locked(route_id, session_generation)) return true;
+  // Fences are never evicted. Once their bounded registry is exhausted, an
+  // unseen authenticated route fails closed until the AE plug-in restarts.
+  return !route_id.empty() && route_fences_saturated_
+      && route_fences_.find(std::string(route_id)) == route_fences_.end();
+}
+
+bool HostDispatcher::pending_outbound_locked(const RequestKey& key) const {
+  return std::any_of(outbound_.begin(), outbound_.end(), [&](const Completion& completion) {
+    return completion.route_id == key.route_id
+        && completion.session_generation == key.session_generation
+        && completion.request_id == key.request_id;
+  });
+}
+
+bool HostDispatcher::terminal_locked(const RequestKey& key) const {
+  return std::any_of(
+      terminal_tombstones_.begin(), terminal_tombstones_.end(),
+      [&](const TerminalTombstone& tombstone) { return tombstone.key == key; });
+}
+
+void HostDispatcher::purge_terminal_locked(TimePoint now) {
+  std::erase_if(terminal_tombstones_, [&](const TerminalTombstone& tombstone) {
+    return tombstone.expires_at <= now;
+  });
+}
+
+void HostDispatcher::remember_terminal_locked(RequestKey key, TimePoint now) {
+  // Active admission excludes an existing tombstone for this key, so append
+  // before eviction. Allocation failure then preserves every older fence.
+  terminal_tombstones_.push_back({std::move(key), now + config_.terminal_ttl});
+  while (terminal_tombstones_.size() > config_.max_terminal_tombstones) {
+    terminal_tombstones_.pop_front();
+  }
+}
+
+bool HostDispatcher::fence_route_locked(
+    std::string route_id, std::uint64_t session_generation) {
+  const auto existing = route_fences_.find(route_id);
+  if (existing != route_fences_.end()) {
+    existing->second = std::max(existing->second, session_generation);
+    return true;
+  }
+  if (route_fences_.size() >= config_.max_route_fences) {
+    route_fences_saturated_ = true;
+    return false;
+  }
+  route_fences_.emplace(std::move(route_id), session_generation);
+  return true;
+}
+
+void HostDispatcher::finish_request_locked(
+    const RequestKey& key, Completion& completion, TimePoint now) {
+  if (route_revoked_locked(key.route_id, key.session_generation)
+      || detached_requests_.contains(key)) {
+    completion.route_revoked = true;
+  }
+  outbound_.push_back(completion);
+  remember_terminal_locked(key, now);
+  active_requests_.erase(key);
+  detached_requests_.erase(key);
 }
 
 }  // namespace aemcp::native

--- a/native/ae-plugin/src/core/native_rpc_connection.cpp
+++ b/native/ae-plugin/src/core/native_rpc_connection.cpp
@@ -1,0 +1,439 @@
+#include "aemcp_native/native_rpc_connection.hpp"
+
+#include <poll.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace aemcp::native {
+namespace {
+
+using namespace std::chrono_literals;
+using rpc::CancelState;
+using rpc::ParsedRequest;
+using rpc::RpcErrorCode;
+using rpc::RpcMethod;
+
+constexpr std::chrono::milliseconds kSocketWriteTimeout{1500};
+
+struct ActiveEvidence {
+  std::string request_digest;
+  std::uint64_t started_at_unix_ms{0};
+};
+
+bool write_frame(int socket_fd, const std::vector<std::uint8_t>& frame) {
+  const auto deadline = std::chrono::steady_clock::now() + kSocketWriteTimeout;
+  std::size_t sent = 0;
+  while (sent < frame.size()) {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) return false;
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+    pollfd item{socket_fd, POLLOUT, 0};
+    const int polled = ::poll(
+        &item, 1, static_cast<int>(std::clamp<std::int64_t>(remaining.count(), 1, 1000)));
+    if (polled < 0 && errno == EINTR) continue;
+    if (polled <= 0 || (item.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0
+        || (item.revents & POLLOUT) == 0) {
+      return false;
+    }
+    const ssize_t count = ::send(socket_fd, frame.data() + sent, frame.size() - sent, 0);
+    if (count > 0) sent += static_cast<std::size_t>(count);
+    else if (count < 0 && errno == EINTR) continue;
+    else return false;
+  }
+  return true;
+}
+
+RpcErrorCode rpc_error_code(std::string_view code) {
+  if (code == "NATIVE_UNAVAILABLE") return RpcErrorCode::kNativeUnavailable;
+  if (code == "NATIVE_UNSUPPORTED") return RpcErrorCode::kNativeUnsupported;
+  if (code == "WIRE_VERSION_MISMATCH") return RpcErrorCode::kWireVersionMismatch;
+  if (code == "INVALID_ARGUMENT") return RpcErrorCode::kInvalidArgument;
+  if (code == "DUPLICATE_REQUEST") return RpcErrorCode::kDuplicateRequest;
+  if (code == "DEADLINE_EXCEEDED") return RpcErrorCode::kDeadlineExceeded;
+  if (code == "CANCELLED") return RpcErrorCode::kCancelled;
+  if (code == "QUEUE_FULL") return RpcErrorCode::kQueueFull;
+  if (code == "AE_SHUTTING_DOWN") return RpcErrorCode::kAeShuttingDown;
+  if (code == "SESSION_STALE") return RpcErrorCode::kSessionStale;
+  if (code == "CAPABILITY_FAILED") return RpcErrorCode::kCapabilityFailed;
+  return RpcErrorCode::kInvalidRequest;
+}
+
+std::string recovery_hint(RpcErrorCode code) {
+  switch (code) {
+    case RpcErrorCode::kNativeUnavailable: return "Reconnect to the native After Effects host.";
+    case RpcErrorCode::kNativeUnsupported: return "Refresh capabilities before retrying.";
+    case RpcErrorCode::kWireVersionMismatch: return "Reconnect with a supported wire version.";
+    case RpcErrorCode::kInvalidArgument: return "Change the invalid request arguments.";
+    case RpcErrorCode::kDuplicateRequest: return "Inspect the original request state.";
+    case RpcErrorCode::kDeadlineExceeded: return "Retry only if the result is still needed.";
+    case RpcErrorCode::kCancelled: return "Issue a new request only if the result is still needed.";
+    case RpcErrorCode::kQueueFull: return "Retry after the bounded native queue drains.";
+    case RpcErrorCode::kAeShuttingDown: return "Reconnect after After Effects restarts.";
+    case RpcErrorCode::kSessionStale: return "Reconnect and establish a fresh session.";
+    case RpcErrorCode::kCapabilityFailed: return "Inspect After Effects state before retrying.";
+    default: return "Correct the request before retrying.";
+  }
+}
+
+rpc::ErrorResponse error_for(
+    const ParsedRequest& request,
+    const std::string& session_id,
+    std::string code,
+    std::string message) {
+  RpcErrorCode mapped = rpc_error_code(code);
+  // A repeated hello is a malformed handshake, not a session-scoped failure.
+  // Keep the response inside the closed hello error union instead of letting
+  // the serializer throw and silently tear down the connection.
+  if (request.method == RpcMethod::kHello
+      && mapped != RpcErrorCode::kNativeUnavailable
+      && mapped != RpcErrorCode::kWireVersionMismatch
+      && mapped != RpcErrorCode::kInvalidRequest
+      && mapped != RpcErrorCode::kInvalidArgument) {
+    mapped = RpcErrorCode::kInvalidRequest;
+  }
+  rpc::ErrorResponse response;
+  response.method = request.method;
+  response.request_id = request.request_id;
+  if (request.method != RpcMethod::kHello) response.session_id = session_id;
+  response.code = mapped;
+  response.message = std::move(message);
+  response.recovery_hint = recovery_hint(mapped);
+  if (mapped == RpcErrorCode::kQueueFull) response.retry_after_ms = 50;
+  if (mapped == RpcErrorCode::kWireVersionMismatch) {
+    response.details = rpc::ErrorDetails{};
+    response.details->supported_wire_minimum = 1;
+    response.details->supported_wire_maximum = 1;
+  }
+  if (mapped == RpcErrorCode::kNativeUnsupported
+      || mapped == RpcErrorCode::kCapabilityFailed) {
+    response.details = rpc::ErrorDetails{};
+    response.details->capability_id = "ae.project.summary";
+  }
+  return response;
+}
+
+CancelState cancel_state(CancelCode code) {
+  switch (code) {
+    case CancelCode::kQueuedCancelled: return CancelState::kQueuedCancelled;
+    case CancelCode::kRunningNotCancellable: return CancelState::kRunningNotCancellable;
+    case CancelCode::kAlreadyTerminal: return CancelState::kAlreadyTerminal;
+    case CancelCode::kNotFound: return CancelState::kNotFound;
+    case CancelCode::kInvalidRequest: return CancelState::kNotFound;
+    case CancelCode::kStaleRoute: return CancelState::kNotFound;
+  }
+  return CancelState::kNotFound;
+}
+
+bool valid_digest(std::string_view value) {
+  return value.size() == 64 && std::all_of(value.begin(), value.end(), [](char character) {
+    return (character >= '0' && character <= '9')
+        || (character >= 'a' && character <= 'f');
+  });
+}
+
+bool valid_timing_evidence(
+    const ActiveEvidence& evidence, std::uint64_t completed_at_unix_ms) {
+  return valid_digest(evidence.request_digest)
+      && evidence.started_at_unix_ms >= 1
+      && evidence.started_at_unix_ms <= rpc::kMaxSafeInteger
+      && completed_at_unix_ms >= evidence.started_at_unix_ms
+      && completed_at_unix_ms <= rpc::kMaxSafeInteger;
+}
+
+}  // namespace
+
+NativeRpcConnectionHandler::NativeRpcConnectionHandler(
+    HostDispatcher& dispatcher,
+    Clock& dispatcher_clock,
+    rpc::SessionClock& session_clock,
+    NativeRpcRuntimeInfo runtime,
+    NativeRpcObserver& observer)
+    : dispatcher_(dispatcher),
+      dispatcher_clock_(dispatcher_clock),
+      session_clock_(session_clock),
+      runtime_(std::move(runtime)),
+      observer_(observer) {
+  if (runtime_.plugin_version.empty() || runtime_.compiled_sdk_version.empty()
+      || runtime_.compiled_sdk_build == 0 || runtime_.host_version.empty()
+      || runtime_.host_build == 0 || runtime_.host_instance_id.empty()
+      || runtime_.capabilities_digest.size() != 64
+      || runtime_.project_summary_contract_digest.size() != 64) {
+    throw std::invalid_argument("invalid native RPC runtime identity");
+  }
+}
+
+void NativeRpcConnectionHandler::serve(
+    const AuthenticatedConnection& connection) noexcept {
+  try {
+    rpc::RpcSessionFrontDoor front_door(
+        connection.peer.connection_id,
+        runtime_.host_instance_id,
+        connection.session_id,
+        session_clock_);
+    if (!front_door.authorize_pairing()) {
+      throw std::runtime_error("paired RPC session could not be authorized");
+    }
+    rpc::FrameDecoder decoder;
+    std::unordered_map<std::string, ActiveEvidence> active;
+    std::array<std::uint8_t, 16384> input{};
+    bool connected = true;
+    while (connected) {
+      for (Completion& completion : dispatcher_.take_outbound()) {
+        if (completion.route_id != connection.peer.connection_id
+            || completion.session_generation != connection.session_generation) {
+          observer_.on_rpc_event("terminal.detached", completion.request_id, "route-mismatch");
+          continue;
+        }
+        const auto evidence = active.find(completion.request_id);
+        if (evidence == active.end()) {
+          observer_.on_rpc_event(
+              "terminal.detached", completion.request_id, "missing-request-evidence");
+          continue;
+        }
+        const std::uint64_t completed_at = session_clock_.now_unix_ms();
+        const std::string& request_digest = evidence->second.request_digest;
+        const std::uint64_t started_at = evidence->second.started_at_unix_ms;
+        std::string postcondition_digest;
+        bool evidence_valid = valid_timing_evidence(evidence->second, completed_at);
+        if (completion.ok && evidence_valid) {
+          if (completion.result.item_count < 0
+              || static_cast<std::uint64_t>(completion.result.item_count)
+                  > rpc::kMaxSafeInteger) {
+            evidence_valid = false;
+          } else {
+            try {
+              postcondition_digest = rpc::digest_project_summary_postcondition(
+                  completion.result.project_open,
+                  completion.result.project_name,
+                  static_cast<std::uint64_t>(completion.result.item_count));
+            } catch (...) {
+              evidence_valid = false;
+            }
+          }
+        }
+        if (!evidence_valid) {
+          completion.ok = false;
+          completion.error_code = "CAPABILITY_FAILED";
+          completion.message = "native result evidence failed validation";
+          postcondition_digest.clear();
+          observer_.on_rpc_event(
+              "terminal.validation", completion.request_id, "invalid-evidence");
+        }
+        observer_.on_rpc_terminal(
+            completion,
+            valid_digest(request_digest) ? request_digest : std::string_view{},
+            postcondition_digest,
+            started_at,
+            completed_at);
+        if (completion.route_revoked) {
+          active.erase(completion.request_id);
+          continue;
+        }
+        std::vector<std::uint8_t> response;
+        if (completion.ok) {
+          response = rpc::encode_project_summary_success({
+              completion.request_id,
+              connection.session_id,
+              runtime_.host_instance_id,
+              completion.result.project_open,
+              completion.result.project_name,
+              static_cast<std::uint64_t>(completion.result.item_count),
+              started_at,
+              completed_at,
+              request_digest,
+              postcondition_digest,
+              false,
+          });
+        } else {
+          ParsedRequest synthetic;
+          synthetic.method = RpcMethod::kInvoke;
+          synthetic.request_id = completion.request_id;
+          response = rpc::encode_error_response(error_for(
+              synthetic,
+              connection.session_id,
+              completion.error_code,
+              completion.message.empty() ? "native request failed" : completion.message));
+        }
+        if (!write_frame(connection.socket_fd, response)) {
+          connected = false;
+          break;
+        }
+        (void)front_door.complete_request(completion.request_id);
+        active.erase(completion.request_id);
+      }
+      if (!connected) break;
+
+      pollfd socket{connection.socket_fd, POLLIN, 0};
+      const int polled = ::poll(&socket, 1, 20);
+      if (polled < 0 && errno == EINTR) continue;
+      if (polled < 0 || (polled > 0 && (socket.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0)) {
+        break;
+      }
+      if (polled == 0 || (socket.revents & POLLIN) == 0) continue;
+      const ssize_t received = ::recv(connection.socket_fd, input.data(), input.size(), 0);
+      if (received == 0) break;
+      if (received < 0) {
+        if (errno == EINTR) continue;
+        break;
+      }
+      for (ParsedRequest& request : decoder.push(
+              std::span<const std::uint8_t>(input.data(), static_cast<std::size_t>(received)))) {
+        const rpc::SessionIngressResult ingress = front_door.admit(request);
+        if (!ingress.accepted()) {
+          if (ingress.error_code == "AUTH_REQUIRED") {
+            connected = false;
+            break;
+          }
+          const std::string message = ingress.error_code.empty()
+              ? "native request admission failed" : "native request was rejected";
+          if (!write_frame(connection.socket_fd, rpc::encode_error_response(error_for(
+                  request, connection.session_id, ingress.error_code, message)))) {
+            connected = false;
+            break;
+          }
+          continue;
+        }
+
+        if (request.method == RpcMethod::kHello) {
+          const auto& hello = std::get<rpc::HelloParams>(request.params);
+          if (!write_frame(connection.socket_fd, rpc::encode_hello_success({
+                  request.request_id,
+                  connection.session_id,
+                  hello.nonce,
+                  runtime_.plugin_version,
+                  runtime_.compiled_sdk_version,
+                  runtime_.compiled_sdk_build,
+                  "arm64",
+                  runtime_.host_version,
+                  runtime_.host_build,
+                  "macos-arm64",
+                  runtime_.host_instance_id,
+                  connection.session_generation,
+                  {},
+                  runtime_.capabilities_digest,
+              }))) {
+            connected = false;
+            break;
+          }
+          observer_.on_rpc_event("hello", request.request_id, "ok");
+          continue;
+        }
+
+        if (request.method == RpcMethod::kCapabilities) {
+          const auto& query = std::get<rpc::CapabilitiesParams>(request.params);
+          bool include = !query.ids.has_value() || std::find(
+              query.ids->begin(), query.ids->end(), "ae.project.summary") != query.ids->end();
+          if (!write_frame(connection.socket_fd, rpc::encode_capabilities_success({
+                  request.request_id,
+                  connection.session_id,
+                  query.detail,
+                  include,
+                  rpc::digest_capabilities_query(connection.session_id, query),
+                  runtime_.capabilities_digest,
+                  runtime_.project_summary_contract_digest,
+              }))) {
+            connected = false;
+            break;
+          }
+          (void)front_door.complete_request(request.request_id);
+          observer_.on_rpc_event("capabilities", request.request_id, "ok");
+          continue;
+        }
+
+        if (request.method == RpcMethod::kCancel) {
+          const auto& cancel = std::get<rpc::CancelParams>(request.params);
+          const CancelResult result = dispatcher_.cancel(
+              connection.peer.connection_id,
+              connection.session_generation,
+              cancel.target_request_id);
+          if (result.code == CancelCode::kInvalidRequest
+              || result.code == CancelCode::kStaleRoute) {
+            const std::string code = result.code == CancelCode::kStaleRoute
+                ? "SESSION_STALE" : "INVALID_ARGUMENT";
+            if (!write_frame(connection.socket_fd, rpc::encode_error_response(error_for(
+                    request, connection.session_id, code, "cancel request was rejected")))) {
+              connected = false;
+              break;
+            }
+          } else if (!write_frame(connection.socket_fd, rpc::encode_cancel_success({
+                  request.request_id,
+                  connection.session_id,
+                  cancel.target_request_id,
+                  cancel_state(result.code),
+                  result.terminal_response_expected,
+              }))) {
+            connected = false;
+            break;
+          }
+          (void)front_door.complete_request(request.request_id);
+          observer_.on_rpc_event("cancel", request.request_id, "handled");
+          continue;
+        }
+
+        const std::uint64_t now_unix = session_clock_.now_unix_ms();
+        const std::uint64_t effective_deadline = *ingress.effective_deadline_unix_ms;
+        const std::uint64_t ttl = effective_deadline > now_unix
+            ? effective_deadline - now_unix : 0;
+        const EnqueueResult enqueued = dispatcher_.enqueue({
+            request.request_id,
+            std::string(kProjectSummaryCapability),
+            dispatcher_clock_.now() + std::chrono::milliseconds(ttl),
+            connection.peer.connection_id,
+            connection.session_generation,
+        });
+        if (enqueued.code != EnqueueCode::kAccepted) {
+          if (!write_frame(connection.socket_fd, rpc::encode_error_response(error_for(
+                  request,
+                  connection.session_id,
+                  enqueued.error_code,
+                  "native dispatcher rejected the request")))) {
+            connected = false;
+            break;
+          }
+          (void)front_door.complete_request(request.request_id);
+          continue;
+        }
+        active.emplace(request.request_id, ActiveEvidence{
+            request.request_fingerprint_sha256,
+            now_unix,
+        });
+        if (!write_frame(connection.socket_fd, rpc::encode_progress_event({
+                request.request_id,
+                connection.session_id,
+                1,
+                rpc::ProgressPhase::kQueued,
+                0.0,
+                "Queued for the bounded After Effects main-thread dispatcher.",
+            }))) {
+          connected = false;
+          break;
+        }
+        observer_.on_rpc_event("invoke", request.request_id, "queued");
+      }
+    }
+    front_door.close();
+  } catch (...) {
+    observer_.on_rpc_event("connection", "none", "codec-or-transport-failure");
+  }
+  try {
+    (void)dispatcher_.revoke_route(
+        connection.peer.connection_id,
+        connection.session_generation);
+  } catch (...) {
+    observer_.on_rpc_event("connection", "none", "route-revoke-failure");
+  }
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/core/pairing_gate.cpp
+++ b/native/ae-plugin/src/core/pairing_gate.cpp
@@ -1,0 +1,221 @@
+#include "aemcp_native/pairing_gate.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+#include <utility>
+
+namespace aemcp::native {
+
+namespace {
+
+void zeroize(std::array<std::uint8_t, 32>& bytes) noexcept {
+  volatile std::uint8_t* output = bytes.data();
+  for (std::size_t index = 0; index < bytes.size(); ++index) output[index] = 0;
+}
+
+}  // namespace
+
+bool PeerBinding::valid() const noexcept {
+  if (pid <= 1 || pid_version == 0 || connection_id.size() < 8
+      || connection_id.size() > 64 || host_instance_id.size() != 36) {
+    return false;
+  }
+  const auto safe_identifier = [](const std::string& value) {
+    return std::all_of(value.begin(), value.end(), [](unsigned char character) {
+      return std::isalnum(character) != 0 || character == '-';
+    });
+  };
+  return safe_identifier(connection_id) && safe_identifier(host_instance_id);
+}
+
+PairingTimePoint SystemPairingGateClock::now() const noexcept {
+  return std::chrono::steady_clock::now();
+}
+
+PairingGate::PairingGate(
+    PairingGateClock& clock,
+    PairingMaterialSource& material_source,
+    PairingGateConfig config)
+    : clock_(clock), material_source_(material_source), config_(config) {
+  if (config_.pending_ttl < std::chrono::seconds(5)
+      || config_.pending_ttl > std::chrono::minutes(2)) {
+    throw std::invalid_argument("invalid pairing TTL");
+  }
+}
+
+PairingGate::~PairingGate() {
+  shutdown();
+}
+
+BeginPairingResult PairingGate::begin(const PeerBinding& binding) {
+  if (!binding.valid()) return {BeginPairingCode::kInvalidBinding, {}, {}};
+  const PairingTimePoint now = clock_.now();
+  std::unique_lock lock(mutex_);
+  expire_locked(now);
+  if (shutting_down_) return {BeginPairingCode::kShuttingDown, {}, {}};
+  if (entry_.has_value()
+      && (entry_->state == State::kRejected || entry_->state == State::kRevoked)) {
+    clear_locked();
+  }
+  if (entry_.has_value()) return {BeginPairingCode::kBusy, {}, {}};
+
+  PairingMaterial material;
+  try {
+    // Material generation is deliberately serialized with admission: two
+    // concurrent peers can never both become the pending connection.
+    material = material_source_.create();
+  } catch (...) {
+    return {BeginPairingCode::kMaterialFailure, {}, {}};
+  }
+  if (!valid_fingerprint(material.fingerprint)
+      || std::all_of(material.capability.begin(), material.capability.end(),
+          [](std::uint8_t byte) { return byte == 0; })) {
+    zeroize(material.capability);
+    return {BeginPairingCode::kMaterialFailure, {}, {}};
+  }
+
+  Entry entry;
+  entry.binding = binding;
+  entry.capability = material.capability;
+  entry.fingerprint = std::move(material.fingerprint);
+  entry.expires_at = now + config_.pending_ttl;
+  entry_ = std::move(entry);
+  zeroize(material.capability);
+  changed_.notify_all();
+  return {
+      BeginPairingCode::kPending,
+      entry_->fingerprint,
+      std::chrono::duration_cast<std::chrono::milliseconds>(entry_->expires_at - now),
+  };
+}
+
+std::optional<PendingPairingSnapshot> PairingGate::pending() {
+  const PairingTimePoint now = clock_.now();
+  std::lock_guard lock(mutex_);
+  expire_locked(now);
+  if (!entry_.has_value() || entry_->state != State::kPending) return std::nullopt;
+  return PendingPairingSnapshot{
+      entry_->binding,
+      entry_->fingerprint,
+      std::chrono::duration_cast<std::chrono::milliseconds>(entry_->expires_at - now),
+  };
+}
+
+bool PairingGate::confirm(
+    const std::string& connection_id,
+    const std::string& fingerprint) {
+  std::lock_guard lock(mutex_);
+  expire_locked(clock_.now());
+  if (shutting_down_ || !entry_.has_value() || entry_->state != State::kPending
+      || entry_->binding.connection_id != connection_id
+      || entry_->fingerprint != fingerprint) {
+    return false;
+  }
+  entry_->state = State::kAuthorized;
+  // The capability's only purpose was to make this pending authorization
+  // unguessable and single-use. Session material is generated independently.
+  zeroize(entry_->capability);
+  changed_.notify_all();
+  return true;
+}
+
+bool PairingGate::reject(
+    const std::string& connection_id,
+    const std::string& fingerprint) {
+  std::lock_guard lock(mutex_);
+  expire_locked(clock_.now());
+  if (!entry_.has_value() || entry_->state != State::kPending
+      || entry_->binding.connection_id != connection_id
+      || entry_->fingerprint != fingerprint) {
+    return false;
+  }
+  entry_->state = State::kRejected;
+  zeroize(entry_->capability);
+  changed_.notify_all();
+  return true;
+}
+
+PairingDecision PairingGate::wait_for_decision(
+    const PeerBinding& binding,
+    PairingTimePoint deadline) {
+  std::unique_lock lock(mutex_);
+  for (;;) {
+    const PairingTimePoint now = clock_.now();
+    expire_locked(now);
+    if (shutting_down_) return PairingDecision::kShuttingDown;
+    if (!entry_.has_value() || entry_->binding != binding) return PairingDecision::kUnknown;
+    switch (entry_->state) {
+      case State::kAuthorized: return PairingDecision::kAuthorized;
+      case State::kRejected: return PairingDecision::kRejected;
+      case State::kRevoked: return PairingDecision::kRevoked;
+      case State::kPending: break;
+    }
+    if (now >= deadline || now >= entry_->expires_at) {
+      clear_locked();
+      changed_.notify_all();
+      return PairingDecision::kExpired;
+    }
+    const PairingTimePoint wake_at = std::min(deadline, entry_->expires_at);
+    changed_.wait_until(lock, wake_at);
+  }
+}
+
+bool PairingGate::authorized(const PeerBinding& binding) {
+  std::lock_guard lock(mutex_);
+  expire_locked(clock_.now());
+  return !shutting_down_ && entry_.has_value()
+      && entry_->state == State::kAuthorized && entry_->binding == binding;
+}
+
+void PairingGate::revoke(const PeerBinding& binding) {
+  std::lock_guard lock(mutex_);
+  if (!entry_.has_value() || entry_->binding != binding) return;
+  entry_->state = State::kRevoked;
+  zeroize(entry_->capability);
+  changed_.notify_all();
+}
+
+void PairingGate::revoke_connection(const std::string& connection_id) {
+  std::lock_guard lock(mutex_);
+  if (!entry_.has_value() || entry_->binding.connection_id != connection_id) return;
+  entry_->state = State::kRevoked;
+  zeroize(entry_->capability);
+  changed_.notify_all();
+}
+
+void PairingGate::shutdown() {
+  std::lock_guard lock(mutex_);
+  if (shutting_down_) return;
+  shutting_down_ = true;
+  clear_locked();
+  changed_.notify_all();
+}
+
+void PairingGate::expire_locked(PairingTimePoint now) {
+  if (entry_.has_value() && entry_->state == State::kPending
+      && now >= entry_->expires_at) {
+    clear_locked();
+    changed_.notify_all();
+  }
+}
+
+void PairingGate::clear_locked() noexcept {
+  if (entry_.has_value()) zeroize(entry_->capability);
+  entry_.reset();
+}
+
+bool PairingGate::valid_fingerprint(const std::string& value) noexcept {
+  if (value.size() != 9 || value[4] != '-') return false;
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (index == 4) continue;
+    const unsigned char character = static_cast<unsigned char>(value[index]);
+    if (!(std::isdigit(character) != 0
+          || (character >= 'A' && character <= 'F'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/core/rpc_codec.cpp
+++ b/native/ae-plugin/src/core/rpc_codec.cpp
@@ -1,0 +1,1463 @@
+#include "aemcp_native/rpc_codec.hpp"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <set>
+#include <sstream>
+#include <type_traits>
+#include <utility>
+
+namespace aemcp::native::rpc {
+namespace {
+
+using Bytes = std::span<const std::uint8_t>;
+
+[[noreturn]] void invalid_request(std::string message) {
+  throw CodecError(CodecErrorKind::kInvalidRequest, std::move(message));
+}
+
+[[noreturn]] void invalid_argument(std::string message) {
+  throw CodecError(CodecErrorKind::kInvalidArgument, std::move(message));
+}
+
+[[noreturn]] void session_stale(std::string message) {
+  throw CodecError(CodecErrorKind::kSessionStale, std::move(message));
+}
+
+struct JsonNumber {
+  double value{0};
+};
+
+struct JsonValue {
+  using Array = std::vector<JsonValue>;
+  using Object = std::vector<std::pair<std::string, JsonValue>>;
+  std::variant<std::nullptr_t, bool, JsonNumber, std::string, Array, Object> value;
+};
+
+std::size_t utf8_sequence_length(unsigned char lead) {
+  if (lead <= 0x7f) return 1;
+  if (lead >= 0xc2 && lead <= 0xdf) return 2;
+  if (lead >= 0xe0 && lead <= 0xef) return 3;
+  if (lead >= 0xf0 && lead <= 0xf4) return 4;
+  return 0;
+}
+
+std::uint32_t decode_utf8_scalar(std::string_view input, std::size_t& offset) {
+  if (offset >= input.size()) invalid_request("incomplete UTF-8 sequence");
+  const auto first = static_cast<unsigned char>(input[offset]);
+  const std::size_t length = utf8_sequence_length(first);
+  if (length == 0 || offset + length > input.size()) invalid_request("invalid UTF-8");
+  if (length == 1) {
+    ++offset;
+    return first;
+  }
+  std::uint32_t scalar = first & ((1U << (7U - static_cast<unsigned>(length))) - 1U);
+  for (std::size_t index = 1; index < length; ++index) {
+    const auto next = static_cast<unsigned char>(input[offset + index]);
+    if ((next & 0xc0U) != 0x80U) invalid_request("invalid UTF-8 continuation byte");
+    scalar = (scalar << 6U) | (next & 0x3fU);
+  }
+  const std::uint32_t minimum = length == 2 ? 0x80U : (length == 3 ? 0x800U : 0x10000U);
+  if (scalar < minimum || scalar > 0x10ffffU || (scalar >= 0xd800U && scalar <= 0xdfffU)) {
+    invalid_request("non-scalar UTF-8 sequence");
+  }
+  offset += length;
+  return scalar;
+}
+
+std::size_t validate_utf8_and_count(std::string_view input) {
+  std::size_t offset = 0;
+  std::size_t scalars = 0;
+  while (offset < input.size()) {
+    (void)decode_utf8_scalar(input, offset);
+    ++scalars;
+  }
+  return scalars;
+}
+
+void append_utf8(std::string& output, std::uint32_t scalar) {
+  if (scalar <= 0x7fU) {
+    output.push_back(static_cast<char>(scalar));
+  } else if (scalar <= 0x7ffU) {
+    output.push_back(static_cast<char>(0xc0U | (scalar >> 6U)));
+    output.push_back(static_cast<char>(0x80U | (scalar & 0x3fU)));
+  } else if (scalar <= 0xffffU) {
+    output.push_back(static_cast<char>(0xe0U | (scalar >> 12U)));
+    output.push_back(static_cast<char>(0x80U | ((scalar >> 6U) & 0x3fU)));
+    output.push_back(static_cast<char>(0x80U | (scalar & 0x3fU)));
+  } else {
+    output.push_back(static_cast<char>(0xf0U | (scalar >> 18U)));
+    output.push_back(static_cast<char>(0x80U | ((scalar >> 12U) & 0x3fU)));
+    output.push_back(static_cast<char>(0x80U | ((scalar >> 6U) & 0x3fU)));
+    output.push_back(static_cast<char>(0x80U | (scalar & 0x3fU)));
+  }
+}
+
+int hex_value(char character) {
+  if (character >= '0' && character <= '9') return character - '0';
+  if (character >= 'a' && character <= 'f') return character - 'a' + 10;
+  if (character >= 'A' && character <= 'F') return character - 'A' + 10;
+  return -1;
+}
+
+class JsonParser final {
+ public:
+  explicit JsonParser(std::string_view text) : text_(text) {
+    (void)validate_utf8_and_count(text_);
+  }
+
+  JsonValue parse() {
+    skip_space();
+    JsonValue result = parse_value(1);
+    skip_space();
+    if (offset_ != text_.size()) invalid_request("trailing JSON bytes");
+    return result;
+  }
+
+ private:
+  void count_node(std::size_t depth) {
+    if (depth > kMaxJsonDepth) invalid_request("JSON depth exceeded");
+    if (++nodes_ > kMaxJsonNodes) invalid_request("JSON node limit exceeded");
+  }
+
+  JsonValue parse_value(std::size_t depth) {
+    count_node(depth);
+    if (offset_ >= text_.size()) invalid_request("missing JSON value");
+    switch (text_[offset_]) {
+      case '{': return JsonValue{parse_object(depth)};
+      case '[': return JsonValue{parse_array(depth)};
+      case '"': return JsonValue{parse_string()};
+      case 't': parse_literal("true"); return JsonValue{true};
+      case 'f': parse_literal("false"); return JsonValue{false};
+      case 'n': parse_literal("null"); return JsonValue{nullptr};
+      default: return JsonValue{parse_number()};
+    }
+  }
+
+  JsonValue::Object parse_object(std::size_t depth) {
+    ++offset_;
+    skip_space();
+    JsonValue::Object result;
+    std::set<std::string> keys;
+    if (consume('}')) return result;
+    while (true) {
+      if (offset_ >= text_.size() || text_[offset_] != '"') {
+        invalid_request("object key must be a string");
+      }
+      std::string key = parse_string();
+      if (!keys.insert(key).second) invalid_request("duplicate JSON object key");
+      skip_space();
+      if (!consume(':')) invalid_request("missing object colon");
+      skip_space();
+      result.emplace_back(std::move(key), parse_value(depth + 1));
+      skip_space();
+      if (consume('}')) return result;
+      if (!consume(',')) invalid_request("invalid object separator");
+      skip_space();
+      if (offset_ < text_.size() && text_[offset_] == '}') {
+        invalid_request("trailing object comma");
+      }
+    }
+  }
+
+  JsonValue::Array parse_array(std::size_t depth) {
+    ++offset_;
+    skip_space();
+    JsonValue::Array result;
+    if (consume(']')) return result;
+    while (true) {
+      result.push_back(parse_value(depth + 1));
+      skip_space();
+      if (consume(']')) return result;
+      if (!consume(',')) invalid_request("invalid array separator");
+      skip_space();
+      if (offset_ < text_.size() && text_[offset_] == ']') {
+        invalid_request("trailing array comma");
+      }
+    }
+  }
+
+  std::uint16_t parse_hex_quad() {
+    if (offset_ + 4 > text_.size()) invalid_request("incomplete Unicode escape");
+    std::uint16_t value = 0;
+    for (int count = 0; count < 4; ++count) {
+      const int digit = hex_value(text_[offset_++]);
+      if (digit < 0) invalid_request("invalid Unicode escape");
+      value = static_cast<std::uint16_t>((value << 4U) | static_cast<unsigned>(digit));
+    }
+    return value;
+  }
+
+  std::string parse_string() {
+    ++offset_;
+    std::string result;
+    std::size_t scalars = 0;
+    while (offset_ < text_.size()) {
+      const auto byte = static_cast<unsigned char>(text_[offset_]);
+      if (byte == '"') {
+        ++offset_;
+        return result;
+      }
+      if (byte < 0x20U) invalid_request("unescaped string control character");
+      if (byte == '\\') {
+        ++offset_;
+        if (offset_ >= text_.size()) invalid_request("incomplete string escape");
+        const char escaped = text_[offset_++];
+        switch (escaped) {
+          case '"': result.push_back('"'); break;
+          case '\\': result.push_back('\\'); break;
+          case '/': result.push_back('/'); break;
+          case 'b': result.push_back('\b'); break;
+          case 'f': result.push_back('\f'); break;
+          case 'n': result.push_back('\n'); break;
+          case 'r': result.push_back('\r'); break;
+          case 't': result.push_back('\t'); break;
+          case 'u': {
+            std::uint32_t scalar = parse_hex_quad();
+            if (scalar >= 0xd800U && scalar <= 0xdbffU) {
+              if (offset_ + 2 > text_.size() || text_[offset_] != '\\'
+                  || text_[offset_ + 1] != 'u') {
+                invalid_request("lone high surrogate");
+              }
+              offset_ += 2;
+              const std::uint32_t low = parse_hex_quad();
+              if (low < 0xdc00U || low > 0xdfffU) invalid_request("invalid surrogate pair");
+              scalar = 0x10000U + ((scalar - 0xd800U) << 10U) + (low - 0xdc00U);
+            } else if (scalar >= 0xdc00U && scalar <= 0xdfffU) {
+              invalid_request("lone low surrogate");
+            }
+            append_utf8(result, scalar);
+            break;
+          }
+          default: invalid_request("invalid string escape");
+        }
+        ++scalars;
+      } else {
+        const std::size_t start = offset_;
+        (void)decode_utf8_scalar(text_, offset_);
+        result.append(text_.substr(start, offset_ - start));
+        ++scalars;
+      }
+      if (scalars > kMaxStringScalars) invalid_request("JSON string limit exceeded");
+    }
+    invalid_request("unterminated string");
+  }
+
+  JsonNumber parse_number() {
+    const std::size_t start = offset_;
+    if (consume('-') && offset_ >= text_.size()) invalid_request("incomplete JSON number");
+    if (consume('0')) {
+      if (offset_ < text_.size() && text_[offset_] >= '0' && text_[offset_] <= '9') {
+        invalid_request("leading zero in JSON number");
+      }
+    } else {
+      if (offset_ >= text_.size() || text_[offset_] < '1' || text_[offset_] > '9') {
+        invalid_request("invalid JSON value");
+      }
+      while (offset_ < text_.size() && text_[offset_] >= '0' && text_[offset_] <= '9') ++offset_;
+    }
+    if (consume('.')) {
+      const std::size_t digits = offset_;
+      while (offset_ < text_.size() && text_[offset_] >= '0' && text_[offset_] <= '9') ++offset_;
+      if (digits == offset_) invalid_request("missing fractional digits");
+    }
+    if (offset_ < text_.size() && (text_[offset_] == 'e' || text_[offset_] == 'E')) {
+      ++offset_;
+      if (offset_ < text_.size() && (text_[offset_] == '+' || text_[offset_] == '-')) ++offset_;
+      const std::size_t digits = offset_;
+      while (offset_ < text_.size() && text_[offset_] >= '0' && text_[offset_] <= '9') ++offset_;
+      if (digits == offset_) invalid_request("missing exponent digits");
+    }
+    const std::string_view token = text_.substr(start, offset_ - start);
+    double value = 0;
+    std::istringstream stream{std::string(token)};
+    stream.imbue(std::locale::classic());
+    stream >> std::noskipws >> value;
+    if (!stream || stream.peek() != std::char_traits<char>::eof() || !std::isfinite(value)) {
+      invalid_request("non-finite or invalid JSON number");
+    }
+    if (std::trunc(value) == value
+        && std::fabs(value) > static_cast<double>(kMaxSafeInteger)) {
+      invalid_request("unsafe JSON integer");
+    }
+    return JsonNumber{value};
+  }
+
+  void parse_literal(std::string_view literal) {
+    if (text_.substr(offset_, literal.size()) != literal) invalid_request("invalid JSON literal");
+    offset_ += literal.size();
+  }
+
+  void skip_space() {
+    while (offset_ < text_.size()
+        && (text_[offset_] == ' ' || text_[offset_] == '\t'
+          || text_[offset_] == '\r' || text_[offset_] == '\n')) ++offset_;
+  }
+
+  bool consume(char expected) {
+    if (offset_ < text_.size() && text_[offset_] == expected) {
+      ++offset_;
+      return true;
+    }
+    return false;
+  }
+
+  std::string_view text_;
+  std::size_t offset_{0};
+  std::size_t nodes_{0};
+};
+
+const JsonValue::Object* object_of(const JsonValue& value) {
+  return std::get_if<JsonValue::Object>(&value.value);
+}
+
+const JsonValue::Array* array_of(const JsonValue& value) {
+  return std::get_if<JsonValue::Array>(&value.value);
+}
+
+const std::string* string_of(const JsonValue& value) {
+  return std::get_if<std::string>(&value.value);
+}
+
+const JsonNumber* number_of(const JsonValue& value) {
+  return std::get_if<JsonNumber>(&value.value);
+}
+
+const JsonValue* member(const JsonValue::Object& object, std::string_view name) {
+  const auto found = std::find_if(object.begin(), object.end(), [&](const auto& item) {
+    return item.first == name;
+  });
+  return found == object.end() ? nullptr : &found->second;
+}
+
+bool exact_keys(
+    const JsonValue::Object& object,
+    std::initializer_list<std::string_view> allowed,
+    std::initializer_list<std::string_view> required = {}) {
+  const auto permitted = [&](std::string_view key) {
+    return std::find(allowed.begin(), allowed.end(), key) != allowed.end();
+  };
+  return std::all_of(object.begin(), object.end(), [&](const auto& item) {
+      return permitted(item.first);
+    }) && std::all_of(required.begin(), required.end(), [&](std::string_view key) {
+      return member(object, key) != nullptr;
+    });
+}
+
+std::string required_string(
+    const JsonValue::Object& object, std::string_view name, CodecErrorKind kind) {
+  const JsonValue* value = member(object, name);
+  const std::string* result = value == nullptr ? nullptr : string_of(*value);
+  if (result == nullptr) {
+    if (kind == CodecErrorKind::kInvalidArgument) invalid_argument("invalid string field");
+    invalid_request("invalid string field");
+  }
+  return *result;
+}
+
+std::uint64_t required_uint(
+    const JsonValue::Object& object, std::string_view name, CodecErrorKind kind,
+    std::uint64_t minimum, std::uint64_t maximum) {
+  const JsonValue* value = member(object, name);
+  const JsonNumber* number = value == nullptr ? nullptr : number_of(*value);
+  if (number == nullptr || std::trunc(number->value) != number->value || number->value < 0
+      || number->value < static_cast<double>(minimum)
+      || number->value > static_cast<double>(maximum)) {
+    if (kind == CodecErrorKind::kInvalidArgument) invalid_argument("invalid integer field");
+    invalid_request("invalid integer field");
+  }
+  return static_cast<std::uint64_t>(number->value);
+}
+
+bool ascii_alphanumeric(char value) {
+  return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z')
+      || (value >= '0' && value <= '9');
+}
+
+bool valid_request_id(std::string_view value) {
+  if (value.empty() || value.size() > 64 || !ascii_alphanumeric(value.front())) return false;
+  return std::all_of(value.begin() + 1, value.end(), [](char character) {
+    return ascii_alphanumeric(character) || character == '.' || character == '_'
+        || character == ':' || character == '-';
+  });
+}
+
+bool valid_uuid(std::string_view value) {
+  if (value.size() != 36 || value[8] != '-' || value[13] != '-'
+      || value[18] != '-' || value[23] != '-') return false;
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (index == 8 || index == 13 || index == 18 || index == 23) continue;
+    if (!((value[index] >= '0' && value[index] <= '9')
+        || (value[index] >= 'a' && value[index] <= 'f'))) return false;
+  }
+  if (value[14] < '1' || value[14] > '5') return false;
+  return value[19] == '8' || value[19] == '9' || value[19] == 'a' || value[19] == 'b';
+}
+
+bool valid_sha256(std::string_view value) {
+  return value.size() == 64 && std::all_of(value.begin(), value.end(), [](char character) {
+    return (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f');
+  });
+}
+
+bool valid_capability_id(std::string_view value) {
+  if (value.size() < 3 || value.size() > 96 || !value.starts_with("ae.")) return false;
+  std::size_t start = 3;
+  while (true) {
+    if (start >= value.size() || value[start] < 'a' || value[start] > 'z') return false;
+    std::size_t end = start + 1;
+    while (end < value.size() && value[end] != '.') {
+      const char character = value[end];
+      if (!((character >= 'a' && character <= 'z')
+          || (character >= '0' && character <= '9') || character == '_' || character == '-')) {
+        return false;
+      }
+      ++end;
+    }
+    if (end == value.size()) return true;
+    start = end + 1;
+  }
+}
+
+bool bounded_ascii_token(
+    std::string_view value, std::size_t minimum, std::size_t maximum,
+    bool (*allowed)(char)) {
+  return value.size() >= minimum && value.size() <= maximum
+      && std::all_of(value.begin(), value.end(), allowed);
+}
+
+std::string method_name(RpcMethod method) {
+  switch (method) {
+    case RpcMethod::kHello: return "hello";
+    case RpcMethod::kCapabilities: return "capabilities";
+    case RpcMethod::kInvoke: return "invoke";
+    case RpcMethod::kCancel: return "cancel";
+  }
+  invalid_argument("unknown RPC method");
+}
+
+std::size_t output_scalar_count(std::string_view value) {
+  try {
+    return validate_utf8_and_count(value);
+  } catch (const CodecError&) {
+    invalid_argument("output string is not valid UTF-8 scalar data");
+  }
+}
+
+std::string json_string(std::string_view value) {
+  const std::size_t scalars = output_scalar_count(value);
+  if (scalars > kMaxStringScalars) invalid_argument("output string limit exceeded");
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string output;
+  output.reserve(value.size() + 2);
+  output.push_back('"');
+  for (unsigned char character : value) {
+    switch (character) {
+      case '"': output += "\\\""; break;
+      case '\\': output += "\\\\"; break;
+      case '\b': output += "\\b"; break;
+      case '\f': output += "\\f"; break;
+      case '\n': output += "\\n"; break;
+      case '\r': output += "\\r"; break;
+      case '\t': output += "\\t"; break;
+      default:
+        if (character < 0x20U) {
+          output += "\\u00";
+          output.push_back(kHex[(character >> 4U) & 0x0fU]);
+          output.push_back(kHex[character & 0x0fU]);
+        } else {
+          output.push_back(static_cast<char>(character));
+        }
+    }
+  }
+  output.push_back('"');
+  return output;
+}
+
+std::string canonical_request(const ParsedRequest& request) {
+  std::string params;
+  switch (request.method) {
+    case RpcMethod::kHello: {
+      const auto& value = std::get<HelloParams>(request.params);
+      const std::string component = value.component == ClientComponent::kCoreBroker
+          ? "core-broker" : "development-smoke";
+      params = "{\"client\":{\"component\":" + json_string(component)
+          + ",\"instanceId\":" + json_string(value.client_instance_id)
+          + ",\"version\":" + json_string(value.client_version) + "},\"nonce\":"
+          + json_string(value.nonce) + ",\"supportedWireVersions\":{\"maximum\":"
+          + std::to_string(value.maximum_wire_version) + ",\"minimum\":"
+          + std::to_string(value.minimum_wire_version) + "}}";
+      break;
+    }
+    case RpcMethod::kCapabilities: {
+      const auto& value = std::get<CapabilitiesParams>(request.params);
+      std::vector<std::string> members;
+      if (value.detail_was_provided) {
+        members.push_back(value.detail == CapabilityDetail::kFull
+            ? "\"detail\":\"full\"" : "\"detail\":\"summary\"");
+      }
+      if (value.ids.has_value()) {
+        std::string ids = "\"ids\":[";
+        for (std::size_t index = 0; index < value.ids->size(); ++index) {
+          if (index != 0) ids.push_back(',');
+          ids += json_string((*value.ids)[index]);
+        }
+        ids.push_back(']');
+        members.push_back(std::move(ids));
+      }
+      if (value.limit_was_provided) {
+        members.push_back("\"limit\":" + std::to_string(value.limit));
+      }
+      std::sort(members.begin(), members.end());
+      params = "{";
+      for (std::size_t index = 0; index < members.size(); ++index) {
+        if (index != 0) params.push_back(',');
+        params += members[index];
+      }
+      params.push_back('}');
+      break;
+    }
+    case RpcMethod::kInvoke: {
+      const auto& value = std::get<InvokeParams>(request.params);
+      params = "{\"arguments\":{},\"capabilityId\":" + json_string(value.capability_id)
+          + ",\"capabilityVersion\":" + std::to_string(value.capability_version) + "}";
+      break;
+    }
+    case RpcMethod::kCancel: {
+      const auto& value = std::get<CancelParams>(request.params);
+      params = "{\"targetRequestId\":" + json_string(value.target_request_id) + "}";
+      break;
+    }
+  }
+  std::vector<std::string> members;
+  if (request.deadline_unix_ms.has_value()) {
+    members.push_back("\"deadlineUnixMs\":" + std::to_string(*request.deadline_unix_ms));
+  }
+  members.push_back("\"kind\":\"request\"");
+  members.push_back("\"method\":" + json_string(method_name(request.method)));
+  members.push_back("\"params\":" + params);
+  members.push_back("\"requestId\":" + json_string(request.request_id));
+  if (request.session_id.has_value()) {
+    members.push_back("\"sessionId\":" + json_string(*request.session_id));
+  }
+  members.push_back("\"wireVersion\":1");
+  std::sort(members.begin(), members.end());
+  std::string result = "{";
+  for (std::size_t index = 0; index < members.size(); ++index) {
+    if (index != 0) result.push_back(',');
+    result += members[index];
+  }
+  result.push_back('}');
+  return result;
+}
+
+constexpr std::array<std::uint32_t, 64> kSha256Constants = {
+  0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU, 0x59f111f1U,
+  0x923f82a4U, 0xab1c5ed5U, 0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U,
+  0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U, 0xe49b69c1U, 0xefbe4786U,
+  0x0fc19dc6U, 0x240ca1ccU, 0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+  0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U,
+  0x06ca6351U, 0x14292967U, 0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U,
+  0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U, 0xa2bfe8a1U, 0xa81a664bU,
+  0xc24b8b70U, 0xc76c51a3U, 0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+  0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU,
+  0x5b9cca4fU, 0x682e6ff3U, 0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+  0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U,
+};
+
+std::string sha256_hex(std::string_view input) {
+  std::vector<std::uint8_t> message(input.begin(), input.end());
+  const std::uint64_t bit_length = static_cast<std::uint64_t>(message.size()) * 8U;
+  message.push_back(0x80U);
+  while ((message.size() % 64U) != 56U) message.push_back(0);
+  for (int shift = 56; shift >= 0; shift -= 8) {
+    message.push_back(static_cast<std::uint8_t>(bit_length >> shift));
+  }
+  std::array<std::uint32_t, 8> state = {
+    0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+    0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U,
+  };
+  for (std::size_t chunk = 0; chunk < message.size(); chunk += 64) {
+    std::array<std::uint32_t, 64> words{};
+    for (std::size_t index = 0; index < 16; ++index) {
+      const std::size_t base = chunk + index * 4;
+      words[index] = (static_cast<std::uint32_t>(message[base]) << 24U)
+          | (static_cast<std::uint32_t>(message[base + 1]) << 16U)
+          | (static_cast<std::uint32_t>(message[base + 2]) << 8U)
+          | static_cast<std::uint32_t>(message[base + 3]);
+    }
+    for (std::size_t index = 16; index < 64; ++index) {
+      const std::uint32_t s0 = std::rotr(words[index - 15], 7)
+          ^ std::rotr(words[index - 15], 18) ^ (words[index - 15] >> 3U);
+      const std::uint32_t s1 = std::rotr(words[index - 2], 17)
+          ^ std::rotr(words[index - 2], 19) ^ (words[index - 2] >> 10U);
+      words[index] = words[index - 16] + s0 + words[index - 7] + s1;
+    }
+    std::uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+    std::uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (std::size_t index = 0; index < 64; ++index) {
+      const std::uint32_t sum1 = std::rotr(e, 6) ^ std::rotr(e, 11) ^ std::rotr(e, 25);
+      const std::uint32_t choice = (e & f) ^ (~e & g);
+      const std::uint32_t temp1 = h + sum1 + choice + kSha256Constants[index] + words[index];
+      const std::uint32_t sum0 = std::rotr(a, 2) ^ std::rotr(a, 13) ^ std::rotr(a, 22);
+      const std::uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+      const std::uint32_t temp2 = sum0 + majority;
+      h = g; g = f; f = e; e = d + temp1; d = c; c = b; b = a; a = temp1 + temp2;
+    }
+    state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+    state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+  }
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string output;
+  output.reserve(64);
+  for (std::uint32_t word : state) {
+    for (int shift = 28; shift >= 0; shift -= 4) output.push_back(kHex[(word >> shift) & 0xfU]);
+  }
+  return output;
+}
+
+ParsedRequest classify_request(const JsonValue& root) {
+  const JsonValue::Object* envelope = object_of(root);
+  if (envelope == nullptr || !exact_keys(*envelope,
+      {"wireVersion", "kind", "sessionId", "requestId", "method", "deadlineUnixMs", "params"},
+      {"wireVersion", "kind", "requestId", "method", "params"})) {
+    invalid_request("request envelope is not closed");
+  }
+  if (required_uint(*envelope, "wireVersion", CodecErrorKind::kInvalidRequest, 1, 1) != 1
+      || required_string(*envelope, "kind", CodecErrorKind::kInvalidRequest) != "request") {
+    invalid_request("invalid request envelope discriminator");
+  }
+  ParsedRequest request;
+  request.request_id = required_string(*envelope, "requestId", CodecErrorKind::kInvalidRequest);
+  if (!valid_request_id(request.request_id)) invalid_request("invalid request ID");
+  const std::string method = required_string(*envelope, "method", CodecErrorKind::kInvalidRequest);
+  if (method == "hello") request.method = RpcMethod::kHello;
+  else if (method == "capabilities") request.method = RpcMethod::kCapabilities;
+  else if (method == "invoke") request.method = RpcMethod::kInvoke;
+  else if (method == "cancel") request.method = RpcMethod::kCancel;
+  else invalid_request("unknown RPC method");
+
+  if (const JsonValue* value = member(*envelope, "deadlineUnixMs")) {
+    const JsonNumber* number = number_of(*value);
+    if (number == nullptr || std::trunc(number->value) != number->value || number->value < 1
+        || number->value > static_cast<double>(kMaxSafeInteger)) {
+      invalid_argument("invalid request deadline");
+    }
+    request.deadline_unix_ms = static_cast<std::uint64_t>(number->value);
+  }
+  if (request.method == RpcMethod::kHello && member(*envelope, "sessionId") != nullptr) {
+    invalid_request("hello must not include a session ID");
+  }
+  if (const JsonValue* value = member(*envelope, "sessionId")) {
+    const std::string* session = string_of(*value);
+    if (session == nullptr || !valid_uuid(*session)) session_stale("invalid session ID");
+    request.session_id = *session;
+  }
+  const JsonValue* params_value = member(*envelope, "params");
+  const JsonValue::Object* params = params_value == nullptr ? nullptr : object_of(*params_value);
+  if (params == nullptr) invalid_argument("params must be an object");
+
+  if (request.method == RpcMethod::kHello) {
+    if (!exact_keys(*params, {"supportedWireVersions", "client", "nonce"},
+        {"supportedWireVersions", "client", "nonce"})) invalid_argument("invalid hello params");
+    const JsonValue* range_value = member(*params, "supportedWireVersions");
+    const JsonValue::Object* range = range_value == nullptr ? nullptr : object_of(*range_value);
+    const JsonValue* client_value = member(*params, "client");
+    const JsonValue::Object* client = client_value == nullptr ? nullptr : object_of(*client_value);
+    if (range == nullptr || !exact_keys(*range, {"minimum", "maximum"}, {"minimum", "maximum"})
+        || client == nullptr || !exact_keys(*client, {"component", "version", "instanceId"},
+          {"component", "version", "instanceId"})) invalid_argument("invalid hello object");
+    HelloParams result;
+    result.minimum_wire_version = static_cast<std::uint16_t>(required_uint(
+        *range, "minimum", CodecErrorKind::kInvalidArgument, 1, 65'535));
+    result.maximum_wire_version = static_cast<std::uint16_t>(required_uint(
+        *range, "maximum", CodecErrorKind::kInvalidArgument, 1, 65'535));
+    if (result.minimum_wire_version > result.maximum_wire_version) {
+      invalid_argument("wire range minimum exceeds maximum");
+    }
+    const std::string component = required_string(*client, "component", CodecErrorKind::kInvalidArgument);
+    if (component == "core-broker") result.component = ClientComponent::kCoreBroker;
+    else if (component == "development-smoke") result.component = ClientComponent::kDevelopmentSmoke;
+    else invalid_argument("invalid client component");
+    result.client_version = required_string(*client, "version", CodecErrorKind::kInvalidArgument);
+    if (validate_utf8_and_count(result.client_version) < 1
+        || validate_utf8_and_count(result.client_version) > 64) invalid_argument("invalid client version");
+    result.client_instance_id = required_string(*client, "instanceId", CodecErrorKind::kInvalidArgument);
+    if (!valid_uuid(result.client_instance_id)) invalid_argument("invalid client instance ID");
+    result.nonce = required_string(*params, "nonce", CodecErrorKind::kInvalidArgument);
+    const auto nonce_character = [](char character) {
+      return ascii_alphanumeric(character) || character == '_' || character == '-';
+    };
+    if (!bounded_ascii_token(result.nonce, 32, 128, nonce_character)) invalid_argument("invalid nonce");
+    request.params = std::move(result);
+  } else {
+    if (!request.session_id.has_value()) session_stale("session ID is required");
+    if (request.method == RpcMethod::kCapabilities) {
+      if (!exact_keys(*params, {"ids", "detail", "limit"})) {
+        invalid_argument("invalid capabilities params");
+      }
+      CapabilitiesParams result;
+      if (const JsonValue* value = member(*params, "detail")) {
+        const std::string* detail = string_of(*value);
+        if (detail == nullptr || (*detail != "summary" && *detail != "full")) {
+          invalid_argument("invalid capabilities detail");
+        }
+        result.detail = *detail == "full" ? CapabilityDetail::kFull : CapabilityDetail::kSummary;
+        result.detail_was_provided = true;
+      }
+      if (member(*params, "limit") != nullptr) {
+        result.limit = static_cast<std::uint16_t>(required_uint(
+            *params, "limit", CodecErrorKind::kInvalidArgument, 1, 100));
+        result.limit_was_provided = true;
+      }
+      if (const JsonValue* value = member(*params, "ids")) {
+        const JsonValue::Array* ids = array_of(*value);
+        if (ids == nullptr || ids->empty() || ids->size() > 32) invalid_argument("invalid capability IDs");
+        std::vector<std::string> parsed_ids;
+        std::set<std::string> unique;
+        for (const JsonValue& item : *ids) {
+          const std::string* id = string_of(item);
+          if (id == nullptr || !valid_capability_id(*id) || !unique.insert(*id).second) {
+            invalid_argument("invalid or duplicate capability ID");
+          }
+          parsed_ids.push_back(*id);
+        }
+        result.ids = std::move(parsed_ids);
+      }
+      request.params = std::move(result);
+    } else if (request.method == RpcMethod::kInvoke) {
+      if (!exact_keys(*params, {"capabilityId", "capabilityVersion", "arguments"},
+          {"capabilityId", "capabilityVersion", "arguments"})) invalid_argument("invalid invoke params");
+      const std::string capability = required_string(*params, "capabilityId", CodecErrorKind::kInvalidArgument);
+      const std::uint64_t version = required_uint(
+          *params, "capabilityVersion", CodecErrorKind::kInvalidArgument, 1, kMaxSafeInteger);
+      const JsonValue* arguments_value = member(*params, "arguments");
+      const JsonValue::Object* arguments = arguments_value == nullptr ? nullptr : object_of(*arguments_value);
+      if (capability != "ae.project.summary" || version != 1 || arguments == nullptr
+          || !arguments->empty()) invalid_argument("invoke is not in the compile-time allowlist");
+      request.params = InvokeParams{};
+    } else {
+      if (!exact_keys(*params, {"targetRequestId"}, {"targetRequestId"})) {
+        invalid_argument("invalid cancel params");
+      }
+      CancelParams result;
+      result.target_request_id = required_string(
+          *params, "targetRequestId", CodecErrorKind::kInvalidArgument);
+      if (!valid_request_id(result.target_request_id)) invalid_argument("invalid cancel target ID");
+      request.params = std::move(result);
+    }
+  }
+  request.request_fingerprint_sha256 = sha256_hex(canonical_request(request));
+  return request;
+}
+
+std::uint32_t read_be32(Bytes bytes) {
+  return (static_cast<std::uint32_t>(bytes[0]) << 24U)
+      | (static_cast<std::uint32_t>(bytes[1]) << 16U)
+      | (static_cast<std::uint32_t>(bytes[2]) << 8U)
+      | static_cast<std::uint32_t>(bytes[3]);
+}
+
+}  // namespace
+
+CodecError::CodecError(CodecErrorKind kind, std::string message)
+    : std::runtime_error(std::move(message)), kind_(kind) {}
+
+std::string_view CodecError::error_code() const noexcept {
+  switch (kind_) {
+    case CodecErrorKind::kInvalidRequest: return "INVALID_REQUEST";
+    case CodecErrorKind::kInvalidArgument: return "INVALID_ARGUMENT";
+    case CodecErrorKind::kSessionStale: return "SESSION_STALE";
+  }
+  return "INVALID_REQUEST";
+}
+
+ParsedRequest decode_request_frame(std::span<const std::uint8_t> frame) {
+  if (frame.size() < kFramePrefixBytes) invalid_request("incomplete frame prefix");
+  const std::uint32_t size = read_be32(frame.first<4>());
+  if (size == 0 || size > kMaxFrameBytes) invalid_request("frame size rejected");
+  if (frame.size() != static_cast<std::size_t>(size) + kFramePrefixBytes) {
+    invalid_request("incomplete or trailing frame bytes");
+  }
+  const char* body = reinterpret_cast<const char*>(frame.data() + kFramePrefixBytes);
+  return classify_request(JsonParser(std::string_view(body, size)).parse());
+}
+
+std::string digest_capabilities_query(
+    std::string_view session_id,
+    const CapabilitiesParams& params) {
+  if (!valid_uuid(session_id) || params.limit < 1 || params.limit > 100) {
+    invalid_argument("invalid capabilities query digest input");
+  }
+  std::string ids = "null";
+  if (params.ids.has_value()) {
+    if (params.ids->empty() || params.ids->size() > 32) {
+      invalid_argument("invalid capabilities IDs for query digest");
+    }
+    ids = "[";
+    for (std::size_t index = 0; index < params.ids->size(); ++index) {
+      if (!valid_capability_id((*params.ids)[index])) {
+        invalid_argument("invalid capability ID for query digest");
+      }
+      if (index != 0) ids.push_back(',');
+      ids += json_string((*params.ids)[index]);
+    }
+    ids.push_back(']');
+  }
+  const std::string canonical = "{\"detail\":"
+      + json_string(params.detail == CapabilityDetail::kFull ? "full" : "summary")
+      + ",\"ids\":" + ids + ",\"limit\":" + std::to_string(params.limit)
+      + ",\"sessionId\":" + json_string(session_id) + "}";
+  return sha256_hex(canonical);
+}
+
+std::string digest_project_summary_postcondition(
+    bool project_open,
+    std::string_view project_name,
+    std::uint64_t item_count) {
+  if (item_count > kMaxSafeInteger) invalid_argument("project item count exceeds safe integer");
+  if (validate_utf8_and_count(project_name) > 1'024) {
+    invalid_argument("project name exceeds result contract");
+  }
+  const std::string canonical = "{\"capabilityId\":\"ae.project.summary\","
+      "\"capabilityVersion\":1,\"value\":{\"itemCount\":" + std::to_string(item_count)
+      + ",\"projectName\":" + json_string(project_name)
+      + ",\"projectOpen\":" + (project_open ? "true" : "false") + "}}";
+  return sha256_hex(canonical);
+}
+
+std::vector<ParsedRequest> FrameDecoder::push(std::span<const std::uint8_t> chunk) {
+  if (failed_) invalid_request("frame decoder is poisoned");
+  if (chunk.size() > kMaxFrameBytes + kFramePrefixBytes) {
+    failed_ = true;
+    invalid_request("transport chunk exceeds bounded decoder input");
+  }
+  try {
+    pending_.insert(pending_.end(), chunk.begin(), chunk.end());
+    std::vector<ParsedRequest> result;
+    while (pending_.size() >= kFramePrefixBytes) {
+      const std::uint32_t size = read_be32(Bytes(pending_.data(), 4));
+      if (size == 0 || size > kMaxFrameBytes) invalid_request("frame size rejected");
+      const std::size_t total = static_cast<std::size_t>(size) + kFramePrefixBytes;
+      if (pending_.size() < total) break;
+      result.push_back(decode_request_frame(Bytes(pending_.data(), total)));
+      pending_.erase(pending_.begin(), pending_.begin() + static_cast<std::ptrdiff_t>(total));
+    }
+    return result;
+  } catch (...) {
+    failed_ = true;
+    pending_.clear();
+    throw;
+  }
+}
+
+void FrameDecoder::finalize() {
+  if (failed_) invalid_request("frame decoder is poisoned");
+  if (!pending_.empty()) {
+    failed_ = true;
+    pending_.clear();
+    invalid_request("incomplete frame at end of stream");
+  }
+}
+
+std::uint64_t SystemSessionClock::now_unix_ms() const noexcept {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
+RpcSessionFrontDoor::RpcSessionFrontDoor(
+    std::string connection_id, std::string host_instance_id, std::string session_id,
+    SessionClock& clock, SessionFrontDoorConfig config)
+    : connection_id_(std::move(connection_id)),
+      host_instance_id_(std::move(host_instance_id)),
+      session_id_(std::move(session_id)),
+      clock_(clock),
+      config_(config) {
+  if (connection_id_.empty() || connection_id_.size() > 1'024
+      || output_scalar_count(connection_id_) > 256 || !valid_uuid(host_instance_id_)
+      || !valid_uuid(session_id_) || config_.max_active_requests == 0
+      || config_.max_active_requests > 64 || config_.max_terminal_tombstones == 0
+      || config_.max_terminal_tombstones > 4'096 || config_.tombstone_ttl_ms < 1'000
+      || config_.tombstone_ttl_ms > 300'000 || config_.default_deadline_ms == 0
+      || config_.maximum_deadline_ms < 100 || config_.maximum_deadline_ms > 30'000
+      || config_.default_deadline_ms > config_.maximum_deadline_ms) {
+    throw std::invalid_argument("invalid RPC session front-door configuration");
+  }
+}
+
+bool RpcSessionFrontDoor::authorize_pairing() noexcept {
+  if (closed_) return false;
+  paired_ = true;
+  return true;
+}
+
+void RpcSessionFrontDoor::revoke_pairing() noexcept {
+  paired_ = false;
+  hello_complete_ = false;
+  active_.clear();
+  tombstones_.clear();
+}
+
+SessionIngressResult RpcSessionFrontDoor::admit(const ParsedRequest& request) {
+  if (closed_) return {SessionIngressCode::kClosed, "SESSION_STALE", std::nullopt, false};
+  if (!valid_request_id(request.request_id)
+      || !valid_sha256(request.request_fingerprint_sha256)) {
+    return {SessionIngressCode::kInvalidRequest, "INVALID_REQUEST", std::nullopt, false};
+  }
+  const bool params_match = (request.method == RpcMethod::kHello
+        && std::holds_alternative<HelloParams>(request.params))
+      || (request.method == RpcMethod::kCapabilities
+        && std::holds_alternative<CapabilitiesParams>(request.params))
+      || (request.method == RpcMethod::kInvoke
+        && std::holds_alternative<InvokeParams>(request.params))
+      || (request.method == RpcMethod::kCancel
+        && std::holds_alternative<CancelParams>(request.params));
+  if (!params_match) {
+    return {SessionIngressCode::kInvalidRequest, "INVALID_REQUEST", std::nullopt, false};
+  }
+  if (request.method == RpcMethod::kHello) {
+    const auto* hello = std::get_if<HelloParams>(&request.params);
+    if (hello == nullptr || request.session_id.has_value()) {
+      return {SessionIngressCode::kInvalidRequest, "INVALID_REQUEST", std::nullopt, false};
+    }
+    if (!paired_) {
+      return {SessionIngressCode::kPairingRequired, "AUTH_REQUIRED", std::nullopt, false};
+    }
+    if (hello_complete_) {
+      return {SessionIngressCode::kSessionStale, "SESSION_STALE", std::nullopt, false};
+    }
+    if (hello->minimum_wire_version > 1 || hello->maximum_wire_version < 1) {
+      return {SessionIngressCode::kWireVersionMismatch, "WIRE_VERSION_MISMATCH", std::nullopt, false};
+    }
+    hello_complete_ = true;
+    return {SessionIngressCode::kAcceptedHello, {}, std::nullopt, false};
+  }
+  if (!paired_) {
+    return {SessionIngressCode::kAuthorizationRequired, "AUTH_REQUIRED", std::nullopt, false};
+  }
+  if (!hello_complete_) {
+    return {SessionIngressCode::kHelloRequired, "SESSION_STALE", std::nullopt, false};
+  }
+  if (!request.session_id.has_value() || *request.session_id != session_id_) {
+    return {SessionIngressCode::kSessionStale, "SESSION_STALE", std::nullopt, false};
+  }
+  const std::uint64_t now = clock_.now_unix_ms();
+  cleanup(now);
+  std::uint64_t deadline = 0;
+  if (request.deadline_unix_ms.has_value()) {
+    deadline = *request.deadline_unix_ms;
+  } else if (now > kMaxSafeInteger - config_.default_deadline_ms) {
+    return {SessionIngressCode::kInvalidDeadline, "INVALID_ARGUMENT", std::nullopt, false};
+  } else {
+    deadline = now + config_.default_deadline_ms;
+  }
+  if (deadline <= now) {
+    return {SessionIngressCode::kDeadlineExceeded, "DEADLINE_EXCEEDED", std::nullopt, false};
+  }
+  if (now > kMaxSafeInteger - config_.maximum_deadline_ms
+      || deadline > now + config_.maximum_deadline_ms) {
+    return {SessionIngressCode::kInvalidDeadline, "INVALID_ARGUMENT", std::nullopt, false};
+  }
+  if (const auto found = active_.find(request.request_id); found != active_.end()) {
+    return {SessionIngressCode::kDuplicateRequest, "DUPLICATE_REQUEST", std::nullopt,
+      found->second.fingerprint == request.request_fingerprint_sha256};
+  }
+  const auto terminal = std::find_if(tombstones_.begin(), tombstones_.end(), [&](const Tombstone& item) {
+    return item.request_id == request.request_id;
+  });
+  if (terminal != tombstones_.end()) {
+    return {SessionIngressCode::kDuplicateRequest, "DUPLICATE_REQUEST", std::nullopt,
+      terminal->fingerprint == request.request_fingerprint_sha256};
+  }
+  if (active_.size() >= config_.max_active_requests) {
+    return {SessionIngressCode::kLedgerFull, "QUEUE_FULL", std::nullopt, false};
+  }
+  active_.emplace(request.request_id, ActiveEntry{request.request_fingerprint_sha256, deadline});
+  return {SessionIngressCode::kAcceptedRequest, {}, deadline};
+}
+
+bool RpcSessionFrontDoor::complete_request(std::string_view request_id) {
+  const auto found = active_.find(std::string(request_id));
+  if (found == active_.end()) return false;
+  std::string id = found->first;
+  std::string fingerprint = found->second.fingerprint;
+  active_.erase(found);
+  add_tombstone(std::move(id), std::move(fingerprint), clock_.now_unix_ms());
+  return true;
+}
+
+void RpcSessionFrontDoor::close() noexcept {
+  closed_ = true;
+  paired_ = false;
+  hello_complete_ = false;
+  active_.clear();
+  tombstones_.clear();
+}
+
+void RpcSessionFrontDoor::cleanup(std::uint64_t now) {
+  while (!tombstones_.empty() && tombstones_.front().expires_at_unix_ms <= now) {
+    tombstones_.pop_front();
+  }
+  std::vector<std::pair<std::string, std::string>> expired;
+  for (const auto& [id, entry] : active_) {
+    if (entry.effective_deadline_unix_ms <= now) expired.emplace_back(id, entry.fingerprint);
+  }
+  for (auto& [id, fingerprint] : expired) {
+    active_.erase(id);
+    add_tombstone(std::move(id), std::move(fingerprint), now);
+  }
+}
+
+void RpcSessionFrontDoor::add_tombstone(
+    std::string request_id, std::string fingerprint, std::uint64_t now) {
+  while (tombstones_.size() >= config_.max_terminal_tombstones) tombstones_.pop_front();
+  const std::uint64_t expiry = now > kMaxSafeInteger - config_.tombstone_ttl_ms
+      ? kMaxSafeInteger : now + config_.tombstone_ttl_ms;
+  tombstones_.push_back({std::move(request_id), std::move(fingerprint), expiry});
+}
+
+namespace {
+
+void require_output_string(
+    std::string_view value, std::size_t minimum, std::size_t maximum,
+    std::string_view field) {
+  const std::size_t count = output_scalar_count(value);
+  if (count < minimum || count > maximum) {
+    invalid_argument(std::string(field) + " violates its output string bound");
+  }
+}
+
+void require_request_id(std::string_view value) {
+  if (!valid_request_id(value)) invalid_argument("invalid output request ID");
+}
+
+void require_uuid(std::string_view value, std::string_view field) {
+  if (!valid_uuid(value)) invalid_argument(std::string("invalid output ") + std::string(field));
+}
+
+void require_digest(std::string_view value, std::string_view field) {
+  if (!valid_sha256(value)) invalid_argument(std::string("invalid output ") + std::string(field));
+}
+
+bool valid_numeric_version(std::string_view value) {
+  std::size_t parts = 0;
+  std::size_t start = 0;
+  while (start < value.size()) {
+    std::size_t end = value.find('.', start);
+    if (end == std::string_view::npos) end = value.size();
+    if (end == start || !std::all_of(value.begin() + static_cast<std::ptrdiff_t>(start),
+        value.begin() + static_cast<std::ptrdiff_t>(end), [](char character) {
+          return character >= '0' && character <= '9';
+        })) return false;
+    ++parts;
+    if (end == value.size()) break;
+    start = end + 1;
+  }
+  return parts == 2 || parts == 3;
+}
+
+std::vector<std::uint8_t> frame_output(std::string json) {
+  if (json.empty() || json.size() > kMaxFrameBytes) invalid_argument("output frame size rejected");
+  (void)JsonParser(json).parse();
+  std::vector<std::uint8_t> frame(json.size() + 4);
+  const auto size = static_cast<std::uint32_t>(json.size());
+  frame[0] = static_cast<std::uint8_t>(size >> 24U);
+  frame[1] = static_cast<std::uint8_t>(size >> 16U);
+  frame[2] = static_cast<std::uint8_t>(size >> 8U);
+  frame[3] = static_cast<std::uint8_t>(size);
+  std::memcpy(frame.data() + 4, json.data(), json.size());
+  return frame;
+}
+
+std::string progress_phase_name(ProgressPhase phase) {
+  switch (phase) {
+    case ProgressPhase::kQueued: return "queued";
+    case ProgressPhase::kDispatched: return "dispatched";
+    case ProgressPhase::kRunning: return "running";
+    case ProgressPhase::kValidating: return "validating";
+  }
+  invalid_argument("unknown progress phase");
+}
+
+std::string double_json(double value) {
+  if (!std::isfinite(value)) invalid_argument("non-finite output number");
+  std::ostringstream stream;
+  stream.imbue(std::locale::classic());
+  stream << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
+  if (!stream) invalid_argument("could not encode output number");
+  return stream.str();
+}
+
+void validate_limits(const NegotiatedLimits& limits) {
+  if (limits.max_frame_bytes < 4'096 || limits.max_frame_bytes > kMaxFrameBytes
+      || limits.max_in_flight < 1 || limits.max_in_flight > 64
+      || limits.max_queue_depth < 1 || limits.max_queue_depth > 256
+      || limits.max_deadline_ms < 100 || limits.max_deadline_ms > 30'000
+      || limits.max_requests_per_second < 1 || limits.max_requests_per_second > 100
+      || limits.max_burst < 1 || limits.max_burst > 100
+      || limits.max_control_in_flight < 1 || limits.max_control_in_flight > 8
+      || limits.max_control_requests_per_second < 1
+      || limits.max_control_requests_per_second > 100
+      || limits.max_control_burst < 1 || limits.max_control_burst > 100
+      || limits.max_terminal_cache_entries < 1 || limits.max_terminal_cache_entries > 4'096
+      || limits.terminal_cache_ttl_ms < 1'000 || limits.terminal_cache_ttl_ms > 300'000) {
+    invalid_argument("negotiated limits are outside the v1 contract");
+  }
+}
+
+std::string capability_descriptor(const CapabilitiesSuccess& response) {
+  const std::string detail = response.detail == CapabilityDetail::kFull ? "full" : "summary";
+  std::string descriptor = "{\"cancellation\":\"before-dispatch\","
+      "\"compatibility\":{\"intendedPlatforms\":[\"macos-arm64\",\"windows-x64\"],"
+      "\"status\":\"unverified\"},\"detail\":" + json_string(detail)
+      + ",\"id\":\"ae.project.summary\",\"idempotency\":\"idempotent\","
+        "\"mutability\":\"read-only\",\"preconditions\":[],\"risk\":\"read\","
+        "\"schemaVersion\":1,\"sideEffectSummary\":"
+      + json_string("Reads project state without modifying it.")
+      + ",\"summary\":"
+      + json_string("Read bounded facts about the active After Effects project.")
+      + ",\"undo\":\"not-applicable\",\"version\":1";
+  if (response.detail == CapabilityDetail::kFull) {
+    require_digest(response.project_summary_contract_digest, "contract digest");
+    descriptor += ",\"contractDigest\":" + json_string(response.project_summary_contract_digest)
+        + ",\"examples\":[{\"arguments\":{},\"expected\":{\"outcome\":\"succeeded\","
+          "\"value\":{\"itemCount\":0,\"projectName\":\"SYNTHETIC_EXAMPLE\","
+          "\"projectOpen\":false}},\"id\":\"aemcp-example-project-summary-empty\","
+          "\"kind\":\"positive\",\"summary\":"
+        + json_string("Read a bounded summary when no project content exists.")
+        + "},{\"arguments\":{},\"expected\":{\"errorCode\":\"NATIVE_UNAVAILABLE\","
+          "\"recoveryAction\":\"reconnect\"},"
+          "\"id\":\"aemcp-example-project-summary-unavailable\",\"kind\":\"negative\","
+          "\"summary\":"
+        + json_string("Return a typed unavailable error before native dispatch.")
+        + "}],\"inputContractId\":\"aemcp.contract.ae.project.summary.input.v1\","
+          "\"inputSchema\":{\"additionalProperties\":false,\"properties\":{},"
+          "\"required\":[],\"type\":\"object\"},\"requirements\":[{"
+          "\"contractVersion\":1,\"id\":\"aemcp.requirement.native.project-read\"}],"
+          "\"resultContractId\":\"aemcp.contract.ae.project.summary.result.v1\","
+          "\"resultSchema\":{\"additionalProperties\":false,\"properties\":{"
+          "\"itemCount\":{\"maximum\":9007199254740991,\"minimum\":0,"
+          "\"type\":\"integer\"},\"projectName\":{\"maxLength\":1024,"
+          "\"type\":\"string\"},\"projectOpen\":{\"type\":\"boolean\"}},"
+          "\"required\":[\"projectOpen\",\"projectName\",\"itemCount\"],"
+          "\"type\":\"object\"}";
+  }
+  descriptor.push_back('}');
+  return descriptor;
+}
+
+struct ErrorPolicy {
+  const char* code;
+  bool retryable;
+  const char* side_effect;
+  const char* recovery;
+  bool capability_details;
+};
+
+ErrorPolicy error_policy(RpcErrorCode code) {
+  switch (code) {
+    case RpcErrorCode::kNativeUnavailable:
+      return {"NATIVE_UNAVAILABLE", true, "not-started", "reconnect", false};
+    case RpcErrorCode::kNativeUnsupported:
+      return {"NATIVE_UNSUPPORTED", false, "not-started", "refresh-capabilities", true};
+    case RpcErrorCode::kWireVersionMismatch:
+      return {"WIRE_VERSION_MISMATCH", false, "not-started", "reconnect", false};
+    case RpcErrorCode::kInvalidRequest:
+      return {"INVALID_REQUEST", false, "not-started", "none", false};
+    case RpcErrorCode::kInvalidArgument:
+      return {"INVALID_ARGUMENT", false, "not-started", "change-arguments", false};
+    case RpcErrorCode::kDuplicateRequest:
+      return {"DUPLICATE_REQUEST", false, "not-started", "inspect-state", false};
+    case RpcErrorCode::kPreconditionFailed:
+      return {"PRECONDITION_FAILED", false, "not-started", "open-project", true};
+    case RpcErrorCode::kStaleLocator:
+      return {"STALE_LOCATOR", true, "not-started", "refresh-locator", true};
+    case RpcErrorCode::kDeadlineExceeded:
+      return {"DEADLINE_EXCEEDED", true, "not-started", "retry", false};
+    case RpcErrorCode::kCancelled:
+      return {"CANCELLED", false, "not-started", "none", false};
+    case RpcErrorCode::kQueueFull:
+      return {"QUEUE_FULL", true, "not-started", "retry", false};
+    case RpcErrorCode::kAeShuttingDown:
+      return {"AE_SHUTTING_DOWN", true, "not-started", "reconnect", false};
+    case RpcErrorCode::kSessionStale:
+      return {"SESSION_STALE", true, "not-started", "reconnect", false};
+    case RpcErrorCode::kCapabilityFailed:
+      return {"CAPABILITY_FAILED", false, "not-started", "inspect-state", true};
+    case RpcErrorCode::kPossiblySideEffectingFailure:
+      return {"POSSIBLY_SIDE_EFFECTING_FAILURE", false, "may-have-occurred", "inspect-state", true};
+  }
+  invalid_argument("unknown RPC error code");
+}
+
+}  // namespace
+
+std::vector<std::uint8_t> encode_hello_success(const HelloSuccess& response) {
+  require_request_id(response.request_id);
+  require_uuid(response.session_id, "session ID");
+  require_uuid(response.host_instance_id, "host instance ID");
+  require_output_string(response.client_nonce, 32, 128, "client nonce");
+  if (!std::all_of(response.client_nonce.begin(), response.client_nonce.end(), [](char character) {
+      return ascii_alphanumeric(character) || character == '_' || character == '-';
+    })) invalid_argument("client nonce is not URL-safe base64 text");
+  require_output_string(response.plugin_version, 1, 64, "plugin version");
+  if (!valid_numeric_version(response.compiled_sdk_version)
+      || !valid_numeric_version(response.host_version)
+      || response.compiled_sdk_build < 1 || response.compiled_sdk_build > kMaxSafeInteger
+      || response.host_build < 1 || response.host_build > kMaxSafeInteger
+      || response.session_generation < 1 || response.session_generation > kMaxSafeInteger
+      || (response.architecture != "arm64" && response.architecture != "x86_64")
+      || (response.platform != "macos-arm64" && response.platform != "windows-x64")
+      || (response.platform == "macos-arm64" && response.architecture != "arm64")
+      || (response.platform == "windows-x64" && response.architecture != "x86_64")) {
+    invalid_argument("invalid hello identity");
+  }
+  validate_limits(response.limits);
+  require_digest(response.capabilities_digest, "capabilities digest");
+  const NegotiatedLimits& limits = response.limits;
+  std::string json = "{\"kind\":\"response\",\"method\":\"hello\",\"ok\":true,"
+      "\"replayed\":false,\"requestId\":" + json_string(response.request_id)
+      + ",\"result\":{\"capabilitiesDigest\":" + json_string(response.capabilities_digest)
+      + ",\"clientNonce\":" + json_string(response.client_nonce)
+      + ",\"compiledSdk\":{\"architecture\":" + json_string(response.architecture)
+      + ",\"build\":" + std::to_string(response.compiled_sdk_build)
+      + ",\"version\":" + json_string(response.compiled_sdk_version)
+      + "},\"host\":{\"application\":\"after-effects\",\"build\":"
+      + std::to_string(response.host_build) + ",\"instanceId\":"
+      + json_string(response.host_instance_id) + ",\"platform\":"
+      + json_string(response.platform) + ",\"version\":" + json_string(response.host_version)
+      + "},\"limits\":{\"maxBurst\":" + std::to_string(limits.max_burst)
+      + ",\"maxControlBurst\":" + std::to_string(limits.max_control_burst)
+      + ",\"maxControlInFlight\":" + std::to_string(limits.max_control_in_flight)
+      + ",\"maxControlRequestsPerSecond\":"
+      + std::to_string(limits.max_control_requests_per_second)
+      + ",\"maxDeadlineMs\":" + std::to_string(limits.max_deadline_ms)
+      + ",\"maxFrameBytes\":" + std::to_string(limits.max_frame_bytes)
+      + ",\"maxInFlight\":" + std::to_string(limits.max_in_flight)
+      + ",\"maxQueueDepth\":" + std::to_string(limits.max_queue_depth)
+      + ",\"maxRequestsPerSecond\":" + std::to_string(limits.max_requests_per_second)
+      + ",\"maxTerminalCacheEntries\":"
+      + std::to_string(limits.max_terminal_cache_entries)
+      + ",\"terminalCacheTtlMs\":" + std::to_string(limits.terminal_cache_ttl_ms)
+      + "},\"pluginVersion\":" + json_string(response.plugin_version)
+      + ",\"selectedWireVersion\":1,\"sessionGeneration\":"
+      + std::to_string(response.session_generation) + ",\"sessionId\":"
+      + json_string(response.session_id) + "},\"sessionId\":" + json_string(response.session_id)
+      + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_capabilities_success(const CapabilitiesSuccess& response) {
+  require_request_id(response.request_id);
+  require_uuid(response.session_id, "session ID");
+  require_digest(response.query_digest, "query digest");
+  require_digest(response.capabilities_digest, "capabilities digest");
+  const std::string detail = response.detail == CapabilityDetail::kFull ? "full" : "summary";
+  std::string items = "[";
+  if (response.include_project_summary) items += capability_descriptor(response);
+  items.push_back(']');
+  std::string json = "{\"kind\":\"response\",\"method\":\"capabilities\",\"ok\":true,"
+      "\"replayed\":false,\"requestId\":" + json_string(response.request_id)
+      + ",\"result\":{\"capabilitiesDigest\":" + json_string(response.capabilities_digest)
+      + ",\"detail\":" + json_string(detail) + ",\"items\":" + items
+      + ",\"nextCursor\":null,\"queryDigest\":" + json_string(response.query_digest)
+      + "},\"sessionId\":" + json_string(response.session_id) + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_progress_event(const ProgressEvent& event) {
+  require_request_id(event.request_id);
+  require_uuid(event.session_id, "session ID");
+  if (event.sequence < 1 || event.sequence > kMaxSafeInteger || !std::isfinite(event.fraction)
+      || event.fraction < 0 || event.fraction > 1) invalid_argument("invalid progress value");
+  require_output_string(event.message, 1, 160, "progress message");
+  std::string json = "{\"event\":\"progress\",\"kind\":\"event\",\"progress\":{"
+      "\"fraction\":" + double_json(event.fraction) + ",\"message\":"
+      + json_string(event.message) + ",\"phase\":" + json_string(progress_phase_name(event.phase))
+      + "},\"requestId\":" + json_string(event.request_id) + ",\"sequence\":"
+      + std::to_string(event.sequence) + ",\"sessionId\":" + json_string(event.session_id)
+      + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_project_summary_success(
+    const ProjectSummarySuccess& response) {
+  require_request_id(response.request_id);
+  require_uuid(response.session_id, "session ID");
+  require_uuid(response.host_instance_id, "host instance ID");
+  require_output_string(response.project_name, 0, 1'024, "project name");
+  require_digest(response.request_digest, "request digest");
+  require_digest(response.postcondition_digest, "postcondition digest");
+  if (response.replayed || response.item_count > kMaxSafeInteger || response.started_at_unix_ms < 1
+      || response.started_at_unix_ms > kMaxSafeInteger || response.completed_at_unix_ms < 1
+      || response.completed_at_unix_ms > kMaxSafeInteger
+      || response.completed_at_unix_ms < response.started_at_unix_ms) {
+    invalid_argument("invalid or unvalidated project summary evidence");
+  }
+  std::string json = "{\"kind\":\"response\",\"method\":\"invoke\",\"ok\":true,"
+      "\"replayed\":" + std::string(response.replayed ? "true" : "false")
+      + ",\"requestId\":" + json_string(response.request_id)
+      + ",\"result\":{\"capabilityId\":\"ae.project.summary\","
+        "\"capabilityVersion\":1,\"engine\":\"native-aegp\",\"evidence\":{"
+        "\"capabilityId\":\"ae.project.summary\",\"capabilityVersion\":1,"
+        "\"completedAtUnixMs\":" + std::to_string(response.completed_at_unix_ms)
+      + ",\"effect\":\"none\",\"engine\":\"native-aegp\",\"hostInstanceId\":"
+      + json_string(response.host_instance_id) + ",\"postcondition\":{"
+        "\"algorithm\":\"sha256-rfc8785-jcs-v1\",\"digest\":"
+      + json_string(response.postcondition_digest)
+      + ",\"kind\":\"project-summary\",\"verified\":true},\"requestDigest\":"
+      + json_string(response.request_digest) + ",\"requestId\":"
+      + json_string(response.request_id) + ",\"sessionId\":" + json_string(response.session_id)
+      + ",\"startedAtUnixMs\":" + std::to_string(response.started_at_unix_ms)
+      + "},\"outcome\":\"succeeded\",\"value\":{\"itemCount\":"
+      + std::to_string(response.item_count) + ",\"projectName\":"
+      + json_string(response.project_name) + ",\"projectOpen\":"
+      + (response.project_open ? "true" : "false") + "}},\"sessionId\":"
+      + json_string(response.session_id) + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_cancel_success(const CancelSuccess& response) {
+  require_request_id(response.request_id);
+  require_request_id(response.target_request_id);
+  require_uuid(response.session_id, "session ID");
+  std::string_view state;
+  bool terminal_expected = false;
+  switch (response.state) {
+    case CancelState::kQueuedCancelled:
+      state = "queued-cancelled";
+      terminal_expected = true;
+      break;
+    case CancelState::kRunningCancelRequested:
+      state = "running-cancel-requested";
+      terminal_expected = true;
+      break;
+    case CancelState::kRunningNotCancellable:
+      state = "running-not-cancellable";
+      terminal_expected = true;
+      break;
+    case CancelState::kAlreadyTerminal:
+      state = "already-terminal";
+      break;
+    case CancelState::kNotFound:
+      state = "not-found";
+      break;
+  }
+  if (response.terminal_response_expected != terminal_expected) {
+    invalid_argument("cancel terminal expectation does not match state");
+  }
+  std::string json = "{\"kind\":\"response\",\"method\":\"cancel\",\"ok\":true,"
+      "\"replayed\":false,\"requestId\":" + json_string(response.request_id)
+      + ",\"result\":{\"state\":" + json_string(state)
+      + ",\"targetRequestId\":" + json_string(response.target_request_id)
+      + ",\"terminalResponseExpected\":"
+      + (response.terminal_response_expected ? "true" : "false")
+      + "},\"sessionId\":" + json_string(response.session_id)
+      + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_error_response(const ErrorResponse& response) {
+  require_request_id(response.request_id);
+  const ErrorPolicy policy = error_policy(response.code);
+  require_output_string(response.message, 1, 512, "error message");
+  require_output_string(response.recovery_hint, 1, 256, "recovery hint");
+  if (response.method == RpcMethod::kHello) {
+    if (response.session_id.has_value()
+        || !(response.code == RpcErrorCode::kNativeUnavailable
+          || response.code == RpcErrorCode::kWireVersionMismatch
+          || response.code == RpcErrorCode::kInvalidRequest
+          || response.code == RpcErrorCode::kInvalidArgument)) {
+      invalid_argument("invalid hello failure shape");
+    }
+  } else {
+    if (!response.session_id.has_value()) invalid_argument("session failure needs a session ID");
+    require_uuid(*response.session_id, "session ID");
+    if (response.code == RpcErrorCode::kWireVersionMismatch) {
+      invalid_argument("wire mismatch is only valid during hello");
+    }
+  }
+  if (response.code == RpcErrorCode::kQueueFull) {
+    if (!response.retry_after_ms.has_value() || *response.retry_after_ms < 1
+        || *response.retry_after_ms > 30'000) invalid_argument("QUEUE_FULL needs retryAfterMs");
+  } else if (response.retry_after_ms.has_value()) {
+    invalid_argument("retryAfterMs is only valid for QUEUE_FULL");
+  }
+  if (response.code == RpcErrorCode::kWireVersionMismatch) {
+    if (!response.details.has_value() || !response.details->supported_wire_minimum.has_value()
+        || !response.details->supported_wire_maximum.has_value()
+        || *response.details->supported_wire_minimum < 1
+        || *response.details->supported_wire_maximum
+          < *response.details->supported_wire_minimum) {
+      invalid_argument("wire mismatch needs a valid supported range");
+    }
+  }
+  if (policy.capability_details
+      && (!response.details.has_value() || !response.details->capability_id.has_value()
+        || !valid_capability_id(*response.details->capability_id))) {
+    invalid_argument("capability failure needs capabilityId details");
+  }
+  std::string recovery = "{\"action\":" + json_string(policy.recovery)
+      + ",\"hint\":" + json_string(response.recovery_hint);
+  if (response.retry_after_ms.has_value()) {
+    recovery += ",\"retryAfterMs\":" + std::to_string(*response.retry_after_ms);
+  }
+  recovery.push_back('}');
+
+  std::string details;
+  if (response.details.has_value()) {
+    const ErrorDetails& value = *response.details;
+    std::vector<std::string> members;
+    if (value.field.has_value()) {
+      require_output_string(*value.field, 1, 128, "error field");
+      members.push_back("\"field\":" + json_string(*value.field));
+    }
+    if (value.capability_id.has_value()) {
+      if (!valid_capability_id(*value.capability_id)) invalid_argument("invalid detail capability ID");
+      members.push_back("\"capabilityId\":" + json_string(*value.capability_id));
+    }
+    if (value.supported_wire_minimum.has_value() || value.supported_wire_maximum.has_value()) {
+      if (!value.supported_wire_minimum.has_value() || !value.supported_wire_maximum.has_value()
+          || *value.supported_wire_minimum < 1
+          || *value.supported_wire_minimum > *value.supported_wire_maximum) {
+        invalid_argument("invalid detail wire range");
+      }
+      members.push_back("\"supportedWireVersions\":{\"maximum\":"
+          + std::to_string(*value.supported_wire_maximum) + ",\"minimum\":"
+          + std::to_string(*value.supported_wire_minimum) + "}");
+    }
+    if (value.current_generation.has_value()) {
+      if (*value.current_generation < 1 || *value.current_generation > kMaxSafeInteger) {
+        invalid_argument("invalid detail generation");
+      }
+      members.push_back("\"currentGeneration\":" + std::to_string(*value.current_generation));
+    }
+    std::sort(members.begin(), members.end());
+    details = ",\"details\":{";
+    for (std::size_t index = 0; index < members.size(); ++index) {
+      if (index != 0) details.push_back(',');
+      details += members[index];
+    }
+    details.push_back('}');
+  }
+  std::string json = "{\"error\":{\"code\":" + json_string(policy.code) + details
+      + ",\"message\":" + json_string(response.message) + ",\"recovery\":" + recovery
+      + ",\"retryable\":" + (policy.retryable ? "true" : "false")
+      + ",\"sideEffect\":" + json_string(policy.side_effect) + "},\"kind\":\"response\","
+        "\"method\":" + json_string(method_name(response.method))
+      + ",\"ok\":false,\"replayed\":false,\"requestId\":"
+      + json_string(response.request_id);
+  if (response.session_id.has_value()) json += ",\"sessionId\":" + json_string(*response.session_id);
+  json += ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+}  // namespace aemcp::native::rpc

--- a/native/ae-plugin/src/core/transport_auth.cpp
+++ b/native/ae-plugin/src/core/transport_auth.cpp
@@ -1,0 +1,175 @@
+#include "aemcp_native/transport_auth.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+#include <string_view>
+
+namespace aemcp::native {
+namespace {
+
+constexpr std::array<std::uint8_t, 8> kPrefaceMagic{
+    'A', 'E', 'M', 'C', 'P', '-', 'A', '1'};
+constexpr std::array<std::uint8_t, 8> kPendingMagic{
+    'A', 'E', 'M', 'C', 'P', '-', 'P', '1'};
+constexpr std::array<std::uint8_t, 8> kDecisionMagic{
+    'A', 'E', 'M', 'C', 'P', '-', 'D', '1'};
+constexpr std::string_view kNilUuid = "00000000-0000-0000-0000-000000000000";
+
+bool uuid_v4(std::string_view value) {
+  if (value.size() != 36 || value[8] != '-' || value[13] != '-'
+      || value[18] != '-' || value[23] != '-' || value[14] != '4'
+      || !(value[19] == '8' || value[19] == '9'
+          || value[19] == 'a' || value[19] == 'b')) {
+    return false;
+  }
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (index == 8 || index == 13 || index == 18 || index == 23) continue;
+    const unsigned char character = static_cast<unsigned char>(value[index]);
+    if (!((character >= '0' && character <= '9')
+          || (character >= 'a' && character <= 'f'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool fingerprint(std::string_view value) {
+  if (value.size() != 9 || value[4] != '-') return false;
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (index == 4) continue;
+    const unsigned char character = static_cast<unsigned char>(value[index]);
+    if (!((character >= '0' && character <= '9')
+          || (character >= 'A' && character <= 'F'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void write_u32(std::uint8_t* output, std::uint32_t value) {
+  output[0] = static_cast<std::uint8_t>(value >> 24);
+  output[1] = static_cast<std::uint8_t>(value >> 16);
+  output[2] = static_cast<std::uint8_t>(value >> 8);
+  output[3] = static_cast<std::uint8_t>(value);
+}
+
+std::uint32_t read_u32(const std::uint8_t* input) {
+  return (static_cast<std::uint32_t>(input[0]) << 24)
+      | (static_cast<std::uint32_t>(input[1]) << 16)
+      | (static_cast<std::uint32_t>(input[2]) << 8)
+      | static_cast<std::uint32_t>(input[3]);
+}
+
+template <std::size_t Size>
+bool starts_with(
+    const std::array<std::uint8_t, Size>& bytes,
+    const std::array<std::uint8_t, 8>& magic) {
+  return std::equal(magic.begin(), magic.end(), bytes.begin());
+}
+
+}  // namespace
+
+std::array<std::uint8_t, kTransportAuthPrefaceBytes> serialize_auth_preface(
+    const TransportAuthPreface& value) {
+  if (std::all_of(value.client_nonce.begin(), value.client_nonce.end(),
+          [](std::uint8_t byte) { return byte == 0; })) {
+    throw std::invalid_argument("transport client nonce cannot be all zero");
+  }
+  std::array<std::uint8_t, kTransportAuthPrefaceBytes> output{};
+  std::copy(kPrefaceMagic.begin(), kPrefaceMagic.end(), output.begin());
+  std::copy(value.client_nonce.begin(), value.client_nonce.end(), output.begin() + 8);
+  return output;
+}
+
+bool parse_auth_preface(
+    const std::array<std::uint8_t, kTransportAuthPrefaceBytes>& bytes,
+    TransportAuthPreface& output) noexcept {
+  if (!starts_with(bytes, kPrefaceMagic)) return false;
+  TransportAuthPreface parsed;
+  std::copy(bytes.begin() + 8, bytes.end(), parsed.client_nonce.begin());
+  if (std::all_of(parsed.client_nonce.begin(), parsed.client_nonce.end(),
+          [](std::uint8_t byte) { return byte == 0; })) {
+    return false;
+  }
+  output = parsed;
+  return true;
+}
+
+std::array<std::uint8_t, kTransportAuthPendingBytes> serialize_auth_pending(
+    const TransportAuthPending& value) {
+  if (!fingerprint(value.fingerprint) || !uuid_v4(value.host_instance_id)
+      || value.expires_in < std::chrono::seconds(1)
+      || value.expires_in > std::chrono::minutes(2)) {
+    throw std::invalid_argument("invalid transport pending message");
+  }
+  std::array<std::uint8_t, kTransportAuthPendingBytes> output{};
+  std::copy(kPendingMagic.begin(), kPendingMagic.end(), output.begin());
+  std::copy(value.fingerprint.begin(), value.fingerprint.end(), output.begin() + 8);
+  write_u32(output.data() + 17, static_cast<std::uint32_t>(value.expires_in.count()));
+  std::copy(value.host_instance_id.begin(), value.host_instance_id.end(), output.begin() + 21);
+  return output;
+}
+
+bool parse_auth_pending(
+    const std::array<std::uint8_t, kTransportAuthPendingBytes>& bytes,
+    TransportAuthPending& output) noexcept {
+  if (!starts_with(bytes, kPendingMagic)) return false;
+  TransportAuthPending parsed;
+  parsed.fingerprint.assign(reinterpret_cast<const char*>(bytes.data() + 8), 9);
+  parsed.expires_in = std::chrono::milliseconds(read_u32(bytes.data() + 17));
+  parsed.host_instance_id.assign(reinterpret_cast<const char*>(bytes.data() + 21), 36);
+  if (!fingerprint(parsed.fingerprint) || !uuid_v4(parsed.host_instance_id)
+      || parsed.expires_in < std::chrono::seconds(1)
+      || parsed.expires_in > std::chrono::minutes(2)) {
+    return false;
+  }
+  output = std::move(parsed);
+  return true;
+}
+
+std::array<std::uint8_t, kTransportAuthDecisionBytes> serialize_auth_decision(
+    const TransportAuthDecision& value) {
+  const bool authorized = value.code == TransportAuthDecisionCode::kAuthorized;
+  if ((authorized && (!uuid_v4(value.session_id) || value.session_generation == 0))
+      || (!authorized && (!value.session_id.empty() || value.session_generation != 0))) {
+    throw std::invalid_argument("invalid transport auth decision");
+  }
+  const auto raw_code = static_cast<std::uint8_t>(value.code);
+  if (raw_code < static_cast<std::uint8_t>(TransportAuthDecisionCode::kAuthorized)
+      || raw_code > static_cast<std::uint8_t>(TransportAuthDecisionCode::kShuttingDown)) {
+    throw std::invalid_argument("unknown transport auth decision");
+  }
+  std::array<std::uint8_t, kTransportAuthDecisionBytes> output{};
+  std::copy(kDecisionMagic.begin(), kDecisionMagic.end(), output.begin());
+  output[8] = raw_code;
+  const std::string_view session = authorized ? std::string_view(value.session_id) : kNilUuid;
+  std::copy(session.begin(), session.end(), output.begin() + 9);
+  write_u32(output.data() + 45, value.session_generation);
+  return output;
+}
+
+bool parse_auth_decision(
+    const std::array<std::uint8_t, kTransportAuthDecisionBytes>& bytes,
+    TransportAuthDecision& output) noexcept {
+  if (!starts_with(bytes, kDecisionMagic)) return false;
+  const std::uint8_t raw_code = bytes[8];
+  if (raw_code < static_cast<std::uint8_t>(TransportAuthDecisionCode::kAuthorized)
+      || raw_code > static_cast<std::uint8_t>(TransportAuthDecisionCode::kShuttingDown)) {
+    return false;
+  }
+  const std::string session(reinterpret_cast<const char*>(bytes.data() + 9), 36);
+  const std::uint32_t generation = read_u32(bytes.data() + 45);
+  const auto code = static_cast<TransportAuthDecisionCode>(raw_code);
+  if (code == TransportAuthDecisionCode::kAuthorized) {
+    if (!uuid_v4(session) || generation == 0) return false;
+    output = {code, session, generation};
+  } else {
+    if (session != kNilUuid || generation != 0) return false;
+    output = {code, {}, 0};
+  }
+  return true;
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/platform/macos/endpoint_registry_macos.cpp
+++ b/native/ae-plugin/src/platform/macos/endpoint_registry_macos.cpp
@@ -1,0 +1,543 @@
+#include "aemcp_native/endpoint_registry_macos.hpp"
+
+#include <arpa/inet.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace aemcp::native {
+namespace {
+
+constexpr std::string_view kDirectoryName = "aemcp-n1";
+constexpr std::size_t kMaximumDescriptorBytes = 1024;
+
+bool ascii_hex(std::string_view value, std::size_t size) {
+  return value.size() == size && std::all_of(value.begin(), value.end(), [](unsigned char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+  });
+}
+
+bool uuid_v4(std::string_view value) {
+  if (value.size() != 36 || value[8] != '-' || value[13] != '-'
+      || value[18] != '-' || value[23] != '-' || value[14] != '4'
+      || !(value[19] == '8' || value[19] == '9'
+          || value[19] == 'a' || value[19] == 'b')) {
+    return false;
+  }
+  for (std::size_t index = 0; index < value.size(); ++index) {
+    if (index == 8 || index == 13 || index == 18 || index == 23) continue;
+    const unsigned char c = static_cast<unsigned char>(value[index]);
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+  }
+  return true;
+}
+
+bool socket_basename(std::string_view value) {
+  constexpr std::string_view prefix = "s-";
+  constexpr std::string_view suffix = ".sock";
+  if (!value.starts_with(prefix) || !value.ends_with(suffix)) return false;
+  return ascii_hex(value.substr(prefix.size(), value.size() - prefix.size() - suffix.size()), 12);
+}
+
+bool descriptor_basename(std::string_view value) {
+  constexpr std::string_view prefix = "d-";
+  constexpr std::string_view suffix = ".endpoint";
+  if (!value.starts_with(prefix) || !value.ends_with(suffix)) return false;
+  return uuid_v4(value.substr(prefix.size(), value.size() - prefix.size() - suffix.size()));
+}
+
+bool private_directory(const struct stat& status, uid_t uid) {
+  return S_ISDIR(status.st_mode) && status.st_uid == uid
+      && (status.st_mode & 0077) == 0;
+}
+
+bool private_regular(const struct stat& status, uid_t uid) {
+  return S_ISREG(status.st_mode) && status.st_uid == uid && status.st_nlink == 1
+      && (status.st_mode & 0777) == 0600;
+}
+
+bool private_socket(const struct stat& status, uid_t uid) {
+  return S_ISSOCK(status.st_mode) && status.st_uid == uid && status.st_nlink == 1
+      && (status.st_mode & 0777) == 0600;
+}
+
+bool read_bounded_file(int descriptor, std::string& output) {
+  struct stat status {};
+  if (::fstat(descriptor, &status) != 0 || !private_regular(status, ::getuid())
+      || status.st_size <= 0
+      || static_cast<std::uint64_t>(status.st_size) > kMaximumDescriptorBytes) {
+    return false;
+  }
+  output.assign(static_cast<std::size_t>(status.st_size), '\0');
+  std::size_t read_bytes = 0;
+  while (read_bytes < output.size()) {
+    const ssize_t count = ::pread(
+        descriptor, output.data() + read_bytes, output.size() - read_bytes,
+        static_cast<off_t>(read_bytes));
+    if (count > 0) read_bytes += static_cast<std::size_t>(count);
+    else if (count < 0 && errno == EINTR) continue;
+    else return false;
+  }
+  struct stat after {};
+  return ::fstat(descriptor, &after) == 0 && after.st_dev == status.st_dev
+      && after.st_ino == status.st_ino && after.st_size == status.st_size;
+}
+
+template <typename Integer>
+bool parse_integer(std::string_view value, Integer& output) {
+  if (value.empty() || value.size() > 20) return false;
+  Integer parsed{};
+  const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), parsed);
+  if (error != std::errc{} || end != value.data() + value.size()) return false;
+  output = parsed;
+  return true;
+}
+
+std::vector<std::string_view> exact_lines(const std::string& text) {
+  std::vector<std::string_view> lines;
+  std::size_t start = 0;
+  while (start < text.size()) {
+    const std::size_t end = text.find('\n', start);
+    if (end == std::string::npos) return {};
+    lines.emplace_back(text.data() + start, end - start);
+    start = end + 1;
+  }
+  return lines;
+}
+
+bool safe_name_value(std::string_view line, std::string_view name, std::string_view& value) {
+  if (!line.starts_with(name) || line.size() <= name.size()) return false;
+  value = line.substr(name.size());
+  return true;
+}
+
+}  // namespace
+
+MacEndpointRegistry::MacEndpointRegistry(
+    PeerIdentityBackend& process_backend,
+    EndpointRegistryConfig config)
+    : process_backend_(process_backend), config_(std::move(config)) {}
+
+MacEndpointRegistry::~MacEndpointRegistry() {
+  stop();
+}
+
+EndpointResult MacEndpointRegistry::start(NativeEndpointDescriptor descriptor) {
+  if (started_ || listener_fd_ >= 0) return {EndpointCode::kAlreadyStarted, "already-started"};
+  descriptor_ = std::move(descriptor);
+  if (descriptor_.schema_version != 1 || !uuid_v4(descriptor_.host_instance_id)
+      || !descriptor_.host_process.valid() || descriptor_.wire_version != 1
+      || !ascii_hex(descriptor_.source_commit, 40)
+      || !ascii_hex(config_.endpoint_nonce, 12)
+      || config_.listen_backlog < 1 || config_.listen_backlog > 8
+      || config_.maximum_directory_entries < 8
+      || config_.maximum_directory_entries > 1024) {
+    stop();
+    return {EndpointCode::kInvalidArgument, "invalid-endpoint-config"};
+  }
+  descriptor_.socket_name = "s-" + config_.endpoint_nonce + ".sock";
+  if (EndpointResult result = open_directories(); !result.ok()) {
+    stop();
+    return result;
+  }
+  if (EndpointResult result = cleanup_stale(); !result.ok()) {
+    stop();
+    return result;
+  }
+  if (EndpointResult result = create_listener(); !result.ok()) {
+    stop();
+    return result;
+  }
+  if (EndpointResult result = publish_descriptor(); !result.ok()) {
+    stop();
+    return result;
+  }
+  started_ = true;
+  if (EndpointResult result = verify(); !result.ok()) {
+    stop();
+    return result;
+  }
+  return {EndpointCode::kOk, "ok"};
+}
+
+EndpointResult MacEndpointRegistry::verify() const {
+  if (!started_ || directory_fd_ < 0 || listener_fd_ < 0
+      || descriptor_entry_.name.empty() || socket_entry_.name.empty()) {
+    return {EndpointCode::kEndpointReplaced, "endpoint-not-active"};
+  }
+  struct stat directory {};
+  if (::fstat(directory_fd_, &directory) != 0 || !private_directory(directory, ::getuid())) {
+    return {EndpointCode::kEndpointReplaced, "endpoint-directory-changed"};
+  }
+  struct stat socket_status {};
+  if (::fstatat(
+          directory_fd_, socket_entry_.name.c_str(), &socket_status,
+          AT_SYMLINK_NOFOLLOW) != 0
+      || !private_socket(socket_status, ::getuid())
+      || static_cast<std::uint64_t>(socket_status.st_dev) != socket_entry_.device
+      || static_cast<std::uint64_t>(socket_status.st_ino) != socket_entry_.inode) {
+    return {EndpointCode::kEndpointReplaced, "endpoint-socket-changed"};
+  }
+  struct stat descriptor_status {};
+  if (::fstatat(
+          directory_fd_, descriptor_entry_.name.c_str(), &descriptor_status,
+          AT_SYMLINK_NOFOLLOW) != 0
+      || !private_regular(descriptor_status, ::getuid())
+      || static_cast<std::uint64_t>(descriptor_status.st_dev) != descriptor_entry_.device
+      || static_cast<std::uint64_t>(descriptor_status.st_ino) != descriptor_entry_.inode) {
+    return {EndpointCode::kEndpointReplaced, "endpoint-descriptor-changed"};
+  }
+  return {EndpointCode::kOk, "ok"};
+}
+
+void MacEndpointRegistry::stop() noexcept {
+  started_ = false;
+  if (listener_fd_ >= 0) {
+    ::shutdown(listener_fd_, SHUT_RDWR);
+    ::close(listener_fd_);
+    listener_fd_ = -1;
+  }
+  const bool descriptor_removed = safe_unlink(descriptor_entry_, false);
+  const bool socket_removed = safe_unlink(socket_entry_, true);
+  (void)descriptor_removed;
+  (void)socket_removed;
+  descriptor_entry_ = {};
+  socket_entry_ = {};
+  descriptor_path_.clear();
+  socket_path_.clear();
+  if (directory_fd_ >= 0) {
+    ::close(directory_fd_);
+    directory_fd_ = -1;
+  }
+  if (root_fd_ >= 0) {
+    ::close(root_fd_);
+    root_fd_ = -1;
+  }
+  directory_path_.clear();
+  runtime_root_.clear();
+}
+
+bool MacEndpointRegistry::parse_descriptor(
+    const std::string& text,
+    NativeEndpointDescriptor& output) noexcept {
+  try {
+    const auto lines = exact_lines(text);
+    if (lines.size() != 8 || lines[0] != "AEMCP_NATIVE_ENDPOINT_V1") return false;
+    std::string_view host;
+    std::string_view pid;
+    std::string_view seconds;
+    std::string_view micros;
+    std::string_view socket;
+    std::string_view wire;
+    std::string_view source;
+    if (!safe_name_value(lines[1], "host=", host)
+        || !safe_name_value(lines[2], "pid=", pid)
+        || !safe_name_value(lines[3], "startSeconds=", seconds)
+        || !safe_name_value(lines[4], "startMicros=", micros)
+        || !safe_name_value(lines[5], "socket=", socket)
+        || !safe_name_value(lines[6], "wire=", wire)
+        || !safe_name_value(lines[7], "source=", source)
+        || !uuid_v4(host) || !socket_basename(socket) || !ascii_hex(source, 40)) {
+      return false;
+    }
+    NativeEndpointDescriptor parsed;
+    parsed.host_instance_id = std::string(host);
+    parsed.socket_name = std::string(socket);
+    parsed.source_commit = std::string(source);
+    if (!parse_integer(pid, parsed.host_process.pid)
+        || !parse_integer(seconds, parsed.host_process.generation.start_seconds)
+        || !parse_integer(micros, parsed.host_process.generation.start_microseconds)
+        || !parse_integer(wire, parsed.wire_version)
+        || !parsed.host_process.valid() || parsed.wire_version != 1
+        || parsed.host_process.generation.start_microseconds >= 1000000) {
+      return false;
+    }
+    output = std::move(parsed);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::string MacEndpointRegistry::serialize_descriptor(
+    const NativeEndpointDescriptor& descriptor) {
+  if (descriptor.schema_version != 1 || !uuid_v4(descriptor.host_instance_id)
+      || !descriptor.host_process.valid() || !socket_basename(descriptor.socket_name)
+      || descriptor.wire_version != 1 || !ascii_hex(descriptor.source_commit, 40)) {
+    throw std::invalid_argument("invalid native endpoint descriptor");
+  }
+  return "AEMCP_NATIVE_ENDPOINT_V1\n"
+      "host=" + descriptor.host_instance_id + "\n"
+      "pid=" + std::to_string(descriptor.host_process.pid) + "\n"
+      "startSeconds=" + std::to_string(descriptor.host_process.generation.start_seconds) + "\n"
+      "startMicros=" + std::to_string(descriptor.host_process.generation.start_microseconds) + "\n"
+      "socket=" + descriptor.socket_name + "\n"
+      "wire=" + std::to_string(descriptor.wire_version) + "\n"
+      "source=" + descriptor.source_commit + "\n";
+}
+
+EndpointResult MacEndpointRegistry::open_directories() {
+  if (config_.runtime_root.empty()) {
+    const std::size_t bytes = ::confstr(_CS_DARWIN_USER_TEMP_DIR, nullptr, 0);
+    if (bytes <= 1 || bytes > 4096) {
+      return {EndpointCode::kRuntimeRootUnavailable, "darwin-user-temp-unavailable"};
+    }
+    runtime_root_.assign(bytes, '\0');
+    if (::confstr(_CS_DARWIN_USER_TEMP_DIR, runtime_root_.data(), bytes) != bytes) {
+      return {EndpointCode::kRuntimeRootUnavailable, "darwin-user-temp-changed"};
+    }
+    runtime_root_.resize(std::char_traits<char>::length(runtime_root_.c_str()));
+  } else {
+    runtime_root_ = config_.runtime_root;
+  }
+  root_fd_ = ::open(
+      runtime_root_.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  struct stat root_status {};
+  if (root_fd_ < 0 || ::fstat(root_fd_, &root_status) != 0
+      || !private_directory(root_status, ::getuid())) {
+    return {EndpointCode::kRuntimeRootUnsafe, "runtime-root-unsafe"};
+  }
+  if (::mkdirat(root_fd_, kDirectoryName.data(), 0700) != 0 && errno != EEXIST) {
+    return {EndpointCode::kRuntimeRootUnsafe, "endpoint-directory-create-failed"};
+  }
+  directory_fd_ = ::openat(
+      root_fd_, kDirectoryName.data(), O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  struct stat directory_status {};
+  if (directory_fd_ < 0 || ::fstat(directory_fd_, &directory_status) != 0
+      || !private_directory(directory_status, ::getuid())
+      || ::fchmod(directory_fd_, 0700) != 0) {
+    return {EndpointCode::kRuntimeRootUnsafe, "endpoint-directory-unsafe"};
+  }
+  std::array<char, 4096> path{};
+  if (::fcntl(directory_fd_, F_GETPATH, path.data()) != 0) {
+    return {EndpointCode::kRuntimeRootUnavailable, "endpoint-directory-path-unavailable"};
+  }
+  directory_path_ = path.data();
+  return {EndpointCode::kOk, "ok"};
+}
+
+EndpointResult MacEndpointRegistry::cleanup_stale() {
+  const int duplicate = ::dup(directory_fd_);
+  if (duplicate < 0) return {EndpointCode::kRuntimeRootUnsafe, "directory-scan-failed"};
+  DIR* stream = ::fdopendir(duplicate);
+  if (stream == nullptr) {
+    ::close(duplicate);
+    return {EndpointCode::kRuntimeRootUnsafe, "directory-scan-failed"};
+  }
+  std::vector<std::string> descriptors;
+  std::size_t observed = 0;
+  errno = 0;
+  while (dirent* entry = ::readdir(stream)) {
+    const std::string_view name(entry->d_name);
+    if (name == "." || name == "..") continue;
+    if (++observed > config_.maximum_directory_entries) {
+      ::closedir(stream);
+      return {EndpointCode::kDirectoryLimitExceeded, "endpoint-directory-limit"};
+    }
+    if (descriptor_basename(name)) descriptors.emplace_back(name);
+  }
+  const int scan_error = errno;
+  ::closedir(stream);
+  if (scan_error != 0) return {EndpointCode::kRuntimeRootUnsafe, "directory-scan-failed"};
+
+  for (const std::string& name : descriptors) {
+    const int file = ::openat(directory_fd_, name.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (file < 0) return {EndpointCode::kStaleEntryUnsafe, "managed-descriptor-unsafe"};
+    struct stat descriptor_status {};
+    std::string text;
+    const bool readable = ::fstat(file, &descriptor_status) == 0
+        && read_bounded_file(file, text);
+    ::close(file);
+    NativeEndpointDescriptor stale;
+    if (!readable || !parse_descriptor(text, stale)
+        || name != "d-" + stale.host_instance_id + ".endpoint") {
+      return {EndpointCode::kStaleEntryUnsafe, "managed-descriptor-invalid"};
+    }
+    ProcessSnapshot live;
+    if (process_backend_.process_snapshot(stale.host_process.pid, live)
+        && live.pid == stale.host_process.pid
+        && live.generation == stale.host_process.generation) {
+      continue;
+    }
+
+    struct stat socket_status {};
+    if (::fstatat(
+            directory_fd_, stale.socket_name.c_str(), &socket_status,
+            AT_SYMLINK_NOFOLLOW) == 0) {
+      if (!private_socket(socket_status, ::getuid())) {
+        return {EndpointCode::kStaleEntryUnsafe, "managed-stale-socket-unsafe"};
+      }
+      PublishedEntry socket_entry{
+          stale.socket_name,
+          static_cast<std::uint64_t>(socket_status.st_dev),
+          static_cast<std::uint64_t>(socket_status.st_ino),
+      };
+      if (!safe_unlink(socket_entry, true)) {
+        return {EndpointCode::kStaleEntryUnsafe, "managed-stale-socket-changed"};
+      }
+    } else if (errno != ENOENT) {
+      return {EndpointCode::kStaleEntryUnsafe, "managed-stale-socket-unreadable"};
+    }
+    PublishedEntry descriptor_entry{
+        name,
+        static_cast<std::uint64_t>(descriptor_status.st_dev),
+        static_cast<std::uint64_t>(descriptor_status.st_ino),
+    };
+    if (!safe_unlink(descriptor_entry, false)) {
+      return {EndpointCode::kStaleEntryUnsafe, "managed-stale-descriptor-changed"};
+    }
+  }
+  return {EndpointCode::kOk, "ok"};
+}
+
+EndpointResult MacEndpointRegistry::create_listener() {
+  socket_entry_.name = descriptor_.socket_name;
+  socket_path_ = directory_path_ + "/" + socket_entry_.name;
+  if (socket_path_.size() >= sizeof(sockaddr_un::sun_path)) {
+    return {EndpointCode::kSocketCreateFailed, "endpoint-path-too-long"};
+  }
+  struct stat existing {};
+  if (::fstatat(
+          directory_fd_, socket_entry_.name.c_str(), &existing,
+          AT_SYMLINK_NOFOLLOW) == 0 || errno != ENOENT) {
+    return {EndpointCode::kSocketPublishFailed, "endpoint-name-not-empty"};
+  }
+  listener_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (listener_fd_ < 0) return {EndpointCode::kSocketCreateFailed, "socket-create-failed"};
+  if (::fcntl(listener_fd_, F_SETFD, FD_CLOEXEC) != 0) {
+    return {EndpointCode::kSocketCreateFailed, "socket-cloexec-failed"};
+  }
+  int no_sigpipe = 1;
+  if (::setsockopt(listener_fd_, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0) {
+    return {EndpointCode::kSocketCreateFailed, "socket-option-failed"};
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::memcpy(address.sun_path, socket_path_.c_str(), socket_path_.size() + 1);
+  address.sun_len = SUN_LEN(&address);
+  if (::bind(
+          listener_fd_, reinterpret_cast<const sockaddr*>(&address),
+          address.sun_len) != 0) {
+    return {EndpointCode::kSocketPublishFailed,
+        "socket-bind-failed-" + std::to_string(errno)};
+  }
+  if (::fchmodat(directory_fd_, socket_entry_.name.c_str(), 0600, AT_SYMLINK_NOFOLLOW) != 0) {
+    return {EndpointCode::kSocketPublishFailed, "socket-permission-failed"};
+  }
+  struct stat status {};
+  if (::fstatat(
+          directory_fd_, socket_entry_.name.c_str(), &status,
+          AT_SYMLINK_NOFOLLOW) != 0 || !private_socket(status, ::getuid())) {
+    return {EndpointCode::kSocketPublishFailed, "socket-validation-failed"};
+  }
+  socket_entry_.device = static_cast<std::uint64_t>(status.st_dev);
+  socket_entry_.inode = static_cast<std::uint64_t>(status.st_ino);
+  if (::listen(listener_fd_, config_.listen_backlog) != 0) {
+    return {EndpointCode::kSocketCreateFailed, "socket-listen-failed"};
+  }
+  return {EndpointCode::kOk, "ok"};
+}
+
+EndpointResult MacEndpointRegistry::publish_descriptor() {
+  descriptor_entry_.name = "d-" + descriptor_.host_instance_id + ".endpoint";
+  descriptor_path_ = directory_path_ + "/" + descriptor_entry_.name;
+  struct stat existing {};
+  if (::fstatat(
+          directory_fd_, descriptor_entry_.name.c_str(), &existing,
+          AT_SYMLINK_NOFOLLOW) == 0 || errno != ENOENT) {
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-name-not-empty"};
+  }
+  const std::string temporary = ".tmp-" + config_.endpoint_nonce;
+  const int file = ::openat(
+      directory_fd_, temporary.c_str(),
+      O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+      0600);
+  if (file < 0) return {EndpointCode::kDescriptorPublishFailed, "descriptor-create-failed"};
+  bool published = false;
+  const auto cleanup = [&] {
+    ::close(file);
+    if (!published) ::unlinkat(directory_fd_, temporary.c_str(), 0);
+  };
+  const std::string text = serialize_descriptor(descriptor_);
+  std::size_t written = 0;
+  while (written < text.size()) {
+    const ssize_t count = ::write(file, text.data() + written, text.size() - written);
+    if (count > 0) written += static_cast<std::size_t>(count);
+    else if (count < 0 && errno == EINTR) continue;
+    else {
+      cleanup();
+      return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
+    }
+  }
+  struct stat status {};
+  if (::fchmod(file, 0600) != 0 || ::fsync(file) != 0 || ::fstat(file, &status) != 0
+      || !private_regular(status, ::getuid())
+      || status.st_size != static_cast<off_t>(text.size())) {
+    cleanup();
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-validation-failed"};
+  }
+  if (::renameat(
+          directory_fd_, temporary.c_str(),
+          directory_fd_, descriptor_entry_.name.c_str()) != 0
+      || ::fsync(directory_fd_) != 0) {
+    cleanup();
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-rename-failed"};
+  }
+  published = true;
+  descriptor_entry_.device = static_cast<std::uint64_t>(status.st_dev);
+  descriptor_entry_.inode = static_cast<std::uint64_t>(status.st_ino);
+  cleanup();
+  return {EndpointCode::kOk, "ok"};
+}
+
+bool MacEndpointRegistry::safe_unlink(
+    const PublishedEntry& entry,
+    bool socket) const noexcept {
+  if (directory_fd_ < 0 || entry.name.empty() || entry.device == 0 || entry.inode == 0) {
+    return false;
+  }
+  struct stat status {};
+  if (::fstatat(directory_fd_, entry.name.c_str(), &status, AT_SYMLINK_NOFOLLOW) != 0) {
+    return errno == ENOENT;
+  }
+  const bool safe_type = socket
+      ? private_socket(status, ::getuid()) : private_regular(status, ::getuid());
+  if (!safe_type || static_cast<std::uint64_t>(status.st_dev) != entry.device
+      || static_cast<std::uint64_t>(status.st_ino) != entry.inode) {
+    return false;
+  }
+  return ::unlinkat(directory_fd_, entry.name.c_str(), 0) == 0 || errno == ENOENT;
+}
+
+const char* endpoint_code_name(EndpointCode code) noexcept {
+  switch (code) {
+    case EndpointCode::kOk: return "ok";
+    case EndpointCode::kInvalidArgument: return "invalid-argument";
+    case EndpointCode::kRuntimeRootUnavailable: return "runtime-root-unavailable";
+    case EndpointCode::kRuntimeRootUnsafe: return "runtime-root-unsafe";
+    case EndpointCode::kDirectoryLimitExceeded: return "directory-limit-exceeded";
+    case EndpointCode::kStaleEntryUnsafe: return "stale-entry-unsafe";
+    case EndpointCode::kSocketCreateFailed: return "socket-create-failed";
+    case EndpointCode::kSocketPublishFailed: return "socket-publish-failed";
+    case EndpointCode::kDescriptorPublishFailed: return "descriptor-publish-failed";
+    case EndpointCode::kEndpointReplaced: return "endpoint-replaced";
+    case EndpointCode::kAlreadyStarted: return "already-started";
+  }
+  return "unknown";
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/platform/macos/mac_ipc_server.cpp
+++ b/native/ae-plugin/src/platform/macos/mac_ipc_server.cpp
@@ -1,0 +1,360 @@
+#include "aemcp_native/mac_ipc_server.hpp"
+
+#include "aemcp_native/secure_random_macos.hpp"
+
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace aemcp::native {
+namespace {
+
+using namespace std::chrono_literals;
+
+bool poll_ready(int descriptor, short events, std::chrono::steady_clock::time_point deadline) {
+  for (;;) {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) return false;
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+    const int timeout = static_cast<int>(std::clamp<std::int64_t>(remaining.count(), 1, 1000));
+    pollfd item{descriptor, events, 0};
+    const int result = ::poll(&item, 1, timeout);
+    if (result > 0) {
+      if ((item.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) return false;
+      return (item.revents & events) != 0;
+    }
+    if (result == 0) continue;
+    if (errno != EINTR) return false;
+  }
+}
+
+TransportAuthDecisionCode decision_for_stop(bool stopping) {
+  return stopping
+      ? TransportAuthDecisionCode::kShuttingDown
+      : TransportAuthDecisionCode::kRejected;
+}
+
+}  // namespace
+
+MacIpcServer::MacIpcServer(
+    MacEndpointRegistry& endpoint,
+    PeerIdentityBackend& peer_backend,
+    PairingGate& pairing_gate,
+    AuthenticatedConnectionHandler& handler,
+    NativeIpcObserver& observer,
+    MacIpcServerConfig config)
+    : endpoint_(endpoint),
+      peer_backend_(peer_backend),
+      pairing_gate_(pairing_gate),
+      handler_(handler),
+      observer_(observer),
+      config_(config) {}
+
+MacIpcServer::~MacIpcServer() {
+  stop();
+}
+
+bool MacIpcServer::start() {
+  if (worker_.joinable() || running_.load() || endpoint_.listener_fd() < 0
+      || !endpoint_.verify().ok() || config_.handshake_timeout < 250ms
+      || config_.handshake_timeout > 5s || config_.pairing_poll_interval < 25ms
+      || config_.pairing_poll_interval > 500ms
+      || config_.maximum_ancestor_depth < 2 || config_.maximum_ancestor_depth > 64
+      || config_.expected_cpu_type == 0) {
+    return false;
+  }
+  stop_requested_.store(false);
+  try {
+    worker_ = std::thread([this] { run(); });
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+void MacIpcServer::stop() noexcept {
+  stop_requested_.store(true);
+  pairing_gate_.shutdown();
+  {
+    std::lock_guard lock(active_mutex_);
+    if (active_fd_ >= 0) ::shutdown(active_fd_, SHUT_RDWR);
+  }
+  if (worker_.joinable() && worker_.get_id() != std::this_thread::get_id()) {
+    worker_.join();
+  }
+  // The worker reads endpoint descriptors and the listener fd. Keep the
+  // registry alive until it has observed stop_requested_ and fully exited;
+  // otherwise AE unload races endpoint teardown and fd reuse.
+  endpoint_.stop();
+  running_.store(false);
+}
+
+std::optional<PendingPairingSnapshot> MacIpcServer::pending_pairing() {
+  return pairing_gate_.pending();
+}
+
+bool MacIpcServer::confirm_pending(
+    const std::string& connection_id,
+    const std::string& fingerprint) {
+  return pairing_gate_.confirm(connection_id, fingerprint);
+}
+
+bool MacIpcServer::reject_pending(
+    const std::string& connection_id,
+    const std::string& fingerprint) {
+  return pairing_gate_.reject(connection_id, fingerprint);
+}
+
+void MacIpcServer::run() noexcept {
+  running_.store(true);
+  observer_.on_ipc_event("listener", "started");
+  while (!stop_requested_.load()) {
+    if (!endpoint_.verify().ok()) {
+      observer_.on_ipc_event("listener", "endpoint-invalid");
+      break;
+    }
+    pollfd listener{endpoint_.listener_fd(), POLLIN, 0};
+    const int polled = ::poll(&listener, 1, 250);
+    if (polled < 0 && errno == EINTR) continue;
+    if (polled < 0 || (polled > 0 && (listener.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0)) {
+      if (!stop_requested_.load()) observer_.on_ipc_event("listener", "poll-failed");
+      break;
+    }
+    if (polled == 0 || (listener.revents & POLLIN) == 0) continue;
+    const int connection = ::accept(endpoint_.listener_fd(), nullptr, nullptr);
+    if (connection < 0) {
+      if (errno == EINTR) continue;
+      if (!stop_requested_.load()) observer_.on_ipc_event("connection", "accept-failed");
+      continue;
+    }
+    if (::fcntl(connection, F_SETFD, FD_CLOEXEC) != 0) {
+      ::close(connection);
+      continue;
+    }
+    int no_sigpipe = 1;
+    if (::setsockopt(connection, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0) {
+      ::close(connection);
+      continue;
+    }
+    {
+      std::lock_guard lock(active_mutex_);
+      active_fd_ = connection;
+    }
+    handle_connection(connection);
+    close_active(connection);
+  }
+  running_.store(false);
+  observer_.on_ipc_event("listener", "stopped");
+}
+
+void MacIpcServer::handle_connection(int socket_fd) noexcept {
+  try {
+    const std::string connection_id = secure_uuid_v4();
+    std::optional<PeerBinding> peer = admit_peer(socket_fd, connection_id);
+    if (!peer.has_value()) {
+      observer_.on_ipc_event("connection", "peer-rejected");
+      return;
+    }
+    const auto handshake_deadline = std::chrono::steady_clock::now() + config_.handshake_timeout;
+    std::array<std::uint8_t, kTransportAuthPrefaceBytes> preface_bytes{};
+    if (!read_exact(
+            socket_fd, preface_bytes.data(), preface_bytes.size(), handshake_deadline)) {
+      observer_.on_ipc_event("connection", "preface-timeout");
+      return;
+    }
+    TransportAuthPreface preface;
+    if (!parse_auth_preface(preface_bytes, preface)) {
+      observer_.on_ipc_event("connection", "preface-invalid");
+      return;
+    }
+    const BeginPairingResult begin = pairing_gate_.begin(*peer);
+    if (begin.code != BeginPairingCode::kPending) {
+      observer_.on_ipc_event("pairing", "busy-or-unavailable");
+      return;
+    }
+    const auto pending_bytes = serialize_auth_pending({
+        begin.fingerprint,
+        begin.expires_in,
+        endpoint_.descriptor().host_instance_id,
+    });
+    if (!write_exact(
+            socket_fd, pending_bytes.data(), pending_bytes.size(),
+            std::chrono::steady_clock::now() + config_.handshake_timeout)) {
+      pairing_gate_.revoke(*peer);
+      observer_.on_ipc_event("pairing", "pending-write-failed");
+      return;
+    }
+    observer_.on_ipc_event("pairing", "pending");
+    const auto pairing_deadline = std::chrono::steady_clock::now() + begin.expires_in;
+    bool authorized = false;
+    while (!stop_requested_.load() && std::chrono::steady_clock::now() < pairing_deadline) {
+      if (pairing_gate_.authorized(*peer)) {
+        authorized = true;
+        break;
+      }
+      const auto snapshot = pairing_gate_.pending();
+      if (!snapshot.has_value() || snapshot->binding != *peer) break;
+      pollfd connection{socket_fd, POLLIN, 0};
+      const int polled = ::poll(
+          &connection, 1, static_cast<int>(config_.pairing_poll_interval.count()));
+      if (polled < 0 && errno == EINTR) continue;
+      if (polled < 0 || (polled > 0 && connection.revents != 0)) break;
+    }
+    if (!authorized || !same_peer(socket_fd, *peer) || !endpoint_.verify().ok()) {
+      const TransportAuthDecisionCode code = decision_for_stop(stop_requested_.load());
+      const auto decision = serialize_auth_decision({code, {}, 0});
+      const bool sent = write_exact(
+          socket_fd, decision.data(), decision.size(),
+          std::chrono::steady_clock::now() + config_.handshake_timeout);
+      (void)sent;
+      pairing_gate_.revoke(*peer);
+      observer_.on_ipc_event("pairing", authorized ? "peer-changed" : "not-authorized");
+      return;
+    }
+
+    const std::uint32_t generation = next_session_generation_.fetch_add(1);
+    if (generation == 0 || generation == std::numeric_limits<std::uint32_t>::max()) {
+      pairing_gate_.revoke(*peer);
+      observer_.on_ipc_event("session", "generation-exhausted");
+      stop_requested_.store(true);
+      return;
+    }
+    AuthenticatedConnection authenticated{
+        socket_fd,
+        *peer,
+        preface.client_nonce,
+        secure_uuid_v4(),
+        generation,
+    };
+    const auto authorized_bytes = serialize_auth_decision({
+        TransportAuthDecisionCode::kAuthorized,
+        authenticated.session_id,
+        authenticated.session_generation,
+    });
+    if (!write_exact(
+            socket_fd, authorized_bytes.data(), authorized_bytes.size(),
+            std::chrono::steady_clock::now() + config_.handshake_timeout)) {
+      pairing_gate_.revoke(*peer);
+      observer_.on_ipc_event("session", "decision-write-failed");
+      return;
+    }
+    observer_.on_ipc_event("session", "authorized");
+    handler_.serve(authenticated);
+    pairing_gate_.revoke(*peer);
+    observer_.on_ipc_event("session", "closed");
+  } catch (...) {
+    observer_.on_ipc_event("connection", "internal-failure");
+  }
+}
+
+std::optional<PeerBinding> MacIpcServer::admit_peer(
+    int socket_fd,
+    const std::string& connection_id) noexcept {
+  SocketPeerEvidence peer;
+  if (!peer_backend_.socket_peer(socket_fd, peer) || peer.pid <= 1
+      || peer.euid != static_cast<std::uint32_t>(::getuid()) || peer.pid_version == 0) {
+    return std::nullopt;
+  }
+  std::unordered_set<std::int32_t> seen;
+  std::vector<ProcessSnapshot> chain;
+  std::int32_t pid = peer.pid;
+  bool reached_host = false;
+  for (std::size_t depth = 0; depth < config_.maximum_ancestor_depth; ++depth) {
+    ProcessSnapshot snapshot;
+    if (!peer_backend_.process_snapshot(pid, snapshot) || snapshot.pid != pid
+        || snapshot.uid != peer.euid || snapshot.exiting || snapshot.traced
+        || snapshot.cpu_type != config_.expected_cpu_type
+        || !seen.insert(pid).second) {
+      return std::nullopt;
+    }
+    chain.push_back(snapshot);
+    if (pid == endpoint_.descriptor().host_process.pid) {
+      reached_host = snapshot.generation == endpoint_.descriptor().host_process.generation;
+      break;
+    }
+    if (snapshot.parent_pid <= 1 || snapshot.parent_pid == pid) return std::nullopt;
+    pid = snapshot.parent_pid;
+  }
+  if (!reached_host) return std::nullopt;
+  for (const ProcessSnapshot& before : chain) {
+    ProcessSnapshot after;
+    if (!peer_backend_.process_snapshot(before.pid, after) || after != before) return std::nullopt;
+  }
+  SocketPeerEvidence after;
+  if (!peer_backend_.socket_peer(socket_fd, after) || after != peer) return std::nullopt;
+  PeerBinding binding{
+      peer.pid,
+      peer.pid_version,
+      peer.euid,
+      peer.audit_session,
+      connection_id,
+      endpoint_.descriptor().host_instance_id,
+  };
+  return binding.valid() ? std::optional<PeerBinding>(std::move(binding)) : std::nullopt;
+}
+
+bool MacIpcServer::same_peer(int socket_fd, const PeerBinding& binding) noexcept {
+  SocketPeerEvidence current;
+  return peer_backend_.socket_peer(socket_fd, current)
+      && current.pid == binding.pid
+      && current.pid_version == binding.pid_version
+      && current.euid == binding.uid
+      && current.audit_session == binding.audit_session;
+}
+
+bool MacIpcServer::read_exact(
+    int socket_fd,
+    std::uint8_t* output,
+    std::size_t size,
+    std::chrono::steady_clock::time_point deadline) noexcept {
+  std::size_t received = 0;
+  while (received < size && !stop_requested_.load()) {
+    if (!poll_ready(socket_fd, POLLIN, deadline)) return false;
+    const ssize_t count = ::recv(socket_fd, output + received, size - received, 0);
+    if (count > 0) received += static_cast<std::size_t>(count);
+    else if (count < 0 && errno == EINTR) continue;
+    else return false;
+  }
+  return received == size;
+}
+
+bool MacIpcServer::write_exact(
+    int socket_fd,
+    const std::uint8_t* input,
+    std::size_t size,
+    std::chrono::steady_clock::time_point deadline) noexcept {
+  std::size_t sent = 0;
+  while (sent < size && !stop_requested_.load()) {
+    if (!poll_ready(socket_fd, POLLOUT, deadline)) return false;
+    const ssize_t count = ::send(socket_fd, input + sent, size - sent, 0);
+    if (count > 0) sent += static_cast<std::size_t>(count);
+    else if (count < 0 && errno == EINTR) continue;
+    else return false;
+  }
+  return sent == size;
+}
+
+void MacIpcServer::close_active(int socket_fd) noexcept {
+  {
+    std::lock_guard lock(active_mutex_);
+    if (active_fd_ == socket_fd) active_fd_ = -1;
+  }
+  ::shutdown(socket_fd, SHUT_RDWR);
+  ::close(socket_fd);
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/platform/macos/pairing_ui_macos.mm
+++ b/native/ae-plugin/src/platform/macos/pairing_ui_macos.mm
@@ -1,0 +1,49 @@
+#import <AppKit/AppKit.h>
+
+#include "aemcp_native/pairing_ui_macos.hpp"
+
+#include <algorithm>
+#include <string>
+
+namespace aemcp::native {
+
+PairingUiDecision show_pairing_confirmation(
+    std::string_view fingerprint,
+    std::chrono::milliseconds expires_in) noexcept {
+  @autoreleasepool {
+    try {
+      if (fingerprint.size() != 9 || expires_in.count() <= 0) {
+        return PairingUiDecision::kUnavailable;
+      }
+      const std::string fingerprint_text(fingerprint);
+      NSAlert* alert = [[NSAlert alloc] init];
+      alert.alertStyle = NSAlertStyleWarning;
+      alert.messageText = @"Authorize ae-mcp native connection?";
+      const auto seconds = std::max<long long>(1, expires_in.count() / 1000);
+      alert.informativeText = [NSString stringWithFormat:
+          @"Compare this fingerprint with the ae-mcp panel:\n\n%s\n\n"
+           "Only authorize if both match. This request expires in about %lld seconds.",
+          fingerprint_text.c_str(), seconds];
+      [alert addButtonWithTitle:@"Authorize"];
+      [alert addButtonWithTitle:@"Reject"];
+      const NSModalResponse response = [alert runModal];
+      return response == NSAlertFirstButtonReturn
+          ? PairingUiDecision::kAuthorize : PairingUiDecision::kReject;
+    } catch (...) {
+      return PairingUiDecision::kUnavailable;
+    }
+  }
+}
+
+void show_no_pending_pairing() noexcept {
+  @autoreleasepool {
+    NSAlert* alert = [[NSAlert alloc] init];
+    alert.alertStyle = NSAlertStyleInformational;
+    alert.messageText = @"No ae-mcp connection is waiting";
+    alert.informativeText = @"Start the native connection from the ae-mcp panel, then choose this command again.";
+    [alert addButtonWithTitle:@"OK"];
+    [alert runModal];
+  }
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/platform/macos/peer_identity_macos.cpp
+++ b/native/ae-plugin/src/platform/macos/peer_identity_macos.cpp
@@ -1,0 +1,94 @@
+#include "aemcp_native/peer_identity_macos.hpp"
+
+#include <bsm/libbsm.h>
+#include <libproc.h>
+#include <mach/machine.h>
+#include <sys/proc_info.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <memory>
+
+namespace aemcp::native {
+namespace {
+
+class MacPeerIdentityBackend final : public PeerIdentityBackend {
+ public:
+  bool socket_peer(int socket_fd, SocketPeerEvidence& output) override {
+    uid_t euid = 0;
+    gid_t egid = 0;
+    if (::getpeereid(socket_fd, &euid, &egid) != 0) return false;
+    pid_t peer_pid = 0;
+    socklen_t pid_size = sizeof(peer_pid);
+    if (::getsockopt(
+            socket_fd, SOL_LOCAL, LOCAL_PEERPID, &peer_pid, &pid_size) != 0
+        || pid_size != sizeof(peer_pid)) {
+      return false;
+    }
+    audit_token_t token{};
+    socklen_t token_size = sizeof(token);
+    if (::getsockopt(
+            socket_fd, SOL_LOCAL, LOCAL_PEERTOKEN, &token, &token_size) != 0
+        || token_size != sizeof(token)) {
+      return false;
+    }
+    const pid_t audit_pid = audit_token_to_pid(token);
+    const uid_t audit_euid = audit_token_to_euid(token);
+    if (audit_pid != peer_pid || audit_euid != euid) return false;
+    const int pid_version = audit_token_to_pidversion(token);
+    const au_asid_t audit_session = audit_token_to_asid(token);
+    if (pid_version <= 0 || audit_session < 0) return false;
+    output = {
+        static_cast<std::int32_t>(peer_pid),
+        static_cast<std::uint32_t>(euid),
+        static_cast<std::uint32_t>(egid),
+        static_cast<std::uint32_t>(audit_session),
+        static_cast<std::uint32_t>(pid_version),
+    };
+    return true;
+  }
+
+  bool process_snapshot(std::int32_t pid, ProcessSnapshot& output) override {
+    proc_bsdinfo bsd{};
+    const int bsd_bytes = ::proc_pidinfo(
+        pid, PROC_PIDTBSDINFO, 0, &bsd, sizeof(bsd));
+    if (bsd_bytes != static_cast<int>(sizeof(bsd))
+        || static_cast<std::int32_t>(bsd.pbi_pid) != pid) {
+      return false;
+    }
+    proc_archinfo architecture{};
+    const int arch_bytes = ::proc_pidinfo(
+        pid, PROC_PIDARCHINFO, 0, &architecture, sizeof(architecture));
+    if (arch_bytes != static_cast<int>(sizeof(architecture))) return false;
+    output = {
+        pid,
+        static_cast<std::int32_t>(bsd.pbi_ppid),
+        static_cast<std::uint32_t>(bsd.pbi_uid),
+        {bsd.pbi_start_tvsec, bsd.pbi_start_tvusec},
+        static_cast<std::int32_t>(architecture.p_cputype),
+        (bsd.pbi_flags & PROC_FLAG_TRACED) != 0,
+        (bsd.pbi_flags & PROC_FLAG_INEXIT) != 0,
+    };
+    return true;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<PeerIdentityBackend> create_macos_peer_identity_backend() {
+  return std::make_unique<MacPeerIdentityBackend>();
+}
+
+ExpectedProcess current_macos_process(PeerIdentityBackend& backend) {
+  ProcessSnapshot snapshot;
+  const auto pid = static_cast<std::int32_t>(::getpid());
+  if (!backend.process_snapshot(pid, snapshot)) return {};
+  return {snapshot.pid, snapshot.generation};
+}
+
+std::int32_t macos_native_cpu_type() noexcept {
+  return static_cast<std::int32_t>(CPU_TYPE_ARM64);
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/src/platform/macos/secure_random_macos.cpp
+++ b/native/ae-plugin/src/platform/macos/secure_random_macos.cpp
@@ -1,0 +1,51 @@
+#include "aemcp_native/secure_random_macos.hpp"
+
+#include <Security/SecRandom.h>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+
+namespace aemcp::native {
+namespace {
+
+constexpr char kUpperHex[] = "0123456789ABCDEF";
+constexpr char kLowerHex[] = "0123456789abcdef";
+
+template <std::size_t Size>
+void fill_random(std::array<std::uint8_t, Size>& bytes) {
+  if (SecRandomCopyBytes(kSecRandomDefault, bytes.size(), bytes.data()) != errSecSuccess) {
+    throw std::runtime_error("secure random generation failed");
+  }
+}
+
+}  // namespace
+
+PairingMaterial MacPairingMaterialSource::create() {
+  PairingMaterial material;
+  fill_random(material.capability);
+  material.fingerprint.reserve(9);
+  for (std::size_t index = 0; index < 4; ++index) {
+    if (index == 2) material.fingerprint.push_back('-');
+    material.fingerprint.push_back(kUpperHex[material.capability[index] >> 4]);
+    material.fingerprint.push_back(kUpperHex[material.capability[index] & 0x0f]);
+  }
+  return material;
+}
+
+std::string secure_uuid_v4() {
+  std::array<std::uint8_t, 16> bytes{};
+  fill_random(bytes);
+  bytes[6] = static_cast<std::uint8_t>((bytes[6] & 0x0f) | 0x40);
+  bytes[8] = static_cast<std::uint8_t>((bytes[8] & 0x3f) | 0x80);
+  std::string output;
+  output.reserve(36);
+  for (std::size_t index = 0; index < bytes.size(); ++index) {
+    if (index == 4 || index == 6 || index == 8 || index == 10) output.push_back('-');
+    output.push_back(kLowerHex[bytes[index] >> 4]);
+    output.push_back(kLowerHex[bytes[index] & 0x0f]);
+  }
+  return output;
+}
+
+}  // namespace aemcp::native

--- a/native/ae-plugin/tests/endpoint_registry_macos_test.cpp
+++ b/native/ae-plugin/tests/endpoint_registry_macos_test.cpp
@@ -1,0 +1,191 @@
+#include "aemcp_native/endpoint_registry_macos.hpp"
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <string>
+
+namespace {
+
+using aemcp::native::EndpointCode;
+using aemcp::native::EndpointRegistryConfig;
+using aemcp::native::ExpectedProcess;
+using aemcp::native::MacEndpointRegistry;
+using aemcp::native::NativeEndpointDescriptor;
+using aemcp::native::PeerIdentityBackend;
+using aemcp::native::ProcessSnapshot;
+using aemcp::native::SocketPeerEvidence;
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+class FakeBackend final : public PeerIdentityBackend {
+ public:
+  bool socket_peer(int, SocketPeerEvidence&) override { return false; }
+  bool process_snapshot(std::int32_t pid, ProcessSnapshot& output) override {
+    const auto found = processes.find(pid);
+    if (found == processes.end()) return false;
+    output = found->second;
+    return true;
+  }
+  std::map<std::int32_t, ProcessSnapshot> processes;
+};
+
+struct TempRoot {
+  TempRoot() {
+    std::array<char, 64> pattern{};
+    const std::string prefix = "/private/tmp/aemcp-endpoint-test-XXXXXX";
+    std::copy(prefix.begin(), prefix.end(), pattern.begin());
+    char* created = ::mkdtemp(pattern.data());
+    if (created == nullptr) fail("could not create temp root");
+    path = created;
+    if (::chmod(path.c_str(), 0700) != 0) fail("could not secure temp root");
+  }
+  ~TempRoot() { std::filesystem::remove_all(path); }
+  std::string path;
+};
+
+NativeEndpointDescriptor descriptor(
+    std::string host = "11111111-1111-4111-8111-111111111111",
+    std::int32_t pid = 1234,
+    std::uint64_t start = 50) {
+  return {
+      1,
+      std::move(host),
+      ExpectedProcess{pid, {start, 7}},
+      "s-abcdef123456.sock",
+      1,
+      "0123456789abcdef0123456789abcdef01234567",
+  };
+}
+
+void publish_verify_and_cleanup() {
+  TempRoot root;
+  FakeBackend backend;
+  MacEndpointRegistry registry(backend, EndpointRegistryConfig{
+      root.path, "a1b2c3d4e5f6", 2, 32});
+  const auto started = registry.start(descriptor());
+  require(started.ok(), "valid endpoint did not start: " + started.diagnostic);
+  require(registry.listener_fd() >= 0 && registry.verify().ok(),
+      "published endpoint did not verify");
+  struct stat socket_status {};
+  struct stat descriptor_status {};
+  require(::lstat(registry.socket_path().c_str(), &socket_status) == 0
+          && S_ISSOCK(socket_status.st_mode) && (socket_status.st_mode & 0777) == 0600,
+      "socket was not private");
+  require(::lstat(registry.descriptor_path().c_str(), &descriptor_status) == 0
+          && S_ISREG(descriptor_status.st_mode) && (descriptor_status.st_mode & 0777) == 0600,
+      "descriptor was not private");
+  const std::string socket_path = registry.socket_path();
+  const std::string descriptor_path = registry.descriptor_path();
+  registry.stop();
+  require(::lstat(socket_path.c_str(), &socket_status) != 0 && errno == ENOENT,
+      "socket remained after stop");
+  require(::lstat(descriptor_path.c_str(), &descriptor_status) != 0 && errno == ENOENT,
+      "descriptor remained after stop");
+}
+
+void replacement_is_detected_and_not_deleted() {
+  TempRoot root;
+  FakeBackend backend;
+  MacEndpointRegistry registry(backend, EndpointRegistryConfig{
+      root.path, "112233445566", 2, 32});
+  require(registry.start(descriptor()).ok(), "replacement setup failed");
+  const std::string descriptor_path = registry.descriptor_path();
+  require(::unlink(descriptor_path.c_str()) == 0, "could not replace descriptor");
+  const int replacement = ::open(
+      descriptor_path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+  require(replacement >= 0, "could not create replacement descriptor");
+  require(::write(replacement, "attacker\n", 9) == 9, "could not write replacement");
+  ::close(replacement);
+  require(registry.verify().code == EndpointCode::kEndpointReplaced,
+      "descriptor replacement was not detected");
+  registry.stop();
+  struct stat status {};
+  require(::lstat(descriptor_path.c_str(), &status) == 0 && S_ISREG(status.st_mode),
+      "stop deleted a replacement it did not own");
+}
+
+void stale_owned_endpoint_is_recovered() {
+  TempRoot root;
+  FakeBackend backend;
+  std::string stale_socket;
+  std::string stale_descriptor;
+  {
+    MacEndpointRegistry stale(backend, EndpointRegistryConfig{
+        root.path, "aaaabbbbcccc", 2, 32});
+    require(stale.start(descriptor(
+                "22222222-2222-4222-8222-222222222222", 9999, 99)).ok(),
+        "stale setup failed");
+    stale_socket = stale.socket_path();
+    stale_descriptor = stale.descriptor_path();
+    // Simulate SIGKILL: prevent the destructor from seeing its original inode
+    // ownership by leaving copied managed entries after the normal stop.
+    const std::string descriptor_text = MacEndpointRegistry::serialize_descriptor(stale.descriptor());
+    const std::string directory = std::filesystem::path(stale_descriptor).parent_path();
+    const std::string expected_socket = directory + "/" + stale.descriptor().socket_name;
+    stale.stop();
+    const int socket_fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    require(socket_fd >= 0, "could not recreate stale socket");
+    sockaddr_un address{};
+    address.sun_family = AF_UNIX;
+    std::copy(expected_socket.begin(), expected_socket.end(), address.sun_path);
+    address.sun_len = SUN_LEN(&address);
+    require(::bind(socket_fd, reinterpret_cast<const sockaddr*>(&address), address.sun_len) == 0,
+        "could not bind stale socket");
+    require(::chmod(expected_socket.c_str(), 0600) == 0, "could not chmod stale socket");
+    const int file = ::open(stale_descriptor.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0600);
+    require(file >= 0, "could not recreate stale descriptor");
+    require(::write(file, descriptor_text.data(), descriptor_text.size())
+            == static_cast<ssize_t>(descriptor_text.size()),
+        "could not recreate stale descriptor text");
+    ::close(file);
+    ::close(socket_fd);
+  }
+  MacEndpointRegistry fresh(backend, EndpointRegistryConfig{
+      root.path, "ddddeeeeffff", 2, 32});
+  require(fresh.start(descriptor()).ok(), "fresh endpoint did not recover stale endpoint");
+  struct stat status {};
+  require(::lstat(stale_socket.c_str(), &status) != 0 && errno == ENOENT,
+      "stale socket was not removed");
+  require(::lstat(stale_descriptor.c_str(), &status) != 0 && errno == ENOENT,
+      "stale descriptor was not removed");
+}
+
+void descriptor_parser_is_closed() {
+  NativeEndpointDescriptor parsed;
+  const std::string valid = MacEndpointRegistry::serialize_descriptor(descriptor());
+  require(MacEndpointRegistry::parse_descriptor(valid, parsed), "valid descriptor rejected");
+  require(parsed.host_process.pid == 1234 && parsed.socket_name.empty() == false,
+      "descriptor fields changed");
+  require(!MacEndpointRegistry::parse_descriptor(valid + "extra=x\n", parsed),
+      "extra descriptor field accepted");
+  require(!MacEndpointRegistry::parse_descriptor(
+              valid.substr(0, valid.size() - 1), parsed),
+      "unterminated descriptor accepted");
+}
+
+}  // namespace
+
+int main() {
+  publish_verify_and_cleanup();
+  replacement_is_detected_and_not_deleted();
+  stale_owned_endpoint_is_recovered();
+  descriptor_parser_is_closed();
+  std::cout << "endpoint_registry_macos_test: PASS\n";
+  return 0;
+}

--- a/native/ae-plugin/tests/host_dispatcher_test.cpp
+++ b/native/ae-plugin/tests/host_dispatcher_test.cpp
@@ -1,8 +1,12 @@
 #include "aemcp_native/host_dispatcher.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <utility>
@@ -11,13 +15,15 @@
 namespace {
 
 using namespace std::chrono_literals;
+using aemcp::native::CancelCode;
+using aemcp::native::CancelResult;
 using aemcp::native::DispatcherConfig;
 using aemcp::native::EnqueueCode;
 using aemcp::native::HostApi;
 using aemcp::native::HostDispatcher;
 using aemcp::native::HostReadResult;
-using aemcp::native::ProjectSummary;
 using aemcp::native::Request;
+using aemcp::native::RouteRevocationResult;
 using aemcp::native::TimePoint;
 using aemcp::native::kProjectSummaryCapability;
 
@@ -32,11 +38,13 @@ void require(bool condition, const std::string& message) {
 
 class FakeClock final : public aemcp::native::Clock {
  public:
-  [[nodiscard]] TimePoint now() const noexcept override { return current_; }
-  void advance(std::chrono::milliseconds amount) { current_ += amount; }
+  [[nodiscard]] TimePoint now() const noexcept override {
+    return TimePoint{} + std::chrono::milliseconds(current_ms_.load());
+  }
+  void advance(std::chrono::milliseconds amount) { current_ms_.fetch_add(amount.count()); }
 
  private:
-  TimePoint current_{TimePoint{} + 1h};
+  std::atomic<std::int64_t> current_ms_{3600000};
 };
 
 class FakeHost final : public HostApi {
@@ -64,46 +72,169 @@ class FakeHost final : public HostApi {
   int calls{0};
 };
 
-Request request(FakeClock& clock, std::string id, std::chrono::milliseconds ttl = 100ms) {
-  return {std::move(id), std::string(kProjectSummaryCapability), clock.now() + ttl};
+class BlockingHost final : public HostApi {
+ public:
+  explicit BlockingHost(std::thread::id expected_thread)
+      : expected_thread_(expected_thread) {}
+
+  [[nodiscard]] HostReadResult read_project_summary(TimePoint) override {
+    require(std::this_thread::get_id() == expected_thread_, "blocking host ran off owner thread");
+    std::unique_lock lock(mutex_);
+    entered_ = true;
+    condition_.notify_all();
+    require(condition_.wait_for(lock, 2s, [&] { return released_; }),
+        "blocking host timed out waiting for worker");
+    return HostReadResult::success({true, "running.aep", 7});
+  }
+
+  void wait_until_entered() {
+    std::unique_lock lock(mutex_);
+    require(condition_.wait_for(lock, 2s, [&] { return entered_; }),
+        "worker timed out waiting for blocking host");
+  }
+
+  void release() {
+    std::lock_guard lock(mutex_);
+    released_ = true;
+    condition_.notify_all();
+  }
+
+ private:
+  std::thread::id expected_thread_;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  bool entered_{false};
+  bool released_{false};
+};
+
+Request request(
+    FakeClock& clock,
+    std::string id,
+    std::chrono::milliseconds ttl = 100ms,
+    std::string route_id = {},
+    std::uint64_t session_generation = 0) {
+  return {
+      std::move(id),
+      std::string(kProjectSummaryCapability),
+      clock.now() + ttl,
+      std::move(route_id),
+      session_generation,
+  };
 }
 
-void worker_to_owner_dispatch() {
+DispatcherConfig config(
+    std::size_t queue,
+    std::size_t tasks,
+    std::chrono::milliseconds budget,
+    std::size_t outbound = 64,
+    std::size_t tombstones = 128,
+    std::chrono::milliseconds tombstone_ttl = 60s,
+    std::size_t route_fences = 128) {
+  return {queue, tasks, budget, outbound, tombstones, tombstone_ttl, route_fences};
+}
+
+void worker_to_owner_dispatch_and_outbound_transfer() {
   FakeClock clock;
   const auto owner = std::this_thread::get_id();
   HostDispatcher dispatcher(owner, clock);
   FakeHost host(clock, owner);
   EnqueueCode result = EnqueueCode::kInvalidRequest;
-  std::thread worker([&] { result = dispatcher.enqueue(request(clock, "worker-1")).code; });
+  std::thread worker([&] {
+    result = dispatcher.enqueue(request(clock, "worker-1", 100ms, "route-a", 7)).code;
+  });
   worker.join();
   require(result == EnqueueCode::kAccepted, "worker enqueue was rejected");
   const auto batch = dispatcher.drain(host);
   require(!batch.wrong_thread && batch.completions.size() == 1, "owner drain failed");
   require(batch.completions[0].ok, "project summary did not succeed");
   require(batch.completions[0].result.item_count == 3, "project summary was changed");
+  require(batch.completions[0].route_id == "route-a"
+          && batch.completions[0].session_generation == 7,
+      "drain completion lost its route generation");
   require(host.calls == 1, "host call count mismatch");
   require(host.observed_deadline == clock.now() - host.delay + 4ms,
       "host did not receive the idle work deadline");
+
+  std::vector<aemcp::native::Completion> outbound;
+  std::thread outbound_worker([&] { outbound = dispatcher.take_outbound(); });
+  outbound_worker.join();
+  require(outbound.size() == 1 && outbound[0].route_id == "route-a"
+          && outbound[0].session_generation == 7 && outbound[0].ok,
+      "worker did not receive typed routed outbound completion");
+  require(dispatcher.outbound() == 0, "outbound transfer did not consume its item");
 }
 
 void admission_is_closed_and_bounded() {
   FakeClock clock;
-  HostDispatcher dispatcher(
-      std::this_thread::get_id(), clock, DispatcherConfig{1, 1, 4ms});
-  require(dispatcher.enqueue({"bad id", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
+  HostDispatcher dispatcher(std::this_thread::get_id(), clock, config(1, 1, 4ms));
+  require(dispatcher.enqueue({
+      "bad id", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
       == EnqueueCode::kInvalidRequest, "invalid request id was accepted");
-  require(dispatcher.enqueue({"-leading", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
+  require(dispatcher.enqueue({
+      "-leading", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
       == EnqueueCode::kInvalidRequest, "leading punctuation in request id was accepted");
-  require(dispatcher.enqueue({"é", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
+  require(dispatcher.enqueue({
+      "é", std::string(kProjectSummaryCapability), clock.now() + 1s}).code
       == EnqueueCode::kInvalidRequest, "non-ASCII request id was accepted");
   require(dispatcher.enqueue({"unknown", "native.raw", clock.now() + 1s}).code
       == EnqueueCode::kUnsupportedCapability, "unknown capability was accepted");
+  require(dispatcher.enqueue(request(clock, "bad-route", 1s, {}, 1)).code
+      == EnqueueCode::kInvalidRequest, "ambiguous legacy route was accepted");
+  require(dispatcher.enqueue(request(clock, "bad-generation", 1s, "route", 0)).code
+      == EnqueueCode::kInvalidRequest, "authenticated zero generation was accepted");
   require(dispatcher.enqueue(request(clock, "first")).code == EnqueueCode::kAccepted,
       "valid request was rejected");
-  require(dispatcher.enqueue(request(clock, "first")).code == EnqueueCode::kDuplicateRequest,
-      "duplicate request was accepted");
+  require(dispatcher.enqueue(request(clock, "first")).code
+      == EnqueueCode::kDuplicateRequest, "duplicate request was accepted");
   require(dispatcher.enqueue(request(clock, "second")).code == EnqueueCode::kQueueFull,
       "queue bound was not enforced");
+}
+
+void request_identity_is_route_scoped_and_tombstones_expire() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(4, 4, 4ms, 8, 8, 10ms));
+  FakeHost host(clock, owner);
+
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-a", 1)).code
+      == EnqueueCode::kAccepted, "first routed identity was rejected");
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-b", 1)).code
+      == EnqueueCode::kAccepted, "request id collided across routes");
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-a", 2)).code
+      == EnqueueCode::kAccepted, "request id collided across route generations");
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-a", 1)).code
+      == EnqueueCode::kDuplicateRequest, "exact active route identity was replayed");
+
+  require(dispatcher.drain(host).completions.size() == 3, "routed requests did not drain");
+  require(dispatcher.has_terminal("route-a", 1, "same"), "terminal tombstone missing");
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-a", 1)).code
+      == EnqueueCode::kDuplicateRequest, "terminal request was replayed");
+  require(dispatcher.take_outbound().size() == 3, "routed outbound count mismatch");
+  clock.advance(11ms);
+  require(!dispatcher.has_terminal("route-a", 1, "same"), "terminal TTL did not expire");
+  require(dispatcher.enqueue(request(clock, "same", 1s, "route-a", 1)).code
+      == EnqueueCode::kAccepted, "expired and observed tombstone still blocked admission");
+  require(dispatcher.shutdown().size() == 1, "TTL test cleanup did not terminate request");
+}
+
+void terminal_tombstones_are_fifo_bounded() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(2, 1, 4ms, 4, 2, 1s));
+  FakeHost host(clock, owner);
+  for (const std::string id : {"one", "two", "three"}) {
+    require(dispatcher.enqueue(request(clock, id, 1s, "route", 1)).code
+        == EnqueueCode::kAccepted, "bounded tombstone setup enqueue failed");
+    require(dispatcher.drain(host).completions.size() == 1,
+        "bounded tombstone setup drain failed");
+    require(dispatcher.take_outbound().size() == 1,
+        "bounded tombstone setup outbound failed");
+  }
+  require(dispatcher.terminal_count() == 2, "terminal tombstone capacity was not enforced");
+  require(!dispatcher.has_terminal("route", 1, "one")
+          && dispatcher.has_terminal("route", 1, "two")
+          && dispatcher.has_terminal("route", 1, "three"),
+      "terminal tombstones were not evicted in deterministic FIFO order");
 }
 
 void wrong_thread_is_state_preserving() {
@@ -118,6 +249,17 @@ void wrong_thread_is_state_preserving() {
   worker.join();
   require(worker_batch.wrong_thread, "worker drain was not rejected");
   require(dispatcher.queued() == 1 && host.calls == 0, "wrong-thread drain changed state");
+  bool shutdown_rejected = false;
+  std::thread shutdown_worker([&] {
+    try {
+      static_cast<void>(dispatcher.shutdown());
+    } catch (const std::logic_error&) {
+      shutdown_rejected = true;
+    }
+  });
+  shutdown_worker.join();
+  require(shutdown_rejected && dispatcher.running() && dispatcher.queued() == 1,
+      "wrong-thread shutdown violated owner lifecycle discipline");
   require(dispatcher.drain(host).completions.size() == 1, "owner could not recover request");
 }
 
@@ -140,12 +282,174 @@ void deadlines_and_late_results_are_safe() {
   require(batch.completions[0].error_code == "DEADLINE_EXCEEDED"
           && batch.completions[0].late_result_discarded,
       "late host result was not discarded");
+  const auto outbound = dispatcher.take_outbound();
+  require(outbound.size() == 2 && outbound[1].late_result_discarded,
+      "deadline terminal evidence did not reach outbound");
+}
+
+void outbound_capacity_applies_backpressure_until_worker_takes() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(4, 4, 4ms, 2));
+  FakeHost host(clock, owner);
+  require(dispatcher.enqueue(request(clock, "one", 1s, "route", 1)).code
+      == EnqueueCode::kAccepted, "first outbound setup failed");
+  require(dispatcher.enqueue(request(clock, "two", 1s, "route", 1)).code
+      == EnqueueCode::kAccepted, "second outbound setup failed");
+  require(dispatcher.drain(host).completions.size() == 2, "outbound setup did not drain");
+  require(dispatcher.outbound() == 2, "outbound queue was not populated");
+  require(dispatcher.enqueue(request(clock, "three", 1s, "route", 1)).code
+      == EnqueueCode::kQueueFull, "outbound saturation admitted hanging work");
+
+  std::vector<aemcp::native::Completion> taken;
+  std::thread worker([&] { taken = dispatcher.take_outbound(1); });
+  worker.join();
+  require(taken.size() == 1, "worker could not take bounded outbound item");
+  require(dispatcher.enqueue(request(clock, "three", 1s, "route", 1)).code
+      == EnqueueCode::kAccepted, "worker take did not release outbound capacity");
+  require(dispatcher.drain(host).completions.size() == 1,
+      "post-backpressure request did not drain");
+  require(dispatcher.outbound() == 2, "outbound capacity accounting drifted");
+}
+
+void queued_and_running_cancellation_are_distinct() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(4, 4, 4ms, 8));
+  FakeHost host(clock, owner);
+  require(dispatcher.enqueue(request(clock, "target", 1s, "route-a", 1)).code
+      == EnqueueCode::kAccepted, "queued cancel target setup failed");
+  require(dispatcher.enqueue(request(clock, "target", 1s, "route-b", 1)).code
+      == EnqueueCode::kAccepted, "cross-route cancel control setup failed");
+  const CancelResult queued = dispatcher.cancel("route-a", 1, "target");
+  require(queued.code == CancelCode::kQueuedCancelled && queued.terminal_response_expected,
+      "queued request did not cancel atomically");
+  require(dispatcher.cancel("route-a", 1, "target").code == CancelCode::kAlreadyTerminal,
+      "repeated queued cancel did not observe terminal state");
+  require(dispatcher.queued() == 1, "queued cancel crossed its route boundary");
+  const auto cancelled = dispatcher.take_outbound();
+  require(cancelled.size() == 1 && cancelled[0].error_code == "CANCELLED"
+          && cancelled[0].route_id == "route-a" && !cancelled[0].route_revoked,
+      "queued cancellation did not produce routed terminal evidence");
+  require(dispatcher.drain(host).completions.size() == 1,
+      "other route did not survive targeted cancellation");
+
+  require(dispatcher.enqueue(request(clock, "running", 1s, "route-a", 1)).code
+      == EnqueueCode::kAccepted, "running cancel target setup failed");
+  BlockingHost blocking(owner);
+  CancelResult running;
+  std::thread cancel_worker([&] {
+    blocking.wait_until_entered();
+    running = dispatcher.cancel("route-a", 1, "running");
+    blocking.release();
+  });
+  const auto batch = dispatcher.drain(blocking);
+  cancel_worker.join();
+  require(running.code == CancelCode::kRunningNotCancellable
+          && running.terminal_response_expected,
+      "running before-dispatch capability did not report running-not-cancellable");
+  require(batch.completions.size() == 1 && batch.completions[0].ok,
+      "running request was incorrectly cancelled after dispatch");
+}
+
+void route_revocation_fences_generations_and_detaches_results() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(6, 6, 4ms, 12, 128, 60s, 1));
+  FakeHost host(clock, owner);
+  require(dispatcher.enqueue(request(clock, "old-a", 1s, "shared", 1)).code
+      == EnqueueCode::kAccepted, "old route request A setup failed");
+  require(dispatcher.enqueue(request(clock, "old-b", 1s, "shared", 1)).code
+      == EnqueueCode::kAccepted, "old route request B setup failed");
+  require(dispatcher.enqueue(request(clock, "old-a", 1s, "shared", 2)).code
+      == EnqueueCode::kAccepted, "new generation request setup failed");
+
+  const RouteRevocationResult queued = dispatcher.revoke_route("shared", 1);
+  require(queued.fence_recorded && !queued.fence_saturated
+          && queued.queued_cancelled == 2 && queued.running_detached == 0,
+      "route revoke did not cancel only its queued generation");
+  require(dispatcher.queued() == 1, "route revoke cancelled the newer generation");
+  const auto cancelled = dispatcher.take_outbound();
+  require(cancelled.size() == 2 && cancelled[0].route_revoked
+          && cancelled[1].route_revoked && cancelled[0].error_code == "CANCELLED",
+      "revoked queued requests did not preserve detached terminal evidence");
+  require(dispatcher.enqueue(request(clock, "stale", 1s, "shared", 1)).code
+      == EnqueueCode::kStaleRoute, "revoked generation bypassed its fence");
+  auto batch = dispatcher.drain(host);
+  require(batch.completions.size() == 1 && batch.completions[0].session_generation == 2
+          && !batch.completions[0].route_revoked,
+      "newer route generation was detached by an older fence");
+  require(dispatcher.revoke_route("shared", 1).pending_outbound_marked == 0,
+      "late old-generation revoke marked a new-generation result");
+  require(dispatcher.take_outbound().size() == 1,
+      "new-generation outbound result was not independently observable");
+
+  require(dispatcher.enqueue(request(clock, "mutation-shaped", 1s, "shared", 3)).code
+      == EnqueueCode::kAccepted, "running revoke target setup failed");
+  BlockingHost blocking(owner);
+  RouteRevocationResult running;
+  RouteRevocationResult repeated;
+  std::thread revoke_worker([&] {
+    blocking.wait_until_entered();
+    running = dispatcher.revoke_route("shared", 3);
+    repeated = dispatcher.revoke_route("shared", 3);
+    blocking.release();
+  });
+  batch = dispatcher.drain(blocking);
+  revoke_worker.join();
+  require(running.running_detached == 1 && running.queued_cancelled == 0,
+      "running request was not generation-detached");
+  require(repeated.running_detached == 0 && repeated.fence_recorded,
+      "repeated route revoke was not idempotent");
+  require(batch.completions.size() == 1 && batch.completions[0].ok
+          && batch.completions[0].route_revoked,
+      "post-disconnect running result lost detached terminal evidence");
+  require(dispatcher.has_terminal("shared", 3, "mutation-shaped"),
+      "post-disconnect terminal tombstone was not retained");
+
+  require(dispatcher.enqueue(request(clock, "mutation-shaped", 1s, "shared", 4)).code
+      == EnqueueCode::kAccepted, "new connection generation inherited stale request state");
+  require(dispatcher.drain(host).completions.size() == 1,
+      "new connection generation did not execute independently");
+  const auto outbound = dispatcher.take_outbound();
+  require(outbound.size() == 2
+          && outbound[0].session_generation == 3 && outbound[0].route_revoked
+          && outbound[1].session_generation == 4 && !outbound[1].route_revoked,
+      "old terminal evidence could be confused with the new connection");
+}
+
+void saturated_route_fences_fail_closed_without_losing_running_evidence() {
+  FakeClock clock;
+  const auto owner = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner, clock, config(4, 4, 4ms, 8, 8, 1s, 1));
+  require(dispatcher.revoke_route("recorded", 1).fence_recorded,
+      "route fence capacity setup failed");
+  require(dispatcher.enqueue(request(clock, "running", 1s, "unseen", 1)).code
+      == EnqueueCode::kAccepted, "pre-saturation running route setup failed");
+
+  BlockingHost blocking(owner);
+  RouteRevocationResult revocation;
+  std::thread worker([&] {
+    blocking.wait_until_entered();
+    revocation = dispatcher.revoke_route("unseen", 1);
+    blocking.release();
+  });
+  const auto batch = dispatcher.drain(blocking);
+  worker.join();
+  require(!revocation.fence_recorded && revocation.fence_saturated
+          && revocation.running_detached == 1,
+      "saturated fence registry did not detach the active unknown route");
+  require(batch.completions.size() == 1 && batch.completions[0].route_revoked,
+      "saturated fence path lost detached running terminal evidence");
+  require(dispatcher.enqueue(request(clock, "future", 1s, "unseen", 2)).code
+      == EnqueueCode::kStaleRoute,
+      "saturated fence registry evicted history instead of failing closed");
 }
 
 void idle_budget_and_shutdown_are_bounded() {
   FakeClock clock;
   const auto owner = std::this_thread::get_id();
-  HostDispatcher dispatcher(owner, clock, DispatcherConfig{4, 4, 2ms});
+  HostDispatcher dispatcher(owner, clock, config(4, 4, 2ms));
   FakeHost host(clock, owner);
   host.delay = 2ms;
   require(dispatcher.enqueue(request(clock, "budget-1", 1s)).code == EnqueueCode::kAccepted,
@@ -158,6 +462,11 @@ void idle_budget_and_shutdown_are_bounded() {
   const auto stopped = dispatcher.shutdown();
   require(stopped.size() == 1 && stopped[0].error_code == "AE_SHUTTING_DOWN",
       "shutdown did not terminate queued request");
+  require(dispatcher.outbound() == 2,
+      "shutdown did not place every terminal completion on outbound");
+  require(dispatcher.has_terminal({}, 0, "budget-1")
+          && dispatcher.has_terminal({}, 0, "budget-2"),
+      "shutdown terminal tombstones are incomplete");
   require(dispatcher.enqueue(request(clock, "after-stop", 1s)).code
       == EnqueueCode::kShuttingDown, "request was admitted after shutdown");
   require(dispatcher.shutdown().empty(), "shutdown was not idempotent");
@@ -166,10 +475,16 @@ void idle_budget_and_shutdown_are_bounded() {
 }  // namespace
 
 int main() {
-  worker_to_owner_dispatch();
+  worker_to_owner_dispatch_and_outbound_transfer();
   admission_is_closed_and_bounded();
+  request_identity_is_route_scoped_and_tombstones_expire();
+  terminal_tombstones_are_fifo_bounded();
   wrong_thread_is_state_preserving();
   deadlines_and_late_results_are_safe();
+  outbound_capacity_applies_backpressure_until_worker_takes();
+  queued_and_running_cancellation_are_distinct();
+  route_revocation_fences_generations_and_detaches_results();
+  saturated_route_fences_fail_closed_without_losing_running_evidence();
   idle_budget_and_shutdown_are_bounded();
   std::cout << "host_dispatcher_test: PASS\n";
   return 0;

--- a/native/ae-plugin/tests/native_rpc_connection_test.cpp
+++ b/native/ae-plugin/tests/native_rpc_connection_test.cpp
@@ -1,0 +1,471 @@
+#include "aemcp_native/native_rpc_connection.hpp"
+
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using aemcp::native::AuthenticatedConnection;
+using aemcp::native::Clock;
+using aemcp::native::Completion;
+using aemcp::native::EnqueueCode;
+using aemcp::native::HostApi;
+using aemcp::native::HostDispatcher;
+using aemcp::native::HostReadResult;
+using aemcp::native::NativeRpcConnectionHandler;
+using aemcp::native::NativeRpcObserver;
+using aemcp::native::NativeRpcRuntimeInfo;
+using aemcp::native::ProjectSummary;
+using aemcp::native::Request;
+using aemcp::native::TimePoint;
+using aemcp::native::kProjectSummaryCapability;
+using aemcp::native::rpc::SessionClock;
+
+constexpr std::string_view kSession = "11111111-1111-4111-8111-111111111111";
+constexpr std::string_view kHost = "22222222-2222-4222-8222-222222222222";
+constexpr std::string_view kClient = "33333333-3333-4333-8333-333333333333";
+constexpr std::string_view kZeroDigest =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+class FakeDispatcherClock final : public Clock {
+ public:
+  [[nodiscard]] TimePoint now() const noexcept override {
+    return TimePoint{} + std::chrono::milliseconds(now_ms_.load());
+  }
+
+ private:
+  std::atomic<std::int64_t> now_ms_{3'600'000};
+};
+
+class FakeSessionClock final : public SessionClock {
+ public:
+  [[nodiscard]] std::uint64_t now_unix_ms() const noexcept override {
+    return now_ms_.load();
+  }
+
+ private:
+  std::atomic<std::uint64_t> now_ms_{1'900'000'000'000ULL};
+};
+
+class FakeHost final : public HostApi {
+ public:
+  [[nodiscard]] HostReadResult read_project_summary(TimePoint) override {
+    return HostReadResult::success(summary);
+  }
+
+  ProjectSummary summary{true, "fixture.aep", 3};
+};
+
+struct EventRecord {
+  std::string event;
+  std::string request_id;
+  std::string decision;
+};
+
+struct TerminalRecord {
+  std::string request_id;
+  bool ok{false};
+  std::string error_code;
+  std::string request_digest;
+  std::string postcondition_digest;
+};
+
+class RecordingObserver final : public NativeRpcObserver {
+ public:
+  void on_rpc_event(
+      std::string_view event,
+      std::string_view request_id,
+      std::string_view decision) noexcept override {
+    try {
+      std::lock_guard lock(mutex_);
+      events_.push_back({std::string(event), std::string(request_id), std::string(decision)});
+    } catch (...) {
+    }
+  }
+
+  void on_rpc_terminal(
+      const Completion& completion,
+      std::string_view request_digest,
+      std::string_view postcondition_digest,
+      std::uint64_t,
+      std::uint64_t) noexcept override {
+    try {
+      std::lock_guard lock(mutex_);
+      terminals_.push_back({
+          completion.request_id,
+          completion.ok,
+          completion.error_code,
+          std::string(request_digest),
+          std::string(postcondition_digest),
+      });
+    } catch (...) {
+    }
+  }
+
+  [[nodiscard]] bool has_event(
+      std::string_view event,
+      std::string_view request_id,
+      std::string_view decision) const {
+    std::lock_guard lock(mutex_);
+    for (const EventRecord& item : events_) {
+      if (item.event == event && item.request_id == request_id && item.decision == decision) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] TerminalRecord terminal(std::string_view request_id) const {
+    std::lock_guard lock(mutex_);
+    for (const TerminalRecord& item : terminals_) {
+      if (item.request_id == request_id) return item;
+    }
+    return {};
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<EventRecord> events_;
+  std::vector<TerminalRecord> terminals_;
+};
+
+NativeRpcRuntimeInfo runtime() {
+  return {
+      "0.0.0-test",
+      "25.6",
+      61,
+      "26.3.0",
+      87,
+      std::string(kHost),
+      std::string(64, 'a'),
+      std::string(64, 'b'),
+  };
+}
+
+AuthenticatedConnection connection(int socket_fd, std::string route, std::uint32_t generation) {
+  AuthenticatedConnection value;
+  value.socket_fd = socket_fd;
+  value.peer.pid = 100;
+  value.peer.pid_version = 1;
+  value.peer.uid = 501;
+  value.peer.audit_session = 7;
+  value.peer.connection_id = std::move(route);
+  value.peer.host_instance_id = std::string(kHost);
+  value.session_id = std::string(kSession);
+  value.session_generation = generation;
+  return value;
+}
+
+std::vector<std::uint8_t> frame(std::string_view json) {
+  require(!json.empty() && json.size() <= 65'536, "test JSON frame size is invalid");
+  std::vector<std::uint8_t> output(json.size() + 4);
+  const auto size = static_cast<std::uint32_t>(json.size());
+  output[0] = static_cast<std::uint8_t>(size >> 24U);
+  output[1] = static_cast<std::uint8_t>(size >> 16U);
+  output[2] = static_cast<std::uint8_t>(size >> 8U);
+  output[3] = static_cast<std::uint8_t>(size);
+  std::memcpy(output.data() + 4, json.data(), json.size());
+  return output;
+}
+
+void write_all(int socket_fd, const std::vector<std::uint8_t>& bytes) {
+  std::size_t offset = 0;
+  while (offset < bytes.size()) {
+    const ssize_t sent = ::send(socket_fd, bytes.data() + offset, bytes.size() - offset, 0);
+    if (sent < 0 && errno == EINTR) continue;
+    require(sent > 0, "test client could not write a request frame");
+    offset += static_cast<std::size_t>(sent);
+  }
+}
+
+void send_json(int socket_fd, std::string_view json) {
+  write_all(socket_fd, frame(json));
+}
+
+bool wait_readable(int socket_fd, std::chrono::milliseconds timeout) {
+  pollfd item{socket_fd, POLLIN, 0};
+  int result = 0;
+  do {
+    result = ::poll(&item, 1, static_cast<int>(timeout.count()));
+  } while (result < 0 && errno == EINTR);
+  return result > 0 && (item.revents & POLLIN) != 0;
+}
+
+void read_exact(int socket_fd, std::uint8_t* output, std::size_t size) {
+  std::size_t offset = 0;
+  while (offset < size) {
+    require(wait_readable(socket_fd, 2s), "timed out waiting for response bytes");
+    const ssize_t received = ::recv(socket_fd, output + offset, size - offset, 0);
+    if (received < 0 && errno == EINTR) continue;
+    require(received > 0, "test server closed before a complete response");
+    offset += static_cast<std::size_t>(received);
+  }
+}
+
+std::string read_body(int socket_fd) {
+  std::array<std::uint8_t, 4> prefix{};
+  read_exact(socket_fd, prefix.data(), prefix.size());
+  const std::uint32_t size = (static_cast<std::uint32_t>(prefix[0]) << 24U)
+      | (static_cast<std::uint32_t>(prefix[1]) << 16U)
+      | (static_cast<std::uint32_t>(prefix[2]) << 8U)
+      | static_cast<std::uint32_t>(prefix[3]);
+  require(size > 0 && size <= 65'536, "response frame prefix is invalid");
+  std::vector<std::uint8_t> body(size);
+  read_exact(socket_fd, body.data(), body.size());
+  return std::string(reinterpret_cast<const char*>(body.data()), body.size());
+}
+
+template <typename Predicate>
+void wait_until(Predicate&& predicate, const std::string& label) {
+  const auto deadline = std::chrono::steady_clock::now() + 2s;
+  while (!predicate()) {
+    if (std::chrono::steady_clock::now() >= deadline) fail("timed out waiting for " + label);
+    std::this_thread::sleep_for(2ms);
+  }
+}
+
+std::string hello_json() {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"requestId\":\"hello-1\","
+      "\"method\":\"hello\",\"params\":{\"supportedWireVersions\":{\"minimum\":1,"
+      "\"maximum\":1},\"client\":{\"component\":\"core-broker\",\"version\":\"0.9.2\","
+      "\"instanceId\":\"" + std::string(kClient)
+      + "\"},\"nonce\":\"abcdefghijklmnopqrstuvwxyzABCDEF\"}}";
+}
+
+std::string capabilities_json() {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession)
+      + "\",\"requestId\":\"capabilities-1\",\"method\":\"capabilities\","
+        "\"params\":{\"ids\":[\"ae.project.summary\"],\"detail\":\"full\",\"limit\":1}}";
+}
+
+std::string invoke_json(
+    std::string_view request_id,
+    std::string_view session_id = kSession) {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(session_id) + "\",\"requestId\":\"" + std::string(request_id)
+      + "\",\"method\":\"invoke\",\"deadlineUnixMs\":1900000005000,"
+        "\"params\":{\"capabilityId\":\"ae.project.summary\","
+        "\"capabilityVersion\":1,\"arguments\":{}}}";
+}
+
+std::string cancel_json(std::string_view request_id, std::string_view target_request_id) {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"" + std::string(request_id)
+      + "\",\"method\":\"cancel\",\"params\":{\"targetRequestId\":\""
+      + std::string(target_request_id) + "\"}}";
+}
+
+void require_contains(
+    const std::string& value, std::string_view expected, const std::string& label) {
+  require(value.find(expected) != std::string::npos, label + " omitted " + std::string(expected));
+}
+
+void finish_connection(int client_fd, int server_fd, std::thread& worker) {
+  (void)::shutdown(client_fd, SHUT_RDWR);
+  (void)::close(client_fd);
+  worker.join();
+  (void)::close(server_fd);
+}
+
+void hello_capabilities_invoke_cancel_and_fencing_work() {
+  FakeDispatcherClock dispatcher_clock;
+  FakeSessionClock session_clock;
+  HostDispatcher dispatcher(std::this_thread::get_id(), dispatcher_clock);
+  RecordingObserver observer;
+  NativeRpcConnectionHandler handler(
+      dispatcher, dispatcher_clock, session_clock, runtime(), observer);
+  std::array<int, 2> sockets{};
+  require(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets.data()) == 0, "socketpair failed");
+  const AuthenticatedConnection authenticated = connection(sockets[1], "route-e2e", 7);
+  std::thread worker([&] { handler.serve(authenticated); });
+
+  send_json(sockets[0], hello_json());
+  const std::string hello = read_body(sockets[0]);
+  require_contains(hello, "\"method\":\"hello\"", "hello response");
+  require_contains(hello, "\"sessionGeneration\":7", "hello response");
+  require_contains(hello, "\"ok\":true", "hello response");
+
+  send_json(sockets[0], hello_json());
+  const std::string repeated_hello = read_body(sockets[0]);
+  require_contains(repeated_hello, "\"code\":\"INVALID_REQUEST\"", "repeated hello");
+  require_contains(repeated_hello, "\"method\":\"hello\"", "repeated hello");
+
+  send_json(sockets[0], invoke_json(
+      "wrong-session", "44444444-4444-4444-8444-444444444444"));
+  const std::string stale = read_body(sockets[0]);
+  require_contains(stale, "\"code\":\"SESSION_STALE\"", "stale session response");
+  require_contains(stale, "\"ok\":false", "stale session response");
+
+  send_json(sockets[0], capabilities_json());
+  const std::string capabilities = read_body(sockets[0]);
+  require_contains(capabilities, "\"method\":\"capabilities\"", "capabilities response");
+  require_contains(capabilities, "\"id\":\"ae.project.summary\"", "capabilities response");
+  require_contains(capabilities,
+      "\"queryDigest\":\"aa3c66bc21e50b6a35db9c3cb12fcb1627694cd8f9fc411f21f7e3de46b3e56a\"",
+      "capabilities response");
+
+  send_json(sockets[0], invoke_json("invoke-read"));
+  const std::string progress = read_body(sockets[0]);
+  require_contains(progress, "\"event\":\"progress\"", "invoke progress");
+  require_contains(progress, "\"phase\":\"queued\"", "invoke progress");
+  wait_until([&] { return dispatcher.queued() == 1; }, "queued invoke");
+  FakeHost host;
+  const auto read_batch = dispatcher.drain(host);
+  require(read_batch.completions.size() == 1 && read_batch.completions[0].ok,
+      "owner dispatcher did not produce the read result");
+  const std::string summary = read_body(sockets[0]);
+  require_contains(summary, "\"engine\":\"native-aegp\"", "summary response");
+  require_contains(summary, "\"projectName\":\"fixture.aep\"", "summary response");
+  require(summary.find(kZeroDigest) == std::string::npos,
+      "summary response forged a zero evidence digest");
+  wait_until([&] { return !observer.terminal("invoke-read").request_id.empty(); },
+      "read terminal audit");
+  const TerminalRecord read_terminal = observer.terminal("invoke-read");
+  require(read_terminal.ok && read_terminal.request_digest.size() == 64
+      && read_terminal.postcondition_digest
+          == "0e82d012b2b7f26e310703c35b1d82e744809137f1ea5e6d1920aa29c0baca77",
+      "read terminal evidence was not deterministic and verified");
+
+  send_json(sockets[0], invoke_json("invoke-cancel"));
+  require_contains(read_body(sockets[0]), "\"event\":\"progress\"", "cancel setup progress");
+  wait_until([&] { return dispatcher.queued() == 1; }, "queued cancel target");
+  send_json(sockets[0], cancel_json("cancel-1", "invoke-cancel"));
+  const std::string cancel = read_body(sockets[0]);
+  require_contains(cancel, "\"state\":\"queued-cancelled\"", "cancel response");
+  require_contains(cancel, "\"terminalResponseExpected\":true", "cancel response");
+  const std::string cancelled_terminal = read_body(sockets[0]);
+  require_contains(cancelled_terminal, "\"code\":\"CANCELLED\"", "cancel terminal");
+
+  require(dispatcher.enqueue(Request{
+      "wrong-generation",
+      std::string(kProjectSummaryCapability),
+      dispatcher_clock.now() + 1s,
+      "route-e2e",
+      8,
+  }).code == EnqueueCode::kAccepted, "generation fence setup enqueue failed");
+  require(dispatcher.enqueue(Request{
+      "missing-evidence",
+      std::string(kProjectSummaryCapability),
+      dispatcher_clock.now() + 1s,
+      "route-e2e",
+      7,
+  }).code == EnqueueCode::kAccepted, "missing evidence setup enqueue failed");
+  require(dispatcher.drain(host).completions.size() == 2,
+      "fencing setup completions did not drain");
+  wait_until([&] {
+    return observer.has_event("terminal.detached", "wrong-generation", "route-mismatch")
+        && observer.has_event(
+            "terminal.detached", "missing-evidence", "missing-request-evidence");
+  }, "exact route and evidence fencing");
+  require(!wait_readable(sockets[0], 150ms),
+      "detached completion leaked a response onto the active connection");
+
+  finish_connection(sockets[0], sockets[1], worker);
+  require(dispatcher.enqueue(Request{
+      "old-generation",
+      std::string(kProjectSummaryCapability),
+      dispatcher_clock.now() + 1s,
+      "route-e2e",
+      7,
+  }).code == EnqueueCode::kStaleRoute, "closed session generation was not fenced");
+  require(dispatcher.enqueue(Request{
+      "new-generation",
+      std::string(kProjectSummaryCapability),
+      dispatcher_clock.now() + 1s,
+      "route-e2e",
+      8,
+  }).code == EnqueueCode::kAccepted, "new session generation was incorrectly fenced");
+  (void)dispatcher.shutdown();
+}
+
+void invalid_postcondition_becomes_structured_failure() {
+  FakeDispatcherClock dispatcher_clock;
+  FakeSessionClock session_clock;
+  HostDispatcher dispatcher(std::this_thread::get_id(), dispatcher_clock);
+  RecordingObserver observer;
+  NativeRpcConnectionHandler handler(
+      dispatcher, dispatcher_clock, session_clock, runtime(), observer);
+  std::array<int, 2> sockets{};
+  require(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets.data()) == 0, "socketpair failed");
+  const AuthenticatedConnection authenticated = connection(sockets[1], "route-invalid", 3);
+  std::thread worker([&] { handler.serve(authenticated); });
+
+  send_json(sockets[0], hello_json());
+  require_contains(read_body(sockets[0]), "\"ok\":true", "invalid evidence hello");
+  send_json(sockets[0], invoke_json("invalid-result"));
+  require_contains(read_body(sockets[0]), "\"event\":\"progress\"", "invalid evidence progress");
+  wait_until([&] { return dispatcher.queued() == 1; }, "invalid evidence invoke");
+  FakeHost host;
+  host.summary.item_count = -1;
+  require(dispatcher.drain(host).completions.size() == 1,
+      "invalid host result did not reach transport validation");
+  const std::string failure = read_body(sockets[0]);
+  require_contains(failure, "\"code\":\"CAPABILITY_FAILED\"", "invalid evidence failure");
+  require_contains(failure, "\"capabilityId\":\"ae.project.summary\"", "invalid evidence failure");
+  require(failure.find(kZeroDigest) == std::string::npos,
+      "invalid evidence failure forged a zero digest");
+  wait_until([&] { return !observer.terminal("invalid-result").request_id.empty(); },
+      "invalid evidence terminal audit");
+  const TerminalRecord terminal = observer.terminal("invalid-result");
+  require(!terminal.ok && terminal.error_code == "CAPABILITY_FAILED"
+      && terminal.request_digest.size() == 64 && terminal.postcondition_digest.empty(),
+      "invalid postcondition was audited as a verified success");
+  require(observer.has_event("terminal.validation", "invalid-result", "invalid-evidence"),
+      "invalid postcondition did not emit a validation decision");
+
+  finish_connection(sockets[0], sockets[1], worker);
+  (void)dispatcher.shutdown();
+}
+
+void construction_failure_is_contained_by_noexcept_boundary() {
+  FakeDispatcherClock dispatcher_clock;
+  FakeSessionClock session_clock;
+  HostDispatcher dispatcher(std::this_thread::get_id(), dispatcher_clock);
+  RecordingObserver observer;
+  NativeRpcConnectionHandler handler(
+      dispatcher, dispatcher_clock, session_clock, runtime(), observer);
+  AuthenticatedConnection invalid = connection(-1, std::string(1'025, 'x'), 1);
+  handler.serve(invalid);
+  require(observer.has_event(
+      "connection", "none", "codec-or-transport-failure"),
+      "front-door construction exception escaped the noexcept serve boundary");
+  require(dispatcher.running(), "construction failure changed dispatcher lifecycle state");
+  (void)dispatcher.shutdown();
+}
+
+}  // namespace
+
+int main() {
+  hello_capabilities_invoke_cancel_and_fencing_work();
+  invalid_postcondition_becomes_structured_failure();
+  construction_failure_is_contained_by_noexcept_boundary();
+  std::cout << "native_rpc_connection_test: PASS\n";
+  return 0;
+}

--- a/native/ae-plugin/tests/pairing_gate_test.cpp
+++ b/native/ae-plugin/tests/pairing_gate_test.cpp
@@ -1,0 +1,133 @@
+#include "aemcp_native/pairing_gate.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+using aemcp::native::BeginPairingCode;
+using aemcp::native::PairingDecision;
+using aemcp::native::PairingGate;
+using aemcp::native::PairingMaterial;
+using aemcp::native::PairingMaterialSource;
+using aemcp::native::PairingTimePoint;
+using aemcp::native::PeerBinding;
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+class FakeClock final : public aemcp::native::PairingGateClock {
+ public:
+  [[nodiscard]] PairingTimePoint now() const noexcept override { return now_; }
+  void advance(std::chrono::milliseconds amount) { now_ += amount; }
+
+ private:
+  PairingTimePoint now_{PairingTimePoint{} + 1h};
+};
+
+class FakeMaterial final : public PairingMaterialSource {
+ public:
+  [[nodiscard]] PairingMaterial create() override {
+    PairingMaterial material;
+    material.capability.fill(static_cast<std::uint8_t>(++issued));
+    material.fingerprint = issued == 1 ? "A1B2-C3D4" : "1122-3344";
+    return material;
+  }
+  int issued{0};
+};
+
+PeerBinding binding(std::string connection = "connection-1", std::uint32_t generation = 7) {
+  return {
+      1234,
+      generation,
+      501,
+      100001,
+      std::move(connection),
+      "11111111-1111-4111-8111-111111111111",
+  };
+}
+
+void authorization_is_exact_and_single_pending() {
+  FakeClock clock;
+  FakeMaterial material;
+  PairingGate gate(clock, material, {30s});
+  const PeerBinding first = binding();
+  const auto pending = gate.begin(first);
+  require(pending.code == BeginPairingCode::kPending, "valid peer did not become pending");
+  require(pending.fingerprint == "A1B2-C3D4", "fingerprint changed");
+  require(gate.begin(binding("connection-2")).code == BeginPairingCode::kBusy,
+      "second connection replaced pending peer");
+  require(!gate.confirm("connection-2", pending.fingerprint),
+      "wrong connection confirmed pending peer");
+  require(!gate.confirm(first.connection_id, "FFFF-FFFF"),
+      "wrong fingerprint confirmed pending peer");
+  require(gate.confirm(first.connection_id, pending.fingerprint),
+      "AEGP-owned confirmation failed");
+  require(gate.authorized(first), "confirmed exact peer was not authorized");
+  require(!gate.authorized(binding(first.connection_id, 8)),
+      "changed process generation inherited authorization");
+  require(gate.wait_for_decision(first, clock.now() + 1s) == PairingDecision::kAuthorized,
+      "authorized waiter did not observe decision");
+}
+
+void expiry_revoke_and_shutdown_are_fail_closed() {
+  FakeClock clock;
+  FakeMaterial material;
+  PairingGate gate(clock, material, {5s});
+  const PeerBinding first = binding();
+  require(gate.begin(first).code == BeginPairingCode::kPending, "expiry setup failed");
+  clock.advance(6s);
+  require(!gate.pending().has_value(), "expired pairing remained visible");
+  require(!gate.authorized(first), "expired pairing remained authorized");
+
+  const PeerBinding second = binding("connection-2");
+  const auto next = gate.begin(second);
+  require(next.code == BeginPairingCode::kPending, "new peer could not pair after expiry");
+  require(gate.reject(second.connection_id, next.fingerprint), "reject failed");
+  require(gate.wait_for_decision(second, clock.now() + 1s) == PairingDecision::kRejected,
+      "rejection was not observable");
+  gate.revoke(second);
+  require(gate.wait_for_decision(second, clock.now() + 1s) == PairingDecision::kRevoked,
+      "revocation was not observable");
+  require(gate.begin(binding("connection-3")).code == BeginPairingCode::kPending,
+      "revoked connection permanently blocked new pairing");
+  gate.shutdown();
+  require(gate.begin(binding("connection-4")).code == BeginPairingCode::kShuttingDown,
+      "shutdown admitted a new peer");
+}
+
+void waiting_wakes_on_user_confirmation() {
+  FakeClock clock;
+  FakeMaterial material;
+  PairingGate gate(clock, material, {30s});
+  const PeerBinding peer = binding();
+  const auto pending = gate.begin(peer);
+  PairingDecision decision = PairingDecision::kUnknown;
+  std::thread waiter([&] {
+    decision = gate.wait_for_decision(peer, clock.now() + 20s);
+  });
+  require(gate.confirm(peer.connection_id, pending.fingerprint),
+      "concurrent confirmation failed");
+  waiter.join();
+  require(decision == PairingDecision::kAuthorized, "waiter did not wake authorized");
+}
+
+}  // namespace
+
+int main() {
+  authorization_is_exact_and_single_pending();
+  expiry_revoke_and_shutdown_are_fail_closed();
+  waiting_wakes_on_user_confirmation();
+  std::cout << "pairing_gate_test: PASS\n";
+  return 0;
+}

--- a/native/ae-plugin/tests/rpc_codec_test.cpp
+++ b/native/ae-plugin/tests/rpc_codec_test.cpp
@@ -1,0 +1,558 @@
+#include "aemcp_native/rpc_codec.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using aemcp::native::rpc::CapabilitiesParams;
+using aemcp::native::rpc::CapabilitiesSuccess;
+using aemcp::native::rpc::CapabilityDetail;
+using aemcp::native::rpc::CancelState;
+using aemcp::native::rpc::CancelSuccess;
+using aemcp::native::rpc::CodecError;
+using aemcp::native::rpc::ErrorDetails;
+using aemcp::native::rpc::ErrorResponse;
+using aemcp::native::rpc::FrameDecoder;
+using aemcp::native::rpc::HelloParams;
+using aemcp::native::rpc::HelloSuccess;
+using aemcp::native::rpc::InvokeParams;
+using aemcp::native::rpc::ParsedRequest;
+using aemcp::native::rpc::ProgressEvent;
+using aemcp::native::rpc::ProgressPhase;
+using aemcp::native::rpc::ProjectSummarySuccess;
+using aemcp::native::rpc::RpcErrorCode;
+using aemcp::native::rpc::RpcMethod;
+using aemcp::native::rpc::RpcSessionFrontDoor;
+using aemcp::native::rpc::SessionClock;
+using aemcp::native::rpc::SessionFrontDoorConfig;
+using aemcp::native::rpc::SessionIngressCode;
+using aemcp::native::rpc::decode_request_frame;
+using aemcp::native::rpc::digest_capabilities_query;
+using aemcp::native::rpc::digest_project_summary_postcondition;
+using aemcp::native::rpc::encode_capabilities_success;
+using aemcp::native::rpc::encode_cancel_success;
+using aemcp::native::rpc::encode_error_response;
+using aemcp::native::rpc::encode_hello_success;
+using aemcp::native::rpc::encode_progress_event;
+using aemcp::native::rpc::encode_project_summary_success;
+using aemcp::native::rpc::kMaxFrameBytes;
+
+constexpr std::string_view kSession = "11111111-1111-4111-8111-111111111111";
+constexpr std::string_view kHost = "22222222-2222-4222-8222-222222222222";
+constexpr std::string_view kClient = "33333333-3333-4333-8333-333333333333";
+constexpr std::string_view kDigest = "778a01733fcf37510f56894a46ec5bd87c7429de2e06d2d5eafb4cdbbae88557";
+constexpr std::string_view kContractDigest = "baecd602479045f71288b2a7e0df645d4a5313453a34b89ced07178867ccaf9a";
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+std::vector<std::uint8_t> frame(std::string_view json) {
+  require(json.size() <= kMaxFrameBytes, "test frame exceeds protocol limit");
+  std::vector<std::uint8_t> result(json.size() + 4);
+  const auto size = static_cast<std::uint32_t>(json.size());
+  result[0] = static_cast<std::uint8_t>(size >> 24U);
+  result[1] = static_cast<std::uint8_t>(size >> 16U);
+  result[2] = static_cast<std::uint8_t>(size >> 8U);
+  result[3] = static_cast<std::uint8_t>(size);
+  std::memcpy(result.data() + 4, json.data(), json.size());
+  return result;
+}
+
+std::string body(const std::vector<std::uint8_t>& framed) {
+  require(framed.size() >= 4, "encoded output has no prefix");
+  const std::uint32_t size = (static_cast<std::uint32_t>(framed[0]) << 24U)
+      | (static_cast<std::uint32_t>(framed[1]) << 16U)
+      | (static_cast<std::uint32_t>(framed[2]) << 8U)
+      | static_cast<std::uint32_t>(framed[3]);
+  require(size == framed.size() - 4, "encoded output prefix does not match body");
+  return std::string(reinterpret_cast<const char*>(framed.data() + 4), size);
+}
+
+template <typename Callable>
+void expect_codec_error(Callable&& callable, std::string_view code, const std::string& label) {
+  try {
+    callable();
+  } catch (const CodecError& error) {
+    require(error.error_code() == code, label + " returned " + std::string(error.error_code()));
+    return;
+  }
+  fail(label + " was accepted");
+}
+
+template <typename Callable>
+void expect_argument_error(Callable&& callable, const std::string& label) {
+  try {
+    callable();
+  } catch (const std::invalid_argument&) {
+    return;
+  } catch (const CodecError& error) {
+    require(error.error_code() == "INVALID_ARGUMENT", label + " returned wrong codec error");
+    return;
+  }
+  fail(label + " was accepted");
+}
+
+std::string hello_json(std::uint16_t minimum = 1, std::uint16_t maximum = 1) {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"requestId\":\"hello-1\","
+      "\"method\":\"hello\",\"params\":{\"supportedWireVersions\":{\"minimum\":"
+      + std::to_string(minimum) + ",\"maximum\":" + std::to_string(maximum)
+      + "},\"client\":{\"component\":\"core-broker\",\"version\":\"0.9.2\","
+        "\"instanceId\":\"" + std::string(kClient)
+      + "\"},\"nonce\":\"abcdefghijklmnopqrstuvwxyzABCDEF\"}}";
+}
+
+std::string invoke_json(
+    std::string_view request_id = "invoke-summary-1",
+    std::uint64_t deadline = 1'900'000'005'000ULL,
+    std::string_view arguments = "{}") {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"" + std::string(request_id)
+      + "\",\"method\":\"invoke\",\"deadlineUnixMs\":" + std::to_string(deadline)
+      + ",\"params\":{\"capabilityId\":\"ae.project.summary\","
+        "\"capabilityVersion\":1,\"arguments\":" + std::string(arguments) + "}}";
+}
+
+void golden_requests_are_typed_and_closed() {
+  const ParsedRequest hello = decode_request_frame(frame(hello_json()));
+  require(hello.method == RpcMethod::kHello && !hello.session_id.has_value(), "hello classification failed");
+  const auto& hello_params = std::get<HelloParams>(hello.params);
+  require(hello_params.minimum_wire_version == 1 && hello_params.maximum_wire_version == 1,
+      "hello wire range changed");
+  require(hello_params.client_instance_id == kClient && hello_params.nonce.size() == 32,
+      "hello identity changed");
+  require(hello.request_fingerprint_sha256
+      == "a8b609ec240f4b730c6b4b5b17a68be4aa94ba568562b74036b55aa83ab5f336",
+      "hello normalized SHA-256 changed");
+  require(decode_request_frame(frame(" \n" + hello_json() + "\t")).request_fingerprint_sha256
+      == hello.request_fingerprint_sha256,
+      "insignificant JSON whitespace changed the request digest");
+
+  const std::string capabilities_json = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"capabilities-1\",\"method\":\"capabilities\","
+        "\"params\":{\"ids\":[\"ae.project.summary\"],\"detail\":\"full\",\"limit\":1}}";
+  const ParsedRequest capabilities = decode_request_frame(frame(capabilities_json));
+  const auto& capabilities_params = std::get<CapabilitiesParams>(capabilities.params);
+  require(capabilities.method == RpcMethod::kCapabilities
+      && capabilities_params.detail == CapabilityDetail::kFull
+      && capabilities_params.detail_was_provided && capabilities_params.limit == 1
+      && capabilities_params.limit_was_provided && capabilities_params.ids->size() == 1,
+      "capabilities golden vector changed");
+  require(digest_capabilities_query(*capabilities.session_id, capabilities_params)
+      == "aa3c66bc21e50b6a35db9c3cb12fcb1627694cd8f9fc411f21f7e3de46b3e56a",
+      "capabilities query digest diverged from the protocol fixture");
+
+  const std::string omitted_defaults = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"cap-default\",\"method\":\"capabilities\",\"params\":{}}";
+  const std::string explicit_defaults = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"cap-default\",\"method\":\"capabilities\","
+        "\"params\":{\"detail\":\"summary\",\"limit\":50}}";
+  const ParsedRequest omitted = decode_request_frame(frame(omitted_defaults));
+  const ParsedRequest explicit_value = decode_request_frame(frame(explicit_defaults));
+  require(omitted.request_fingerprint_sha256 != explicit_value.request_fingerprint_sha256,
+      "request digest collapsed explicit defaults into omission");
+
+  const ParsedRequest invoke = decode_request_frame(frame(invoke_json()));
+  require(invoke.method == RpcMethod::kInvoke && invoke.session_id == kSession
+      && invoke.deadline_unix_ms == 1'900'000'005'000ULL,
+      "invoke golden vector changed");
+  require(invoke.request_fingerprint_sha256
+      == "9df120d0b016b1313035b94329245474a0dc31bad5c0383a9ecde11db5fbdc8f",
+      "invoke RFC 8785 request digest changed");
+  require(std::get<InvokeParams>(invoke.params).capability_id == "ae.project.summary",
+      "invoke capability changed");
+
+  const std::string cancel_json = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"cancel-1\",\"method\":\"cancel\","
+        "\"params\":{\"targetRequestId\":\"invoke-summary-1\"}}";
+  const ParsedRequest cancel = decode_request_frame(frame(cancel_json));
+  require(cancel.method == RpcMethod::kCancel, "cancel golden vector changed");
+
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(hello_json().substr(0, hello_json().size() - 1) + ",\"extra\":1}"));
+  }, "INVALID_REQUEST", "unknown envelope field");
+  expect_codec_error([&] { (void)decode_request_frame(frame(invoke_json("raw", 1'900'000'005'000ULL,
+    "{\"jsx\":\"alert(1)\"}"))); }, "INVALID_ARGUMENT", "raw JSX argument");
+  const std::string hello_with_session = hello_json().substr(0, hello_json().size() - 1)
+      + ",\"sessionId\":\"not-a-uuid\"}";
+  expect_codec_error([&] { (void)decode_request_frame(frame(hello_with_session)); },
+      "INVALID_REQUEST", "hello with forbidden session");
+}
+
+void framing_fragmentation_and_multiple_frames_work() {
+  const auto first = frame(hello_json());
+  const auto second = frame("{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"cap-default\","
+        "\"method\":\"capabilities\",\"params\":{}}");
+  FrameDecoder decoder;
+  std::vector<ParsedRequest> all;
+  for (std::size_t offset = 0; offset < first.size();) {
+    const std::size_t size = std::min<std::size_t>((offset % 7) + 1, first.size() - offset);
+    auto parsed = decoder.push(std::span(first).subspan(offset, size));
+    all.insert(all.end(), parsed.begin(), parsed.end());
+    offset += size;
+  }
+  require(all.size() == 1 && decoder.pending_bytes() == 0, "fragmented frame was not decoded once");
+  std::vector<std::uint8_t> joined(first);
+  joined.insert(joined.end(), second.begin(), second.end());
+  require(joined.size() <= kMaxFrameBytes + 4, "test multiframe chunk violates adapter bound");
+  FrameDecoder multi;
+  auto parsed = multi.push(joined);
+  require(parsed.size() == 2 && parsed[1].method == RpcMethod::kCapabilities,
+      "multiple frames in one chunk failed");
+  multi.finalize();
+
+  FrameDecoder unfinished;
+  (void)unfinished.push(std::span(first).first(first.size() - 1));
+  expect_codec_error([&] { unfinished.finalize(); }, "INVALID_REQUEST", "unfinished stream");
+  require(unfinished.failed(), "unfinished decoder was not poisoned");
+}
+
+void strict_json_and_frame_limits_fail_closed() {
+  const std::array<std::pair<std::string, std::string>, 10> cases = {{
+    {"duplicate key", "{\"wireVersion\":1,\"wireVersion\":1}"},
+    {"trailing bytes", hello_json() + "x"},
+    {"invalid escape", "{\"x\":\"\\q\"}"},
+    {"lone high surrogate", "{\"x\":\"\\ud800\"}"},
+    {"lone low surrogate", "{\"x\":\"\\udc00\"}"},
+    {"unsafe integer", invoke_json("unsafe", 9'007'199'254'740'991ULL).replace(
+      invoke_json("unsafe", 9'007'199'254'740'991ULL).find("9007199254740991"), 16,
+      "9007199254740992")},
+    {"non-finite", "{\"wireVersion\":1e999,\"kind\":\"request\"}"},
+    {"trailing comma", "{\"wireVersion\":1,}"},
+    {"leading zero", "{\"wireVersion\":01}"},
+    {"bad literal", "{\"wireVersion\":tru}"},
+  }};
+  for (const auto& [name, json] : cases) {
+    expect_codec_error([&] { (void)decode_request_frame(frame(json)); }, "INVALID_REQUEST", name);
+  }
+
+  std::string nested = "0";
+  for (int level = 0; level < 17; ++level) nested = "[" + nested + "]";
+  expect_codec_error([&] { (void)decode_request_frame(frame(nested)); }, "INVALID_REQUEST", "depth 17");
+
+  std::string nodes = "[";
+  for (int index = 0; index < 2'048; ++index) {
+    if (index != 0) nodes.push_back(',');
+    nodes += "null";
+  }
+  nodes.push_back(']');
+  expect_codec_error([&] { (void)decode_request_frame(frame(nodes)); }, "INVALID_REQUEST", "node 2049");
+
+  std::string long_nonce(8'193, 'a');
+  expect_codec_error([&] { (void)decode_request_frame(frame("{\"x\":\"" + long_nonce + "\"}")); },
+      "INVALID_REQUEST", "string scalar 8193");
+
+  std::vector<std::uint8_t> invalid_utf8 = {0, 0, 0, 2, 0xc3, 0x28};
+  expect_codec_error([&] { (void)decode_request_frame(invalid_utf8); }, "INVALID_REQUEST", "invalid UTF-8");
+  expect_codec_error([&] { (void)decode_request_frame(std::array<std::uint8_t, 4>{0, 0, 0, 0}); },
+      "INVALID_REQUEST", "zero frame");
+  expect_codec_error([&] { (void)decode_request_frame(std::array<std::uint8_t, 4>{0, 1, 0, 1}); },
+      "INVALID_REQUEST", "oversize frame");
+
+  std::string maximum_body = hello_json();
+  maximum_body.append(kMaxFrameBytes - maximum_body.size(), ' ');
+  require(decode_request_frame(frame(maximum_body)).method == RpcMethod::kHello,
+      "maximum-size frame was rejected");
+
+  std::string at_depth = "0";
+  for (int level = 0; level < 12; ++level) at_depth = "[" + at_depth + "]";
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invoke_json("depth-16", 1'900'000'005'000ULL,
+      "{\"x\":" + at_depth + "}")));
+  }, "INVALID_ARGUMENT", "depth 16 closed-argument rejection");
+  at_depth = "[" + at_depth + "]";
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invoke_json("depth-17", 1'900'000'005'000ULL,
+      "{\"x\":" + at_depth + "}")));
+  }, "INVALID_REQUEST", "depth 17 parser rejection");
+}
+
+void negative_contract_vectors_are_classified() {
+  const std::vector<std::tuple<std::string, std::string, std::string>> cases = {
+    {"unknown method", "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"bad-1\",\"method\":\"execute\","
+        "\"params\":{}}", "INVALID_REQUEST"},
+    {"invoke missing session", "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"requestId\":\"bad-2\",\"method\":\"invoke\",\"params\":{"
+      "\"capabilityId\":\"ae.project.summary\",\"capabilityVersion\":1,"
+      "\"arguments\":{}}}", "SESSION_STALE"},
+    {"wrong detail enum", "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"bad-3\","
+        "\"method\":\"capabilities\",\"params\":{\"detail\":\"everything\"}}",
+      "INVALID_ARGUMENT"},
+    {"missing capability version", "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession) + "\",\"requestId\":\"bad-5\","
+      "\"method\":\"invoke\",\"params\":{\"capabilityId\":\"ae.project.summary\","
+      "\"arguments\":{}}}", "INVALID_ARGUMENT"},
+    {"nested executable alias", invoke_json("bad-7", 1'900'000'005'000ULL,
+      "{\"payload\":{\"code\":\"synthetic executable input\"}}"), "INVALID_ARGUMENT"},
+  };
+  for (const auto& [name, json, expected] : cases) {
+    expect_codec_error([&] { (void)decode_request_frame(frame(json)); }, expected, name);
+  }
+
+  const std::vector<std::uint8_t> overlong = {0, 0, 0, 2, 0xc0, 0xaf};
+  expect_codec_error([&] { (void)decode_request_frame(overlong); },
+      "INVALID_REQUEST", "overlong UTF-8");
+  const std::vector<std::uint8_t> encoded_surrogate = {0, 0, 0, 3, 0xed, 0xa0, 0x80};
+  expect_codec_error([&] { (void)decode_request_frame(encoded_surrogate); },
+      "INVALID_REQUEST", "UTF-8 encoded surrogate");
+}
+
+class FakeClock final : public SessionClock {
+ public:
+  [[nodiscard]] std::uint64_t now_unix_ms() const noexcept override { return now; }
+  std::uint64_t now{1'900'000'000'000ULL};
+};
+
+void authorization_session_and_replay_gate_are_bounded() {
+  FakeClock clock;
+  RpcSessionFrontDoor door(
+      "opaque-connection-7", std::string(kHost), std::string(kSession), clock,
+      SessionFrontDoorConfig{1, 2, 1'000, 5'000, 30'000});
+  const ParsedRequest hello = decode_request_frame(frame(hello_json()));
+  require(door.admit(hello).code == SessionIngressCode::kPairingRequired,
+      "unauthorized hello was not kept pending");
+  const ParsedRequest invoke = decode_request_frame(frame(invoke_json(
+      "invoke-1", clock.now + 5'000)));
+  require(door.admit(invoke).code == SessionIngressCode::kAuthorizationRequired,
+      "unauthorized invoke passed the gate");
+  require(door.authorize_pairing(), "pairing authorization failed");
+  require(door.admit(invoke).code == SessionIngressCode::kHelloRequired,
+      "request was accepted before hello");
+  require(door.admit(hello).code == SessionIngressCode::kAcceptedHello && door.hello_complete(),
+      "authorized hello did not establish session");
+  const auto admitted = door.admit(invoke);
+  require(admitted.dispatchable() && admitted.effective_deadline_unix_ms == clock.now + 5'000,
+      "valid request was not dispatchable");
+  const auto active_duplicate = door.admit(invoke);
+  require(active_duplicate.code == SessionIngressCode::kDuplicateRequest
+      && active_duplicate.duplicate_content_matches, "active replay was not recognized");
+
+  ParsedRequest mismatched = invoke;
+  mismatched.request_fingerprint_sha256[0] = mismatched.request_fingerprint_sha256[0] == 'a' ? 'b' : 'a';
+  const auto content_mismatch = door.admit(mismatched);
+  require(content_mismatch.code == SessionIngressCode::kDuplicateRequest
+      && !content_mismatch.duplicate_content_matches, "content-mismatched replay was not distinguished");
+
+  const ParsedRequest second = decode_request_frame(frame(invoke_json("invoke-2", clock.now + 5'000)));
+  require(door.admit(second).code == SessionIngressCode::kLedgerFull,
+      "active ledger capacity was not enforced");
+  require(door.complete_request("invoke-1") && door.tombstone_count() == 1,
+      "terminal tombstone was not recorded");
+  require(door.admit(invoke).code == SessionIngressCode::kDuplicateRequest,
+      "terminal replay was accepted");
+  clock.now += 1'001;
+  require(door.admit(second).code == SessionIngressCode::kAcceptedRequest,
+      "expired tombstone did not release the request ID ledger");
+  door.revoke_pairing();
+  require(!door.paired() && door.active_request_count() == 0
+      && door.admit(second).code == SessionIngressCode::kAuthorizationRequired,
+      "revocation did not purge and close the dispatch gate");
+  door.close();
+  require(door.admit(hello).code == SessionIngressCode::kClosed && !door.authorize_pairing(),
+      "closed session could be reopened");
+
+  RpcSessionFrontDoor mismatch("conn", std::string(kHost), std::string(kSession), clock);
+  require(mismatch.authorize_pairing(), "mismatch pairing setup failed");
+  const ParsedRequest future = decode_request_frame(frame(hello_json(2, 3)));
+  require(mismatch.admit(future).code == SessionIngressCode::kWireVersionMismatch
+      && !mismatch.hello_complete(), "wire mismatch established a session");
+
+  RpcSessionFrontDoor deadlines("deadline-conn", std::string(kHost), std::string(kSession), clock);
+  require(deadlines.authorize_pairing()
+      && deadlines.admit(hello).code == SessionIngressCode::kAcceptedHello,
+      "deadline session setup failed");
+  const std::string capabilities_without_deadline = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"cap-deadline\",\"method\":\"capabilities\",\"params\":{}}";
+  const auto defaulted = deadlines.admit(decode_request_frame(frame(capabilities_without_deadline)));
+  require(defaulted.effective_deadline_unix_ms == clock.now + 5'000,
+      "omitted deadline did not materialize to five seconds");
+  require(deadlines.complete_request("cap-deadline"), "defaulted request did not complete");
+  require(deadlines.admit(decode_request_frame(frame(invoke_json("expired", clock.now)))).code
+      == SessionIngressCode::kDeadlineExceeded, "expired request entered dispatch");
+  require(deadlines.admit(decode_request_frame(frame(invoke_json("too-far", clock.now + 30'001)))).code
+      == SessionIngressCode::kInvalidDeadline, "over-maximum deadline entered dispatch");
+  std::string wrong_session_json = invoke_json("wrong-session", clock.now + 5'000);
+  wrong_session_json.replace(wrong_session_json.find(kSession), kSession.size(),
+      "44444444-4444-4444-8444-444444444444");
+  require(deadlines.admit(decode_request_frame(frame(wrong_session_json))).code
+      == SessionIngressCode::kSessionStale, "cross-session request entered dispatch");
+}
+
+void response_helpers_are_bounded_and_typed() {
+  HelloSuccess hello;
+  hello.request_id = "hello-1";
+  hello.session_id = std::string(kSession);
+  hello.client_nonce = "abcdefghijklmnopqrstuvwxyzABCDEF";
+  hello.plugin_version = "0.0.0-test";
+  hello.compiled_sdk_version = "25.6";
+  hello.compiled_sdk_build = 61;
+  hello.architecture = "arm64";
+  hello.host_version = "26.3.0";
+  hello.host_build = 87;
+  hello.platform = "macos-arm64";
+  hello.host_instance_id = std::string(kHost);
+  hello.session_generation = 1;
+  hello.capabilities_digest = std::string(kDigest);
+  const std::string hello_body = body(encode_hello_success(hello));
+  require(hello_body.find("\"selectedWireVersion\":1") != std::string::npos
+      && hello_body.find("\"clientNonce\":\"abcdefghijklmnopqrstuvwxyzABCDEF\"") != std::string::npos,
+      "hello serializer omitted negotiated bindings");
+
+  CapabilitiesSuccess capabilities;
+  capabilities.request_id = "capabilities-1";
+  capabilities.session_id = std::string(kSession);
+  capabilities.detail = CapabilityDetail::kFull;
+  capabilities.query_digest = std::string(kDigest);
+  capabilities.capabilities_digest = std::string(kDigest);
+  capabilities.project_summary_contract_digest = std::string(kContractDigest);
+  const std::string capabilities_body = body(encode_capabilities_success(capabilities));
+  require(capabilities_body.find("\"additionalProperties\":false") != std::string::npos
+      && capabilities_body.find("aemcp.requirement.native.project-read") != std::string::npos,
+      "full capability serializer omitted the closed contract");
+
+  const std::string progress_body = body(encode_progress_event(ProgressEvent{
+    "invoke-1", std::string(kSession), 1, ProgressPhase::kQueued, 0.25, "Queued safely."}));
+  require(progress_body.find("\"fraction\":0.25") != std::string::npos,
+      "progress serializer changed the fraction");
+
+  ProjectSummarySuccess summary;
+  summary.request_id = "invoke-1";
+  summary.session_id = std::string(kSession);
+  summary.host_instance_id = std::string(kHost);
+  summary.project_open = true;
+  summary.project_name = "测试 🎬.aep";
+  summary.item_count = 3;
+  summary.started_at_unix_ms = 1'900'000'000'000ULL;
+  summary.completed_at_unix_ms = 1'900'000'000'025ULL;
+  summary.request_digest = std::string(kDigest);
+  summary.postcondition_digest = std::string(kDigest);
+  const std::string summary_body = body(encode_project_summary_success(summary));
+  require(summary_body.find("\"engine\":\"native-aegp\"") != std::string::npos
+      && summary_body.find("\"itemCount\":3") != std::string::npos,
+      "project summary serializer omitted typed provenance");
+  require(digest_project_summary_postcondition(true, "fixture.aep", 3)
+      == "0e82d012b2b7f26e310703c35b1d82e744809137f1ea5e6d1920aa29c0baca77",
+      "project summary postcondition digest changed its canonical contract");
+  expect_argument_error([&] {
+    (void)digest_project_summary_postcondition(
+        true, "fixture.aep", aemcp::native::rpc::kMaxSafeInteger + 1);
+  }, "unsafe postcondition item count");
+
+  CancelSuccess cancel;
+  cancel.request_id = "cancel-1";
+  cancel.session_id = std::string(kSession);
+  cancel.target_request_id = "invoke-1";
+  cancel.state = CancelState::kQueuedCancelled;
+  cancel.terminal_response_expected = true;
+  const std::string cancel_body = body(encode_cancel_success(cancel));
+  require(cancel_body.find("\"state\":\"queued-cancelled\"") != std::string::npos
+      && cancel_body.find("\"terminalResponseExpected\":true") != std::string::npos,
+      "cancel serializer omitted its typed terminal contract");
+  cancel.terminal_response_expected = false;
+  expect_argument_error([&] { (void)encode_cancel_success(cancel); },
+      "cancel terminal expectation mismatch");
+
+  ErrorResponse error;
+  error.method = RpcMethod::kInvoke;
+  error.request_id = "invoke-1";
+  error.session_id = std::string(kSession);
+  error.code = RpcErrorCode::kQueueFull;
+  error.message = "The bounded native queue is full.";
+  error.recovery_hint = "Retry after the bounded delay.";
+  error.retry_after_ms = 250;
+  const std::string error_body = body(encode_error_response(error));
+  require(error_body.find("\"code\":\"QUEUE_FULL\"") != std::string::npos
+      && error_body.find("\"retryAfterMs\":250") != std::string::npos,
+      "error serializer violated the bound policy tuple");
+
+  error.code = RpcErrorCode::kWireVersionMismatch;
+  error.method = RpcMethod::kHello;
+  error.session_id.reset();
+  error.retry_after_ms.reset();
+  error.details = ErrorDetails{};
+  expect_argument_error([&] { (void)encode_error_response(error); }, "mismatch without supported range");
+  summary.project_name = std::string(1'025, 'x');
+  expect_argument_error([&] { (void)encode_project_summary_success(summary); }, "oversized project name");
+  summary.project_name = "fixture.aep";
+  summary.replayed = true;
+  expect_argument_error([&] { (void)encode_project_summary_success(summary); },
+      "unvalidated replay response");
+  summary.replayed = false;
+  summary.project_name = std::string("\xc3\x28", 2);
+  expect_argument_error([&] { (void)encode_project_summary_success(summary); },
+      "invalid UTF-8 project name");
+}
+
+void fixed_seed_mutation_fuzz_is_bounded() {
+  const auto golden = frame(invoke_json("fuzz-1", 1'900'000'005'000ULL));
+  std::uint32_t state = 0x5eed1234U;
+  std::size_t accepted = 0;
+  std::size_t rejected = 0;
+  for (int iteration = 0; iteration < 512; ++iteration) {
+    auto candidate = golden;
+    state = state * 1'664'525U + 1'013'904'223U;
+    const std::size_t mutations = 1 + (state % 4U);
+    for (std::size_t count = 0; count < mutations; ++count) {
+      state = state * 1'664'525U + 1'013'904'223U;
+      const std::size_t index = 4 + (state % (candidate.size() - 4));
+      state = state * 1'664'525U + 1'013'904'223U;
+      candidate[index] ^= static_cast<std::uint8_t>(1U << (state % 8U));
+    }
+    try {
+      FrameDecoder decoder;
+      std::vector<ParsedRequest> parsed;
+      std::size_t offset = 0;
+      while (offset < candidate.size()) {
+        state = state * 1'664'525U + 1'013'904'223U;
+        const std::size_t chunk = std::min<std::size_t>(1 + state % 31U, candidate.size() - offset);
+        auto values = decoder.push(std::span(candidate).subspan(offset, chunk));
+        parsed.insert(parsed.end(), values.begin(), values.end());
+        offset += chunk;
+      }
+      decoder.finalize();
+      require(parsed.size() == 1, "accepted fuzz input did not yield exactly one request");
+      ++accepted;
+    } catch (const CodecError&) {
+      ++rejected;
+    }
+  }
+  require(accepted > 0 && rejected > 400, "fixed-seed fuzz did not exercise both paths");
+}
+
+}  // namespace
+
+int main() {
+  golden_requests_are_typed_and_closed();
+  framing_fragmentation_and_multiple_frames_work();
+  strict_json_and_frame_limits_fail_closed();
+  negative_contract_vectors_are_classified();
+  authorization_session_and_replay_gate_are_bounded();
+  response_helpers_are_bounded_and_typed();
+  fixed_seed_mutation_fuzz_is_bounded();
+  std::cout << "rpc_codec_test: PASS\n";
+  return 0;
+}

--- a/native/ae-plugin/tests/secure_random_macos_test.cpp
+++ b/native/ae-plugin/tests/secure_random_macos_test.cpp
@@ -1,0 +1,40 @@
+#include "aemcp_native/secure_random_macos.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+
+namespace {
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+}  // namespace
+
+int main() {
+  aemcp::native::MacPairingMaterialSource source;
+  std::set<std::string> uuids;
+  std::set<std::string> fingerprints;
+  for (int index = 0; index < 32; ++index) {
+    const std::string uuid = aemcp::native::secure_uuid_v4();
+    require(uuid.size() == 36 && uuid[14] == '4'
+            && (uuid[19] == '8' || uuid[19] == '9'
+                || uuid[19] == 'a' || uuid[19] == 'b'),
+        "secure UUID shape is invalid");
+    require(uuids.insert(uuid).second, "secure UUID repeated in smoke sample");
+    const auto material = source.create();
+    require(material.fingerprint.size() == 9 && material.fingerprint[4] == '-',
+        "pairing fingerprint shape is invalid");
+    require(fingerprints.insert(material.fingerprint).second,
+        "pairing fingerprint repeated in smoke sample");
+  }
+  std::cout << "secure_random_macos_test: PASS\n";
+  return 0;
+}

--- a/native/ae-plugin/tests/transport_auth_test.cpp
+++ b/native/ae-plugin/tests/transport_auth_test.cpp
@@ -1,0 +1,78 @@
+#include "aemcp_native/transport_auth.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+using namespace std::chrono_literals;
+using aemcp::native::TransportAuthDecision;
+using aemcp::native::TransportAuthDecisionCode;
+using aemcp::native::TransportAuthPending;
+using aemcp::native::TransportAuthPreface;
+
+[[noreturn]] void fail(const std::string& message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void require(bool condition, const std::string& message) {
+  if (!condition) fail(message);
+}
+
+}  // namespace
+
+int main() {
+  TransportAuthPreface preface;
+  preface.client_nonce.fill(7);
+  const auto preface_bytes = aemcp::native::serialize_auth_preface(preface);
+  TransportAuthPreface parsed_preface;
+  require(aemcp::native::parse_auth_preface(preface_bytes, parsed_preface)
+          && parsed_preface.client_nonce == preface.client_nonce,
+      "auth preface did not round trip");
+  auto bad_preface = preface_bytes;
+  bad_preface[0] ^= 1;
+  require(!aemcp::native::parse_auth_preface(bad_preface, parsed_preface),
+      "bad auth magic was accepted");
+
+  TransportAuthPending pending{
+      "A1B2-C3D4", 30000ms, "11111111-1111-4111-8111-111111111111"};
+  const auto pending_bytes = aemcp::native::serialize_auth_pending(pending);
+  TransportAuthPending parsed_pending;
+  require(aemcp::native::parse_auth_pending(pending_bytes, parsed_pending)
+          && parsed_pending.fingerprint == pending.fingerprint
+          && parsed_pending.expires_in == pending.expires_in,
+      "pending auth message did not round trip");
+  auto bad_pending = pending_bytes;
+  bad_pending[8] = 'z';
+  require(!aemcp::native::parse_auth_pending(bad_pending, parsed_pending),
+      "bad fingerprint was accepted");
+
+  TransportAuthDecision authorized{
+      TransportAuthDecisionCode::kAuthorized,
+      "22222222-2222-4222-8222-222222222222",
+      9,
+  };
+  const auto decision_bytes = aemcp::native::serialize_auth_decision(authorized);
+  TransportAuthDecision parsed_decision;
+  require(aemcp::native::parse_auth_decision(decision_bytes, parsed_decision)
+          && parsed_decision.code == TransportAuthDecisionCode::kAuthorized
+          && parsed_decision.session_id == authorized.session_id
+          && parsed_decision.session_generation == 9,
+      "authorized decision did not round trip");
+  const auto rejected_bytes = aemcp::native::serialize_auth_decision(
+      {TransportAuthDecisionCode::kRejected, {}, 0});
+  require(aemcp::native::parse_auth_decision(rejected_bytes, parsed_decision)
+          && parsed_decision.code == TransportAuthDecisionCode::kRejected
+          && parsed_decision.session_id.empty(),
+      "rejected decision did not round trip");
+  auto forged = rejected_bytes;
+  forged[45] = 1;
+  require(!aemcp::native::parse_auth_decision(forged, parsed_decision),
+      "unauthorized decision carried a generation");
+
+  std::cout << "transport_auth_test: PASS\n";
+  return 0;
+}

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -33245,6 +33245,9 @@ data: ${JSON.stringify(payload)}
           throw new Error("Host runtime dependency binding is unavailable");
         }
         nextHost.setRuntimeDependencies(runtimeDependencies);
+        if (nextHost.setNativeAegpRuntime) {
+          nextHost.setNativeAegpRuntime(helperRuntime(adapter.id));
+        }
         nextHost.setCSInterface(cs2);
         if (nextHost.setPlatformRoots) nextHost.setPlatformRoots(roots);
         host = nextHost;

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1,0 +1,606 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const MAX_FRAME_BYTES = 65536;
+const MAX_BUFFERED_BYTES = MAX_FRAME_BYTES * 8;
+const MAX_ENDPOINT_ENTRIES = 128;
+const AUTH_PENDING_BYTES = 57;
+const AUTH_DECISION_BYTES = 49;
+const ENDPOINT_DIRECTORY = 'aemcp-n1';
+const ENDPOINT_PATTERN = /^d-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.endpoint$/;
+const SOCKET_PATTERN = /^s-[0-9a-f]{12}\.sock$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+function nativeError(code, message, retryable, cause) {
+    const error = new Error(message);
+    error.code = code;
+    error.retryable = Boolean(retryable);
+    if (cause !== undefined) error.cause = cause;
+    return error;
+}
+
+function exactKeys(value, required, optional) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+    const allowed = new Set(required.concat(optional || []));
+    return required.every(function (key) { return Object.hasOwn(value, key); })
+        && Object.keys(value).every(function (key) { return allowed.has(key); });
+}
+
+function uuidV4(randomBytes) {
+    const bytes = Buffer.from(randomBytes(16));
+    if (bytes.length !== 16) throw nativeError('NATIVE_CLIENT_INVALID', 'random source returned an invalid UUID', false);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = bytes.toString('hex');
+    return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20)].join('-');
+}
+
+function endpointDescriptor(text) {
+    const lines = String(text).split('\n');
+    if (lines.length !== 9 || lines[8] !== '' || lines[0] !== 'AEMCP_NATIVE_ENDPOINT_V1') return null;
+    const names = ['host', 'pid', 'startSeconds', 'startMicros', 'socket', 'wire', 'source'];
+    const values = {};
+    for (let index = 0; index < names.length; index += 1) {
+        const prefix = names[index] + '=';
+        if (!lines[index + 1].startsWith(prefix) || lines[index + 1].length === prefix.length) return null;
+        values[names[index]] = lines[index + 1].slice(prefix.length);
+    }
+    const pid = Number(values.pid);
+    const startSeconds = Number(values.startSeconds);
+    const startMicros = Number(values.startMicros);
+    if (!UUID_PATTERN.test(values.host)
+        || !Number.isSafeInteger(pid) || pid <= 1
+        || !Number.isSafeInteger(startSeconds) || startSeconds <= 0
+        || !Number.isSafeInteger(startMicros) || startMicros < 0 || startMicros >= 1000000
+        || !SOCKET_PATTERN.test(values.socket)
+        || values.wire !== '1'
+        || !/^[0-9a-f]{40}$/.test(values.source)) return null;
+    return Object.freeze({
+        hostInstanceId: values.host,
+        pid,
+        startSeconds,
+        startMicros,
+        socketName: values.socket,
+        wireVersion: 1,
+        sourceCommit: values.source,
+    });
+}
+
+function privateMode(stats, mode) {
+    return (stats.mode & 0o777) === mode;
+}
+
+function discoverNativeEndpoints(options) {
+    const input = options || {};
+    const fsImpl = input.fsImpl || fs;
+    const osImpl = input.osImpl || os;
+    const pathImpl = input.pathImpl || path;
+    const uid = input.uid === undefined
+        ? (typeof process.getuid === 'function' ? process.getuid() : null)
+        : input.uid;
+    if (!Number.isSafeInteger(uid) || uid < 0) {
+        throw nativeError('NATIVE_UNAVAILABLE', 'native endpoint discovery requires a local macOS user identity', true);
+    }
+    let runtimeRoot;
+    try {
+        runtimeRoot = fsImpl.realpathSync(input.runtimeRoot || osImpl.tmpdir());
+        const runtimeStats = fsImpl.lstatSync(runtimeRoot);
+        if (!runtimeStats.isDirectory() || runtimeStats.isSymbolicLink()
+            || runtimeStats.uid !== uid || (runtimeStats.mode & 0o077) !== 0) {
+            throw new Error('unsafe runtime root');
+        }
+    } catch (cause) {
+        throw nativeError('NATIVE_UNAVAILABLE', 'native runtime root is unavailable', true, cause);
+    }
+    const directory = pathImpl.join(runtimeRoot, ENDPOINT_DIRECTORY);
+    let names;
+    try {
+        const directoryStats = fsImpl.lstatSync(directory);
+        if (!directoryStats.isDirectory() || directoryStats.isSymbolicLink()
+            || directoryStats.uid !== uid || !privateMode(directoryStats, 0o700)) {
+            throw new Error('unsafe endpoint directory');
+        }
+        names = fsImpl.readdirSync(directory);
+    } catch (cause) {
+        throw nativeError('NATIVE_UNAVAILABLE', 'native endpoint directory is unavailable', true, cause);
+    }
+    if (!Array.isArray(names) || names.length > MAX_ENDPOINT_ENTRIES) {
+        throw nativeError('NATIVE_UNAVAILABLE', 'native endpoint directory exceeds its discovery bound', true);
+    }
+    const endpoints = [];
+    for (const name of names.sort()) {
+        const match = ENDPOINT_PATTERN.exec(name);
+        if (!match) continue;
+        const descriptorPath = pathImpl.join(directory, name);
+        let descriptor;
+        let descriptorStats;
+        try {
+            descriptorStats = fsImpl.lstatSync(descriptorPath);
+            if (!descriptorStats.isFile() || descriptorStats.isSymbolicLink()
+                || descriptorStats.uid !== uid || descriptorStats.nlink !== 1
+                || !privateMode(descriptorStats, 0o600)
+                || descriptorStats.size <= 0 || descriptorStats.size > 1024) continue;
+            descriptor = endpointDescriptor(fsImpl.readFileSync(descriptorPath, 'utf8'));
+        } catch (_) {
+            continue;
+        }
+        if (!descriptor || descriptor.hostInstanceId !== match[1]) continue;
+        const socketPath = pathImpl.join(directory, descriptor.socketName);
+        try {
+            const socketStats = fsImpl.lstatSync(socketPath);
+            if (!socketStats.isSocket() || socketStats.isSymbolicLink()
+                || socketStats.uid !== uid || socketStats.nlink !== 1
+                || !privateMode(socketStats, 0o600)) continue;
+        } catch (_) {
+            continue;
+        }
+        endpoints.push(Object.freeze({ ...descriptor, descriptorPath, socketPath }));
+    }
+    return Object.freeze(endpoints);
+}
+
+function parseAuthPending(bytes) {
+    if (!Buffer.isBuffer(bytes) || bytes.length !== AUTH_PENDING_BYTES
+        || !bytes.subarray(0, 8).equals(Buffer.from('AEMCP-P1', 'ascii'))) return null;
+    const fingerprint = bytes.toString('ascii', 8, 17);
+    const expiresInMs = bytes.readUInt32BE(17);
+    const hostInstanceId = bytes.toString('ascii', 21, 57);
+    if (!/^[0-9A-F]{4}-[0-9A-F]{4}$/.test(fingerprint)
+        || expiresInMs < 1000 || expiresInMs > 120000
+        || !UUID_PATTERN.test(hostInstanceId)) return null;
+    return Object.freeze({ fingerprint, expiresInMs, hostInstanceId });
+}
+
+function parseAuthDecision(bytes) {
+    if (!Buffer.isBuffer(bytes) || bytes.length !== AUTH_DECISION_BYTES
+        || !bytes.subarray(0, 8).equals(Buffer.from('AEMCP-D1', 'ascii'))) return null;
+    const code = bytes[8];
+    const sessionId = bytes.toString('ascii', 9, 45);
+    const sessionGeneration = bytes.readUInt32BE(45);
+    if (code === 1) {
+        if (!UUID_PATTERN.test(sessionId) || sessionGeneration === 0) return null;
+        return Object.freeze({ code: 'authorized', sessionId, sessionGeneration });
+    }
+    const names = ['rejected', 'expired', 'revoked', 'shutting-down'];
+    if (code < 2 || code > 5
+        || sessionId !== '00000000-0000-0000-0000-000000000000'
+        || sessionGeneration !== 0) return null;
+    return Object.freeze({ code: names[code - 2], sessionId: null, sessionGeneration: 0 });
+}
+
+function encodeFrame(value) {
+    const body = Buffer.from(JSON.stringify(value), 'utf8');
+    if (body.length === 0 || body.length > MAX_FRAME_BYTES) {
+        throw nativeError('INVALID_ARGUMENT', 'native request exceeds the frame limit', false);
+    }
+    const frame = Buffer.allocUnsafe(body.length + 4);
+    frame.writeUInt32BE(body.length, 0);
+    body.copy(frame, 4);
+    return frame;
+}
+
+function sha256Canonical(value) {
+    return crypto.createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex');
+}
+
+function capabilitiesQueryDigest(sessionId, detail) {
+    return sha256Canonical({
+        detail,
+        ids: ['ae.project.summary'],
+        limit: 1,
+        sessionId,
+    });
+}
+
+function projectSummaryPostconditionDigest(value) {
+    return sha256Canonical({
+        capabilityId: 'ae.project.summary',
+        capabilityVersion: 1,
+        value: {
+            itemCount: value.itemCount,
+            projectName: value.projectName,
+            projectOpen: value.projectOpen,
+        },
+    });
+}
+
+// This client currently exposes one closed invoke contract. Construct the
+// RFC 8785 member order explicitly so the broker can bind native evidence to
+// the exact request it sent instead of trusting a digest-shaped string.
+function projectSummaryRequestDigest(request) {
+    return sha256Canonical({
+        deadlineUnixMs: request.deadlineUnixMs,
+        kind: request.kind,
+        method: request.method,
+        params: {
+            arguments: request.params.arguments,
+            capabilityId: request.params.capabilityId,
+            capabilityVersion: request.params.capabilityVersion,
+        },
+        requestId: request.requestId,
+        sessionId: request.sessionId,
+        wireVersion: request.wireVersion,
+    });
+}
+
+function createNativeAegpClient(options) {
+    const input = options || {};
+    const runtime = input.runtime;
+    if (!runtime || runtime.platform !== 'darwin' || runtime.arch !== 'arm64') {
+        throw nativeError('NATIVE_UNAVAILABLE', 'native AEGP transport currently supports macOS arm64 only', true);
+    }
+    const netImpl = input.netImpl || net;
+    const discoverEndpoints = input.discoverEndpoints || discoverNativeEndpoints;
+    const randomBytes = input.randomBytes || crypto.randomBytes;
+    const now = input.now || Date.now;
+    const requestTimeoutMs = input.requestTimeoutMs === undefined ? 7000 : input.requestTimeoutMs;
+    if (!Number.isSafeInteger(requestTimeoutMs) || requestTimeoutMs < 100 || requestTimeoutMs > 30000) {
+        throw new TypeError('requestTimeoutMs must be an integer between 100 and 30000');
+    }
+    const clientInstanceId = input.clientInstanceId || uuidV4(randomBytes);
+    if (!UUID_PATTERN.test(clientInstanceId)) throw new TypeError('clientInstanceId must be a UUID');
+
+    let state = 'disconnected';
+    let endpoint = null;
+    let socket = null;
+    let sessionId = null;
+    let sessionGeneration = 0;
+    let capabilitiesDigest = null;
+    let projectSummaryContractDigest = null;
+    let nextRequest = 1;
+    let inputBuffer = Buffer.alloc(0);
+    let pairingResolve;
+    let pairingReject;
+    let connectedResolve;
+    let connectedReject;
+    let pairingPromise = null;
+    let connectedPromise = null;
+    const pendingRequests = new Map();
+
+    function fail(error) {
+        const protocolCodes = new Set([
+            'AUTH_REQUIRED', 'INVALID_ARGUMENT', 'INVALID_REQUEST', 'NATIVE_UNAVAILABLE',
+            'NATIVE_UNSUPPORTED', 'WIRE_VERSION_MISMATCH', 'DUPLICATE_REQUEST',
+            'DEADLINE_EXCEEDED', 'CANCELLED', 'QUEUE_FULL', 'AE_SHUTTING_DOWN',
+            'SESSION_STALE', 'CAPABILITY_FAILED',
+        ]);
+        const failure = error && protocolCodes.has(error.code)
+            ? error : nativeError('NATIVE_UNAVAILABLE', 'native AEGP connection failed', true, error);
+        if (pairingReject) pairingReject(failure);
+        if (connectedReject) connectedReject(failure);
+        pairingResolve = null;
+        pairingReject = null;
+        connectedResolve = null;
+        connectedReject = null;
+        for (const pending of pendingRequests.values()) {
+            clearTimeout(pending.timer);
+            pending.reject(failure);
+        }
+        pendingRequests.clear();
+        if (state !== 'closed') state = 'disconnected';
+        sessionId = null;
+        sessionGeneration = 0;
+        capabilitiesDigest = null;
+        projectSummaryContractDigest = null;
+        if (socket) {
+            const current = socket;
+            socket = null;
+            try { current.destroy(); } catch (_) {}
+        }
+    }
+
+    function responseError(response) {
+        const error = response && response.error;
+        const code = typeof error?.code === 'string' && /^[A-Z][A-Z0-9_]{2,63}$/.test(error.code)
+            ? error.code : 'INVALID_REQUEST';
+        return nativeError(code, 'native AEGP request failed with ' + code, Boolean(error?.retryable));
+    }
+
+    function handleFrame(frame) {
+        let response;
+        try { response = JSON.parse(frame.toString('utf8')); } catch (cause) {
+            throw nativeError('INVALID_REQUEST', 'native AEGP returned malformed JSON', false, cause);
+        }
+        if (!response || typeof response !== 'object' || Array.isArray(response)) {
+            throw nativeError('INVALID_REQUEST', 'native AEGP returned an invalid envelope', false);
+        }
+        if (response.kind === 'event') return;
+        const pending = pendingRequests.get(response.requestId);
+        if (!pending || response.wireVersion !== 1 || response.kind !== 'response'
+            || response.method !== pending.method
+            || (pending.method !== 'hello' && response.sessionId !== sessionId)) {
+            throw nativeError('INVALID_REQUEST', 'native AEGP response did not match an active request', false);
+        }
+        if (response.ok === true && pending.method === 'invoke') {
+            const evidence = response.result?.evidence;
+            if (evidence?.requestId !== response.requestId
+                || evidence?.sessionId !== sessionId
+                || evidence?.capabilityId !== 'ae.project.summary'
+                || evidence?.capabilityVersion !== 1
+                || evidence?.requestDigest !== pending.requestDigest) {
+                throw nativeError('INVALID_REQUEST', 'native AEGP evidence did not match its response envelope', false);
+            }
+        }
+        pendingRequests.delete(response.requestId);
+        clearTimeout(pending.timer);
+        if (response.ok === true) pending.resolve(response.result);
+        else pending.reject(responseError(response));
+    }
+
+    function consumeFrames() {
+        while (inputBuffer.length >= 4) {
+            const length = inputBuffer.readUInt32BE(0);
+            if (length === 0 || length > MAX_FRAME_BYTES) {
+                throw nativeError('INVALID_REQUEST', 'native AEGP returned an invalid frame size', false);
+            }
+            if (inputBuffer.length < length + 4) return;
+            const frame = inputBuffer.subarray(4, length + 4);
+            inputBuffer = inputBuffer.subarray(length + 4);
+            handleFrame(frame);
+        }
+    }
+
+    function send(method, params, deadlineUnixMs) {
+        if (!socket || (method !== 'hello' && state !== 'connected')) {
+            return Promise.reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP session is not connected', true));
+        }
+        const requestId = method + '-' + String(nextRequest++) + '-' + randomBytes(4).toString('hex');
+        const request = { wireVersion: 1, kind: 'request', requestId, method, params };
+        if (method !== 'hello') request.sessionId = sessionId;
+        if (deadlineUnixMs !== undefined) request.deadlineUnixMs = deadlineUnixMs;
+        const requestDigest = method === 'invoke' ? projectSummaryRequestDigest(request) : null;
+        return new Promise(function (resolve, reject) {
+            const timer = setTimeout(function () {
+                pendingRequests.delete(requestId);
+                reject(nativeError('DEADLINE_EXCEEDED', 'native AEGP request timed out', true));
+            }, requestTimeoutMs);
+            pendingRequests.set(requestId, { method, requestDigest, resolve, reject, timer });
+            try {
+                socket.write(encodeFrame(request), function (error) {
+                    if (!error) return;
+                    const pending = pendingRequests.get(requestId);
+                    if (!pending) return;
+                    pendingRequests.delete(requestId);
+                    clearTimeout(pending.timer);
+                    pending.reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP request write failed', true, error));
+                });
+            } catch (cause) {
+                pendingRequests.delete(requestId);
+                clearTimeout(timer);
+                reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP request write failed', true, cause));
+            }
+        });
+    }
+
+    async function hello() {
+        const nonce = randomBytes(24).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+        const result = await send('hello', {
+            supportedWireVersions: { minimum: 1, maximum: 1 },
+            client: { component: input.component || 'core-broker', version: input.version || '0.9.2', instanceId: clientInstanceId },
+            nonce,
+        });
+        if (!exactKeys(result, [
+            'selectedWireVersion', 'pluginVersion', 'compiledSdk', 'host', 'sessionId',
+            'sessionGeneration', 'limits', 'capabilitiesDigest', 'clientNonce',
+        ]) || result.selectedWireVersion !== 1 || result.sessionId !== sessionId
+            || result.sessionGeneration !== sessionGeneration || result.clientNonce !== nonce
+            || !SHA256_PATTERN.test(result.capabilitiesDigest)
+            || result.host?.instanceId !== endpoint.hostInstanceId
+            || result.host?.application !== 'after-effects'
+            || result.host?.platform !== 'macos-arm64'
+            || result.compiledSdk?.architecture !== 'arm64') {
+            throw nativeError('INVALID_REQUEST', 'native AEGP hello identity did not match discovery', false);
+        }
+        capabilitiesDigest = result.capabilitiesDigest;
+        return result;
+    }
+
+    function onData(chunk) {
+        try {
+            if (!chunk || inputBuffer.length + chunk.length > MAX_BUFFERED_BYTES) {
+                throw nativeError('INVALID_REQUEST', 'native AEGP buffered input exceeded its bound', false);
+            }
+            inputBuffer = Buffer.concat([inputBuffer, Buffer.from(chunk)]);
+            if (state === 'pairing-pending') {
+                if (inputBuffer.length < AUTH_PENDING_BYTES) return;
+                const pending = parseAuthPending(inputBuffer.subarray(0, AUTH_PENDING_BYTES));
+                inputBuffer = inputBuffer.subarray(AUTH_PENDING_BYTES);
+                if (!pending || pending.hostInstanceId !== endpoint.hostInstanceId) {
+                    throw nativeError('INVALID_REQUEST', 'native pairing challenge did not match discovery', false);
+                }
+                state = 'pairing-decision';
+                const resolve = pairingResolve;
+                pairingResolve = null;
+                pairingReject = null;
+                resolve(Object.freeze({ ...pending, sourceCommit: endpoint.sourceCommit }));
+            }
+            if (state === 'pairing-decision') {
+                if (inputBuffer.length < AUTH_DECISION_BYTES) return;
+                const decision = parseAuthDecision(inputBuffer.subarray(0, AUTH_DECISION_BYTES));
+                inputBuffer = inputBuffer.subarray(AUTH_DECISION_BYTES);
+                if (!decision) throw nativeError('INVALID_REQUEST', 'native pairing decision was malformed', false);
+                if (decision.code !== 'authorized') {
+                    throw nativeError('AUTH_REQUIRED', 'native pairing was ' + decision.code, decision.code === 'expired');
+                }
+                sessionId = decision.sessionId;
+                sessionGeneration = decision.sessionGeneration;
+                state = 'authenticating';
+                hello().then(function (identity) {
+                    state = 'connected';
+                    const resolve = connectedResolve;
+                    connectedResolve = null;
+                    connectedReject = null;
+                    resolve(identity);
+                    if (inputBuffer.length) consumeFrames();
+                }).catch(fail);
+                return;
+            }
+            if (state === 'authenticating' || state === 'connected') consumeFrames();
+        } catch (error) {
+            fail(error);
+        }
+    }
+
+    function open(candidate) {
+        endpoint = candidate;
+        inputBuffer = Buffer.alloc(0);
+        state = 'pairing-pending';
+        const current = netImpl.createConnection({ path: candidate.socketPath });
+        socket = current;
+        current.on('data', function (chunk) {
+            if (socket === current) onData(chunk);
+        });
+        current.on('error', function (error) {
+            if (socket === current) fail(error);
+        });
+        current.on('close', function () {
+            if (socket !== current) return;
+            if (state !== 'closed' && state !== 'disconnected') {
+                fail(nativeError('NATIVE_UNAVAILABLE', 'native AEGP connection closed', true));
+            }
+        });
+        current.once('connect', function () {
+            if (socket !== current) return;
+            const preface = Buffer.concat([Buffer.from('AEMCP-A1', 'ascii'), randomBytes(16)]);
+            current.write(preface, function (error) {
+                if (error && socket === current) {
+                    fail(nativeError('NATIVE_UNAVAILABLE', 'native pairing preface failed', true, error));
+                }
+            });
+        });
+    }
+
+    function beginPairing() {
+        if (state === 'closed') return Promise.reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP client is closed', false));
+        if (pairingPromise && state.startsWith('pairing')) return pairingPromise;
+        if (state === 'connected' || state === 'authenticating') {
+            return Promise.reject(nativeError('DUPLICATE_REQUEST', 'native AEGP client is already connected', false));
+        }
+        let endpoints;
+        try { endpoints = discoverEndpoints(input); } catch (error) { return Promise.reject(error); }
+        if (endpoints.length !== 1) {
+            return Promise.reject(nativeError(
+                'NATIVE_UNAVAILABLE',
+                endpoints.length === 0 ? 'no native AEGP endpoint is available' : 'multiple native AEGP endpoints require host selection',
+                true,
+            ));
+        }
+        pairingPromise = new Promise(function (resolve, reject) {
+            pairingResolve = resolve;
+            pairingReject = reject;
+        });
+        connectedPromise = new Promise(function (resolve, reject) {
+            connectedResolve = resolve;
+            connectedReject = reject;
+        });
+        // The connection may outlive the HTTP request that surfaced the pairing
+        // fingerprint. Mark this promise handled without changing what a later
+        // waitUntilConnected() caller observes.
+        connectedPromise.catch(function () {});
+        try {
+            open(endpoints[0]);
+        } catch (cause) {
+            fail(nativeError('NATIVE_UNAVAILABLE', 'native AEGP connection could not be opened', true, cause));
+        }
+        return pairingPromise;
+    }
+
+    function waitUntilConnected() {
+        if (state === 'connected') return Promise.resolve({ sessionId, sessionGeneration });
+        if (!connectedPromise) return Promise.reject(nativeError('AUTH_REQUIRED', 'begin native pairing first', false));
+        return connectedPromise;
+    }
+
+    async function capabilities(detail) {
+        if (state !== 'connected') await waitUntilConnected();
+        const requestedDetail = detail || 'full';
+        const result = await send('capabilities', {
+            ids: ['ae.project.summary'], detail: requestedDetail, limit: 1,
+        });
+        const item = Array.isArray(result?.items)
+            ? result.items.find(function (candidate) { return candidate?.id === 'ae.project.summary'; })
+            : null;
+        if (!exactKeys(result, ['detail', 'items', 'nextCursor', 'queryDigest', 'capabilitiesDigest'])
+            || result.detail !== requestedDetail || result.nextCursor !== null
+            || result.queryDigest !== capabilitiesQueryDigest(sessionId, requestedDetail)
+            || result.capabilitiesDigest !== capabilitiesDigest
+            || !item || item.version !== 1 || item.detail !== requestedDetail
+            || (requestedDetail === 'full' && !SHA256_PATTERN.test(item.contractDigest))) {
+            throw nativeError('INVALID_REQUEST', 'native capabilities result was malformed', false);
+        }
+        if (requestedDetail === 'full') projectSummaryContractDigest = item.contractDigest;
+        return result;
+    }
+
+    async function projectSummary() {
+        if (state !== 'connected') await waitUntilConnected();
+        const deadline = now() + Math.min(requestTimeoutMs, 5000);
+        const result = await send('invoke', {
+            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+        }, deadline);
+        const value = result?.value;
+        const evidence = result?.evidence;
+        if (result?.capabilityId !== 'ae.project.summary' || result?.capabilityVersion !== 1
+            || result?.engine !== 'native-aegp' || result?.outcome !== 'succeeded'
+            || evidence?.engine !== 'native-aegp' || evidence?.hostInstanceId !== endpoint.hostInstanceId
+            || evidence?.sessionId !== sessionId || evidence?.effect !== 'none'
+            || !TOKEN_PATTERN.test(evidence?.requestId || '')
+            || !SHA256_PATTERN.test(evidence?.requestDigest || '')
+            || !Number.isSafeInteger(evidence?.startedAtUnixMs) || evidence.startedAtUnixMs <= 0
+            || !Number.isSafeInteger(evidence?.completedAtUnixMs)
+            || evidence.completedAtUnixMs < evidence.startedAtUnixMs
+            || evidence?.postcondition?.verified !== true
+            || evidence.postcondition.kind !== 'project-summary'
+            || evidence.postcondition.algorithm !== 'sha256-rfc8785-jcs-v1'
+            || !SHA256_PATTERN.test(evidence.postcondition.digest || '')
+            || typeof value?.projectOpen !== 'boolean' || typeof value?.projectName !== 'string'
+            || value.projectName.length > 1024
+            || !Number.isSafeInteger(value?.itemCount) || value.itemCount < 0
+            || !SHA256_PATTERN.test(projectSummaryContractDigest || '')
+            || evidence.postcondition.digest !== projectSummaryPostconditionDigest(value)) {
+            throw nativeError('INVALID_REQUEST', 'native project summary result lacked verified AEGP evidence', false);
+        }
+        return result;
+    }
+
+    async function close() {
+        if (state === 'closed') return;
+        state = 'closed';
+        fail(nativeError('NATIVE_UNAVAILABLE', 'native AEGP client was closed', false));
+        state = 'closed';
+    }
+
+    return Object.freeze({
+        beginPairing,
+        waitUntilConnected,
+        capabilities,
+        projectSummary,
+        close,
+        status: function () {
+            return Object.freeze({
+                state,
+                hostInstanceId: endpoint?.hostInstanceId || null,
+                sourceCommit: endpoint?.sourceCommit || null,
+                sessionGeneration: sessionGeneration || null,
+                capabilitiesDigest,
+                projectSummaryContractDigest,
+            });
+        },
+    });
+}
+
+module.exports = {
+    createNativeAegpClient,
+    discoverNativeEndpoints,
+    endpointDescriptor,
+    parseAuthPending,
+    parseAuthDecision,
+    encodeFrame,
+};

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -1,0 +1,407 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+const { EventEmitter } = require('node:events');
+
+const {
+    createNativeAegpClient,
+    discoverNativeEndpoints,
+    endpointDescriptor,
+    parseAuthPending,
+    parseAuthDecision,
+} = require('./native-aegp-client');
+
+const HOST = '22222222-2222-4222-8222-222222222222';
+const SESSION = '11111111-1111-4111-8111-111111111111';
+const CLIENT = '33333333-3333-4333-8333-333333333333';
+const SOURCE = 'a'.repeat(40);
+const DIGEST = 'b'.repeat(64);
+
+function descriptor(socketName) {
+    return [
+        'AEMCP_NATIVE_ENDPOINT_V1',
+        'host=' + HOST,
+        'pid=4242',
+        'startSeconds=1700000000',
+        'startMicros=123456',
+        'socket=' + socketName,
+        'wire=1',
+        'source=' + SOURCE,
+        '',
+    ].join('\n');
+}
+
+function pendingMessage() {
+    const result = Buffer.alloc(57);
+    result.write('AEMCP-P1', 0, 'ascii');
+    result.write('12AB-34CD', 8, 'ascii');
+    result.writeUInt32BE(60000, 17);
+    result.write(HOST, 21, 'ascii');
+    return result;
+}
+
+function decisionMessage(code, sessionId, generation) {
+    const result = Buffer.alloc(49);
+    result.write('AEMCP-D1', 0, 'ascii');
+    result[8] = code;
+    result.write(sessionId || '00000000-0000-0000-0000-000000000000', 9, 'ascii');
+    result.writeUInt32BE(generation || 0, 45);
+    return result;
+}
+
+function frame(value) {
+    const body = Buffer.from(JSON.stringify(value), 'utf8');
+    const result = Buffer.alloc(body.length + 4);
+    result.writeUInt32BE(body.length, 0);
+    body.copy(result, 4);
+    return result;
+}
+
+async function endpointFixture(t) {
+    const temporaryRoot = process.platform === 'darwin' ? '/private/tmp' : os.tmpdir();
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(temporaryRoot, 'aemcp-native-client-')));
+    fs.chmodSync(root, 0o700);
+    const directory = path.join(root, 'aemcp-n1');
+    fs.mkdirSync(directory, { mode: 0o700 });
+    const socketName = 's-123456abcdef.sock';
+    const socketPath = path.join(directory, socketName);
+    const server = net.createServer();
+    const openSockets = new Set();
+    server.on('connection', function (socket) {
+        openSockets.add(socket);
+        socket.once('close', function () { openSockets.delete(socket); });
+    });
+    await new Promise(function (resolve, reject) {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+    });
+    fs.chmodSync(socketPath, 0o600);
+    const descriptorPath = path.join(directory, 'd-' + HOST + '.endpoint');
+    fs.writeFileSync(descriptorPath, descriptor(socketName), { mode: 0o600 });
+    fs.chmodSync(descriptorPath, 0o600);
+    t.after(async function () {
+        for (const socket of openSockets) socket.destroy();
+        await new Promise(function (resolve) { server.close(resolve); });
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+    return { root, server, socketPath };
+}
+
+function invokeRequestDigest(request) {
+    const canonical = {
+        deadlineUnixMs: request.deadlineUnixMs,
+        kind: request.kind,
+        method: request.method,
+        params: {
+            arguments: request.params.arguments,
+            capabilityId: request.params.capabilityId,
+            capabilityVersion: request.params.capabilityVersion,
+        },
+        requestId: request.requestId,
+        sessionId: request.sessionId,
+        wireVersion: request.wireVersion,
+    };
+    return crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
+}
+
+function installProtocol(server, options) {
+    const input = options || {};
+    let authorize;
+    const authorized = new Promise(function (resolve) { authorize = resolve; });
+    const requests = [];
+    server.on('connection', function (socket) {
+        let bytes = Buffer.alloc(0);
+        let authenticated = false;
+        socket.on('data', function (chunk) {
+            bytes = Buffer.concat([bytes, chunk]);
+            if (!authenticated) {
+                if (bytes.length < 24) return;
+                assert.equal(bytes.subarray(0, 8).toString('ascii'), 'AEMCP-A1');
+                assert.notDeepEqual(bytes.subarray(8, 24), Buffer.alloc(16));
+                bytes = bytes.subarray(24);
+                socket.write(pendingMessage());
+                authorized.then(function () {
+                    authenticated = true;
+                    socket.write(decisionMessage(1, SESSION, 7));
+                    consume();
+                });
+                return;
+            }
+            consume();
+        });
+
+        function consume() {
+            while (authenticated && bytes.length >= 4) {
+                const length = bytes.readUInt32BE(0);
+                if (bytes.length < length + 4) return;
+                const request = JSON.parse(bytes.toString('utf8', 4, length + 4));
+                bytes = bytes.subarray(length + 4);
+                requests.push(request);
+                let result;
+                if (request.method === 'hello') {
+                    result = {
+                        selectedWireVersion: 1,
+                        pluginVersion: '0.1.0-dev',
+                        compiledSdk: { version: '25.6.61', build: 61, architecture: 'arm64' },
+                        host: {
+                            application: 'after-effects', version: '26.3.0', build: 87,
+                            platform: 'macos-arm64', instanceId: HOST,
+                        },
+                        sessionId: SESSION,
+                        sessionGeneration: 7,
+                        limits: { maxFrameBytes: 65536 },
+                        capabilitiesDigest: DIGEST,
+                        clientNonce: request.params.nonce,
+                    };
+                } else if (request.method === 'capabilities') {
+                    result = {
+                        detail: 'full',
+                        capabilitiesDigest: DIGEST,
+                        queryDigest: 'aa3c66bc21e50b6a35db9c3cb12fcb1627694cd8f9fc411f21f7e3de46b3e56a',
+                        nextCursor: null,
+                        items: [{
+                            id: 'ae.project.summary',
+                            version: 1,
+                            detail: 'full',
+                            contractDigest: 'd'.repeat(64),
+                        }],
+                    };
+                } else {
+                    result = {
+                        capabilityId: 'ae.project.summary',
+                        capabilityVersion: 1,
+                        engine: 'native-aegp',
+                        outcome: 'succeeded',
+                        evidence: {
+                            engine: 'native-aegp',
+                            hostInstanceId: HOST,
+                            sessionId: SESSION,
+                            requestId: request.requestId,
+                            capabilityId: 'ae.project.summary',
+                            capabilityVersion: 1,
+                            startedAtUnixMs: 1900000000000,
+                            completedAtUnixMs: 1900000000001,
+                            effect: 'none',
+                            requestDigest: invokeRequestDigest(request),
+                            postcondition: {
+                                verified: true,
+                                kind: 'project-summary',
+                                algorithm: 'sha256-rfc8785-jcs-v1',
+                                digest: '7b5277171cf2d6478d7c95bd99cf25765afac71f8f003c5bf7604f495d7eb4a2',
+                            },
+                        },
+                        value: { projectOpen: true, projectName: 'Fixture.aep', itemCount: 3 },
+                    };
+                    if (input.mutateInvoke) input.mutateInvoke(result, request);
+                }
+                socket.write(frame({
+                    wireVersion: 1,
+                    kind: 'response',
+                    sessionId: SESSION,
+                    requestId: request.requestId,
+                    method: request.method,
+                    ok: true,
+                    replayed: false,
+                    result,
+                }));
+            }
+        }
+    });
+    return { authorize, requests };
+}
+
+test('descriptor and fixed transport messages are strict and closed', () => {
+    assert.equal(endpointDescriptor(descriptor('s-123456abcdef.sock')).hostInstanceId, HOST);
+    assert.equal(endpointDescriptor(descriptor('../escape.sock')), null);
+    assert.equal(endpointDescriptor(descriptor('s-123456abcdef.sock') + 'extra=1\n'), null);
+    assert.deepEqual(parseAuthPending(pendingMessage()), {
+        fingerprint: '12AB-34CD', expiresInMs: 60000, hostInstanceId: HOST,
+    });
+    assert.deepEqual(parseAuthDecision(decisionMessage(1, SESSION, 7)), {
+        code: 'authorized', sessionId: SESSION, sessionGeneration: 7,
+    });
+    assert.equal(parseAuthPending(Buffer.alloc(57)), null);
+    assert.equal(parseAuthDecision(decisionMessage(1, SESSION, 0)), null);
+});
+
+test('discovery accepts only a private descriptor and socket owned by this user', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const endpoints = discoverNativeEndpoints({ runtimeRoot: fixture.root });
+    assert.equal(endpoints.length, 1);
+    assert.equal(endpoints[0].hostInstanceId, HOST);
+    assert.equal(endpoints[0].sourceCommit, SOURCE);
+
+    fs.chmodSync(path.join(fixture.root, 'aemcp-n1', 'd-' + HOST + '.endpoint'), 0o644);
+    assert.deepEqual(discoverNativeEndpoints({ runtimeRoot: fixture.root }), []);
+});
+
+test('CEP client completes pairing, hello, capabilities, and verified native project summary', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const protocol = installProtocol(fixture.server);
+    const deterministic = Buffer.from('00112233445566778899aabbccddeeff0011223344556677', 'hex');
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        randomBytes: function (size) {
+            return Buffer.concat([deterministic, Buffer.alloc(size)]).subarray(0, size);
+        },
+        requestTimeoutMs: 2000,
+        now: function () { return 1900000000000; },
+    });
+    t.after(function () { return client.close(); });
+
+    const pending = await client.beginPairing();
+    assert.deepEqual(pending, {
+        fingerprint: '12AB-34CD',
+        expiresInMs: 60000,
+        hostInstanceId: HOST,
+        sourceCommit: SOURCE,
+    });
+    assert.equal(client.status().state, 'pairing-decision');
+
+    protocol.authorize();
+    const hello = await client.waitUntilConnected();
+    assert.equal(hello.host.instanceId, HOST);
+    assert.equal(client.status().state, 'connected');
+    const capabilities = await client.capabilities();
+    assert.equal(capabilities.items[0].id, 'ae.project.summary');
+    const summary = await client.projectSummary();
+    assert.deepEqual(summary.value, {
+        projectOpen: true, projectName: 'Fixture.aep', itemCount: 3,
+    });
+    assert.equal(summary.engine, 'native-aegp');
+    assert.equal(summary.evidence.postcondition.verified, true);
+    assert.equal(client.status().projectSummaryContractDigest, 'd'.repeat(64));
+    assert.deepEqual(protocol.requests.map(function (request) { return request.method; }), [
+        'hello', 'capabilities', 'invoke',
+    ]);
+    assert.equal(protocol.requests[2].deadlineUnixMs, 1900000002000);
+    assert.equal(summary.evidence.requestDigest, invokeRequestDigest(protocol.requests[2]));
+});
+
+for (const fixture of [
+    {
+        name: 'request digest',
+        mutate: function (result) { result.evidence.requestDigest = '0'.repeat(64); },
+    },
+    {
+        name: 'postcondition value',
+        mutate: function (result) { result.value.itemCount += 1; },
+    },
+]) {
+    test('client rejects tampered native ' + fixture.name + ' evidence', {
+        skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+    }, async (t) => {
+        const endpoint = await endpointFixture(t);
+        const protocol = installProtocol(endpoint.server, { mutateInvoke: fixture.mutate });
+        const client = createNativeAegpClient({
+            runtime: { platform: 'darwin', arch: 'arm64' },
+            runtimeRoot: endpoint.root,
+            clientInstanceId: CLIENT,
+            requestTimeoutMs: 2000,
+            now: function () { return 1900000000000; },
+        });
+        t.after(function () { return client.close(); });
+        await client.beginPairing();
+        protocol.authorize();
+        await client.waitUntilConnected();
+        await client.capabilities();
+        await assert.rejects(client.projectSummary(), { code: 'INVALID_REQUEST', retryable: false });
+    });
+}
+
+test('client does not bypass explicit pairing rejection', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    let rejectPairing;
+    fixture.server.on('connection', function (socket) {
+        socket.once('data', function () {
+            socket.write(pendingMessage());
+            rejectPairing = function () { socket.write(decisionMessage(2)); };
+        });
+    });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+    });
+    t.after(function () { return client.close(); });
+    await client.beginPairing();
+    rejectPairing();
+    await assert.rejects(client.waitUntilConnected(), { code: 'AUTH_REQUIRED', retryable: false });
+});
+
+test('closing after the pairing response does not create an unhandled connected rejection', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    fixture.server.on('connection', function (socket) {
+        socket.once('data', function () { socket.write(pendingMessage()); });
+    });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+    });
+    const unhandled = [];
+    const capture = function (reason) { unhandled.push(reason); };
+    process.on('unhandledRejection', capture);
+    t.after(function () { process.off('unhandledRejection', capture); });
+
+    await client.beginPairing();
+    await client.close();
+    await new Promise(function (resolve) { setImmediate(resolve); });
+    assert.deepEqual(unhandled, []);
+});
+
+test('late events from a failed socket cannot tear down its replacement', async () => {
+    class FakeSocket extends EventEmitter {
+        write(bytes, callback) { if (callback) callback(); return bytes.length > 0; }
+        destroy() { this.destroyed = true; }
+    }
+    const sockets = [];
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        clientInstanceId: CLIENT,
+        discoverEndpoints: function () {
+            return [{
+                hostInstanceId: HOST,
+                sourceCommit: SOURCE,
+                socketPath: '/synthetic/aemcp.sock',
+            }];
+        },
+        netImpl: {
+            createConnection: function () {
+                const socket = new FakeSocket();
+                sockets.push(socket);
+                return socket;
+            },
+        },
+    });
+
+    const first = client.beginPairing();
+    sockets[0].emit('error', Object.assign(new Error('first failed'), { code: 'ECONNRESET' }));
+    await assert.rejects(first, { code: 'NATIVE_UNAVAILABLE', retryable: true });
+
+    const second = client.beginPairing();
+    sockets[0].emit('data', Buffer.alloc(100));
+    sockets[0].emit('close');
+    assert.equal(client.status().state, 'pairing-pending');
+    sockets[1].emit('connect');
+    sockets[1].emit('data', pendingMessage());
+    assert.equal((await second).fingerprint, '12AB-34CD');
+    assert.equal(client.status().state, 'pairing-decision');
+    await client.close();
+});

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 const jsxBridge = require('./jsx-bridge');
 const authToken = require('./auth-token');
 const activity = require('./activity');
+const nativeAegp = require('./native-aegp-client');
 const PKG_VERSION = require('./package.json').version;
 
 let app = null;
@@ -16,6 +17,9 @@ let execToken = null;
 let paused = false;
 let lastHealthAt = null;
 let lastPythonVersion = null;
+let nativeAegpClient = null;
+let nativeAegpClientFactory = null;
+let nativeAegpRuntime = null;
 const clients = new Map();
 const blocked = new Set();
 // Self-reported label of the panel's own diagnostic /exec probes. Must match
@@ -105,6 +109,128 @@ function regenerateToken(cb) {
         else throw e;
         return null;
     }
+}
+
+function makeNativeAegpClient() {
+    if (nativeAegpClient) return nativeAegpClient;
+    const factory = nativeAegpClientFactory || nativeAegp.createNativeAegpClient;
+    nativeAegpClient = factory({
+        version: PKG_VERSION,
+        component: 'core-broker',
+        runtime: nativeAegpRuntime,
+    });
+    if (!nativeAegpClient
+        || typeof nativeAegpClient.beginPairing !== 'function'
+        || typeof nativeAegpClient.waitUntilConnected !== 'function'
+        || typeof nativeAegpClient.capabilities !== 'function'
+        || typeof nativeAegpClient.projectSummary !== 'function'
+        || typeof nativeAegpClient.status !== 'function'
+        || typeof nativeAegpClient.close !== 'function') {
+        nativeAegpClient = null;
+        const error = new Error('native AEGP client factory returned an invalid client');
+        error.code = 'NATIVE_UNAVAILABLE';
+        error.retryable = true;
+        throw error;
+    }
+    return nativeAegpClient;
+}
+
+function closeNativeAegpClient() {
+    const client = nativeAegpClient;
+    nativeAegpClient = null;
+    if (!client) return;
+    try { Promise.resolve(client.close()).catch(() => {}); } catch (_) {}
+}
+
+function setNativeAegpRuntime(runtime) {
+    if (!runtime || typeof runtime !== 'object' || Array.isArray(runtime)
+        || !['darwin', 'win32'].includes(runtime.platform)
+        || !['arm64', 'x64'].includes(runtime.arch)) {
+        throw new TypeError('native AEGP runtime is invalid');
+    }
+    if (nativeAegpRuntime
+        && (nativeAegpRuntime.platform !== runtime.platform || nativeAegpRuntime.arch !== runtime.arch)) {
+        closeNativeAegpClient();
+    }
+    nativeAegpRuntime = Object.freeze({ platform: runtime.platform, arch: runtime.arch });
+}
+
+function nativeErrorPayload(error) {
+    const code = typeof error?.code === 'string' && /^[A-Z][A-Z0-9_]{2,63}$/.test(error.code)
+        ? error.code : 'NATIVE_UNAVAILABLE';
+    return {
+        code,
+        message: code === 'NATIVE_PAIRING_REQUIRED'
+            ? 'Approve the matching fingerprint from the After Effects AE MCP menu, then retry.'
+            : 'Native AEGP request failed with ' + code + '.',
+        retryable: error?.retryable === true || code === 'NATIVE_UNAVAILABLE',
+    };
+}
+
+function nativeRequestGate(req, res) {
+    const provided = req.get(authToken.HEADER);
+    if (!authToken.tokenMatches(provided, execToken)) {
+        res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'unauthorized', retryable: false } });
+        return null;
+    }
+    const client = req.get('x-ae-mcp-client') || 'unknown';
+    const pythonVersion = req.get('x-ae-mcp-python');
+    if (pythonVersion) lastPythonVersion = pythonVersion;
+    if (client !== INTERNAL_CLIENT) touchClient(client);
+    if (blocked.has(client)) {
+        activity.record({ client, engine: 'native-aegp', ok: false, denied: 'blocked' });
+        res.status(403).json({
+            ok: false,
+            error: { code: 'CLIENT_BLOCKED', message: 'this client is blocked in the panel', retryable: false },
+        });
+        return null;
+    }
+    if (paused) {
+        activity.record({ client, engine: 'native-aegp', ok: false, denied: 'paused' });
+        res.status(503).json({
+            ok: false,
+            error: { code: 'ACTIONS_PAUSED', message: 'AI actions are paused in the panel', retryable: true },
+        });
+        return null;
+    }
+    return client;
+}
+
+async function nativePairingRequired(client) {
+    const pending = await client.beginPairing();
+    const error = new Error('native AEGP pairing requires an After Effects decision');
+    error.code = 'NATIVE_PAIRING_REQUIRED';
+    error.retryable = true;
+    error.pairing = pending;
+    throw error;
+}
+
+async function connectedNativeClient() {
+    const client = makeNativeAegpClient();
+    const status = client.status();
+    if (status.state === 'connected') return client;
+    if (status.state === 'authenticating') {
+        await client.waitUntilConnected();
+        return client;
+    }
+    return nativePairingRequired(client);
+}
+
+function sendNativeFailure(res, error) {
+    const payload = nativeErrorPayload(error);
+    const status = payload.code === 'NATIVE_PAIRING_REQUIRED' ? 409
+        : payload.code === 'INVALID_ARGUMENT' ? 400
+            : payload.code === 'AUTH_REQUIRED' ? 401 : 503;
+    const response = { ok: false, error: payload };
+    if (payload.code === 'NATIVE_PAIRING_REQUIRED' && error?.pairing) {
+        response.pairing = {
+            fingerprint: error.pairing.fingerprint,
+            expiresInMs: error.pairing.expiresInMs,
+            hostInstanceId: error.pairing.hostInstanceId,
+            sourceCommit: error.pairing.sourceCommit,
+        };
+    }
+    res.status(status).json(response);
 }
 
 // Wrap user JSX in app.beginUndoGroup / app.endUndoGroup.
@@ -239,6 +365,108 @@ function buildApp() {
         res.json({ ok: true, events: activity.list(Number.isFinite(since) ? since : 0) });
     });
 
+    a.get('/native/status', (req, res) => {
+        if (nativeRequestGate(req, res) === null) return;
+        try {
+            const status = makeNativeAegpClient().status();
+            res.json({ ok: true, status });
+        } catch (error) {
+            sendNativeFailure(res, error);
+        }
+    });
+
+    a.post('/native/pair', async (req, res) => {
+        const clientLabel = nativeRequestGate(req, res);
+        if (clientLabel === null) return;
+        const startedAt = Date.now();
+        try {
+            const client = makeNativeAegpClient();
+            if (client.status().state === 'connected') {
+                return res.json({ ok: true, status: client.status() });
+            }
+            const pending = await client.beginPairing();
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'pair',
+                ok: false,
+                denied: 'pairing_required',
+                durationMs: Date.now() - startedAt,
+            });
+            const error = new Error('native AEGP pairing requires an After Effects decision');
+            error.code = 'NATIVE_PAIRING_REQUIRED';
+            error.retryable = true;
+            error.pairing = pending;
+            sendNativeFailure(res, error);
+        } catch (error) {
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'pair',
+                ok: false,
+                error: nativeErrorPayload(error).code,
+                durationMs: Date.now() - startedAt,
+            });
+            sendNativeFailure(res, error);
+        }
+    });
+
+    a.post('/native/invoke', async (req, res) => {
+        const clientLabel = nativeRequestGate(req, res);
+        if (clientLabel === null) return;
+        const body = req.body || {};
+        if (!body || typeof body !== 'object' || Array.isArray(body)
+            || JSON.stringify(Object.keys(body).sort()) !== JSON.stringify([
+                'arguments', 'capabilityId', 'capabilityVersion',
+            ])
+            || body.capabilityId !== 'ae.project.summary'
+            || body.capabilityVersion !== 1
+            || !body.arguments || typeof body.arguments !== 'object'
+            || Array.isArray(body.arguments) || Object.keys(body.arguments).length !== 0) {
+            return res.status(400).json({
+                ok: false,
+                error: { code: 'INVALID_ARGUMENT', message: 'native invoke parameters are invalid', retryable: false },
+            });
+        }
+        const startedAt = Date.now();
+        try {
+            const client = await connectedNativeClient();
+            await client.capabilities('full');
+            const result = await client.projectSummary();
+            const runtime = client.status();
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                capabilityId: body.capabilityId,
+                ok: true,
+                durationMs: Date.now() - startedAt,
+            });
+            res.json({
+                ok: true,
+                capabilityId: body.capabilityId,
+                engine: 'native-aegp',
+                result,
+                runtime: {
+                    hostInstanceId: runtime.hostInstanceId,
+                    sourceCommit: runtime.sourceCommit,
+                    sessionGeneration: runtime.sessionGeneration,
+                    capabilitiesDigest: runtime.capabilitiesDigest,
+                    projectSummaryContractDigest: runtime.projectSummaryContractDigest,
+                },
+            });
+        } catch (error) {
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                capabilityId: body.capabilityId,
+                ok: false,
+                error: nativeErrorPayload(error).code,
+                durationMs: Date.now() - startedAt,
+            });
+            sendNativeFailure(res, error);
+        }
+    });
+
     a.post('/exec', async (req, res) => {
         // Require the shared-secret token. /exec runs arbitrary ExtendScript, so
         // every caller must prove it can read ~/.ae-mcp/auth-token. Constant-time
@@ -328,6 +556,7 @@ function start(port, callback, roots) {
 }
 
 function stop(callback) {
+    closeNativeAegpClient();
     if (!httpServer) return callback ? callback() : null;
     httpServer.close(() => {
         httpServer = null;
@@ -363,6 +592,7 @@ module.exports = {
     regenerateToken,
     setCSInterface: jsxBridge.setCSInterface,
     setRuntimeDependencies,
+    setNativeAegpRuntime,
     // Exported for unit-testing the wrap shape without spinning up Express.
     wrapWithUndoGroup,
     wrapForEvalScriptTransport,
@@ -371,6 +601,14 @@ module.exports = {
     // touching the real token file.
     buildApp,
     _setExecToken: function (t) { execToken = t; },
+    _setNativeAegpClientForTest: function (client) {
+        closeNativeAegpClient();
+        nativeAegpClient = client;
+    },
+    _setNativeAegpClientFactoryForTest: function (factory) {
+        closeNativeAegpClient();
+        nativeAegpClientFactory = factory;
+    },
     // Test-only state inspection. Platform roots are never exposed over HTTP.
     _getPlatformRootsForTest: function () { return platformRoots; },
 };

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -148,6 +148,157 @@ function post(port, pathname, headers, body) {
     });
 }
 
+async function startNativeApp(nativeClient) {
+    delete require.cache[require.resolve('./server')];
+    const server = bindRuntimeDependencies(require('./server'));
+    server.activity._reset();
+    server.setPaused(false);
+    server._setExecToken('known-secret-token');
+    server._setNativeAegpClientForTest(nativeClient);
+    const app = server.buildApp();
+    const srv = await new Promise((resolve) => {
+        const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+    });
+    return { server, srv, port: srv.address().port };
+}
+
+function fakeNativeClient() {
+    let state = 'disconnected';
+    let closed = 0;
+    const calls = [];
+    const pending = {
+        fingerprint: '12AB-34CD',
+        expiresInMs: 60000,
+        hostInstanceId: '22222222-2222-4222-8222-222222222222',
+        sourceCommit: 'a'.repeat(40),
+    };
+    return {
+        beginPairing: async function () { calls.push('pair'); state = 'pairing-decision'; return pending; },
+        waitUntilConnected: async function () { calls.push('wait'); state = 'connected'; return {}; },
+        capabilities: async function (detail) { calls.push('capabilities:' + detail); return { items: [] }; },
+        projectSummary: async function () {
+            calls.push('projectSummary');
+            return {
+                capabilityId: 'ae.project.summary',
+                capabilityVersion: 1,
+                engine: 'native-aegp',
+                evidence: {
+                    requestDigest: 'b'.repeat(64),
+                    postcondition: { verified: true, digest: 'c'.repeat(64) },
+                },
+                value: { projectOpen: true, projectName: 'Fixture.aep', itemCount: 2 },
+            };
+        },
+        status: function () {
+            return {
+                state,
+                hostInstanceId: pending.hostInstanceId,
+                sourceCommit: pending.sourceCommit,
+                sessionGeneration: state === 'connected' ? 7 : null,
+                capabilitiesDigest: 'd'.repeat(64),
+                projectSummaryContractDigest: 'e'.repeat(64),
+            };
+        },
+        close: async function () { closed += 1; state = 'closed'; },
+        authorize: function () { state = 'connected'; },
+        calls,
+        closed: function () { return closed; },
+    };
+}
+
+test('native routes require the shared token and reject an open-ended invoke envelope', async () => {
+    const nativeClient = fakeNativeClient();
+    const { server, srv, port } = await startNativeApp(nativeClient);
+    try {
+        const unauthorized = await post(port, '/native/invoke', {}, {
+            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+        });
+        assert.strictEqual(unauthorized.status, 401);
+        assert.strictEqual(unauthorized.body.error.code, 'UNAUTHORIZED');
+
+        const arbitrary = await post(port, '/native/invoke', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, {
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: { jsx: 'app.project.close()' },
+        });
+        assert.strictEqual(arbitrary.status, 400);
+        assert.strictEqual(arbitrary.body.error.code, 'INVALID_ARGUMENT');
+        assert.deepStrictEqual(nativeClient.calls, []);
+    } finally {
+        srv.close();
+        server.stop();
+    }
+});
+
+test('native route exposes pairing without logging its fingerprint, then invokes hello-capabilities-read session', async () => {
+    const nativeClient = fakeNativeClient();
+    const { server, srv, port } = await startNativeApp(nativeClient);
+    const headers = {
+        'X-AE-MCP-Token': 'known-secret-token',
+        'x-ae-mcp-client': 'stdio-mcp/test',
+    };
+    try {
+        const pairing = await post(port, '/native/invoke', headers, {
+            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+        });
+        assert.strictEqual(pairing.status, 409);
+        assert.strictEqual(pairing.body.error.code, 'NATIVE_PAIRING_REQUIRED');
+        assert.strictEqual(pairing.body.pairing.fingerprint, '12AB-34CD');
+        assert.strictEqual(pairing.body.pairing.sourceCommit, 'a'.repeat(40));
+        assert.doesNotMatch(JSON.stringify(server.activity.list()), /12AB-34CD/);
+
+        nativeClient.authorize();
+        const invoked = await post(port, '/native/invoke', headers, {
+            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+        });
+        assert.strictEqual(invoked.status, 200);
+        assert.strictEqual(invoked.body.engine, 'native-aegp');
+        assert.strictEqual(invoked.body.result.value.itemCount, 2);
+        assert.strictEqual(invoked.body.result.evidence.postcondition.verified, true);
+        assert.strictEqual(invoked.body.runtime.sourceCommit, 'a'.repeat(40));
+        assert.strictEqual(invoked.body.runtime.projectSummaryContractDigest, 'e'.repeat(64));
+        assert.deepStrictEqual(nativeClient.calls, [
+            'pair', 'capabilities:full', 'projectSummary',
+        ]);
+    } finally {
+        srv.close();
+        server.stop();
+    }
+});
+
+test('native routes preserve panel pause and client-block controls and close the session on stop', async () => {
+    const nativeClient = fakeNativeClient();
+    nativeClient.authorize();
+    const { server, srv, port } = await startNativeApp(nativeClient);
+    const body = { capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {} };
+    try {
+        server.setPaused(true);
+        const paused = await post(port, '/native/invoke', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, body);
+        assert.strictEqual(paused.status, 503);
+        assert.strictEqual(paused.body.error.code, 'ACTIONS_PAUSED');
+        server.setPaused(false);
+
+        server.setClientBlocked('blocked/test', true);
+        const blocked = await post(port, '/native/invoke', {
+            'X-AE-MCP-Token': 'known-secret-token',
+            'x-ae-mcp-client': 'blocked/test',
+        }, body);
+        assert.strictEqual(blocked.status, 403);
+        assert.strictEqual(blocked.body.error.code, 'CLIENT_BLOCKED');
+        assert.deepStrictEqual(nativeClient.calls, []);
+    } finally {
+        server.setPaused(false);
+        server.setClientBlocked('blocked/test', false);
+        srv.close();
+        server.stop();
+    }
+    assert.strictEqual(nativeClient.closed(), 1);
+});
+
 test('/exec returns 401 without a token', async () => {
     const { srv, port } = await startApp();
     try {

--- a/plugin/panel/src/cep/hostBridge.js
+++ b/plugin/panel/src/cep/hostBridge.js
@@ -346,6 +346,9 @@ export function createHostController({
         throw new Error('Host runtime dependency binding is unavailable');
       }
       nextHost.setRuntimeDependencies(runtimeDependencies);
+      if (nextHost.setNativeAegpRuntime) {
+        nextHost.setNativeAegpRuntime(helperRuntime(adapter.id));
+      }
       nextHost.setCSInterface(cs);
       if (nextHost.setPlatformRoots) nextHost.setPlatformRoots(roots);
       host = nextHost;

--- a/plugin/panel/test/hostBridge.test.js
+++ b/plugin/panel/test/hostBridge.test.js
@@ -431,12 +431,14 @@ test('host controller reuses an already-normalized extension root instead of rea
   const calls = [];
   let receivedRoots = null;
   let receivedDependencies = null;
+  let receivedNativeRuntime = null;
   const bundledExpress = function bundledExpress() {};
   const runtime = fakeHostDependencyRuntime({
     platformId: 'macos-arm64', extensionRoot: '/Applications/AE MCP', express: bundledExpress,
   });
   const host = {
     setRuntimeDependencies(dependencies) { receivedDependencies = dependencies; },
+    setNativeAegpRuntime(runtime) { receivedNativeRuntime = runtime; },
     setCSInterface() {},
     start(port, callback, roots) { calls.push(port); receivedRoots = roots; callback(null); },
     stop() {},
@@ -458,6 +460,7 @@ test('host controller reuses an already-normalized extension root instead of rea
   controller.start(11488);
   assert.equal(calls[0], '/Applications/AE MCP/host/server.js');
   assert.equal(receivedDependencies.express, bundledExpress);
+  assert.deepEqual(receivedNativeRuntime, { platform: 'darwin', arch: 'arm64' });
   assert.deepEqual(receivedRoots, {
     extensionRoot: '/Applications/AE MCP',
     runtimeRoot: '/Applications/AE MCP/runtime',

--- a/scripts/package/test/native-aegp-build-contract.test.mjs
+++ b/scripts/package/test/native-aegp-build-contract.test.mjs
@@ -60,26 +60,19 @@ test('native mac build emits the AE-recognized AEGP package metadata', async () 
   assert.match(verifier, /Buffer\.from\('AEgxFXTC', 'ascii'\)/u);
 });
 
-test('native boot probe starts its deadline at the first AE idle callback', () => {
-  const submitStart = PLUGIN_ENTRY.indexOf('void submit_boot_probe_once(');
+test('native idle hook drains only real authenticated requests', () => {
   const idleStart = PLUGIN_ENTRY.indexOf('A_Err idle_hook(');
   const namespaceEnd = PLUGIN_ENTRY.indexOf('}  // namespace', idleStart);
   const entryStart = PLUGIN_ENTRY.indexOf('extern "C"', namespaceEnd);
-  assert.notEqual(submitStart, -1);
   assert.notEqual(idleStart, -1);
   assert.notEqual(namespaceEnd, -1);
   assert.notEqual(entryStart, -1);
 
-  const submitBootProbe = PLUGIN_ENTRY.slice(submitStart, idleStart);
   const idleHook = PLUGIN_ENTRY.slice(idleStart, namespaceEnd);
   const pluginEntry = PLUGIN_ENTRY.slice(entryStart);
-  assert.match(submitBootProbe, /PluginState& state\) noexcept/u);
-  assert.match(submitBootProbe, /if \(state\.boot_probe_submitted\) return;/u);
-  assert.match(submitBootProbe, /state\.boot_probe_submitted = true;\s*try \{/u);
-  assert.match(submitBootProbe, /"boot-project-summary"/u);
-  assert.match(submitBootProbe, /state\.clock\.now\(\) \+ 60s/u);
-  assert.match(submitBootProbe, /catch \(\.\.\.\)/u);
-  assert.match(idleHook, /submit_boot_probe_once\(\*state\)[\s\S]*dispatcher\.drain/u);
+  assert.match(idleHook, /state->dispatcher\.drain\(host\)/u);
+  assert.doesNotMatch(PLUGIN_ENTRY, /submit_boot_probe_once|boot_probe_submitted/u);
+  assert.doesNotMatch(idleHook, /dispatcher\.enqueue/u);
   assert.doesNotMatch(pluginEntry, /"boot-project-summary"/u);
 });
 

--- a/scripts/package/test/native-aegp-build-contract.test.mjs
+++ b/scripts/package/test/native-aegp-build-contract.test.mjs
@@ -76,6 +76,18 @@ test('native idle hook drains only real authenticated requests', () => {
   assert.doesNotMatch(pluginEntry, /"boot-project-summary"/u);
 });
 
+test('native pairing command is enabled by the AE update-menu hook', () => {
+  assert.match(PLUGIN_ENTRY, /A_Err update_menu_hook\(/u);
+  assert.match(
+    PLUGIN_ENTRY,
+    /AEGP_EnableCommand\(\s*state->pairing_command\s*\)/u,
+  );
+  assert.match(
+    PLUGIN_ENTRY,
+    /AEGP_RegisterUpdateMenuHook\(\s*plugin_id, update_menu_hook, 0\s*\)/u,
+  );
+});
+
 test('native README examples use safe shell variables and the complete build inputs', async () => {
   for (const readmePath of ['README.md', 'README.zh-CN.md']) {
     const readme = await fs.promises.readFile(readmePath, 'utf8');


### PR DESCRIPTION
Closes #74

## Outcome

Adds the minimum real macOS AEGP transport required by #74: a private per-AE-instance Unix-domain endpoint, explicit AEGP-owned pairing, a strict typed RPC session, and a real CEP smoke path that reads `ae.project.summary@1` on the AE main thread without JSX or `evalScript`.

This is capability expansion, not an AEGP-over-JSX routing rule. The future resolver remains out of scope.

## Stack and merge gate

- Base: `codex/issue-73-native-plugin-host` / Draft PR #87.
- Depends on #72 and #73.
- Feeds the public MCP/Core broker work in #75/#76 and the minimum audited undoable write.
- Release-grade IPC hardening remains #89; Windows transport remains #88.

**DO NOT MERGE.** Per #74's exit condition, this stacked PR stays Draft until the public MCP read and the minimum audited, undoable native write have passed their real-host gates.

## What changed

- private per-instance macOS AF_UNIX endpoint and bounded endpoint registry
- explicit short-lived fingerprint confirmation owned by the AEGP menu
- strict framed hello/capabilities/invoke/cancel codec and session generation binding
- bounded dispatcher completion routing with deadline, cancel, duplicate and disconnect fencing
- CEP native client plus token-gated `/native/status`, `/native/pair`, and closed-schema `/native/invoke`
- actual `ae.project.summary@1` through AEGP ProjectSuite/ItemSuite on IdleHook
- structured native provenance, request digest, verified postcondition digest and panel audit events
- AEGP UpdateMenuHook that explicitly enables the pairing command; this fixes the real-host-only disabled-menu failure found before publication
- CI coverage for the portable dispatcher, codec/session, transport, CEP client/server and packaging contracts

## Exact build and install evidence

Validated on Apple Silicon with After Effects 26.3.0 build 87 and the developer-supplied After Effects SDK 25.6 build 61.

- source commit: `d959ce7d09968f272bb0b33e3096e23a856cf6e1`
- bundle tree SHA-256: `648a8bd266042ca57d6aa407801d6f25f13c52d2752863d6e4baa70e7b8adf90`
- executable SHA-256: `423a51070bc888183ac376311684f55febb007a2633b320226f78ba9b64cfe6a`
- PiPL SHA-256: `4c439de251ad7d3d8f49bb54967e420152063d06909db29612c7eac60722c665`
- verified arm64 Mach-O bundle and exact sourceCommit receipt
- development install transaction: `7e6c270e-586b-4ace-8456-7446208372e1`
- installed only at the canonical per-user `MediaCore/ae-mcp/AeMcpNative.plugin` path

The Adobe SDK archive, headers, examples, PDFs, PiPLtool and SDK utilities stayed outside the repository and were not uploaded.

## Real request and recovery evidence

The authenticated HTTP request body used by the CEP host was:

```json
{"capabilityId":"ae.project.summary","capabilityVersion":1,"arguments":{}}
```

The shared HTTP token was read locally and is omitted. Before pairing, both launches returned the expected typed `409 NATIVE_PAIRING_REQUIRED`; the short-lived fingerprints were compared in AE and are intentionally not recorded here or in the native log.

### Launch 1

- hostInstanceId: `e5596374-47fd-4f6b-aff7-7f2fff7517a5`
- sessionId: `d48ba05d-cc10-4d29-a9f1-b43f9e4c5d17`
- requestId: `invoke-3-0e1337f4`
- request digest: `9c66560d1f5a49139d5f0ea3c56fbf8570eabf90a34511fcb49a2b280d338e23`
- verified postcondition digest: `469216c3599c7a3236f9e232ad1a55894d19d203c1896bf72c4fd90b86f75c52`
- result: `{"projectOpen":true,"projectName":"无标题项目","itemCount":0}`
- engine/provenance: `native-aegp`; effect: `none`
- audit ring: pairing-required failures followed by one 31 ms successful native invoke
- native log: `pairing.user-decision(authorize) → ipc.session(authorized) → rpc.hello(ok) → rpc.capabilities(ok) → rpc.invoke(queued) → invoke.terminal(ok)`
- `lsof` mapped PID 90536 only to the canonical installed bundle

### Restart and reconnect

AE was quit normally. The log recorded `ipc.session(closed) → ipc.listener(stopped) → death`. A new AE process loaded the same exact source commit and required a fresh pairing.

- new hostInstanceId: `b07b8299-5ce4-44fe-a5e0-c781b63eb250`
- new sessionId: `241624f5-d26a-41a6-93d5-1ae5a81200d9`
- requestId: `invoke-3-4611695f`
- request digest: `cc47d33520b1dc94a3698ceccce0c4d5b407f109e1e60e3f9185fb69f0b86475`
- same verified AE-state postcondition digest: `469216c3599c7a3236f9e232ad1a55894d19d203c1896bf72c4fd90b86f75c52`
- same typed project result and exact `d959ce7…` provenance
- audit ring: pairing-required followed by one 30 ms successful native invoke
- `lsof` mapped new PID 91445 only to the canonical installed bundle

This proves unload, endpoint/session invalidation, restart, fresh pairing and a second real main-thread read.

## Automated and independent verification

- protocol: 28/28
- native build contract: 7/7
- Node protocol/client/server/build-contract independent subset: 76/76
- host suite: all 85 checks passed
- panel suite: 949 passed; 2 existing explicit live-gate tests skipped because `AE_MCP_CODEX_ROUTE_LIVE` was not enabled
- packaging contracts: all 336 checks passed
- portable C++ dispatcher/codec/RPC/pairing/transport tests: all Werror builds and runs passed
- macOS endpoint registry and secure-random tests passed
- SDK repository verification and `git diff --check` passed
- a clean temporary panel rebuild matched the committed `plugin/client/dist` byte-for-byte
- socket tests initially hit sandbox EPERM and passed unchanged outside that sandbox
- two independent code reviews: no P0 blocker

## Deliberately deferred, not claimed

- strict mutual Adobe code-signature enforcement and server attestation
- sibling-CEP/endpoint-replacement/PID-reuse/slowloris/flood/SIGKILL/fuzz matrix
- release signing, notarization and clean-machine distribution
- Windows transport
- multi-AE user selection and any AEGP/JSX resolver

The current multiple-instance behavior fails closed. Route-fence exhaustion also fails closed and requires an AE restart; both are safe P0 boundaries and future reliability work.
