### PR TITLE
refactor(core): add typed native execution contract

### DIFF
--- a/packages/core/ae_mcp/backends/__init__.py
+++ b/packages/core/ae_mcp/backends/__init__.py
@@ -3,6 +3,20 @@
 Concrete backend implementations live in separate pip packages and
 register themselves via the entry point group `ae_mcp.backends`.
 Core never imports any concrete backend module directly."""
-from ae_mcp.backends.base import Backend, ALL_VERBS, BackendError
+from ae_mcp.backends.base import (
+    ALL_VERBS,
+    Backend,
+    BackendError,
+    EXECUTION_ENGINES,
+    ExecutionEngine,
+    LegacyExtendScriptBackend,
+)
 
-__all__ = ["Backend", "ALL_VERBS", "BackendError"]
+__all__ = [
+    "ALL_VERBS",
+    "Backend",
+    "BackendError",
+    "EXECUTION_ENGINES",
+    "ExecutionEngine",
+    "LegacyExtendScriptBackend",
+]

--- a/packages/core/ae_mcp/backends/base.py
+++ b/packages/core/ae_mcp/backends/base.py
@@ -2,7 +2,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Set
+from typing import Literal, Optional, Set
+
+
+ExecutionEngine = Literal["native-aegp", "maintained-jsx", "ephemeral-jsx"]
+EXECUTION_ENGINES: tuple[ExecutionEngine, ...] = (
+    "native-aegp",
+    "maintained-jsx",
+    "ephemeral-jsx",
+)
 
 
 ALL_VERBS: Set[str] = {
@@ -30,12 +38,14 @@ class BackendError(RuntimeError):
     """Raised by backend implementations on protocol / connectivity failures."""
 
 
-class Backend(ABC):
-    """Abstract bridge between core MCP layer and a concrete AE plugin protocol.
+class LegacyExtendScriptBackend(ABC):
+    """Explicit adapter for backends whose execution primitive is JSX.
 
     A backend is a separate pip package that registers itself via entry
     point group `ae_mcp.backends`. Core never imports any concrete
-    backend module.
+    backend module. This contract intentionally remains JSX-specific; native
+    AEGP capabilities use :class:`ae_mcp.backends.native.NativeInvokeBackend`
+    and never receive source text.
     """
 
     name: str  # value matched against AE_MCP_BACKEND env var
@@ -45,6 +55,16 @@ class Backend(ABC):
     # case core should skip its own wrapping/checkpointing).
     manages_undo: bool = False
     manages_checkpoints: bool = False
+
+    @staticmethod
+    def execution_engine_for(*, ephemeral: bool) -> ExecutionEngine:
+        """Label one JSX invocation without selecting or rerouting it.
+
+        The transport alone cannot determine provenance: repository-managed
+        JSX and one-off JSX may use the same backend. Callers therefore
+        classify each invocation explicitly for audit purposes.
+        """
+        return "ephemeral-jsx" if ephemeral else "maintained-jsx"
 
     @abstractmethod
     async def exec(
@@ -69,10 +89,19 @@ class Backend(ABC):
 
     @classmethod
     @abstractmethod
-    def from_env(cls) -> "Backend":
+    def from_env(cls) -> "LegacyExtendScriptBackend":
         """Construct from this backend's own env vars. Raise EnvironmentError
         with a clear message when required vars are missing."""
 
     async def shutdown(self) -> None:
         """Optional cleanup hook. Default no-op."""
         return None
+
+
+class Backend(LegacyExtendScriptBackend):
+    """Backward-compatible name for the legacy ExtendScript adapter.
+
+    Third-party backend packages currently subclass ``Backend``. Keeping this
+    abstract compatibility class avoids a flag-day migration while making the
+    JSX boundary explicit to new Core code.
+    """

--- a/packages/core/ae_mcp/backends/native.py
+++ b/packages/core/ae_mcp/backends/native.py
@@ -1,0 +1,986 @@
+"""Typed Core contract for native After Effects capabilities.
+
+This module deliberately contains no backend discovery and no AEGP/JSX
+resolver.  A caller chooses one explicit native implementation, negotiates its
+contract, and invokes it.  Legacy ExtendScript remains behind
+``LegacyExtendScriptBackend`` in ``base.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from abc import ABC, abstractmethod
+from typing import Annotated, Any, Literal, Mapping, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    model_validator,
+)
+
+from ae_mcp.backends.base import BackendError, ExecutionEngine
+
+
+NativeSideEffect: TypeAlias = Literal[
+    "not-started", "may-have-occurred", "completed"
+]
+NativeRecoveryAction: TypeAlias = Literal[
+    "retry",
+    "refresh-capabilities",
+    "refresh-locator",
+    "reconnect",
+    "open-project",
+    "change-arguments",
+    "inspect-state",
+    "none",
+]
+NativeWireErrorCode: TypeAlias = Literal[
+    "NATIVE_UNAVAILABLE",
+    "NATIVE_UNSUPPORTED",
+    "WIRE_VERSION_MISMATCH",
+    "INVALID_REQUEST",
+    "INVALID_ARGUMENT",
+    "DUPLICATE_REQUEST",
+    "PRECONDITION_FAILED",
+    "STALE_LOCATOR",
+    "DEADLINE_EXCEEDED",
+    "CANCELLED",
+    "QUEUE_FULL",
+    "AE_SHUTTING_DOWN",
+    "SESSION_STALE",
+    "CAPABILITY_FAILED",
+    "POSSIBLY_SIDE_EFFECTING_FAILURE",
+]
+NativeErrorCode: TypeAlias = NativeWireErrorCode | Literal[
+    "NATIVE_CONTRACT_MISMATCH"
+]
+NativePlatform: TypeAlias = Literal["macos-arm64", "windows-x64"]
+CapabilityDetail: TypeAlias = Literal["full"]
+
+_CAPABILITY_ID = r"^ae(?:\.[a-z][a-z0-9_-]*)+$"
+_CONTRACT_ID = r"^aemcp\.contract(?:\.[a-z][a-z0-9_-]*)+\.v[1-9][0-9]*$"
+_REQUIREMENT_ID = r"^aemcp\.requirement(?:\.[a-z][a-z0-9_-]*)+$"
+_REQUEST_ID = r"^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+_UUID = r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+_SHA256 = r"^[0-9a-f]{64}$"
+_SOURCE_COMMIT = r"^[0-9a-f]{40}$"
+_SAFE_MAX = 9_007_199_254_740_991
+
+CapabilityId = Annotated[
+    StrictStr, Field(min_length=3, max_length=96, pattern=_CAPABILITY_ID)
+]
+ContractId = Annotated[
+    StrictStr, Field(min_length=8, max_length=128, pattern=_CONTRACT_ID)
+]
+RequirementId = Annotated[
+    StrictStr, Field(min_length=8, max_length=128, pattern=_REQUIREMENT_ID)
+]
+RequestId = Annotated[
+    StrictStr, Field(min_length=1, max_length=64, pattern=_REQUEST_ID)
+]
+Uuid = Annotated[StrictStr, Field(pattern=_UUID)]
+Sha256 = Annotated[StrictStr, Field(pattern=_SHA256)]
+SourceCommit = Annotated[StrictStr, Field(pattern=_SOURCE_COMMIT)]
+PositiveInt = Annotated[StrictInt, Field(ge=1, le=_SAFE_MAX)]
+NonNegativeInt = Annotated[StrictInt, Field(ge=0, le=_SAFE_MAX)]
+
+
+def _camel(name: str) -> str:
+    first, *rest = name.split("_")
+    return first + "".join(part.capitalize() for part in rest)
+
+
+def _validate_json(value: Any, *, depth: int = 0) -> None:
+    if depth > 16:
+        raise ValueError("native JSON exceeds the maximum nesting depth")
+    if value is None or isinstance(value, (bool, str)):
+        return
+    if isinstance(value, int) and not isinstance(value, bool):
+        if abs(value) <= _SAFE_MAX:
+            return
+        raise ValueError("native JSON integer exceeds the safe range")
+    if isinstance(value, float):
+        raise ValueError("native Core contracts do not accept floating-point JSON")
+    if isinstance(value, list):
+        for item in value:
+            _validate_json(item, depth=depth + 1)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("native JSON object keys must be strings")
+            _validate_json(item, depth=depth + 1)
+        return
+    raise ValueError(f"native value is not JSON: {type(value).__name__}")
+
+
+class _NativeModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
+
+
+class NativeCompatibility(_NativeModel):
+    status: Literal["unverified", "verified"]
+    intended_platforms: tuple[NativePlatform, ...] = Field(
+        min_length=1, max_length=2
+    )
+    minimum_host_major: StrictInt | None = Field(default=None, ge=1)
+    maximum_host_major: StrictInt | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _valid_range(self) -> "NativeCompatibility":
+        if len(set(self.intended_platforms)) != len(self.intended_platforms):
+            raise ValueError("native compatibility platforms must be unique")
+        if self.status == "unverified":
+            if self.minimum_host_major is not None or self.maximum_host_major is not None:
+                raise ValueError("unverified compatibility cannot claim a host range")
+            return self
+        if self.minimum_host_major is None or self.maximum_host_major is None:
+            raise ValueError("verified compatibility requires a complete host range")
+        if self.minimum_host_major > self.maximum_host_major:
+            raise ValueError("native compatibility host range is reversed")
+        return self
+
+
+class NativeRequirement(_NativeModel):
+    id: RequirementId
+    contract_version: Annotated[StrictInt, Field(ge=1, le=65_535)]
+
+
+class NativeCapabilityDescriptor(_NativeModel):
+    """A full negotiated capability descriptor plus its Core engine label."""
+
+    detail: Literal["full"]
+    capability_id: CapabilityId = Field(alias="id")
+    capability_version: PositiveInt = Field(alias="version")
+    schema_version: PositiveInt
+    summary: Annotated[StrictStr, Field(min_length=1, max_length=160)]
+    risk: Literal["read", "write"]
+    mutability: Literal["read-only", "mutating"]
+    idempotency: Literal["idempotent", "idempotency-key", "non-idempotent"]
+    cancellation: Literal["before-dispatch", "cooperative", "none"]
+    undo: Literal[
+        "not-applicable", "ae-undo-group", "checkpoint-required", "none"
+    ]
+    side_effect_summary: Annotated[
+        StrictStr, Field(min_length=1, max_length=160)
+    ]
+    preconditions: tuple[
+        Annotated[StrictStr, Field(min_length=1, max_length=96)], ...
+    ] = Field(max_length=16)
+    compatibility: NativeCompatibility
+    input_contract_id: ContractId
+    result_contract_id: ContractId
+    contract_digest: Sha256
+    input_schema: dict[str, Any]
+    result_schema: dict[str, Any]
+    requirements: tuple[NativeRequirement, ...] = Field(min_length=1, max_length=32)
+    examples: tuple[dict[str, Any], ...] = Field(min_length=1, max_length=4)
+
+    @model_validator(mode="after")
+    def _closed_json_contracts(self) -> "NativeCapabilityDescriptor":
+        _validate_json(self.input_schema)
+        _validate_json(self.result_schema)
+        for example in self.examples:
+            _validate_json(example)
+        return self
+
+    @property
+    def engine(self) -> Literal["native-aegp"]:
+        """Core provenance; this is not a field accepted from the wire."""
+        return "native-aegp"
+
+
+class NativeNegotiation(_NativeModel):
+    selected_wire_version: Literal[1]
+    plugin_version: Annotated[StrictStr, Field(min_length=1, max_length=64)]
+    compiled_sdk_version: Annotated[StrictStr, Field(min_length=1, max_length=64)]
+    source_commit: SourceCommit
+    host_instance_id: Uuid
+    host_platform: NativePlatform
+    session_id: Uuid
+    session_generation: PositiveInt
+    capabilities_digest: Sha256
+
+
+class NativeCapabilities(_NativeModel):
+    session_id: Uuid
+    detail: Literal["full"]
+    items: tuple[NativeCapabilityDescriptor, ...] = Field(max_length=100)
+    next_cursor: None
+    query_digest: Sha256
+    capabilities_digest: Sha256
+
+    @model_validator(mode="after")
+    def _unique_capabilities(self) -> "NativeCapabilities":
+        identities = [
+            (item.capability_id, item.capability_version) for item in self.items
+        ]
+        if len(set(identities)) != len(identities):
+            raise ValueError("native capabilities must have unique identities")
+        return self
+
+
+class NativeInvokeRequest(_NativeModel):
+    request_id: RequestId
+    capability_id: CapabilityId
+    capability_version: PositiveInt
+    arguments: dict[str, Any]
+    deadline_unix_ms: PositiveInt
+
+    @model_validator(mode="after")
+    def _closed_arguments(self) -> "NativeInvokeRequest":
+        _validate_json(self.arguments)
+        return self
+
+
+class NativePostconditionEvidence(_NativeModel):
+    verified: Literal[True]
+    kind: Annotated[
+        StrictStr,
+        Field(min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_-]*$"),
+    ]
+    algorithm: Literal["sha256-rfc8785-jcs-v1"]
+    digest: Sha256
+
+
+class NativeUndoEvidence(_NativeModel):
+    available: StrictBool
+    verified: StrictBool
+    group_id: Annotated[StrictStr, Field(min_length=1, max_length=128)] | None = None
+
+
+class NativeExecutionEvidence(_NativeModel):
+    engine: Literal["native-aegp"]
+    host_instance_id: Uuid
+    session_id: Uuid
+    request_id: RequestId
+    capability_id: CapabilityId
+    capability_version: PositiveInt
+    started_at_unix_ms: PositiveInt
+    completed_at_unix_ms: PositiveInt
+    effect: Literal["none", "committed"]
+    request_digest: Sha256
+    postcondition: NativePostconditionEvidence
+    undo: NativeUndoEvidence | None = None
+
+    @model_validator(mode="after")
+    def _ordered_times(self) -> "NativeExecutionEvidence":
+        if self.completed_at_unix_ms < self.started_at_unix_ms:
+            raise ValueError("native completion time precedes its start")
+        return self
+
+
+class NativeInvokeResult(_NativeModel):
+    capability_id: CapabilityId
+    capability_version: PositiveInt
+    engine: Literal["native-aegp"]
+    outcome: Literal["succeeded"]
+    value: dict[str, Any]
+    evidence: NativeExecutionEvidence
+
+    @model_validator(mode="after")
+    def _matching_evidence(self) -> "NativeInvokeResult":
+        _validate_json(self.value)
+        if (
+            self.evidence.engine != self.engine
+            or self.evidence.capability_id != self.capability_id
+            or self.evidence.capability_version != self.capability_version
+        ):
+            raise ValueError("native result evidence does not match its result")
+        return self
+
+
+class NativeCancelResult(_NativeModel):
+    target_request_id: RequestId
+    state: Literal[
+        "queued-cancelled",
+        "running-cancel-requested",
+        "running-not-cancellable",
+        "already-terminal",
+        "not-found",
+    ]
+    terminal_response_expected: StrictBool
+
+    @model_validator(mode="after")
+    def _terminal_expectation_matches_state(self) -> "NativeCancelResult":
+        expected = self.state in {
+            "queued-cancelled",
+            "running-cancel-requested",
+            "running-not-cancellable",
+        }
+        if self.terminal_response_expected is not expected:
+            raise ValueError("native cancel terminal expectation is invalid")
+        return self
+
+
+class NativeRecovery(_NativeModel):
+    action: NativeRecoveryAction
+    hint: Annotated[StrictStr, Field(min_length=1, max_length=256)]
+    retry_after_ms: Annotated[StrictInt, Field(ge=1, le=30_000)] | None = None
+
+
+class NativeWireRange(_NativeModel):
+    minimum: Annotated[StrictInt, Field(ge=1, le=65_535)]
+    maximum: Annotated[StrictInt, Field(ge=1, le=65_535)]
+
+    @model_validator(mode="after")
+    def _ordered(self) -> "NativeWireRange":
+        if self.minimum > self.maximum:
+            raise ValueError("native wire range is reversed")
+        return self
+
+
+class NativeErrorDetails(_NativeModel):
+    field: Annotated[StrictStr, Field(min_length=1, max_length=128)] | None = None
+    capability_id: CapabilityId | None = None
+    supported_wire_versions: NativeWireRange | None = None
+    current_generation: PositiveInt | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _no_explicit_nulls(cls, value: Any) -> Any:
+        if isinstance(value, Mapping) and any(item is None for item in value.values()):
+            raise ValueError("native error detail fields cannot be null")
+        return value
+
+
+_ERROR_POLICY: dict[
+    NativeErrorCode,
+    tuple[bool, NativeSideEffect, NativeRecoveryAction],
+] = {
+    "NATIVE_UNAVAILABLE": (True, "not-started", "reconnect"),
+    "NATIVE_UNSUPPORTED": (False, "not-started", "refresh-capabilities"),
+    "NATIVE_CONTRACT_MISMATCH": (False, "not-started", "refresh-capabilities"),
+    "WIRE_VERSION_MISMATCH": (False, "not-started", "reconnect"),
+    "INVALID_REQUEST": (False, "not-started", "none"),
+    "INVALID_ARGUMENT": (False, "not-started", "change-arguments"),
+    "DUPLICATE_REQUEST": (False, "not-started", "inspect-state"),
+    "PRECONDITION_FAILED": (False, "not-started", "open-project"),
+    "STALE_LOCATOR": (True, "not-started", "refresh-locator"),
+    "DEADLINE_EXCEEDED": (True, "not-started", "retry"),
+    "CANCELLED": (False, "not-started", "none"),
+    "QUEUE_FULL": (True, "not-started", "retry"),
+    "AE_SHUTTING_DOWN": (True, "not-started", "reconnect"),
+    "SESSION_STALE": (True, "not-started", "reconnect"),
+    "CAPABILITY_FAILED": (False, "not-started", "inspect-state"),
+    "POSSIBLY_SIDE_EFFECTING_FAILURE": (
+        False,
+        "may-have-occurred",
+        "inspect-state",
+    ),
+}
+_CAPABILITY_DETAIL_ERROR_CODES = {
+    "NATIVE_UNSUPPORTED",
+    "PRECONDITION_FAILED",
+    "STALE_LOCATOR",
+    "CAPABILITY_FAILED",
+    "POSSIBLY_SIDE_EFFECTING_FAILURE",
+}
+
+
+class NativeErrorPayload(_NativeModel):
+    code: NativeErrorCode
+    message: Annotated[StrictStr, Field(min_length=1, max_length=512)]
+    retryable: StrictBool
+    side_effect: NativeSideEffect
+    recovery: NativeRecovery
+    details: NativeErrorDetails | None = None
+
+    @model_validator(mode="after")
+    def _policy_matches_code(self) -> "NativeErrorPayload":
+        expected = _ERROR_POLICY[self.code]
+        actual = (self.retryable, self.side_effect, self.recovery.action)
+        if actual != expected:
+            raise ValueError("native error policy does not match its code")
+        if self.code == "QUEUE_FULL":
+            if self.recovery.retry_after_ms is None:
+                raise ValueError("QUEUE_FULL requires retryAfterMs")
+        elif self.recovery.retry_after_ms is not None:
+            raise ValueError("retryAfterMs is only valid for QUEUE_FULL")
+        if self.details is not None:
+            _validate_json(
+                self.details.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    exclude_none=True,
+                )
+            )
+        return self
+
+
+class NativeBackendError(BackendError):
+    """Structured native failure; fields are safe to propagate without guessing."""
+
+    def __init__(
+        self,
+        payload_or_code: NativeErrorPayload | NativeErrorCode,
+        message: str | None = None,
+        *,
+        retryable: bool | None = None,
+        side_effect: NativeSideEffect | None = None,
+        recovery: NativeRecovery | Mapping[str, Any] | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        if isinstance(payload_or_code, NativeErrorPayload):
+            payload = payload_or_code
+        else:
+            if message is None or retryable is None or side_effect is None or recovery is None:
+                raise TypeError("structured native errors require every policy field")
+            payload = NativeErrorPayload(
+                code=payload_or_code,
+                message=message,
+                retryable=retryable,
+                side_effect=side_effect,
+                recovery=recovery,
+                details=dict(details) if details is not None else None,
+            )
+        self.payload = payload
+        self.code = payload.code
+        self.retryable = payload.retryable
+        self.side_effect = payload.side_effect
+        self.recovery = payload.recovery
+        self.details = (
+            payload.details.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            )
+            if payload.details is not None
+            else None
+        )
+        super().__init__(payload.message)
+
+    @classmethod
+    def from_payload(cls, value: Mapping[str, Any]) -> "NativeBackendError":
+        try:
+            raw = dict(value)
+            if raw.get("code") == "NATIVE_CONTRACT_MISMATCH":
+                raise ValueError("Core-only error code appeared on the native wire")
+            if "details" in raw and raw["details"] is None:
+                raise ValueError("native wire error details cannot be null")
+            payload = NativeErrorPayload.model_validate(raw)
+            if payload.code == "WIRE_VERSION_MISMATCH":
+                if (
+                    payload.details is None
+                    or payload.details.supported_wire_versions is None
+                ):
+                    raise ValueError(
+                        "WIRE_VERSION_MISMATCH requires supportedWireVersions"
+                    )
+            elif payload.code in _CAPABILITY_DETAIL_ERROR_CODES:
+                if payload.details is None or payload.details.capability_id is None:
+                    raise ValueError(
+                        f"{payload.code} requires a capabilityId detail"
+                    )
+        except (TypeError, ValueError, ValidationError) as exc:
+            raise cls(
+                "NATIVE_CONTRACT_MISMATCH",
+                "Native error payload did not match the negotiated wire contract.",
+                retryable=False,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="refresh-capabilities",
+                    hint="Refresh negotiated native capabilities before retrying.",
+                ),
+            ) from exc
+        return cls(payload)
+
+    def public_dict(self) -> dict[str, Any]:
+        return self.payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+class NativeCancellationToken:
+    """In-process cancellation signal forwarded to a native transport."""
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._event.is_set()
+
+    def cancel(self) -> None:
+        self._event.set()
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
+class NativeInvokeBackend(ABC):
+    """Validated native transport contract, intentionally unrelated to JSX.
+
+    Implementations own framing, authentication, outer-envelope validation,
+    and conversion of malformed wire data into ``NativeBackendError``.  Models
+    returned here are the validated Core projection, never unchecked JSON.
+    """
+
+    name: str
+
+    @abstractmethod
+    async def negotiate(
+        self,
+        *,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeNegotiation:
+        """Negotiate one authenticated native session."""
+
+    @abstractmethod
+    async def capabilities(
+        self,
+        *,
+        ids: tuple[str, ...] | None,
+        detail: CapabilityDetail,
+        limit: int,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeCapabilities:
+        """Return session-bound descriptors; ``ids=None`` requests the registry."""
+
+    @abstractmethod
+    async def invoke(
+        self,
+        request: NativeInvokeRequest,
+        *,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeInvokeResult:
+        """Invoke one typed native capability; raw source text is impossible."""
+
+    async def cancel(
+        self,
+        target_request_id: str,
+        *,
+        deadline_unix_ms: int,
+    ) -> NativeCancelResult:
+        """Cancel when supported; the default fails explicitly before dispatch."""
+        del target_request_id, deadline_unix_ms
+        raise NativeBackendError(
+            "NATIVE_UNSUPPORTED",
+            "This native transport does not expose cancellation.",
+            retryable=False,
+            side_effect="not-started",
+            recovery=NativeRecovery(
+                action="refresh-capabilities",
+                hint="Inspect the negotiated cancellation contract before retrying.",
+            ),
+        )
+
+
+PROJECT_SUMMARY_CAPABILITY_ID = "ae.project.summary"
+PROJECT_SUMMARY_CAPABILITY_VERSION = 1
+PROJECT_SUMMARY_INPUT_CONTRACT_ID = "aemcp.contract.ae.project.summary.input.v1"
+PROJECT_SUMMARY_RESULT_CONTRACT_ID = "aemcp.contract.ae.project.summary.result.v1"
+PROJECT_SUMMARY_CONTRACT_DIGEST = (
+    "baecd602479045f71288b2a7e0df645d4a5313453a34b89ced07178867ccaf9a"
+)
+_PROJECT_SUMMARY_INPUT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [],
+    "properties": {},
+}
+_PROJECT_SUMMARY_RESULT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["projectOpen", "projectName", "itemCount"],
+    "properties": {
+        "projectOpen": {"type": "boolean"},
+        "projectName": {"type": "string", "maxLength": 1024},
+        "itemCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": _SAFE_MAX,
+        },
+    },
+}
+
+
+class ProjectSummaryValue(_NativeModel):
+    project_open: StrictBool
+    project_name: Annotated[StrictStr, Field(max_length=1024)]
+    item_count: NonNegativeInt
+
+
+class ProjectSummaryExecution(_NativeModel):
+    implementation: NativeCapabilityDescriptor
+    negotiation: NativeNegotiation
+    value: ProjectSummaryValue
+    evidence: NativeExecutionEvidence
+    engine: Literal["native-aegp"] = "native-aegp"
+
+    @property
+    def project_open(self) -> bool:
+        return self.value.project_open
+
+    @property
+    def project_name(self) -> str:
+        return self.value.project_name
+
+    @property
+    def item_count(self) -> int:
+        return self.value.item_count
+
+    def audit_fields(self) -> dict[str, Any]:
+        """Bounded native fields for a future broker audit record."""
+        return {
+            "engine": self.engine,
+            "capabilityId": self.evidence.capability_id,
+            "capabilityVersion": self.evidence.capability_version,
+            "contractDigest": self.implementation.contract_digest,
+            "selectedWireVersion": self.negotiation.selected_wire_version,
+            "pluginVersion": self.negotiation.plugin_version,
+            "compiledSdkVersion": self.negotiation.compiled_sdk_version,
+            "sourceCommit": self.negotiation.source_commit,
+            "hostInstanceId": self.evidence.host_instance_id,
+            "sessionId": self.evidence.session_id,
+            "sessionGeneration": self.negotiation.session_generation,
+            "capabilitiesDigest": self.negotiation.capabilities_digest,
+            "requestId": self.evidence.request_id,
+            "effect": self.evidence.effect,
+            "requestDigest": self.evidence.request_digest,
+            "postconditionAlgorithm": self.evidence.postcondition.algorithm,
+            "postconditionDigest": self.evidence.postcondition.digest,
+            "startedAtUnixMs": self.evidence.started_at_unix_ms,
+            "completedAtUnixMs": self.evidence.completed_at_unix_ms,
+        }
+
+
+def _structured_error(code: NativeErrorCode, message: str) -> NativeBackendError:
+    retryable, side_effect, action = _ERROR_POLICY[code]
+    return NativeBackendError(
+        code,
+        message,
+        retryable=retryable,
+        side_effect=side_effect,
+        recovery=NativeRecovery(
+            action=action,
+            hint=(
+                "Refresh negotiated native capabilities before retrying."
+                if action == "refresh-capabilities"
+                else "Issue a new request only if the result is still needed."
+                if action == "none"
+                else "Retry only after the caller re-evaluates this failure."
+            ),
+        ),
+    )
+
+
+def _ensure_active(
+    deadline_unix_ms: int,
+    cancellation: NativeCancellationToken | None,
+) -> None:
+    if cancellation is not None and cancellation.is_cancelled:
+        raise _structured_error("CANCELLED", "Native request was cancelled before dispatch.")
+    if deadline_unix_ms <= int(time.time() * 1000):
+        raise _structured_error(
+            "DEADLINE_EXCEEDED",
+            "Native request deadline elapsed before dispatch.",
+        )
+
+
+def _validate_project_summary_descriptor(
+    descriptor: NativeCapabilityDescriptor,
+    *,
+    host_platform: NativePlatform,
+) -> None:
+    schemas_digest = _sha256_closed_json(
+        {
+            "inputSchema": descriptor.input_schema,
+            "resultSchema": descriptor.result_schema,
+        }
+    )
+    expected = (
+        descriptor.capability_id == PROJECT_SUMMARY_CAPABILITY_ID
+        and descriptor.capability_version == PROJECT_SUMMARY_CAPABILITY_VERSION
+        and descriptor.engine == "native-aegp"
+        and descriptor.risk == "read"
+        and descriptor.mutability == "read-only"
+        and descriptor.idempotency == "idempotent"
+        and descriptor.cancellation == "before-dispatch"
+        and descriptor.undo == "not-applicable"
+        and descriptor.input_contract_id == PROJECT_SUMMARY_INPUT_CONTRACT_ID
+        and descriptor.result_contract_id == PROJECT_SUMMARY_RESULT_CONTRACT_ID
+        and descriptor.contract_digest == PROJECT_SUMMARY_CONTRACT_DIGEST
+        and schemas_digest == descriptor.contract_digest
+        and descriptor.input_schema == _PROJECT_SUMMARY_INPUT_SCHEMA
+        and descriptor.result_schema == _PROJECT_SUMMARY_RESULT_SCHEMA
+        and host_platform in descriptor.compatibility.intended_platforms
+    )
+    if not expected:
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Negotiated ae.project.summary contract does not match Core.",
+        )
+
+
+def _sha256_closed_json(value: Any) -> str:
+    # All object member names in this closed contract are ASCII, so Python's
+    # lexical key order is identical to RFC 8785's UTF-16 order here.
+    canonical = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _project_summary_digest(value: ProjectSummaryValue) -> str:
+    return _sha256_closed_json(
+        {
+            "capabilityId": PROJECT_SUMMARY_CAPABILITY_ID,
+            "capabilityVersion": PROJECT_SUMMARY_CAPABILITY_VERSION,
+            "value": value.model_dump(mode="json", by_alias=True),
+        }
+    )
+
+
+def _capabilities_query_digest(
+    *,
+    session_id: str,
+    ids: tuple[str, ...] | None,
+    detail: CapabilityDetail,
+    limit: int,
+) -> str:
+    return _sha256_closed_json(
+        {
+            "sessionId": session_id,
+            "ids": list(ids) if ids is not None else None,
+            "detail": detail,
+            "limit": limit,
+        }
+    )
+
+
+def _capabilities_registry_digest(
+    items: tuple[NativeCapabilityDescriptor, ...],
+) -> str:
+    return _sha256_closed_json(
+        [
+            item.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            )
+            for item in items
+        ]
+    )
+
+
+def _invoke_request_digest(
+    request: NativeInvokeRequest,
+    negotiation: NativeNegotiation,
+) -> str:
+    return _sha256_closed_json(
+        {
+            "wireVersion": negotiation.selected_wire_version,
+            "kind": "request",
+            "sessionId": negotiation.session_id,
+            "requestId": request.request_id,
+            "method": "invoke",
+            "deadlineUnixMs": request.deadline_unix_ms,
+            "params": {
+                "capabilityId": request.capability_id,
+                "capabilityVersion": request.capability_version,
+                "arguments": request.arguments,
+            },
+        }
+    )
+
+
+def _validate_invoke_error_binding(
+    error: NativeBackendError,
+    request: NativeInvokeRequest,
+) -> None:
+    if error.code not in _CAPABILITY_DETAIL_ERROR_CODES:
+        return
+    capability_id = (error.details or {}).get("capabilityId")
+    if capability_id == request.capability_id:
+        return
+    if error.side_effect == "may-have-occurred":
+        raise NativeBackendError(
+            "POSSIBLY_SIDE_EFFECTING_FAILURE",
+            "Native failure was not bound to the requested capability; "
+            "side-effect uncertainty is preserved.",
+            retryable=False,
+            side_effect="may-have-occurred",
+            recovery=NativeRecovery(
+                action="inspect-state",
+                hint="Inspect project state before deciding whether to retry.",
+            ),
+            details={"capabilityId": request.capability_id},
+        ) from error
+    raise _structured_error(
+        "NATIVE_CONTRACT_MISMATCH",
+        "Native failure was not bound to the requested capability.",
+    ) from error
+
+
+async def invoke_project_summary(
+    backend: NativeInvokeBackend,
+    *,
+    request_id: str,
+    deadline_unix_ms: int,
+    cancellation: NativeCancellationToken | None = None,
+) -> ProjectSummaryExecution:
+    """Run the single #75 native binding; there is intentionally no fallback."""
+
+    _ensure_active(deadline_unix_ms, cancellation)
+    negotiation = await backend.negotiate(
+        deadline_unix_ms=deadline_unix_ms,
+        cancellation=cancellation,
+    )
+    _ensure_active(deadline_unix_ms, cancellation)
+    capability_ids: tuple[str, ...] | None = None
+    capability_detail: CapabilityDetail = "full"
+    capability_limit = 100
+    capabilities = await backend.capabilities(
+        ids=capability_ids,
+        detail=capability_detail,
+        limit=capability_limit,
+        deadline_unix_ms=deadline_unix_ms,
+        cancellation=cancellation,
+    )
+    expected_query_digest = _capabilities_query_digest(
+        session_id=negotiation.session_id,
+        ids=capability_ids,
+        detail=capability_detail,
+        limit=capability_limit,
+    )
+    try:
+        registry_digest = _capabilities_registry_digest(capabilities.items)
+    except (TypeError, ValueError, UnicodeError) as exc:
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Native capability registry could not be verified.",
+        ) from exc
+    if (
+        capabilities.session_id != negotiation.session_id
+        or capabilities.detail != capability_detail
+        or capabilities.next_cursor is not None
+        or capabilities.query_digest != expected_query_digest
+        or capabilities.capabilities_digest != registry_digest
+        or capabilities.capabilities_digest != negotiation.capabilities_digest
+    ):
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Native capabilities were not bound to the negotiated session.",
+        )
+    matching_descriptors = [
+        item
+        for item in capabilities.items
+        if item.capability_id == PROJECT_SUMMARY_CAPABILITY_ID
+        and item.capability_version == PROJECT_SUMMARY_CAPABILITY_VERSION
+    ]
+    descriptor = matching_descriptors[0] if len(matching_descriptors) == 1 else None
+    if descriptor is None:
+        raise _structured_error(
+            "NATIVE_UNSUPPORTED",
+            "Native host did not advertise ae.project.summary@1.",
+        )
+    _validate_project_summary_descriptor(
+        descriptor,
+        host_platform=negotiation.host_platform,
+    )
+    _ensure_active(deadline_unix_ms, cancellation)
+
+    request = NativeInvokeRequest(
+        request_id=request_id,
+        capability_id=PROJECT_SUMMARY_CAPABILITY_ID,
+        capability_version=PROJECT_SUMMARY_CAPABILITY_VERSION,
+        arguments={},
+        deadline_unix_ms=deadline_unix_ms,
+    )
+    try:
+        result = await backend.invoke(request, cancellation=cancellation)
+    except NativeBackendError as exc:
+        _validate_invoke_error_binding(exc, request)
+        raise
+    _ensure_active(deadline_unix_ms, cancellation)
+    expected_request_digest = _invoke_request_digest(request, negotiation)
+    if (
+        result.capability_id != request.capability_id
+        or result.capability_version != request.capability_version
+        or result.engine != "native-aegp"
+        or result.evidence.request_id != request.request_id
+        or result.evidence.host_instance_id != negotiation.host_instance_id
+        or result.evidence.session_id != negotiation.session_id
+        or result.evidence.effect != "none"
+        or result.evidence.undo is not None
+        or result.evidence.completed_at_unix_ms > deadline_unix_ms
+        or result.evidence.request_digest != expected_request_digest
+    ):
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Native project summary result did not match its negotiated request.",
+        )
+    try:
+        value = ProjectSummaryValue.model_validate(result.value)
+        postcondition_digest = _project_summary_digest(value)
+    except (ValidationError, TypeError, ValueError, UnicodeError) as exc:
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Native project summary value did not match its typed contract.",
+        ) from exc
+    if (
+        result.evidence.postcondition.kind != "project-summary"
+        or result.evidence.postcondition.digest != postcondition_digest
+    ):
+        raise _structured_error(
+            "NATIVE_CONTRACT_MISMATCH",
+            "Native project summary postcondition evidence did not verify.",
+        )
+    return ProjectSummaryExecution(
+        implementation=descriptor,
+        negotiation=negotiation,
+        value=value,
+        evidence=result.evidence,
+    )
+
+
+__all__ = [
+    "CapabilityDetail",
+    "ExecutionEngine",
+    "NativeBackendError",
+    "NativeCancellationToken",
+    "NativeCancelResult",
+    "NativeCapabilities",
+    "NativeCapabilityDescriptor",
+    "NativeCompatibility",
+    "NativeErrorCode",
+    "NativeErrorDetails",
+    "NativeErrorPayload",
+    "NativeExecutionEvidence",
+    "NativeInvokeBackend",
+    "NativeInvokeRequest",
+    "NativeInvokeResult",
+    "NativeNegotiation",
+    "NativePostconditionEvidence",
+    "NativePlatform",
+    "NativeRecovery",
+    "NativeRecoveryAction",
+    "NativeRequirement",
+    "NativeSideEffect",
+    "NativeUndoEvidence",
+    "NativeWireErrorCode",
+    "NativeWireRange",
+    "ProjectSummaryExecution",
+    "ProjectSummaryValue",
+    "PROJECT_SUMMARY_CAPABILITY_ID",
+    "PROJECT_SUMMARY_CAPABILITY_VERSION",
+    "PROJECT_SUMMARY_CONTRACT_DIGEST",
+    "invoke_project_summary",
+]

--- a/packages/core/ae_mcp/handlers/status.py
+++ b/packages/core/ae_mcp/handlers/status.py
@@ -12,6 +12,7 @@ import httpx
 
 from ae_mcp import progress, schemas
 from ae_mcp.backends import discovery as _backend_discovery
+from ae_mcp.backends.base import EXECUTION_ENGINES
 from ae_mcp.handlers import register
 from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.jsx_result import parse_jsx_result as _try_json
@@ -40,6 +41,9 @@ async def _run_status(args: schemas.AeStatusArgs, ctx: Any) -> dict[str, Any]:
         "backend": None,
         "backendError": None,
         "installedBackends": [],
+        "selectedAdapter": None,
+        "activeExecutionEngine": None,
+        "knownExecutionEngines": list(EXECUTION_ENGINES),
         "snapshotter": None,
     }
 
@@ -58,6 +62,7 @@ async def _run_status(args: schemas.AeStatusArgs, ctx: Any) -> dict[str, Any]:
     else:
         result["ok"] = True
         result["backend"] = backend.__class__.__name__
+        result["selectedAdapter"] = "legacy-extendscript"
 
     try:
         snapshotter = _snapshot_discovery.select_snapshotter()

--- a/packages/core/ae_mcp/tool_audit.py
+++ b/packages/core/ae_mcp/tool_audit.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, cast
 
+from ae_mcp.backends.base import EXECUTION_ENGINES, ExecutionEngine
 from ae_mcp.tool_artifact import JsonValue, canonical_json_bytes
 
 
@@ -85,9 +86,14 @@ class AuditRecord:
     started_at: int
     finished_at: int
     error_code: str | None = None
+    engine: ExecutionEngine | None = None
+
+    def __post_init__(self) -> None:
+        if self.engine is not None and self.engine not in EXECUTION_ENGINES:
+            raise ValueError("audit execution engine is invalid")
 
     def public_dict(self) -> dict[str, JsonValue]:
-        return {
+        value: dict[str, JsonValue] = {
             "artifactId": self.artifact_id,
             "contentHash": self.content_hash,
             "planHash": self.plan_hash,
@@ -103,6 +109,9 @@ class AuditRecord:
             "finishedAt": self.finished_at,
             "errorCode": self.error_code,
         }
+        if self.engine is not None:
+            value["engine"] = self.engine
+        return value
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "AuditRecord":
@@ -110,6 +119,9 @@ class AuditRecord:
         target = value.get("target", {})
         if not isinstance(args, Mapping) or not isinstance(target, Mapping):
             raise ValueError("audit args and target must be objects")
+        engine = value.get("engine")
+        if engine is not None and engine not in EXECUTION_ENGINES:
+            raise ValueError("audit execution engine is invalid")
         return cls(
             artifact_id=str(value["artifactId"]),
             content_hash=str(value["contentHash"]),
@@ -125,6 +137,7 @@ class AuditRecord:
             started_at=int(value["startedAt"]),
             finished_at=int(value["finishedAt"]),
             error_code=cast(str | None, value.get("errorCode")),
+            engine=cast(ExecutionEngine | None, engine),
         )
 
 

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -967,6 +967,7 @@ class ToolExecutionEngine:
             started_at=started_at,
             finished_at=self._now(),
             error_code=error_code,
+            engine=("maintained-jsx" if backend is not None else None),
         )
         self.audit_log.append(record)
 

--- a/packages/core/tests/test_backend_base.py
+++ b/packages/core/tests/test_backend_base.py
@@ -1,6 +1,6 @@
-"""Unit tests for the Backend abstract base class."""
+"""Unit tests for the legacy ExtendScript backend boundary."""
 import pytest
-from ae_mcp.backends.base import Backend, ALL_VERBS
+from ae_mcp.backends.base import ALL_VERBS, Backend, LegacyExtendScriptBackend
 
 
 def test_all_verbs_constant_has_42_entries():
@@ -21,6 +21,21 @@ def test_all_verbs_constant_has_42_entries():
 def test_cannot_instantiate_backend_directly():
     with pytest.raises(TypeError):
         Backend()
+
+
+def test_backend_compatibility_name_remains_an_explicit_legacy_jsx_adapter():
+    assert issubclass(Backend, LegacyExtendScriptBackend)
+
+
+def test_legacy_jsx_provenance_distinguishes_maintained_and_ephemeral_code():
+    assert (
+        LegacyExtendScriptBackend.execution_engine_for(ephemeral=False)
+        == "maintained-jsx"
+    )
+    assert (
+        LegacyExtendScriptBackend.execution_engine_for(ephemeral=True)
+        == "ephemeral-jsx"
+    )
 
 
 def test_backend_subclass_must_define_exec_health_from_env():

--- a/packages/core/tests/test_native_backend_contract.py
+++ b/packages/core/tests/test_native_backend_contract.py
@@ -1,0 +1,748 @@
+"""Contract tests for Core's native AEGP invocation boundary.
+
+The checked-in protocol fixtures are synthetic contract vectors.  They are
+useful here because Core must preserve their typed policy and provenance, but
+they are not evidence that After Effects or the native plug-in ran.
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from ae_mcp.backends.base import LegacyExtendScriptBackend
+from ae_mcp.backends.native import (
+    NativeBackendError,
+    NativeCancellationToken,
+    NativeCapabilities,
+    NativeCapabilityDescriptor,
+    NativeInvokeBackend,
+    NativeInvokeRequest,
+    NativeInvokeResult,
+    NativeNegotiation,
+    ProjectSummaryExecution,
+    invoke_project_summary,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "native" / "ae-plugin" / "protocol" / "fixtures"
+PROJECT_SUMMARY_CONTRACT_DIGEST = (
+    "baecd602479045f71288b2a7e0df645d4a5313453a34b89ced07178867ccaf9a"
+)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_ROOT / name).read_text(encoding="utf-8"))
+
+
+def _jcs_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _descriptor() -> NativeCapabilityDescriptor:
+    raw = _fixture("capabilities.json")["response"]["result"]["items"][0]
+    # The model deliberately accepts protocol aliases (id/version and camel
+    # case) so transport adapters need no lossy hand-written field mapping.
+    return NativeCapabilityDescriptor.model_validate(raw)
+
+
+def _capabilities(
+    descriptor: NativeCapabilityDescriptor | None = None,
+) -> NativeCapabilities:
+    response = _fixture("capabilities.json")["response"]
+    result = response["result"]
+    return NativeCapabilities(
+        session_id=response["sessionId"],
+        detail=result["detail"],
+        items=(descriptor or _descriptor(),),
+        next_cursor=result["nextCursor"],
+        query_digest=_jcs_digest(
+            {
+                "sessionId": response["sessionId"],
+                "ids": None,
+                "detail": "full",
+                "limit": 100,
+            }
+        ),
+        capabilities_digest=result["capabilitiesDigest"],
+    )
+
+
+def _negotiation() -> NativeNegotiation:
+    result = _fixture("hello.json")["response"]["result"]
+    return NativeNegotiation(
+        selected_wire_version=result["selectedWireVersion"],
+        plugin_version=result["pluginVersion"],
+        compiled_sdk_version=result["compiledSdk"]["version"],
+        source_commit="0" * 40,
+        host_instance_id=result["host"]["instanceId"],
+        host_platform=result["host"]["platform"],
+        session_id=result["sessionId"],
+        session_generation=result["sessionGeneration"],
+        capabilities_digest=result["capabilitiesDigest"],
+    )
+
+
+def _invoke_result() -> NativeInvokeResult:
+    raw = _fixture("invoke-project-summary.json")["response"]["result"]
+    return NativeInvokeResult(
+        capability_id=raw["capabilityId"],
+        capability_version=raw["capabilityVersion"],
+        engine=raw["engine"],
+        outcome=raw["outcome"],
+        value=raw["value"],
+        evidence=raw["evidence"],
+    )
+
+
+def _invoke_result_with_evidence(**updates: Any) -> NativeInvokeResult:
+    raw = _fixture("invoke-project-summary.json")["response"]["result"]
+    evidence = dict(raw["evidence"])
+    evidence.update(updates)
+    return NativeInvokeResult(
+        capability_id=raw["capabilityId"],
+        capability_version=raw["capabilityVersion"],
+        engine=raw["engine"],
+        outcome=raw["outcome"],
+        value=raw["value"],
+        evidence=evidence,
+    )
+
+
+def _native_error(
+    name: str,
+    *,
+    capability_id: str | None = None,
+) -> NativeBackendError:
+    raw = _fixture("errors.json")["responses"][name]["error"]
+    if capability_id is not None:
+        raw["details"]["capabilityId"] = capability_id
+    return NativeBackendError.from_payload(raw)
+
+
+class FixtureNativeBackend(NativeInvokeBackend):
+    """Transport-free fake that exposes every call made by the binding."""
+
+    name = "fixture-native"
+
+    def __init__(
+        self,
+        *,
+        descriptor: NativeCapabilityDescriptor | None = None,
+        result: NativeInvokeResult | None = None,
+        invoke_error: NativeBackendError | None = None,
+    ) -> None:
+        self.negotiation = _negotiation()
+        self.capability_page = _capabilities(descriptor)
+        self.result = result or _invoke_result()
+        self.invoke_error = invoke_error
+        self.calls: list[tuple[str, Any]] = []
+        self.legacy_exec_calls: list[str] = []
+
+    async def negotiate(
+        self,
+        *,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeNegotiation:
+        self.calls.append(("negotiate", (deadline_unix_ms, cancellation)))
+        return self.negotiation
+
+    async def capabilities(
+        self,
+        *,
+        ids: tuple[str, ...] | None,
+        detail: str,
+        limit: int,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeCapabilities:
+        self.calls.append(
+            (
+                "capabilities",
+                (ids, detail, limit, deadline_unix_ms, cancellation),
+            )
+        )
+        return self.capability_page
+
+    async def invoke(
+        self,
+        request: NativeInvokeRequest,
+        *,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeInvokeResult:
+        self.calls.append(("invoke", (request, cancellation)))
+        if self.invoke_error is not None:
+            raise self.invoke_error
+        return self.result
+
+    async def cancel(
+        self,
+        target_request_id: str,
+        *,
+        deadline_unix_ms: int,
+    ) -> object:
+        self.calls.append(("cancel", (target_request_id, deadline_unix_ms)))
+        return {
+            "targetRequestId": target_request_id,
+            "state": "queued-cancelled",
+            "terminalResponseExpected": True,
+        }
+
+    async def exec(self, code: str, **_: Any) -> str:
+        """Tripwire: native bindings must never route through raw JSX."""
+        self.legacy_exec_calls.append(code)
+        raise AssertionError("native project summary attempted legacy JSX execution")
+
+
+class NoCancellationBackend(NativeInvokeBackend):
+    """Minimal implementation that intentionally uses the default cancel path."""
+
+    name = "no-cancellation"
+
+    async def negotiate(
+        self,
+        *,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeNegotiation:
+        raise AssertionError("negotiate is not part of this cancellation test")
+
+    async def capabilities(
+        self,
+        *,
+        ids: tuple[str, ...] | None,
+        detail: str,
+        limit: int,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeCapabilities:
+        raise AssertionError("capabilities is not part of this cancellation test")
+
+    async def invoke(
+        self,
+        request: NativeInvokeRequest,
+        *,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeInvokeResult:
+        raise AssertionError("invoke is not part of this cancellation test")
+
+
+def test_fixture_models_preserve_descriptor_result_and_error_policy():
+    descriptor = _descriptor()
+    result = _invoke_result()
+    error = _native_error("possiblySideEffecting")
+
+    assert descriptor.capability_id == "ae.project.summary"
+    assert descriptor.capability_version == 1
+    assert descriptor.contract_digest == PROJECT_SUMMARY_CONTRACT_DIGEST
+    assert descriptor.risk == "read"
+    assert descriptor.mutability == "read-only"
+    assert descriptor.idempotency == "idempotent"
+    assert descriptor.cancellation == "before-dispatch"
+    assert descriptor.undo == "not-applicable"
+    assert descriptor.input_schema == {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [],
+        "properties": {},
+    }
+
+    assert result.capability_id == descriptor.capability_id
+    assert result.capability_version == descriptor.capability_version
+    assert result.engine == "native-aegp"
+    assert result.evidence.engine == "native-aegp"
+    assert result.evidence.effect == "none"
+    assert result.evidence.postcondition.verified is True
+
+    assert error.code == "POSSIBLY_SIDE_EFFECTING_FAILURE"
+    assert error.retryable is False
+    assert error.side_effect == "may-have-occurred"
+    assert error.recovery.action == "inspect-state"
+    assert error.details == {"capabilityId": "ae.project.set_current_time"}
+
+
+def test_native_descriptor_cannot_be_relabelled_as_jsx():
+    raw = _fixture("capabilities.json")["response"]["result"]["items"][0]
+    raw["engine"] = "maintained-jsx"
+
+    with pytest.raises(ValidationError):
+        NativeCapabilityDescriptor.model_validate(raw)
+
+
+def test_all_wire_error_fixtures_preserve_their_closed_details():
+    responses = _fixture("errors.json")["responses"]
+
+    parsed = {
+        name: NativeBackendError.from_payload(response["error"])
+        for name, response in responses.items()
+    }
+
+    assert parsed["wireVersionMismatch"].details == {
+        "supportedWireVersions": {"minimum": 1, "maximum": 1}
+    }
+    assert parsed["staleLocator"].details == {
+        "field": "arguments.layer",
+        "capabilityId": "ae.layer.inspect",
+        "currentGeneration": 8,
+    }
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(
+            lambda raw: raw.update({"code": "NATIVE_CONTRACT_MISMATCH"}),
+            id="core-only-code",
+        ),
+        pytest.param(
+            lambda raw: raw.update({"details": None}),
+            id="explicit-null-details",
+        ),
+        pytest.param(
+            lambda raw: raw["details"].update({"unknown": True}),
+            id="unknown-detail",
+        ),
+        pytest.param(
+            lambda raw: raw.pop("details"),
+            id="missing-required-capability-detail",
+        ),
+    ],
+)
+def test_invalid_wire_error_is_mapped_to_structured_contract_mismatch(mutate):
+    raw = _fixture("errors.json")["responses"]["possiblySideEffecting"]["error"]
+    mutate(raw)
+
+    with pytest.raises(NativeBackendError) as raised:
+        NativeBackendError.from_payload(raw)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "refresh-capabilities"
+
+
+def test_wire_version_error_requires_supported_range_detail():
+    raw = _fixture("errors.json")["responses"]["wireVersionMismatch"]["error"]
+    raw.pop("details")
+
+    with pytest.raises(NativeBackendError) as raised:
+        NativeBackendError.from_payload(raw)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_project_summary_binding_is_explicit_native_and_deadline_bound():
+    backend = FixtureNativeBackend()
+    cancellation = NativeCancellationToken()
+    deadline_unix_ms = 1_900_000_005_000
+
+    execution = await invoke_project_summary(
+        backend,
+        request_id="invoke-summary-1",
+        deadline_unix_ms=deadline_unix_ms,
+        cancellation=cancellation,
+    )
+
+    assert isinstance(execution, ProjectSummaryExecution)
+    assert execution.project_open is False
+    assert execution.project_name == "SYNTHETIC_CONTRACT_VECTOR"
+    assert execution.item_count == 0
+    assert execution.engine == "native-aegp"
+    assert execution.implementation.capability_id == "ae.project.summary"
+    assert (
+        execution.implementation.contract_digest
+        == PROJECT_SUMMARY_CONTRACT_DIGEST
+    )
+    assert execution.negotiation.session_id == _negotiation().session_id
+    assert execution.evidence.postcondition.verified is True
+    assert execution.audit_fields() == {
+        "engine": "native-aegp",
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "contractDigest": PROJECT_SUMMARY_CONTRACT_DIGEST,
+        "selectedWireVersion": 1,
+        "pluginVersion": "0.0.0-synthetic",
+        "compiledSdkVersion": "0.0.0",
+        "sourceCommit": "0" * 40,
+        "hostInstanceId": "22222222-2222-4222-8222-222222222222",
+        "sessionId": "11111111-1111-4111-8111-111111111111",
+        "sessionGeneration": 1,
+        "capabilitiesDigest": (
+            "778a01733fcf37510f56894a46ec5bd87"
+            "c7429de2e06d2d5eafb4cdbbae88557"
+        ),
+        "requestId": "invoke-summary-1",
+        "effect": "none",
+        "requestDigest": (
+            "9df120d0b016b1313035b94329245474"
+            "a0dc31bad5c0383a9ecde11db5fbdc8f"
+        ),
+        "postconditionAlgorithm": "sha256-rfc8785-jcs-v1",
+        "postconditionDigest": (
+            "64a69b209d2948d0766fe54b07a34af2"
+            "0e007a1c9884315b109e3019d5f6f433"
+        ),
+        "startedAtUnixMs": 1_900_000_000_000,
+        "completedAtUnixMs": 1_900_000_000_025,
+    }
+
+    assert [name for name, _ in backend.calls] == [
+        "negotiate",
+        "capabilities",
+        "invoke",
+    ]
+    assert backend.calls[0][1] == (deadline_unix_ms, cancellation)
+    assert backend.calls[1][1] == (
+        None,
+        "full",
+        100,
+        deadline_unix_ms,
+        cancellation,
+    )
+    request, invoke_cancellation = backend.calls[2][1]
+    assert request == NativeInvokeRequest(
+        request_id="invoke-summary-1",
+        capability_id="ae.project.summary",
+        capability_version=1,
+        arguments={},
+        deadline_unix_ms=deadline_unix_ms,
+    )
+    assert invoke_cancellation is cancellation
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_untrusted_descriptor_before_dispatch():
+    raw = _fixture("capabilities.json")["response"]["result"]["items"][0]
+    raw["contractDigest"] = "f" * 64
+    backend = FixtureNativeBackend(
+        descriptor=NativeCapabilityDescriptor.model_validate(raw)
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="bad-contract",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "refresh-capabilities"
+    assert [name for name, _ in backend.calls] == ["negotiate", "capabilities"]
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_unbound_capabilities_query_digest():
+    backend = FixtureNativeBackend()
+    backend.capability_page = backend.capability_page.model_copy(
+        update={"query_digest": "0" * 64}
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="bad-query-digest",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert [name for name, _ in backend.calls] == ["negotiate", "capabilities"]
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_unbound_registry_digest():
+    backend = FixtureNativeBackend()
+    backend.capability_page = backend.capability_page.model_copy(
+        update={"capabilities_digest": "0" * 64}
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="bad-registry-digest",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert [name for name, _ in backend.calls] == ["negotiate", "capabilities"]
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_schema_tampering_before_dispatch():
+    raw = _fixture("capabilities.json")["response"]["result"]["items"][0]
+    raw["resultSchema"]["properties"]["itemCount"]["maximum"] = 10
+    backend = FixtureNativeBackend(
+        descriptor=NativeCapabilityDescriptor.model_validate(raw)
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="tampered-result-schema",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert [name for name, _ in backend.calls] == ["negotiate", "capabilities"]
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_incompatible_host_before_dispatch():
+    raw = _fixture("capabilities.json")["response"]["result"]["items"][0]
+    raw["compatibility"]["intendedPlatforms"] = ["windows-x64"]
+    backend = FixtureNativeBackend(
+        descriptor=NativeCapabilityDescriptor.model_validate(raw)
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="incompatible-host",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert [name for name, _ in backend.calls] == ["negotiate", "capabilities"]
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_summary_rejects_result_bound_to_another_request():
+    fixture_result = _fixture("invoke-project-summary.json")["response"]["result"]
+    evidence = dict(fixture_result["evidence"])
+    evidence["requestId"] = "different-native-request"
+    backend = FixtureNativeBackend(
+        result=NativeInvokeResult(
+            capability_id=fixture_result["capabilityId"],
+            capability_version=fixture_result["capabilityVersion"],
+            engine=fixture_result["engine"],
+            outcome=fixture_result["outcome"],
+            value=fixture_result["value"],
+            evidence=evidence,
+        )
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="invalid-result-evidence",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "not-started"
+    assert [name for name, _ in backend.calls].count("invoke") == 1
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "evidence_update",
+    [
+        pytest.param({"requestDigest": "0" * 64}, id="request-digest"),
+        pytest.param(
+            {"completedAtUnixMs": 1_900_000_005_001},
+            id="completed-after-deadline",
+        ),
+        pytest.param(
+            {"undo": {"available": False, "verified": False}},
+            id="unexpected-read-undo",
+        ),
+    ],
+)
+async def test_project_summary_rejects_unbound_execution_evidence(
+    evidence_update: dict[str, Any],
+):
+    backend = FixtureNativeBackend(
+        result=_invoke_result_with_evidence(**evidence_update)
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="invoke-summary-1",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.side_effect == "not-started"
+    assert [name for name, _ in backend.calls].count("invoke") == 1
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_summary_maps_invalid_value_to_structured_contract_error():
+    raw = _fixture("invoke-project-summary.json")["response"]["result"]
+    invalid_result = NativeInvokeResult(
+        capability_id=raw["capabilityId"],
+        capability_version=raw["capabilityVersion"],
+        engine=raw["engine"],
+        outcome=raw["outcome"],
+        value={"projectOpen": False, "projectName": "missing item count"},
+        evidence=raw["evidence"],
+    )
+    backend = FixtureNativeBackend(result=invalid_result)
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="invoke-summary-1",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.recovery.action == "refresh-capabilities"
+
+
+@pytest.mark.asyncio
+async def test_native_failure_is_not_retried_or_fallen_back_to_legacy_exec():
+    expected = _native_error(
+        "possiblySideEffecting",
+        capability_id="ae.project.summary",
+    )
+    backend = FixtureNativeBackend(invoke_error=expected)
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="possibly-side-effecting",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value is expected
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "may-have-occurred"
+    assert [name for name, _ in backend.calls].count("invoke") == 1
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_mismatched_invoke_error_preserves_side_effect_uncertainty():
+    backend = FixtureNativeBackend(
+        invoke_error=_native_error("possiblySideEffecting")
+    )
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="invoke-summary-1",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "POSSIBLY_SIDE_EFFECTING_FAILURE"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "may-have-occurred"
+    assert raised.value.recovery.action == "inspect-state"
+    assert raised.value.details == {"capabilityId": "ae.project.summary"}
+    assert raised.value.__cause__ is backend.invoke_error
+    assert [name for name, _ in backend.calls].count("invoke") == 1
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_safe_mismatched_invoke_error_becomes_contract_mismatch():
+    backend = FixtureNativeBackend(invoke_error=_native_error("staleLocator"))
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="invoke-summary-1",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.__cause__ is backend.invoke_error
+
+
+def test_native_boundary_has_no_legacy_inheritance_fallback_or_resolver():
+    assert not issubclass(NativeInvokeBackend, LegacyExtendScriptBackend)
+    parameters = inspect.signature(invoke_project_summary).parameters
+    assert "legacy_backend" not in parameters
+    assert "fallback" not in parameters
+    assert "resolver" not in parameters
+
+
+@pytest.mark.asyncio
+async def test_cancellation_token_is_observable_without_transport_coupling():
+    token = NativeCancellationToken()
+    assert token.is_cancelled is False
+
+    token.cancel()
+
+    assert token.is_cancelled is True
+    await token.wait()
+
+
+@pytest.mark.asyncio
+async def test_pre_cancelled_project_summary_fails_before_negotiation():
+    backend = FixtureNativeBackend()
+    token = NativeCancellationToken()
+    token.cancel()
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="cancel-before-negotiate",
+            deadline_unix_ms=1_900_000_005_000,
+            cancellation=token,
+        )
+
+    assert raised.value.code == "CANCELLED"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "none"
+    assert backend.calls == []
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_expired_project_summary_deadline_fails_before_negotiation():
+    backend = FixtureNativeBackend()
+
+    with pytest.raises(NativeBackendError) as raised:
+        await invoke_project_summary(
+            backend,
+            request_id="deadline-before-negotiate",
+            deadline_unix_ms=1,
+        )
+
+    assert raised.value.code == "DEADLINE_EXCEEDED"
+    assert raised.value.retryable is True
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "retry"
+    assert backend.calls == []
+    assert backend.legacy_exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_default_native_cancel_fails_explicitly_when_not_supported():
+    with pytest.raises(NativeBackendError) as raised:
+        await NoCancellationBackend().cancel(
+            "invoke-summary-1",
+            deadline_unix_ms=1_900_000_005_000,
+        )
+
+    assert raised.value.code == "NATIVE_UNSUPPORTED"
+    assert raised.value.retryable is False
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "refresh-capabilities"

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -32,6 +32,13 @@ async def test_status_tool_is_only_exposed_when_backend_selection_fails(monkeypa
     assert result["ok"] is False
     assert "pip install" in result["backendError"]
     assert result["backend"] is None
+    assert result["selectedAdapter"] is None
+    assert result["activeExecutionEngine"] is None
+    assert result["knownExecutionEngines"] == [
+        "native-aegp",
+        "maintained-jsx",
+        "ephemeral-jsx",
+    ]
 
 
 @pytest.mark.asyncio
@@ -52,6 +59,13 @@ async def test_status_tool_reports_backend_and_supported_verbs(monkeypatch):
     assert result["backend"] == "MockBackend"
     assert result["backendError"] is None
     assert result["installedBackends"] == ["mock"]
+    assert result["selectedAdapter"] == "legacy-extendscript"
+    assert result["activeExecutionEngine"] is None
+    assert result["knownExecutionEngines"] == [
+        "native-aegp",
+        "maintained-jsx",
+        "ephemeral-jsx",
+    ]
 
 
 def test_filtered_tool_names_ignores_snapshotter_selection_exceptions(monkeypatch):

--- a/packages/core/tests/test_tool_audit.py
+++ b/packages/core/tests/test_tool_audit.py
@@ -26,6 +26,7 @@ def _record(index: int, **overrides) -> AuditRecord:
         "started_at": index,
         "finished_at": index + 1,
         "error_code": None,
+        "engine": "maintained-jsx",
     }
     values.update(overrides)
     return AuditRecord(**values)
@@ -48,9 +49,33 @@ def test_audit_round_trip_contains_required_fields_and_no_rendered_content(
     assert wire["grantId"] == "grant-1"
     assert wire["grantScope"] == "once"
     assert wire["backend"] == "mock"
+    assert wire["engine"] == "maintained-jsx"
     assert wire["outcome"] == "success"
     assert "rendered" not in wire
     assert "content" not in wire
+
+
+def test_audit_reads_legacy_records_without_engine_and_rejects_unknown_engine():
+    legacy = _record(1).public_dict()
+    legacy.pop("engine")
+    assert AuditRecord.from_dict(legacy).engine is None
+
+    invalid = _record(1).public_dict()
+    invalid["engine"] = "backend-name-is-not-an-engine"
+    with pytest.raises(ValueError, match="execution engine"):
+        AuditRecord.from_dict(invalid)
+
+    with pytest.raises(ValueError, match="execution engine"):
+        _record(1, engine="backend-name-is-not-an-engine")
+
+
+@pytest.mark.parametrize(
+    "engine",
+    ["native-aegp", "maintained-jsx", "ephemeral-jsx"],
+)
+def test_audit_round_trips_each_execution_engine(engine: str):
+    record = _record(1, engine=engine)
+    assert AuditRecord.from_dict(record.public_dict()).engine == engine
 
 
 def test_audit_redacts_sensitive_values_and_secret_shaped_keys(tmp_path: Path) -> None:
@@ -99,7 +124,8 @@ def test_audit_rotation_retains_at_most_three_generations(tmp_path: Path) -> Non
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are not authoritative on Windows")
 def test_audit_generations_are_owner_only(tmp_path: Path) -> None:
-    log = ToolAuditLog(tmp_path, max_bytes=500, generations=3)
+    line_size = len(json.dumps(_record(0).public_dict(), separators=(",", ":"))) + 1
+    log = ToolAuditLog(tmp_path, max_bytes=line_size * 2 + 20, generations=3)
     for index in range(8):
         log.append(_record(index))
 

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -767,5 +767,6 @@ async def test_backend_failure_audit_keeps_backend_name_and_no_exception_text(
     persisted = (tmp_path / "audit.jsonl").read_text(encoding="utf-8")
     assert caught.value.code == "tool_backend_failed"
     assert record.backend == "audit-backend"
+    assert record.engine == "maintained-jsx"
     assert record.outcome == "backend-error"
     assert private_error not in persisted


### PR DESCRIPTION
Refs #75. Parent epic: #61.

#91 is merged into `main`. This PR was rebased as one independent #75 commit onto exact `main` commit `e2549c34bd218945c52be0eec76d3bbfd29184e3`. The downstream public native read (#93) and audited undoable native write (#94) have already passed their real-host gates on the same content tree; each will still receive its own fresh CI and post-merge `main` verification.

## What changed

- Split the existing raw-JSX backend contract into the explicit `LegacyExtendScriptBackend` adapter while preserving `Backend` as a compatibility subclass.
- Added an independent typed `NativeInvokeBackend` contract for authenticated negotiate, full-registry capabilities, invoke, and cancel.
- Added the single explicit `ae.project.summary@1` native binding required by #76. It never constructs JSX, never selects an engine, and never falls back.
- Added strict Core projections for capability metadata, compatibility, structured errors/recovery, execution evidence, deadline/cancellation, and native provenance.
- Recompute and bind the capabilities query digest, full registry digest, complete invoke request digest, contract digest, and postcondition digest.
- Fail closed on transcript/session/host/capability mismatches, late completion, unexpected undo evidence, invalid typed values, or malformed wire errors.
- Preserve `POSSIBLY_SIDE_EFFECTING_FAILURE` as non-retryable when a malformed transcript leaves side effects uncertain.
- Added explicit `native-aegp | maintained-jsx | ephemeral-jsx` engine fields to audit/status without introducing a resolver.

## Deliberately out of scope

- No AEGP/JSX resolver, scoring, fallback, Provider work, public MCP tool, or HTTP/CEP native transport adapter.
- #76 extends the CEP surface and implements this validated transport contract. For the full-registry query, `ids=None` means omit `ids` on the wire; the normalized query digest contains `ids:null`.
- The checked-in JSON fixtures are synthetic contract vectors, not real-host execution evidence.

## Verification

- Original full workspace: **676 passed, 4 skipped, 25 deselected**.
- Rebased-head focused Core/protocol suite: **103 passed**.
- Native RPC protocol suite: **28 passed** (included above).
- Python compileall: passed.
- `git diff --check`: passed.
- Rebase tree remained exactly `48f23f5f3b6991586f0d6337fbfb2436a5d34e7c`.
- Two prior independent reviews: **NO BLOCKER** after fixes for request/capabilities digest binding, deadline/undo evidence, closed wire errors, capability-scoped failures, audit, and status.

## Merge gate

Merge only after the fresh CI for rebased head `a7e24f8bcf25c1e449493a3c0c4115c01b8a047f` passes. Then verify the squash-merged `main` commit before starting #76.