### PR TITLE
feat(native): expose verified AEGP project summary through public MCP

### DIFF
--- a/native/ae-plugin/protocol/fixtures/broker-http-errors.json
+++ b/native/ae-plugin/protocol/fixtures/broker-http-errors.json
@@ -1,0 +1,36 @@
+{
+  "authRequired": {
+    "name": "native AUTH_REQUIRED distinct from loopback token auth",
+    "status": 401,
+    "body": {
+      "ok": false,
+      "error": {
+        "code": "AUTH_REQUIRED",
+        "message": "native pairing was rejected",
+        "retryable": false,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "approve-pairing",
+          "hint": "Approve the matching fingerprint in After Effects, then retry."
+        }
+      }
+    }
+  },
+  "contractMismatch": {
+    "name": "broker contract mismatch",
+    "status": 503,
+    "body": {
+      "ok": false,
+      "error": {
+        "code": "NATIVE_CONTRACT_MISMATCH",
+        "message": "native result evidence did not match the request",
+        "retryable": false,
+        "sideEffect": "not-started",
+        "recovery": {
+          "action": "refresh-capabilities",
+          "hint": "Refresh the authenticated native contract before retrying."
+        }
+      }
+    }
+  }
+}

--- a/packages/bridge/ae_mcp_bridge/__init__.py
+++ b/packages/bridge/ae_mcp_bridge/__init__.py
@@ -2,18 +2,33 @@
 from __future__ import annotations
 
 import os
+import re
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import httpx
 
 from ae_mcp import client_identity
 from ae_mcp.backends.base import Backend, BackendError
+from ae_mcp.backends.native import (
+    CapabilityDetail,
+    NativeBackendError,
+    NativeCancellationToken,
+    NativeCapabilities,
+    NativeInvokeBackend,
+    NativeInvokeRequest,
+    NativeInvokeResult,
+    NativeNegotiation,
+    NativeRecovery,
+)
 
 # Header carrying the shared-secret token on /exec requests. Must match the
 # header the Node host (plugin/host/server.js) checks.
 _TOKEN_HEADER = "X-AE-MCP-Token"
 _PY_VERSION_HEADER = "x-ae-mcp-python"
+_ERROR_CODE = re.compile(r"^[A-Z][A-Z0-9_]{2,63}$")
+_ERROR_FIELDS = {"code", "message", "retryable", "sideEffect", "recovery"}
 
 try:
     from importlib.metadata import version as _pkg_version
@@ -29,7 +44,7 @@ def _token_path() -> Path:
     return Path.home() / ".ae-mcp" / "auth-token"
 
 
-class HttpBridge(Backend):
+class HttpBridge(Backend, NativeInvokeBackend):
     name = "ae-mcp"
     manages_undo = False
     manages_checkpoints = False
@@ -72,6 +87,434 @@ class HttpBridge(Backend):
         self._token = token
         return token
 
+    def _headers(self, token: str) -> dict[str, str]:
+        return {
+            _TOKEN_HEADER: token,
+            client_identity.HEADER: client_identity.get_client(),
+            _PY_VERSION_HEADER: _PY_VERSION,
+        }
+
+    @staticmethod
+    def _contract_error(message: str) -> NativeBackendError:
+        return NativeBackendError(
+            "NATIVE_CONTRACT_MISMATCH",
+            message,
+            retryable=False,
+            side_effect="not-started",
+            recovery=NativeRecovery(
+                action="refresh-capabilities",
+                hint="Refresh the authenticated native contract before retrying.",
+            ),
+        )
+
+    @staticmethod
+    def _unavailable_error(message: str, hint: str) -> NativeBackendError:
+        return NativeBackendError(
+            "NATIVE_UNAVAILABLE",
+            message,
+            retryable=True,
+            side_effect="not-started",
+            recovery=NativeRecovery(action="reconnect", hint=hint),
+        )
+
+    @staticmethod
+    def _deadline_error(message: str) -> NativeBackendError:
+        return NativeBackendError(
+            "DEADLINE_EXCEEDED",
+            message,
+            retryable=True,
+            side_effect="not-started",
+            recovery=NativeRecovery(
+                action="retry",
+                hint="Issue a new request only if the native result is still needed.",
+            ),
+        )
+
+    @staticmethod
+    def _cancelled_error() -> NativeBackendError:
+        return NativeBackendError(
+            "CANCELLED",
+            "Native request was cancelled before HTTP dispatch.",
+            retryable=False,
+            side_effect="not-started",
+            recovery=NativeRecovery(
+                action="none",
+                hint="Issue a new request only if the native result is still needed.",
+            ),
+        )
+
+    @staticmethod
+    def _closed_error_payload(error: Any) -> dict[str, Any]:
+        if not isinstance(error, Mapping):
+            raise ValueError("native failure error is not an object")
+        raw = dict(error)
+        keys = set(raw)
+        if keys != _ERROR_FIELDS and keys != _ERROR_FIELDS | {"details"}:
+            raise ValueError("native failure error fields are not closed")
+        code = raw.get("code")
+        message = raw.get("message")
+        retryable = raw.get("retryable")
+        side_effect = raw.get("sideEffect")
+        recovery = raw.get("recovery")
+        if not isinstance(code, str) or _ERROR_CODE.fullmatch(code) is None:
+            raise ValueError("native failure code is invalid")
+        if not isinstance(message, str) or not 1 <= len(message) <= 512:
+            raise ValueError("native failure message is invalid")
+        if not isinstance(retryable, bool):
+            raise ValueError("native failure retryable is invalid")
+        if side_effect not in {"not-started", "may-have-occurred", "completed"}:
+            raise ValueError("native failure sideEffect is invalid")
+        if not isinstance(recovery, Mapping) or set(recovery) not in (
+            {"action", "hint"},
+            {"action", "hint", "retryAfterMs"},
+        ):
+            raise ValueError("native failure recovery fields are not closed")
+        action = recovery.get("action")
+        hint = recovery.get("hint")
+        if not isinstance(action, str) or not 1 <= len(action) <= 64:
+            raise ValueError("native failure recovery action is invalid")
+        if not isinstance(hint, str) or not 1 <= len(hint) <= 256:
+            raise ValueError("native failure recovery hint is invalid")
+        if "retryAfterMs" in recovery and (
+            not isinstance(recovery["retryAfterMs"], int)
+            or isinstance(recovery["retryAfterMs"], bool)
+            or not 1 <= recovery["retryAfterMs"] <= 30_000
+        ):
+            raise ValueError("native failure recovery retryAfterMs is invalid")
+        if "details" in raw and not isinstance(raw["details"], Mapping):
+            raise ValueError("native failure details are invalid")
+        return raw
+
+    @staticmethod
+    def _matches_broker_policy(
+        raw: Mapping[str, Any],
+        *,
+        retryable: bool,
+        action: str,
+        status_code: int,
+        expected_status: int,
+    ) -> bool:
+        return (
+            status_code == expected_status
+            and set(raw) == _ERROR_FIELDS
+            and raw.get("retryable") is retryable
+            and raw.get("sideEffect") == "not-started"
+            and set(raw.get("recovery", {})) == {"action", "hint"}
+            and raw.get("recovery", {}).get("action") == action
+        )
+
+    def _native_failure(
+        self,
+        body: Mapping[str, Any],
+        *,
+        status_code: int,
+    ) -> NativeBackendError:
+        try:
+            raw_error = self._closed_error_payload(body.get("error"))
+        except ValueError:
+            return self._contract_error(
+                "CEP returned a malformed native failure error."
+            )
+        code = raw_error["code"]
+        expected_envelope = (
+            {"ok", "error", "pairing"}
+            if code == "NATIVE_PAIRING_REQUIRED"
+            else {"ok", "error"}
+        )
+        if body.get("ok") is not False or set(body) != expected_envelope:
+            return self._contract_error(
+                "CEP returned a native failure envelope with unexpected fields."
+            )
+        if not 400 <= status_code <= 599:
+            return self._contract_error(
+                "CEP returned a native failure envelope with a non-failing HTTP status."
+            )
+
+        # These failures are generated by the authenticated CEP broker rather
+        # than the AEGP wire. Map its access controls into the strict Core
+        # policy without leaking tokens or weakening the fail-closed boundary.
+        if code == "UNAUTHORIZED":
+            if not self._matches_broker_policy(
+                raw_error,
+                retryable=False,
+                action="reconnect",
+                status_code=status_code,
+                expected_status=401,
+            ):
+                return self._contract_error(
+                    "CEP returned an invalid broker authentication policy."
+                )
+            return NativeBackendError(
+                "NATIVE_BROKER_UNAUTHORIZED",
+                "The authenticated CEP native bridge rejected this session.",
+                retryable=False,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="refresh-auth",
+                    hint="Restart the panel to refresh its local token and native session.",
+                ),
+            )
+        if code == "CLIENT_BLOCKED":
+            if not self._matches_broker_policy(
+                raw_error,
+                retryable=False,
+                action="none",
+                status_code=status_code,
+                expected_status=403,
+            ):
+                return self._contract_error(
+                    "CEP returned an invalid client-block policy."
+                )
+            return NativeBackendError(
+                "NATIVE_CLIENT_BLOCKED",
+                "This MCP client is blocked by the After Effects panel.",
+                retryable=False,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="review-client-access",
+                    hint="Review this client's access in the panel before retrying.",
+                ),
+            )
+        if code == "ACTIONS_PAUSED":
+            if not self._matches_broker_policy(
+                raw_error,
+                retryable=True,
+                action="retry",
+                status_code=status_code,
+                expected_status=503,
+            ):
+                return self._contract_error(
+                    "CEP returned an invalid actions-paused policy."
+                )
+            return NativeBackendError(
+                "NATIVE_ACTIONS_PAUSED",
+                "Native actions are paused in the After Effects panel.",
+                retryable=True,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="resume-actions",
+                    hint="Resume AI actions in the panel, then retry.",
+                ),
+            )
+        if code == "AUTH_REQUIRED":
+            if not (
+                status_code == 401
+                and set(raw_error) == _ERROR_FIELDS
+                and raw_error["sideEffect"] == "not-started"
+                and set(raw_error["recovery"]) == {"action", "hint"}
+                and raw_error["recovery"]["action"] == "approve-pairing"
+            ):
+                return self._contract_error(
+                    "CEP returned an invalid native pairing outcome policy."
+                )
+            return NativeBackendError(
+                "NATIVE_PAIRING_REJECTED",
+                raw_error["message"],
+                retryable=True,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="retry-pairing",
+                    hint="Start a fresh native pairing request and approve it in After Effects.",
+                ),
+            )
+        if code == "NATIVE_CONTRACT_MISMATCH":
+            if not (
+                status_code == 503
+                and set(raw_error) == _ERROR_FIELDS
+                and raw_error["retryable"] is False
+                and raw_error["sideEffect"] == "not-started"
+                and set(raw_error["recovery"]) == {"action", "hint"}
+                and raw_error["recovery"]["action"] == "refresh-capabilities"
+            ):
+                return self._contract_error(
+                    "CEP returned a malformed internal contract-mismatch policy."
+                )
+            return self._contract_error(raw_error["message"])
+
+        if code == "NATIVE_PAIRING_REQUIRED":
+            if not (
+                status_code == 409
+                and set(raw_error) == _ERROR_FIELDS | {"details"}
+                and raw_error["retryable"] is True
+                and raw_error["sideEffect"] == "not-started"
+                and set(raw_error["recovery"]) == {"action", "hint"}
+                and raw_error["recovery"]["action"] == "approve-pairing"
+            ):
+                return self._contract_error(
+                    "CEP returned an invalid native pairing-required policy."
+                )
+            pairing = body.get("pairing")
+            if not isinstance(pairing, Mapping):
+                return self._contract_error(
+                    "CEP omitted the native pairing fingerprint and provenance."
+                )
+            projected = {
+                "pairingFingerprint": pairing.get("fingerprint"),
+                "pairingExpiresInMs": pairing.get("expiresInMs"),
+                "hostInstanceId": pairing.get("hostInstanceId"),
+                "sourceCommit": pairing.get("sourceCommit"),
+            }
+            if set(pairing) != {
+                "fingerprint", "expiresInMs", "hostInstanceId", "sourceCommit"
+            } or dict(raw_error["details"]) != projected:
+                return self._contract_error(
+                    "CEP returned inconsistent native pairing details."
+                )
+            message = raw_error.get("message")
+            return NativeBackendError(
+                "NATIVE_PAIRING_REQUIRED",
+                message,
+                retryable=True,
+                side_effect="not-started",
+                recovery=NativeRecovery(
+                    action="approve-pairing",
+                    hint="Approve the matching fingerprint in After Effects, then retry.",
+                ),
+                details=projected,
+            )
+
+        try:
+            return NativeBackendError.from_payload(raw_error)
+        except NativeBackendError as native_error:
+            return native_error
+
+    async def _native_post(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+        *,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None,
+    ) -> Mapping[str, Any]:
+        if cancellation is not None and cancellation.is_cancelled:
+            raise self._cancelled_error()
+        remaining = (deadline_unix_ms - int(time.time() * 1000)) / 1000.0
+        if remaining <= 0:
+            raise self._deadline_error(
+                "Native request deadline elapsed before HTTP dispatch."
+            )
+        try:
+            token = self._read_token()
+        except BackendError as error:
+            raise self._unavailable_error(
+                "The CEP authentication token is unavailable.",
+                "Start or restart the ae-mcp panel so it can refresh the local token.",
+            ) from error
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(remaining),
+                trust_env=False,
+            ) as http:
+                response = await http.post(
+                    f"{self.url}{path}",
+                    json=dict(payload),
+                    headers=self._headers(token),
+                )
+        except httpx.TimeoutException as error:
+            raise self._deadline_error(
+                "Authenticated CEP native request exceeded its deadline."
+            ) from error
+        except httpx.HTTPError as error:
+            raise self._unavailable_error(
+                "Authenticated CEP native transport is unavailable.",
+                "Confirm the panel is running, then reconnect and retry.",
+            ) from error
+
+        try:
+            body = response.json()
+        except ValueError as error:
+            raise self._contract_error(
+                "CEP returned non-JSON data for a native request."
+            ) from error
+        if not isinstance(body, Mapping):
+            raise self._contract_error(
+                "CEP returned a non-object native response envelope."
+            )
+        if body.get("ok") is False:
+            raise self._native_failure(body, status_code=response.status_code)
+        if response.status_code != 200:
+            raise self._contract_error(
+                "CEP returned a successful native envelope with a failing HTTP status."
+            )
+        if set(body) != {"ok", "result"} or body.get("ok") is not True:
+            raise self._contract_error(
+                "CEP returned an invalid native success envelope."
+            )
+        result = body.get("result")
+        if not isinstance(result, Mapping):
+            raise self._contract_error(
+                "CEP returned a native success envelope without an object result."
+            )
+        return result
+
+    async def negotiate(
+        self,
+        *,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeNegotiation:
+        raw = await self._native_post(
+            "/native/negotiate",
+            {"deadlineUnixMs": deadline_unix_ms},
+            deadline_unix_ms=deadline_unix_ms,
+            cancellation=cancellation,
+        )
+        try:
+            return NativeNegotiation.model_validate(raw)
+        except (TypeError, ValueError) as error:
+            raise self._contract_error(
+                "CEP native negotiation result failed Core validation."
+            ) from error
+
+    async def capabilities(
+        self,
+        *,
+        ids: tuple[str, ...] | None,
+        detail: CapabilityDetail,
+        limit: int,
+        deadline_unix_ms: int,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeCapabilities:
+        payload: dict[str, Any] = {
+            "detail": detail,
+            "limit": limit,
+            "deadlineUnixMs": deadline_unix_ms,
+        }
+        if ids is not None:
+            payload["ids"] = list(ids)
+        raw = await self._native_post(
+            "/native/capabilities",
+            payload,
+            deadline_unix_ms=deadline_unix_ms,
+            cancellation=cancellation,
+        )
+        try:
+            return NativeCapabilities.model_validate(raw)
+        except (TypeError, ValueError) as error:
+            raise self._contract_error(
+                "CEP native capabilities result failed Core validation."
+            ) from error
+
+    async def invoke(
+        self,
+        request: NativeInvokeRequest,
+        *,
+        cancellation: NativeCancellationToken | None = None,
+    ) -> NativeInvokeResult:
+        raw = await self._native_post(
+            "/native/invoke",
+            request.model_dump(mode="json", by_alias=True),
+            deadline_unix_ms=request.deadline_unix_ms,
+            cancellation=cancellation,
+        )
+        try:
+            return NativeInvokeResult.model_validate(raw)
+        except (TypeError, ValueError) as error:
+            raise self._contract_error(
+                "CEP native invocation result failed Core validation."
+            ) from error
+
     async def health_check(self, timeout_sec: float = 5.0) -> bool:
         # /health is unauthenticated (it executes no code), so no token needed.
         try:
@@ -100,11 +543,7 @@ class HttpBridge(Backend):
             "checkpointLabel": checkpoint_label,
             "timeoutMs": int(timeout_sec * 1000),
         }
-        headers = {
-            _TOKEN_HEADER: token,
-            client_identity.HEADER: client_identity.get_client(),
-            _PY_VERSION_HEADER: _PY_VERSION,
-        }
+        headers = self._headers(token)
         try:
             async with httpx.AsyncClient(
                 timeout=timeout_sec + 5.0,

--- a/packages/bridge/tests/test_http_native_bridge.py
+++ b/packages/bridge/tests/test_http_native_bridge.py
@@ -1,0 +1,442 @@
+"""Authenticated CEP HTTP adapter for the typed native Core contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import respx
+from httpx import Response
+
+import ae_mcp_bridge
+from ae_mcp.backends.native import (
+    NativeBackendError,
+    NativeCancellationToken,
+    NativeInvokeRequest,
+)
+from ae_mcp_bridge import HttpBridge
+
+
+_FIXTURES = Path(__file__).resolve().parents[3] / "native" / "ae-plugin" / "protocol" / "fixtures"
+_DEADLINE = 1_900_000_005_000
+_SESSION = "11111111-1111-4111-8111-111111111111"
+_HOST = "22222222-2222-4222-8222-222222222222"
+_SOURCE = "a" * 40
+
+
+@pytest.fixture
+def token_file(tmp_path, monkeypatch):
+    token = tmp_path / "auth-token"
+    token.write_text("native-test-token", encoding="utf-8")
+    monkeypatch.setattr(ae_mcp_bridge, "_token_path", lambda: token)
+    return token
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _broker_fixture(name: str) -> dict:
+    return _fixture("broker-http-errors.json")[name]
+
+
+def _negotiation() -> dict:
+    result = _fixture("hello.json")["response"]["result"]
+    return {
+        "selectedWireVersion": result["selectedWireVersion"],
+        "pluginVersion": result["pluginVersion"],
+        "compiledSdkVersion": result["compiledSdk"]["version"],
+        "sourceCommit": _SOURCE,
+        "hostInstanceId": result["host"]["instanceId"],
+        "hostPlatform": result["host"]["platform"],
+        "sessionId": result["sessionId"],
+        "sessionGeneration": result["sessionGeneration"],
+        "capabilitiesDigest": result["capabilitiesDigest"],
+    }
+
+
+def _capabilities() -> dict:
+    return {
+        "sessionId": _SESSION,
+        **_fixture("capabilities.json")["response"]["result"],
+    }
+
+
+def _invoke_result() -> dict:
+    return _fixture("invoke-project-summary.json")["response"]["result"]
+
+
+@pytest.mark.asyncio
+async def test_native_backend_posts_lossless_typed_contract(token_file):
+    captured: dict[str, dict] = {}
+
+    def respond(name: str, result: dict):
+        def _response(request):
+            captured[name] = {
+                "body": json.loads(request.content),
+                "token": request.headers.get("X-AE-MCP-Token"),
+                "client": request.headers.get("x-ae-mcp-client"),
+            }
+            return Response(200, json={"ok": True, "result": result})
+
+        return _response
+
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(side_effect=respond("negotiate", _negotiation()))
+        mock.post("/native/capabilities").mock(side_effect=respond("capabilities", _capabilities()))
+        mock.post("/native/invoke").mock(side_effect=respond("invoke", _invoke_result()))
+        backend = HttpBridge("http://127.0.0.1:11488")
+
+        negotiation = await backend.negotiate(deadline_unix_ms=_DEADLINE)
+        capabilities = await backend.capabilities(
+            ids=None,
+            detail="full",
+            limit=100,
+            deadline_unix_ms=_DEADLINE,
+        )
+        request = NativeInvokeRequest(
+            request_id="invoke-summary-1",
+            capability_id="ae.project.summary",
+            capability_version=1,
+            arguments={},
+            deadline_unix_ms=_DEADLINE,
+        )
+        result = await backend.invoke(request)
+
+    assert negotiation.host_instance_id == _HOST
+    assert capabilities.session_id == _SESSION
+    assert capabilities.items[0].capability_id == "ae.project.summary"
+    assert result.evidence.request_id == "invoke-summary-1"
+    assert captured["negotiate"]["body"] == {"deadlineUnixMs": _DEADLINE}
+    assert captured["capabilities"]["body"] == {
+        "detail": "full",
+        "limit": 100,
+        "deadlineUnixMs": _DEADLINE,
+    }
+    assert captured["invoke"]["body"] == request.model_dump(
+        mode="json", by_alias=True
+    )
+    assert all(item["token"] == "native-test-token" for item in captured.values())
+    assert all(item["client"] for item in captured.values())
+
+
+@pytest.mark.asyncio
+async def test_native_pairing_error_preserves_fingerprint_and_provenance(token_file):
+    pairing = {
+        "fingerprint": "12AB-34CD",
+        "expiresInMs": 60_000,
+        "hostInstanceId": _HOST,
+        "sourceCommit": _SOURCE,
+    }
+    error = {
+        "code": "NATIVE_PAIRING_REQUIRED",
+        "message": "Approve the matching fingerprint in After Effects.",
+        "retryable": True,
+        "sideEffect": "not-started",
+        "recovery": {
+            "action": "approve-pairing",
+            "hint": "Approve the fingerprint, then retry.",
+        },
+        "details": {
+            "pairingFingerprint": pairing["fingerprint"],
+            "pairingExpiresInMs": pairing["expiresInMs"],
+            "hostInstanceId": pairing["hostInstanceId"],
+            "sourceCommit": pairing["sourceCommit"],
+        },
+    }
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(
+                409,
+                json={"ok": False, "error": error, "pairing": pairing},
+            )
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_PAIRING_REQUIRED"
+    assert raised.value.retryable is True
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == "approve-pairing"
+    assert raised.value.details == error["details"]
+
+
+@pytest.mark.parametrize(
+    (
+        "status",
+        "host_code",
+        "host_retryable",
+        "host_action",
+        "expected_code",
+        "expected_action",
+    ),
+    [
+        (401, "UNAUTHORIZED", False, "reconnect", "NATIVE_BROKER_UNAUTHORIZED", "refresh-auth"),
+        (403, "CLIENT_BLOCKED", False, "none", "NATIVE_CLIENT_BLOCKED", "review-client-access"),
+        (503, "ACTIONS_PAUSED", True, "retry", "NATIVE_ACTIONS_PAUSED", "resume-actions"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_broker_gate_errors_map_to_core_policy(
+    token_file,
+    status: int,
+    host_code: str,
+    host_retryable: bool,
+    host_action: str,
+    expected_code: str,
+    expected_action: str,
+):
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(
+                status,
+                json={
+                    "ok": False,
+                    "error": {
+                        "code": host_code,
+                        "message": host_code,
+                        "retryable": host_retryable,
+                        "sideEffect": "not-started",
+                        "recovery": {
+                            "action": host_action,
+                            "hint": "broker-specific recovery",
+                        },
+                    },
+                },
+            )
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == expected_code
+    assert raised.value.side_effect == "not-started"
+    assert raised.value.recovery.action == expected_action
+
+
+@pytest.mark.parametrize("host_retryable", [False, True])
+@pytest.mark.asyncio
+async def test_internal_auth_required_is_a_fresh_pairing_outcome(
+    token_file,
+    host_retryable: bool,
+):
+    fixture = _broker_fixture("authRequired")
+    body = fixture["body"]
+    body["error"]["retryable"] = host_retryable
+    if host_retryable:
+        body["error"]["message"] = "native pairing was expired"
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(
+                fixture["status"],
+                json=body,
+            )
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_PAIRING_REJECTED"
+    assert raised.value.code != "NATIVE_BROKER_UNAUTHORIZED"
+    assert raised.value.recovery.action == "retry-pairing"
+    assert str(raised.value) == body["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_internal_contract_mismatch_maps_to_core_contract_error(token_file):
+    fixture = _broker_fixture("contractMismatch")
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(
+                fixture["status"],
+                json=fixture["body"],
+            )
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+    assert raised.value.recovery.action == "refresh-capabilities"
+    assert str(raised.value) == fixture["body"]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_true_native_wire_error_uses_strict_native_validator(token_file):
+    error = _fixture("errors.json")["responses"]["queueFull"]["error"]
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(503, json={"ok": False, "error": error})
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "QUEUE_FULL"
+    assert raised.value.recovery.action == "retry"
+    assert raised.value.recovery.retry_after_ms == 250
+
+
+@pytest.mark.asyncio
+async def test_pairing_failure_without_closed_pairing_envelope_fails_closed(token_file):
+    error = {
+        "code": "NATIVE_PAIRING_REQUIRED",
+        "message": "Pairing required.",
+        "retryable": True,
+        "sideEffect": "not-started",
+        "recovery": {
+            "action": "approve-pairing",
+            "hint": "Approve the matching fingerprint.",
+        },
+        "details": {
+            "pairingFingerprint": "12AB-34CD",
+            "pairingExpiresInMs": 60_000,
+            "hostInstanceId": _HOST,
+            "sourceCommit": _SOURCE,
+        },
+    }
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(409, json={"ok": False, "error": error})
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_failure_envelope_with_http_200_fails_closed(token_file):
+    body = {
+        "ok": False,
+        "error": {
+            "code": "UNAUTHORIZED",
+            "message": "unauthorized",
+            "retryable": False,
+            "sideEffect": "not-started",
+            "recovery": {"action": "reconnect", "hint": "Reload token."},
+        },
+    }
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(200, json=body)
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "ok": False,
+            "error": {
+                "code": "UNAUTHORIZED",
+                "message": "unauthorized",
+                "retryable": False,
+                "sideEffect": "not-started",
+                "recovery": {"action": "reconnect", "hint": "Reload token."},
+            },
+            "extra": True,
+        },
+        {
+            "ok": False,
+            "error": {
+                "code": "UNAUTHORIZED",
+                "message": "unauthorized",
+                "retryable": False,
+                "recovery": {"action": "reconnect", "hint": "Reload token."},
+            },
+        },
+        {
+            "ok": False,
+            "error": {
+                "code": "UNAUTHORIZED",
+                "message": "unauthorized",
+                "retryable": False,
+                "sideEffect": "not-started",
+                "recovery": {"action": "reconnect", "hint": "Reload token."},
+                "extra": True,
+            },
+        },
+        {
+            "ok": False,
+            "error": {
+                "code": "UNAUTHORIZED",
+                "message": "unauthorized",
+                "retryable": False,
+                "sideEffect": "not-started",
+                "recovery": {
+                    "action": "reconnect",
+                    "hint": "Reload token.",
+                    "extra": True,
+                },
+            },
+        },
+        {
+            "ok": False,
+            "error": {
+                "code": "ACTIONS_PAUSED",
+                "message": "paused",
+                "retryable": True,
+                "sideEffect": "not-started",
+                "recovery": {"action": "none", "hint": "Resume actions."},
+            },
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_broker_failure_envelopes_fail_closed(token_file, body):
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(503 if body["error"]["code"] == "ACTIONS_PAUSED" else 401, json=body)
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_native_success_envelope_fails_closed_on_extra_member(token_file):
+    async with respx.mock(base_url="http://127.0.0.1:11488") as mock:
+        mock.post("/native/negotiate").mock(
+            return_value=Response(
+                200,
+                json={"ok": True, "result": _negotiation(), "unchecked": True},
+            )
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(deadline_unix_ms=_DEADLINE)
+
+    assert raised.value.code == "NATIVE_CONTRACT_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_native_cancellation_before_dispatch_makes_no_http_request(token_file):
+    cancellation = NativeCancellationToken()
+    cancellation.cancel()
+    async with respx.mock(
+        base_url="http://127.0.0.1:11488",
+        assert_all_called=False,
+    ) as mock:
+        route = mock.post("/native/negotiate").mock(
+            return_value=Response(200, json={"ok": True, "result": _negotiation()})
+        )
+        backend = HttpBridge("http://127.0.0.1:11488")
+        with pytest.raises(NativeBackendError) as raised:
+            await backend.negotiate(
+                deadline_unix_ms=_DEADLINE,
+                cancellation=cancellation,
+            )
+
+    assert raised.value.code == "CANCELLED"
+    assert route.called is False

--- a/packages/core/ae_mcp/annotations.py
+++ b/packages/core/ae_mcp/annotations.py
@@ -25,6 +25,7 @@ def _ann(read_only: bool, destructive: bool, idempotent: bool) -> ToolAnnotation
 VERB_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "ae.init": _ann(True, False, True),
     "ae.overview": _ann(True, False, True),
+    "ae.projectSummary": _ann(True, False, True),
     "ae.layers": _ann(True, False, True),
     "ae.readProps": _ann(True, False, True),
     "ae.exec": _ann(False, True, False),

--- a/packages/core/ae_mcp/backends/native.py
+++ b/packages/core/ae_mcp/backends/native.py
@@ -40,6 +40,11 @@ NativeRecoveryAction: TypeAlias = Literal[
     "open-project",
     "change-arguments",
     "inspect-state",
+    "approve-pairing",
+    "retry-pairing",
+    "refresh-auth",
+    "review-client-access",
+    "resume-actions",
     "none",
 ]
 NativeWireErrorCode: TypeAlias = Literal[
@@ -59,8 +64,15 @@ NativeWireErrorCode: TypeAlias = Literal[
     "CAPABILITY_FAILED",
     "POSSIBLY_SIDE_EFFECTING_FAILURE",
 ]
-NativeErrorCode: TypeAlias = NativeWireErrorCode | Literal[
-    "NATIVE_CONTRACT_MISMATCH"
+NativeBrokerErrorCode: TypeAlias = Literal[
+    "NATIVE_PAIRING_REQUIRED",
+    "NATIVE_PAIRING_REJECTED",
+    "NATIVE_BROKER_UNAUTHORIZED",
+    "NATIVE_CLIENT_BLOCKED",
+    "NATIVE_ACTIONS_PAUSED",
+]
+NativeErrorCode: TypeAlias = NativeWireErrorCode | NativeBrokerErrorCode | Literal[
+    "NATIVE_CONTRACT_MISMATCH",
 ]
 NativePlatform: TypeAlias = Literal["macos-arm64", "windows-x64"]
 CapabilityDetail: TypeAlias = Literal["full"]
@@ -348,6 +360,13 @@ class NativeErrorDetails(_NativeModel):
     capability_id: CapabilityId | None = None
     supported_wire_versions: NativeWireRange | None = None
     current_generation: PositiveInt | None = None
+    pairing_fingerprint: Annotated[
+        StrictStr,
+        Field(pattern=r"^[0-9A-F]{4}(?:-[0-9A-F]{4})+$"),
+    ] | None = None
+    pairing_expires_in_ms: PositiveInt | None = None
+    host_instance_id: Uuid | None = None
+    source_commit: SourceCommit | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -364,6 +383,11 @@ _ERROR_POLICY: dict[
     "NATIVE_UNAVAILABLE": (True, "not-started", "reconnect"),
     "NATIVE_UNSUPPORTED": (False, "not-started", "refresh-capabilities"),
     "NATIVE_CONTRACT_MISMATCH": (False, "not-started", "refresh-capabilities"),
+    "NATIVE_PAIRING_REQUIRED": (True, "not-started", "approve-pairing"),
+    "NATIVE_PAIRING_REJECTED": (True, "not-started", "retry-pairing"),
+    "NATIVE_BROKER_UNAUTHORIZED": (False, "not-started", "refresh-auth"),
+    "NATIVE_CLIENT_BLOCKED": (False, "not-started", "review-client-access"),
+    "NATIVE_ACTIONS_PAUSED": (True, "not-started", "resume-actions"),
     "WIRE_VERSION_MISMATCH": (False, "not-started", "reconnect"),
     "INVALID_REQUEST": (False, "not-started", "none"),
     "INVALID_ARGUMENT": (False, "not-started", "change-arguments"),
@@ -410,6 +434,19 @@ class NativeErrorPayload(_NativeModel):
                 raise ValueError("QUEUE_FULL requires retryAfterMs")
         elif self.recovery.retry_after_ms is not None:
             raise ValueError("retryAfterMs is only valid for QUEUE_FULL")
+        pairing_values = (
+            self.details.pairing_fingerprint,
+            self.details.pairing_expires_in_ms,
+            self.details.host_instance_id,
+            self.details.source_commit,
+        ) if self.details is not None else (None, None, None, None)
+        if self.code == "NATIVE_PAIRING_REQUIRED":
+            if any(value is None for value in pairing_values):
+                raise ValueError(
+                    "NATIVE_PAIRING_REQUIRED requires complete pairing details"
+                )
+        elif any(value is not None for value in pairing_values):
+            raise ValueError("pairing details require NATIVE_PAIRING_REQUIRED")
         if self.details is not None:
             _validate_json(
                 self.details.model_dump(
@@ -467,7 +504,14 @@ class NativeBackendError(BackendError):
     def from_payload(cls, value: Mapping[str, Any]) -> "NativeBackendError":
         try:
             raw = dict(value)
-            if raw.get("code") == "NATIVE_CONTRACT_MISMATCH":
+            if raw.get("code") in {
+                "NATIVE_CONTRACT_MISMATCH",
+                "NATIVE_PAIRING_REQUIRED",
+                "NATIVE_PAIRING_REJECTED",
+                "NATIVE_BROKER_UNAUTHORIZED",
+                "NATIVE_CLIENT_BLOCKED",
+                "NATIVE_ACTIONS_PAUSED",
+            }:
                 raise ValueError("Core-only error code appeared on the native wire")
             if "details" in raw and raw["details"] is None:
                 raise ValueError("native wire error details cannot be null")
@@ -484,6 +528,11 @@ class NativeBackendError(BackendError):
                 if payload.details is None or payload.details.capability_id is None:
                     raise ValueError(
                         f"{payload.code} requires a capabilityId detail"
+                    )
+            elif payload.code == "NATIVE_PAIRING_REQUIRED":
+                if payload.details is None:
+                    raise ValueError(
+                        "NATIVE_PAIRING_REQUIRED requires pairing details"
                     )
         except (TypeError, ValueError, ValidationError) as exc:
             raise cls(
@@ -955,6 +1004,7 @@ __all__ = [
     "CapabilityDetail",
     "ExecutionEngine",
     "NativeBackendError",
+    "NativeBrokerErrorCode",
     "NativeCancellationToken",
     "NativeCancelResult",
     "NativeCapabilities",

--- a/packages/core/ae_mcp/handlers/__init__.py
+++ b/packages/core/ae_mcp/handlers/__init__.py
@@ -23,6 +23,7 @@ def load_all() -> None:
     """Import core + typed modules so they register their handlers."""
     # Imported for side effects (registration via @register or explicit register() calls).
     from ae_mcp.handlers import core  # noqa: F401
+    from ae_mcp.handlers import native  # noqa: F401
     from ae_mcp.handlers import status  # noqa: F401
     from ae_mcp.handlers import typed  # noqa: F401
     from ae_mcp.handlers import skills  # noqa: F401

--- a/packages/core/ae_mcp/handlers/native.py
+++ b/packages/core/ae_mcp/handlers/native.py
@@ -1,0 +1,126 @@
+"""Public MCP handlers explicitly bound to typed native AEGP capabilities."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+from ae_mcp import progress, schemas
+from ae_mcp.backends import discovery as _discovery
+from ae_mcp.backends.native import (
+    NativeBackendError,
+    NativeCancellationToken,
+    NativeInvokeBackend,
+    NativeRecovery,
+    invoke_project_summary,
+)
+from ae_mcp.handlers import register
+
+
+_PROJECT_SUMMARY_TIMEOUT_MS = 10_000
+
+
+def _backend() -> NativeInvokeBackend:
+    backend = _discovery.select_backend()
+    if isinstance(backend, NativeInvokeBackend):
+        return backend
+    raise NativeBackendError(
+        "NATIVE_UNAVAILABLE",
+        "The selected AE adapter does not expose the native AEGP execution plane.",
+        retryable=True,
+        side_effect="not-started",
+        recovery=NativeRecovery(
+            action="reconnect",
+            hint="Select the ae-mcp bridge with native AEGP support, then retry.",
+        ),
+    )
+
+
+async def _run_project_summary(
+    args: schemas.AeProjectSummaryArgs,
+    ctx: Any,
+) -> dict[str, Any]:
+    del args
+    cancellation = NativeCancellationToken()
+    deadline_unix_ms = int(time.time() * 1000) + _PROJECT_SUMMARY_TIMEOUT_MS
+    request_id = f"mcp-{uuid.uuid4().hex}"
+
+    async def _call():
+        return await invoke_project_summary(
+            _backend(),
+            request_id=request_id,
+            deadline_unix_ms=deadline_unix_ms,
+            cancellation=cancellation,
+        )
+
+    try:
+        execution = await progress.with_heartbeat(
+            ctx,
+            _call(),
+            start_msg="ae.projectSummary native AEGP read...",
+        )
+    except asyncio.CancelledError:
+        cancellation.cancel()
+        raise
+
+    implementation = execution.implementation
+    audit = execution.audit_fields()
+    return {
+        "ok": True,
+        "value": execution.value.model_dump(mode="json", by_alias=True),
+        "implementation": {
+            "engine": execution.engine,
+            "capabilityId": implementation.capability_id,
+            "capabilityVersion": implementation.capability_version,
+            "contractDigest": implementation.contract_digest,
+            "risk": implementation.risk,
+            "mutability": implementation.mutability,
+            "idempotency": implementation.idempotency,
+        },
+        "provenance": {
+            key: audit[key]
+            for key in (
+                "engine",
+                "selectedWireVersion",
+                "pluginVersion",
+                "compiledSdkVersion",
+                "sourceCommit",
+                "hostInstanceId",
+                "sessionId",
+                "sessionGeneration",
+                "capabilitiesDigest",
+            )
+        },
+        "audit": {
+            key: audit[key]
+            for key in (
+                "requestId",
+                "capabilityId",
+                "capabilityVersion",
+                "contractDigest",
+                "effect",
+                "requestDigest",
+                "postconditionAlgorithm",
+                "postconditionDigest",
+                "startedAtUnixMs",
+                "completedAtUnixMs",
+            )
+        },
+        "evidence": execution.evidence.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+        ),
+    }
+
+
+register(
+    "ae.projectSummary",
+    schemas.AeProjectSummaryArgs,
+    _run_project_summary,
+)
+
+
+__all__ = ["_run_project_summary"]

--- a/packages/core/ae_mcp/handlers/status.py
+++ b/packages/core/ae_mcp/handlers/status.py
@@ -13,6 +13,7 @@ import httpx
 from ae_mcp import progress, schemas
 from ae_mcp.backends import discovery as _backend_discovery
 from ae_mcp.backends.base import EXECUTION_ENGINES
+from ae_mcp.backends.native import NativeInvokeBackend
 from ae_mcp.handlers import register
 from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.jsx_result import parse_jsx_result as _try_json
@@ -44,6 +45,11 @@ async def _run_status(args: schemas.AeStatusArgs, ctx: Any) -> dict[str, Any]:
         "selectedAdapter": None,
         "activeExecutionEngine": None,
         "knownExecutionEngines": list(EXECUTION_ENGINES),
+        "nativeExecutionPlane": {
+            "available": False,
+            "adapter": None,
+            "engine": None,
+        },
         "snapshotter": None,
     }
 
@@ -63,6 +69,12 @@ async def _run_status(args: schemas.AeStatusArgs, ctx: Any) -> dict[str, Any]:
         result["ok"] = True
         result["backend"] = backend.__class__.__name__
         result["selectedAdapter"] = "legacy-extendscript"
+        if isinstance(backend, NativeInvokeBackend):
+            result["nativeExecutionPlane"] = {
+                "available": True,
+                "adapter": backend.__class__.__name__,
+                "engine": "native-aegp",
+            }
 
     try:
         snapshotter = _snapshot_discovery.select_snapshotter()

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -45,6 +45,16 @@ class AeOverviewArgs(_StrictModel):
     pass
 
 
+class AeProjectSummaryArgs(_StrictModel):
+    """ae.projectSummary — verified native AEGP project summary (no args).
+
+    This public tool is explicitly bound to ae.project.summary@1. It never
+    falls back to ae.overview or to JSX when the native execution plane is
+    unavailable.
+    """
+    pass
+
+
 class AeLayersArgs(_StrictModel):
     """ae.layers — list layers in a comp (paginated)."""
     comp_id: Optional[str] = Field(
@@ -602,6 +612,7 @@ class AeDiagnoseArgs(_StrictModel):
 SCHEMAS = {
     "ae.init": AeInitArgs,
     "ae.overview": AeOverviewArgs,
+    "ae.projectSummary": AeProjectSummaryArgs,
     "ae.layers": AeLayersArgs,
     "ae.readProps": AeReadPropsArgs,
     "ae.exec": AeExecArgs,
@@ -646,4 +657,4 @@ SCHEMAS = {
     "ae.createRig": AeCreateRigArgs,
 }
 
-assert len(SCHEMAS) == 44, f"expected 44 verbs, got {len(SCHEMAS)}"
+assert len(SCHEMAS) == 45, f"expected 45 verbs, got {len(SCHEMAS)}"

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -24,6 +24,7 @@ from mcp.types import CallToolResult, TextContent, Tool
 
 from ae_mcp import approval_gate, client_identity
 from ae_mcp.annotations import VERB_ANNOTATIONS
+from ae_mcp.backends.native import NativeBackendError, NativeInvokeBackend
 from ae_mcp.error_hints import append_hint
 from ae_mcp.handlers import HANDLERS, load_all
 from ae_mcp.instructions import SERVER_INSTRUCTIONS, build_server_instructions
@@ -77,6 +78,10 @@ def _filtered_tool_names() -> set:
         snapshotter = None
     if snapshotter is None:
         supported = supported - {"ae.snapshot"}
+    if isinstance(backend, NativeInvokeBackend):
+        supported = supported | {"ae.projectSummary"}
+    else:
+        supported = supported - {"ae.projectSummary"}
     return supported | {"ae.status", "ae.diagnose"}
 
 
@@ -264,6 +269,9 @@ def build_server() -> Server:
 
         try:
             result = await run_fn(validated, ctx)
+        except NativeBackendError as e:
+            log.info("native handler %s failed with %s", name, e.code)
+            result = {"ok": False, "error": e.public_dict()}
         except Exception as e:  # noqa: BLE001
             log.exception("handler %s raised", name)
             payload = _format_result({"ok": False, "error": append_hint(str(e))})
@@ -273,7 +281,9 @@ def build_server() -> Server:
             )
 
         if isinstance(result, dict) and result.get("ok") is False and "error" in result:
-            result = {**result, "error": append_hint(str(result["error"]))}
+            error = result["error"]
+            if isinstance(error, str):
+                result = {**result, "error": append_hint(error)}
 
         if isinstance(result, dict) and result.get("ok") is True:
             request_id = None

--- a/packages/core/tests/test_annotations.py
+++ b/packages/core/tests/test_annotations.py
@@ -19,6 +19,9 @@ def test_exec_is_destructive_and_reads_are_readonly():
     assert VERB_ANNOTATIONS["ae.exec"].readOnlyHint is False
     assert VERB_ANNOTATIONS["ae.overview"].readOnlyHint is True
     assert VERB_ANNOTATIONS["ae.overview"].destructiveHint is False
+    assert VERB_ANNOTATIONS["ae.projectSummary"].readOnlyHint is True
+    assert VERB_ANNOTATIONS["ae.projectSummary"].destructiveHint is False
+    assert VERB_ANNOTATIONS["ae.projectSummary"].idempotentHint is True
 
 
 def test_no_verb_is_both_readonly_and_destructive():

--- a/packages/core/tests/test_handlers_native.py
+++ b/packages/core/tests/test_handlers_native.py
@@ -1,0 +1,257 @@
+"""Public MCP surface for the explicitly bound native project-summary read."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ae_mcp import schemas
+from ae_mcp.backends.mock import MockBackend
+from ae_mcp.backends.native import (
+    NativeBackendError,
+    NativeCapabilities,
+    NativeCapabilityDescriptor,
+    NativeInvokeBackend,
+    NativeInvokeResult,
+    NativeNegotiation,
+    NativeRecovery,
+    ProjectSummaryExecution,
+    ProjectSummaryValue,
+)
+from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.handlers import native as native_handler
+
+
+_FIXTURES = Path(__file__).resolve().parents[3] / "native" / "ae-plugin" / "protocol" / "fixtures"
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _execution() -> ProjectSummaryExecution:
+    hello = _fixture("hello.json")["response"]["result"]
+    raw_result = _fixture("invoke-project-summary.json")["response"]["result"]
+    descriptor = NativeCapabilityDescriptor.model_validate(
+        _fixture("capabilities.json")["response"]["result"]["items"][0]
+    )
+    negotiation = NativeNegotiation(
+        selected_wire_version=hello["selectedWireVersion"],
+        plugin_version=hello["pluginVersion"],
+        compiled_sdk_version=hello["compiledSdk"]["version"],
+        source_commit="a" * 40,
+        host_instance_id=hello["host"]["instanceId"],
+        host_platform=hello["host"]["platform"],
+        session_id=hello["sessionId"],
+        session_generation=hello["sessionGeneration"],
+        capabilities_digest=hello["capabilitiesDigest"],
+    )
+    result = NativeInvokeResult.model_validate(raw_result)
+    return ProjectSummaryExecution(
+        implementation=descriptor,
+        negotiation=negotiation,
+        value=ProjectSummaryValue.model_validate(result.value),
+        evidence=result.evidence,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _load_handlers():
+    load_all()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_returns_typed_value_provenance_and_evidence(monkeypatch):
+    execution = _execution()
+    sentinel_backend = object()
+    captured: dict[str, Any] = {}
+
+    async def _invoke(backend, **kwargs):
+        captured["backend"] = backend
+        captured.update(kwargs)
+        return execution
+
+    monkeypatch.setattr(native_handler, "_backend", lambda: sentinel_backend)
+    monkeypatch.setattr(native_handler, "invoke_project_summary", _invoke)
+
+    result = await native_handler._run_project_summary(
+        schemas.AeProjectSummaryArgs(),
+        None,
+    )
+
+    assert captured["backend"] is sentinel_backend
+    assert captured["request_id"].startswith("mcp-")
+    assert captured["cancellation"].is_cancelled is False
+    assert result["ok"] is True
+    assert result["value"] == {
+        "projectOpen": False,
+        "projectName": "SYNTHETIC_CONTRACT_VECTOR",
+        "itemCount": 0,
+    }
+    assert result["implementation"] == {
+        "engine": "native-aegp",
+        "capabilityId": "ae.project.summary",
+        "capabilityVersion": 1,
+        "contractDigest": execution.implementation.contract_digest,
+        "risk": "read",
+        "mutability": "read-only",
+        "idempotency": "idempotent",
+    }
+    assert result["provenance"]["sourceCommit"] == "a" * 40
+    assert result["audit"]["requestId"] == "invoke-summary-1"
+    assert result["audit"]["effect"] == "none"
+    assert result["evidence"]["engine"] == "native-aegp"
+    assert result["evidence"]["postcondition"]["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_project_summary_never_falls_back_to_legacy_exec(monkeypatch):
+    legacy = MockBackend()
+    monkeypatch.setattr(native_handler._discovery, "select_backend", lambda: legacy)
+
+    with pytest.raises(NativeBackendError) as raised:
+        await native_handler._run_project_summary(
+            schemas.AeProjectSummaryArgs(),
+            None,
+        )
+
+    assert raised.value.code == "NATIVE_UNAVAILABLE"
+    assert legacy.calls == []
+
+
+def test_project_summary_registration_is_distinct_from_overview():
+    assert HANDLERS["ae.projectSummary"][0] is schemas.AeProjectSummaryArgs
+    assert HANDLERS["ae.projectSummary"][1] is not HANDLERS["ae.overview"][1]
+
+
+@pytest.mark.asyncio
+async def test_mcp_dispatch_preserves_structured_native_error(monkeypatch):
+    from ae_mcp import server as server_module
+
+    error = NativeBackendError(
+        "NATIVE_PAIRING_REQUIRED",
+        "Approve the matching fingerprint in After Effects.",
+        retryable=True,
+        side_effect="not-started",
+        recovery=NativeRecovery(
+            action="approve-pairing",
+            hint="Approve the fingerprint, then retry.",
+        ),
+        details={
+            "pairingFingerprint": "12AB-34CD",
+            "pairingExpiresInMs": 60_000,
+            "hostInstanceId": "22222222-2222-4222-8222-222222222222",
+            "sourceCommit": "a" * 40,
+        },
+    )
+
+    async def _raise(_args, _ctx):
+        raise error
+
+    monkeypatch.setitem(
+        HANDLERS,
+        "ae.projectSummary",
+        (schemas.AeProjectSummaryArgs, _raise),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_filtered_tool_names",
+        lambda: set(HANDLERS),
+    )
+    monkeypatch.setattr(
+        server_module.approval_gate,
+        "enforce",
+        lambda *_args, **_kwargs: _none(),
+    )
+
+    response = await server_module.build_server()._ae_call_tool(
+        "ae_projectSummary",
+        {},
+    )
+    payload = json.loads(response.content[0].text)
+
+    assert response.isError is True
+    assert payload["ok"] is False
+    assert isinstance(payload["error"], dict)
+    assert payload["error"]["code"] == "NATIVE_PAIRING_REQUIRED"
+    assert payload["error"]["details"]["pairingFingerprint"] == "12AB-34CD"
+
+
+@pytest.mark.asyncio
+async def test_mcp_dispatch_preserves_pairing_rejection_as_structured_error(monkeypatch):
+    from ae_mcp import server as server_module
+
+    error = NativeBackendError(
+        "NATIVE_PAIRING_REJECTED",
+        "Native pairing expired before authorization.",
+        retryable=True,
+        side_effect="not-started",
+        recovery=NativeRecovery(
+            action="retry-pairing",
+            hint="Start a fresh native pairing request and approve it in After Effects.",
+        ),
+    )
+
+    async def _raise(_args, _ctx):
+        raise error
+
+    monkeypatch.setitem(
+        HANDLERS,
+        "ae.projectSummary",
+        (schemas.AeProjectSummaryArgs, _raise),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_filtered_tool_names",
+        lambda: set(HANDLERS),
+    )
+    monkeypatch.setattr(
+        server_module.approval_gate,
+        "enforce",
+        lambda *_args, **_kwargs: _none(),
+    )
+
+    response = await server_module.build_server()._ae_call_tool(
+        "ae_projectSummary",
+        {},
+    )
+    payload = json.loads(response.content[0].text)
+
+    assert response.isError is True
+    assert payload["error"]["code"] == "NATIVE_PAIRING_REJECTED"
+    assert payload["error"]["recovery"]["action"] == "retry-pairing"
+
+
+async def _none():
+    return None
+
+
+class _NativeMock(MockBackend, NativeInvokeBackend):
+    async def negotiate(self, **_kwargs):
+        raise AssertionError("filtering must not negotiate")
+
+    async def capabilities(self, **_kwargs) -> NativeCapabilities:
+        raise AssertionError("filtering must not read capabilities")
+
+    async def invoke(self, *_args, **_kwargs) -> NativeInvokeResult:
+        raise AssertionError("filtering must not invoke")
+
+
+def test_tool_filter_exposes_native_read_only_for_native_adapter(monkeypatch):
+    from ae_mcp import server as server_module
+    from ae_mcp.backends import discovery as backend_discovery
+    from ae_mcp.snapshot import discovery as snapshot_discovery
+
+    monkeypatch.setattr(
+        snapshot_discovery,
+        "select_snapshotter",
+        lambda: None,
+    )
+    monkeypatch.setattr(backend_discovery, "select_backend", lambda: MockBackend())
+    assert "ae.projectSummary" not in server_module._filtered_tool_names()
+
+    monkeypatch.setattr(backend_discovery, "select_backend", lambda: _NativeMock())
+    assert "ae.projectSummary" in server_module._filtered_tool_names()

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -9,9 +9,9 @@ from ae_mcp import schemas as S
 
 
 def test_registry_has_all_verbs():
-    assert len(S.SCHEMAS) == 44, f"expected 44 verbs, got {len(S.SCHEMAS)}"
+    assert len(S.SCHEMAS) == 45, f"expected 45 verbs, got {len(S.SCHEMAS)}"
     assert set(S.SCHEMAS) == {
-        "ae.init", "ae.overview", "ae.layers", "ae.readProps", "ae.exec",
+        "ae.init", "ae.overview", "ae.projectSummary", "ae.layers", "ae.readProps", "ae.exec",
         "ae.checkpoint", "ae.revert", "ae.snapshot", "ae.previewFrame",
         "ae.applyEffect", "ae.ping", "ae.status", "ae.diagnose",
         "ae.createLayer", "ae.setProperty", "ae.moveLayer", "ae.selectLayers",
@@ -43,6 +43,12 @@ def test_overview_is_empty():
     S.AeOverviewArgs()  # no error
     with pytest.raises(ValidationError):
         S.AeOverviewArgs(foo=1)
+
+
+def test_native_project_summary_is_empty_and_distinct_from_overview():
+    assert S.AeProjectSummaryArgs() != S.AeOverviewArgs()
+    with pytest.raises(ValidationError):
+        S.AeProjectSummaryArgs(foo=1)
 
 
 def test_layers_optional_comp_id():

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -5,6 +5,7 @@ import pytest
 
 from ae_mcp.backends.discovery import BackendSelectionError
 from ae_mcp.backends.mock import MockBackend
+from ae_mcp.backends.native import NativeInvokeBackend
 from ae_mcp.handlers import HANDLERS, load_all
 from ae_mcp.server import _filtered_tool_names
 
@@ -13,6 +14,17 @@ def _load_status_handler():
     load_all()
     schema_cls, run_fn = HANDLERS["ae.status"]
     return schema_cls, run_fn
+
+
+class NativeMockBackend(MockBackend, NativeInvokeBackend):
+    async def negotiate(self, **_kwargs):
+        raise AssertionError("status must not negotiate")
+
+    async def capabilities(self, **_kwargs):
+        raise AssertionError("status must not read capabilities")
+
+    async def invoke(self, *_args, **_kwargs):
+        raise AssertionError("status must not invoke")
 
 
 @pytest.mark.asyncio
@@ -34,6 +46,11 @@ async def test_status_tool_is_only_exposed_when_backend_selection_fails(monkeypa
     assert result["backend"] is None
     assert result["selectedAdapter"] is None
     assert result["activeExecutionEngine"] is None
+    assert result["nativeExecutionPlane"] == {
+        "available": False,
+        "adapter": None,
+        "engine": None,
+    }
     assert result["knownExecutionEngines"] == [
         "native-aegp",
         "maintained-jsx",
@@ -61,11 +78,33 @@ async def test_status_tool_reports_backend_and_supported_verbs(monkeypatch):
     assert result["installedBackends"] == ["mock"]
     assert result["selectedAdapter"] == "legacy-extendscript"
     assert result["activeExecutionEngine"] is None
+    assert result["nativeExecutionPlane"]["available"] is False
     assert result["knownExecutionEngines"] == [
         "native-aegp",
         "maintained-jsx",
         "ephemeral-jsx",
     ]
+
+
+@pytest.mark.asyncio
+async def test_status_reports_native_plane_without_claiming_active_routing(monkeypatch):
+    backend = NativeMockBackend()
+    monkeypatch.setattr(backend, "supported_verbs", lambda: {"ae.ping"})
+    monkeypatch.setattr("ae_mcp.backends.discovery.select_backend", lambda: backend)
+    monkeypatch.setattr("ae_mcp.backends.discovery.list_installed_backends", lambda: {"mock": NativeMockBackend})
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+
+    assert "ae.projectSummary" in _filtered_tool_names()
+    schema_cls, run_fn = _load_status_handler()
+    result = await run_fn(schema_cls(), None)
+
+    assert result["selectedAdapter"] == "legacy-extendscript"
+    assert result["activeExecutionEngine"] is None
+    assert result["nativeExecutionPlane"] == {
+        "available": True,
+        "adapter": "NativeMockBackend",
+        "engine": "native-aegp",
+    }
 
 
 def test_filtered_tool_names_ignores_snapshotter_selection_exceptions(monkeypatch):

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -17,13 +17,39 @@ const SOCKET_PATTERN = /^s-[0-9a-f]{12}\.sock$/;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const NATIVE_WIRE_ERROR_CODES = new Set([
+    'NATIVE_UNAVAILABLE', 'NATIVE_UNSUPPORTED', 'WIRE_VERSION_MISMATCH',
+    'INVALID_REQUEST', 'INVALID_ARGUMENT', 'DUPLICATE_REQUEST',
+    'PRECONDITION_FAILED', 'STALE_LOCATOR', 'DEADLINE_EXCEEDED', 'CANCELLED',
+    'QUEUE_FULL', 'AE_SHUTTING_DOWN', 'SESSION_STALE', 'CAPABILITY_FAILED',
+    'POSSIBLY_SIDE_EFFECTING_FAILURE',
+]);
 
-function nativeError(code, message, retryable, cause) {
+function nativeError(code, message, retryable, cause, structured) {
     const error = new Error(message);
     error.code = code;
     error.retryable = Boolean(retryable);
     if (cause !== undefined) error.cause = cause;
+    if (structured && structured.sideEffect !== undefined) error.sideEffect = structured.sideEffect;
+    if (structured && structured.recovery !== undefined) error.recovery = structured.recovery;
+    if (structured && structured.details !== undefined) error.details = structured.details;
     return error;
+}
+
+function nativeContractMismatch(message, cause) {
+    return nativeError(
+        'NATIVE_CONTRACT_MISMATCH',
+        message,
+        false,
+        cause,
+        {
+            sideEffect: 'not-started',
+            recovery: {
+                action: 'refresh-capabilities',
+                hint: 'Refresh the authenticated native contract before retrying.',
+            },
+        },
+    );
 }
 
 function exactKeys(value, required, optional) {
@@ -190,11 +216,11 @@ function sha256Canonical(value) {
     return crypto.createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex');
 }
 
-function capabilitiesQueryDigest(sessionId, detail) {
+function capabilitiesQueryDigest(sessionId, ids, detail, limit) {
     return sha256Canonical({
         detail,
-        ids: ['ae.project.summary'],
-        limit: 1,
+        ids: ids === undefined ? null : ids,
+        limit,
         sessionId,
     });
 }
@@ -254,6 +280,7 @@ function createNativeAegpClient(options) {
     let sessionGeneration = 0;
     let capabilitiesDigest = null;
     let projectSummaryContractDigest = null;
+    let helloIdentity = null;
     let nextRequest = 1;
     let inputBuffer = Buffer.alloc(0);
     let pairingResolve;
@@ -266,10 +293,7 @@ function createNativeAegpClient(options) {
 
     function fail(error) {
         const protocolCodes = new Set([
-            'AUTH_REQUIRED', 'INVALID_ARGUMENT', 'INVALID_REQUEST', 'NATIVE_UNAVAILABLE',
-            'NATIVE_UNSUPPORTED', 'WIRE_VERSION_MISMATCH', 'DUPLICATE_REQUEST',
-            'DEADLINE_EXCEEDED', 'CANCELLED', 'QUEUE_FULL', 'AE_SHUTTING_DOWN',
-            'SESSION_STALE', 'CAPABILITY_FAILED',
+            ...NATIVE_WIRE_ERROR_CODES, 'AUTH_REQUIRED', 'NATIVE_CONTRACT_MISMATCH',
         ]);
         const failure = error && protocolCodes.has(error.code)
             ? error : nativeError('NATIVE_UNAVAILABLE', 'native AEGP connection failed', true, error);
@@ -289,6 +313,7 @@ function createNativeAegpClient(options) {
         sessionGeneration = 0;
         capabilitiesDigest = null;
         projectSummaryContractDigest = null;
+        helloIdentity = null;
         if (socket) {
             const current = socket;
             socket = null;
@@ -298,25 +323,32 @@ function createNativeAegpClient(options) {
 
     function responseError(response) {
         const error = response && response.error;
-        const code = typeof error?.code === 'string' && /^[A-Z][A-Z0-9_]{2,63}$/.test(error.code)
-            ? error.code : 'INVALID_REQUEST';
-        return nativeError(code, 'native AEGP request failed with ' + code, Boolean(error?.retryable));
+        if (!exactKeys(error, ['code', 'message', 'retryable', 'sideEffect', 'recovery'], ['details'])
+            || typeof error.code !== 'string' || !NATIVE_WIRE_ERROR_CODES.has(error.code)
+            || typeof error.message !== 'string' || error.message.length === 0
+            || typeof error.retryable !== 'boolean'
+            || !['not-started', 'may-have-occurred', 'completed'].includes(error.sideEffect)
+            || !error.recovery || typeof error.recovery !== 'object' || Array.isArray(error.recovery)
+            || typeof error.recovery.action !== 'string' || typeof error.recovery.hint !== 'string') {
+            return nativeContractMismatch('native AEGP returned a malformed error payload');
+        }
+        return nativeError(error.code, error.message, error.retryable, undefined, error);
     }
 
     function handleFrame(frame) {
         let response;
         try { response = JSON.parse(frame.toString('utf8')); } catch (cause) {
-            throw nativeError('INVALID_REQUEST', 'native AEGP returned malformed JSON', false, cause);
+            throw nativeContractMismatch('native AEGP returned malformed JSON', cause);
         }
         if (!response || typeof response !== 'object' || Array.isArray(response)) {
-            throw nativeError('INVALID_REQUEST', 'native AEGP returned an invalid envelope', false);
+            throw nativeContractMismatch('native AEGP returned an invalid envelope');
         }
         if (response.kind === 'event') return;
         const pending = pendingRequests.get(response.requestId);
         if (!pending || response.wireVersion !== 1 || response.kind !== 'response'
             || response.method !== pending.method
             || (pending.method !== 'hello' && response.sessionId !== sessionId)) {
-            throw nativeError('INVALID_REQUEST', 'native AEGP response did not match an active request', false);
+            throw nativeContractMismatch('native AEGP response did not match an active request');
         }
         if (response.ok === true && pending.method === 'invoke') {
             const evidence = response.result?.evidence;
@@ -325,7 +357,7 @@ function createNativeAegpClient(options) {
                 || evidence?.capabilityId !== 'ae.project.summary'
                 || evidence?.capabilityVersion !== 1
                 || evidence?.requestDigest !== pending.requestDigest) {
-                throw nativeError('INVALID_REQUEST', 'native AEGP evidence did not match its response envelope', false);
+                throw nativeContractMismatch('native AEGP evidence did not match its response envelope');
             }
         }
         pendingRequests.delete(response.requestId);
@@ -338,7 +370,7 @@ function createNativeAegpClient(options) {
         while (inputBuffer.length >= 4) {
             const length = inputBuffer.readUInt32BE(0);
             if (length === 0 || length > MAX_FRAME_BYTES) {
-                throw nativeError('INVALID_REQUEST', 'native AEGP returned an invalid frame size', false);
+                throw nativeContractMismatch('native AEGP returned an invalid frame size');
             }
             if (inputBuffer.length < length + 4) return;
             const frame = inputBuffer.subarray(4, length + 4);
@@ -347,20 +379,35 @@ function createNativeAegpClient(options) {
         }
     }
 
-    function send(method, params, deadlineUnixMs) {
+    function send(method, params, options) {
         if (!socket || (method !== 'hello' && state !== 'connected')) {
             return Promise.reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP session is not connected', true));
         }
-        const requestId = method + '-' + String(nextRequest++) + '-' + randomBytes(4).toString('hex');
+        const call = options || {};
+        const deadlineUnixMs = call.deadlineUnixMs;
+        if (deadlineUnixMs !== undefined
+            && (!Number.isSafeInteger(deadlineUnixMs) || deadlineUnixMs <= now())) {
+            return Promise.reject(nativeError('DEADLINE_EXCEEDED', 'native AEGP request deadline elapsed before dispatch', true));
+        }
+        const requestId = call.requestId
+            || method + '-' + String(nextRequest++) + '-' + randomBytes(4).toString('hex');
+        if (!TOKEN_PATTERN.test(requestId)) {
+            return Promise.reject(nativeError('INVALID_ARGUMENT', 'native AEGP request ID is invalid', false));
+        }
+        if (pendingRequests.has(requestId)) {
+            return Promise.reject(nativeError('DUPLICATE_REQUEST', 'native AEGP request ID is already in flight', false));
+        }
         const request = { wireVersion: 1, kind: 'request', requestId, method, params };
         if (method !== 'hello') request.sessionId = sessionId;
         if (deadlineUnixMs !== undefined) request.deadlineUnixMs = deadlineUnixMs;
         const requestDigest = method === 'invoke' ? projectSummaryRequestDigest(request) : null;
         return new Promise(function (resolve, reject) {
+            const remainingMs = deadlineUnixMs === undefined
+                ? requestTimeoutMs : Math.max(1, deadlineUnixMs - now());
             const timer = setTimeout(function () {
                 pendingRequests.delete(requestId);
                 reject(nativeError('DEADLINE_EXCEEDED', 'native AEGP request timed out', true));
-            }, requestTimeoutMs);
+            }, Math.min(requestTimeoutMs, remainingMs));
             pendingRequests.set(requestId, { method, requestDigest, resolve, reject, timer });
             try {
                 socket.write(encodeFrame(request), function (error) {
@@ -379,13 +426,13 @@ function createNativeAegpClient(options) {
         });
     }
 
-    async function hello() {
+    async function hello(deadlineUnixMs) {
         const nonce = randomBytes(24).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
         const result = await send('hello', {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: { component: input.component || 'core-broker', version: input.version || '0.9.2', instanceId: clientInstanceId },
             nonce,
-        });
+        }, { deadlineUnixMs });
         if (!exactKeys(result, [
             'selectedWireVersion', 'pluginVersion', 'compiledSdk', 'host', 'sessionId',
             'sessionGeneration', 'limits', 'capabilitiesDigest', 'clientNonce',
@@ -396,16 +443,17 @@ function createNativeAegpClient(options) {
             || result.host?.application !== 'after-effects'
             || result.host?.platform !== 'macos-arm64'
             || result.compiledSdk?.architecture !== 'arm64') {
-            throw nativeError('INVALID_REQUEST', 'native AEGP hello identity did not match discovery', false);
+            throw nativeContractMismatch('native AEGP hello identity did not match discovery');
         }
         capabilitiesDigest = result.capabilitiesDigest;
+        helloIdentity = Object.freeze({ ...result, sourceCommit: endpoint.sourceCommit });
         return result;
     }
 
     function onData(chunk) {
         try {
             if (!chunk || inputBuffer.length + chunk.length > MAX_BUFFERED_BYTES) {
-                throw nativeError('INVALID_REQUEST', 'native AEGP buffered input exceeded its bound', false);
+                throw nativeContractMismatch('native AEGP buffered input exceeded its bound');
             }
             inputBuffer = Buffer.concat([inputBuffer, Buffer.from(chunk)]);
             if (state === 'pairing-pending') {
@@ -413,7 +461,7 @@ function createNativeAegpClient(options) {
                 const pending = parseAuthPending(inputBuffer.subarray(0, AUTH_PENDING_BYTES));
                 inputBuffer = inputBuffer.subarray(AUTH_PENDING_BYTES);
                 if (!pending || pending.hostInstanceId !== endpoint.hostInstanceId) {
-                    throw nativeError('INVALID_REQUEST', 'native pairing challenge did not match discovery', false);
+                    throw nativeContractMismatch('native pairing challenge did not match discovery');
                 }
                 state = 'pairing-decision';
                 const resolve = pairingResolve;
@@ -425,7 +473,7 @@ function createNativeAegpClient(options) {
                 if (inputBuffer.length < AUTH_DECISION_BYTES) return;
                 const decision = parseAuthDecision(inputBuffer.subarray(0, AUTH_DECISION_BYTES));
                 inputBuffer = inputBuffer.subarray(AUTH_DECISION_BYTES);
-                if (!decision) throw nativeError('INVALID_REQUEST', 'native pairing decision was malformed', false);
+                if (!decision) throw nativeContractMismatch('native pairing decision was malformed');
                 if (decision.code !== 'authorized') {
                     throw nativeError('AUTH_REQUIRED', 'native pairing was ' + decision.code, decision.code === 'expired');
                 }
@@ -477,9 +525,30 @@ function createNativeAegpClient(options) {
         });
     }
 
-    function beginPairing() {
+    function boundByDeadline(promise, deadlineUnixMs, message) {
+        if (deadlineUnixMs === undefined) return promise;
+        if (!Number.isSafeInteger(deadlineUnixMs) || deadlineUnixMs <= now()) {
+            return Promise.reject(nativeError('DEADLINE_EXCEEDED', message, true));
+        }
+        return new Promise(function (resolve, reject) {
+            const timer = setTimeout(function () {
+                reject(nativeError('DEADLINE_EXCEEDED', message, true));
+            }, Math.min(requestTimeoutMs, Math.max(1, deadlineUnixMs - now())));
+            promise.then(function (value) {
+                clearTimeout(timer);
+                resolve(value);
+            }, function (error) {
+                clearTimeout(timer);
+                reject(error);
+            });
+        });
+    }
+
+    function beginPairing(deadlineUnixMs) {
         if (state === 'closed') return Promise.reject(nativeError('NATIVE_UNAVAILABLE', 'native AEGP client is closed', false));
-        if (pairingPromise && state.startsWith('pairing')) return pairingPromise;
+        if (pairingPromise && state.startsWith('pairing')) {
+            return boundByDeadline(pairingPromise, deadlineUnixMs, 'native pairing deadline elapsed');
+        }
         if (state === 'connected' || state === 'authenticating') {
             return Promise.reject(nativeError('DUPLICATE_REQUEST', 'native AEGP client is already connected', false));
         }
@@ -509,42 +578,89 @@ function createNativeAegpClient(options) {
         } catch (cause) {
             fail(nativeError('NATIVE_UNAVAILABLE', 'native AEGP connection could not be opened', true, cause));
         }
-        return pairingPromise;
+        return boundByDeadline(pairingPromise, deadlineUnixMs, 'native pairing deadline elapsed');
     }
 
-    function waitUntilConnected() {
-        if (state === 'connected') return Promise.resolve({ sessionId, sessionGeneration });
+    function waitUntilConnected(deadlineUnixMs) {
+        if (state === 'connected') {
+            return boundByDeadline(
+                Promise.resolve(helloIdentity), deadlineUnixMs, 'native connection deadline elapsed',
+            );
+        }
         if (!connectedPromise) return Promise.reject(nativeError('AUTH_REQUIRED', 'begin native pairing first', false));
-        return connectedPromise;
+        return boundByDeadline(connectedPromise, deadlineUnixMs, 'native connection deadline elapsed');
     }
 
-    async function capabilities(detail) {
-        if (state !== 'connected') await waitUntilConnected();
-        const requestedDetail = detail || 'full';
-        const result = await send('capabilities', {
-            ids: ['ae.project.summary'], detail: requestedDetail, limit: 1,
+    async function negotiate(options) {
+        const call = options || {};
+        if (call.deadlineUnixMs !== undefined
+            && (!Number.isSafeInteger(call.deadlineUnixMs) || call.deadlineUnixMs <= now())) {
+            throw nativeError('DEADLINE_EXCEEDED', 'native negotiation deadline elapsed', true);
+        }
+        if (state !== 'connected') await waitUntilConnected(call.deadlineUnixMs);
+        if (call.deadlineUnixMs !== undefined && call.deadlineUnixMs <= now()) {
+            throw nativeError('DEADLINE_EXCEEDED', 'native negotiation deadline elapsed', true);
+        }
+        if (!helloIdentity) {
+            throw nativeContractMismatch('native hello identity is unavailable');
+        }
+        return helloIdentity;
+    }
+
+    async function capabilities(options) {
+        const call = typeof options === 'string' ? { detail: options } : (options || {});
+        const requestedDetail = call.detail || 'full';
+        const limit = call.limit === undefined ? 100 : call.limit;
+        const ids = call.ids === null || call.ids === undefined ? undefined : call.ids;
+        if (!['summary', 'full'].includes(requestedDetail)
+            || !Number.isSafeInteger(limit) || limit < 1 || limit > 100
+            || (ids !== undefined && (!Array.isArray(ids) || ids.length === 0 || ids.length > 32
+                || ids.some(function (id) { return typeof id !== 'string' || !TOKEN_PATTERN.test(id); })
+                || new Set(ids).size !== ids.length))) {
+            throw nativeError('INVALID_ARGUMENT', 'native capabilities query is invalid', false);
+        }
+        if (state !== 'connected') await waitUntilConnected(call.deadlineUnixMs);
+        const params = { detail: requestedDetail, limit };
+        // Omission is protocol-significant: no filter is represented on the
+        // wire by an absent member, while its canonical query digest uses
+        // ids:null. Never serialize a JavaScript null for this field.
+        if (ids !== undefined) params.ids = ids;
+        const result = await send('capabilities', params, {
+            deadlineUnixMs: call.deadlineUnixMs,
         });
         const item = Array.isArray(result?.items)
             ? result.items.find(function (candidate) { return candidate?.id === 'ae.project.summary'; })
             : null;
         if (!exactKeys(result, ['detail', 'items', 'nextCursor', 'queryDigest', 'capabilitiesDigest'])
             || result.detail !== requestedDetail || result.nextCursor !== null
-            || result.queryDigest !== capabilitiesQueryDigest(sessionId, requestedDetail)
+            || result.queryDigest !== capabilitiesQueryDigest(sessionId, ids, requestedDetail, limit)
             || result.capabilitiesDigest !== capabilitiesDigest
-            || !item || item.version !== 1 || item.detail !== requestedDetail
-            || (requestedDetail === 'full' && !SHA256_PATTERN.test(item.contractDigest))) {
-            throw nativeError('INVALID_REQUEST', 'native capabilities result was malformed', false);
+            || (ids === undefined && !item)
+            || (item && (item.version !== 1 || item.detail !== requestedDetail
+                || (requestedDetail === 'full' && !SHA256_PATTERN.test(item.contractDigest))))) {
+            throw nativeContractMismatch('native capabilities result was malformed');
         }
-        if (requestedDetail === 'full') projectSummaryContractDigest = item.contractDigest;
+        if (requestedDetail === 'full' && item) projectSummaryContractDigest = item.contractDigest;
         return result;
     }
 
-    async function projectSummary() {
-        if (state !== 'connected') await waitUntilConnected();
-        const deadline = now() + Math.min(requestTimeoutMs, 5000);
+    async function invoke(options) {
+        const call = options || {};
+        if (!exactKeys(call, [
+            'requestId', 'capabilityId', 'capabilityVersion', 'arguments', 'deadlineUnixMs',
+        ]) || !TOKEN_PATTERN.test(call.requestId || '')
+            || call.capabilityId !== 'ae.project.summary' || call.capabilityVersion !== 1
+            || !call.arguments || typeof call.arguments !== 'object' || Array.isArray(call.arguments)
+            || Object.keys(call.arguments).length !== 0
+            || !Number.isSafeInteger(call.deadlineUnixMs) || call.deadlineUnixMs <= 0) {
+            throw nativeError('INVALID_ARGUMENT', 'native invoke request is invalid', false);
+        }
+        if (state !== 'connected') await waitUntilConnected(call.deadlineUnixMs);
         const result = await send('invoke', {
-            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
-        }, deadline);
+            capabilityId: call.capabilityId,
+            capabilityVersion: call.capabilityVersion,
+            arguments: call.arguments,
+        }, { requestId: call.requestId, deadlineUnixMs: call.deadlineUnixMs });
         const value = result?.value;
         const evidence = result?.evidence;
         if (result?.capabilityId !== 'ae.project.summary' || result?.capabilityVersion !== 1
@@ -565,9 +681,19 @@ function createNativeAegpClient(options) {
             || !Number.isSafeInteger(value?.itemCount) || value.itemCount < 0
             || !SHA256_PATTERN.test(projectSummaryContractDigest || '')
             || evidence.postcondition.digest !== projectSummaryPostconditionDigest(value)) {
-            throw nativeError('INVALID_REQUEST', 'native project summary result lacked verified AEGP evidence', false);
+            throw nativeContractMismatch('native project summary result lacked verified AEGP evidence');
         }
         return result;
+    }
+
+    async function projectSummary() {
+        return invoke({
+            requestId: 'invoke-' + String(nextRequest++) + '-' + randomBytes(4).toString('hex'),
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: {},
+            deadlineUnixMs: now() + Math.min(requestTimeoutMs, 5000),
+        });
     }
 
     async function close() {
@@ -580,7 +706,9 @@ function createNativeAegpClient(options) {
     return Object.freeze({
         beginPairing,
         waitUntilConnected,
+        negotiate,
         capabilities,
+        invoke,
         projectSummary,
         close,
         status: function () {
@@ -588,6 +716,7 @@ function createNativeAegpClient(options) {
                 state,
                 hostInstanceId: endpoint?.hostInstanceId || null,
                 sourceCommit: endpoint?.sourceCommit || null,
+                sessionId,
                 sessionGeneration: sessionGeneration || null,
                 capabilitiesDigest,
                 projectSummaryContractDigest,

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -110,6 +110,16 @@ function invokeRequestDigest(request) {
     return crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
 }
 
+function capabilitiesRequestDigest(request) {
+    const canonical = {
+        detail: request.params.detail || 'summary',
+        ids: Object.hasOwn(request.params, 'ids') ? request.params.ids : null,
+        limit: request.params.limit === undefined ? 50 : request.params.limit,
+        sessionId: request.sessionId,
+    };
+    return crypto.createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
+}
+
 function installProtocol(server, options) {
     const input = options || {};
     let authorize;
@@ -161,9 +171,9 @@ function installProtocol(server, options) {
                     };
                 } else if (request.method === 'capabilities') {
                     result = {
-                        detail: 'full',
+                        detail: request.params.detail || 'summary',
                         capabilitiesDigest: DIGEST,
-                        queryDigest: 'aa3c66bc21e50b6a35db9c3cb12fcb1627694cd8f9fc411f21f7e3de46b3e56a',
+                        queryDigest: capabilitiesRequestDigest(request),
                         nextCursor: null,
                         items: [{
                             id: 'ae.project.summary',
@@ -200,15 +210,17 @@ function installProtocol(server, options) {
                     };
                     if (input.mutateInvoke) input.mutateInvoke(result, request);
                 }
+                if (input.suppressHello && request.method === 'hello') continue;
+                const responseError = request.method === 'invoke' ? input.invokeError : null;
                 socket.write(frame({
                     wireVersion: 1,
                     kind: 'response',
                     sessionId: SESSION,
                     requestId: request.requestId,
                     method: request.method,
-                    ok: true,
+                    ok: responseError ? false : true,
                     replayed: false,
-                    result,
+                    ...(responseError ? { error: responseError } : { result }),
                 }));
             }
         }
@@ -274,9 +286,22 @@ test('CEP client completes pairing, hello, capabilities, and verified native pro
     const hello = await client.waitUntilConnected();
     assert.equal(hello.host.instanceId, HOST);
     assert.equal(client.status().state, 'connected');
-    const capabilities = await client.capabilities();
+    const negotiation = await client.negotiate({ deadlineUnixMs: 1900000005000 });
+    assert.equal(negotiation.sourceCommit, SOURCE);
+    const capabilities = await client.capabilities({
+        ids: null,
+        detail: 'full',
+        limit: 100,
+        deadlineUnixMs: 1900000005000,
+    });
     assert.equal(capabilities.items[0].id, 'ae.project.summary');
-    const summary = await client.projectSummary();
+    const summary = await client.invoke({
+        requestId: 'core-project-summary-1',
+        capabilityId: 'ae.project.summary',
+        capabilityVersion: 1,
+        arguments: {},
+        deadlineUnixMs: 1900000002000,
+    });
     assert.deepEqual(summary.value, {
         projectOpen: true, projectName: 'Fixture.aep', itemCount: 3,
     });
@@ -286,8 +311,163 @@ test('CEP client completes pairing, hello, capabilities, and verified native pro
     assert.deepEqual(protocol.requests.map(function (request) { return request.method; }), [
         'hello', 'capabilities', 'invoke',
     ]);
+    assert.equal(Object.hasOwn(protocol.requests[1].params, 'ids'), false);
+    assert.equal(protocol.requests[1].params.limit, 100);
+    assert.equal(protocol.requests[2].requestId, 'core-project-summary-1');
     assert.equal(protocol.requests[2].deadlineUnixMs, 1900000002000);
     assert.equal(summary.evidence.requestDigest, invokeRequestDigest(protocol.requests[2]));
+});
+
+test('CEP client preserves the complete structured native error contract', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const protocol = installProtocol(fixture.server, {
+        invokeError: {
+            code: 'CAPABILITY_FAILED',
+            message: 'project summary failed',
+            retryable: false,
+            sideEffect: 'not-started',
+            recovery: { action: 'inspect-state', hint: 'Inspect the project state.' },
+            details: { capabilityId: 'ae.project.summary' },
+        },
+    });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        requestTimeoutMs: 2000,
+        now: function () { return 1900000000000; },
+    });
+    t.after(function () { return client.close(); });
+    await client.beginPairing();
+    protocol.authorize();
+    await client.waitUntilConnected();
+    await client.capabilities({ detail: 'full', limit: 100 });
+    await assert.rejects(
+        client.invoke({
+            requestId: 'core-project-summary-error',
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: {},
+            deadlineUnixMs: 1900000002000,
+        }),
+        function (error) {
+            assert.equal(error.code, 'CAPABILITY_FAILED');
+            assert.equal(error.message, 'project summary failed');
+            assert.equal(error.retryable, false);
+            assert.equal(error.sideEffect, 'not-started');
+            assert.deepEqual(error.recovery, {
+                action: 'inspect-state', hint: 'Inspect the project state.',
+            });
+            assert.deepEqual(error.details, { capabilityId: 'ae.project.summary' });
+            return true;
+        },
+    );
+});
+
+for (const errorFixture of [
+    {
+        name: 'keeps an actual native INVALID_REQUEST distinct',
+        error: {
+            code: 'INVALID_REQUEST',
+            message: 'native request was invalid',
+            retryable: false,
+            sideEffect: 'not-started',
+            recovery: { action: 'none', hint: 'Do not retry this request.' },
+        },
+        expectedCode: 'INVALID_REQUEST',
+        expectedAction: 'none',
+    },
+    {
+        name: 'labels a malformed native error as a broker contract mismatch',
+        error: {
+            code: 'INVALID_REQUEST',
+            message: 'missing recovery fields',
+            retryable: false,
+            sideEffect: 'not-started',
+        },
+        expectedCode: 'NATIVE_CONTRACT_MISMATCH',
+        expectedAction: 'refresh-capabilities',
+    },
+]) {
+    test('CEP client ' + errorFixture.name, {
+        skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+    }, async (t) => {
+        const fixture = await endpointFixture(t);
+        const protocol = installProtocol(fixture.server, { invokeError: errorFixture.error });
+        const client = createNativeAegpClient({
+            runtime: { platform: 'darwin', arch: 'arm64' },
+            runtimeRoot: fixture.root,
+            clientInstanceId: CLIENT,
+            requestTimeoutMs: 2000,
+            now: function () { return 1900000000000; },
+        });
+        t.after(function () { return client.close(); });
+        await client.beginPairing();
+        protocol.authorize();
+        await client.waitUntilConnected();
+        await client.capabilities({ detail: 'full', limit: 100 });
+        await assert.rejects(
+            client.invoke({
+                requestId: 'core-error-classification',
+                capabilityId: 'ae.project.summary',
+                capabilityVersion: 1,
+                arguments: {},
+                deadlineUnixMs: 1900000002000,
+            }),
+            function (error) {
+                assert.equal(error.code, errorFixture.expectedCode);
+                assert.equal(error.retryable, false);
+                assert.equal(error.sideEffect, 'not-started');
+                assert.equal(error.recovery.action, errorFixture.expectedAction);
+                return true;
+            },
+        );
+    });
+}
+
+test('CEP client bounds an authenticating wait by the Core absolute deadline', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const protocol = installProtocol(fixture.server, { suppressHello: true });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        requestTimeoutMs: 2000,
+    });
+    t.after(function () { return client.close(); });
+    await client.beginPairing();
+    protocol.authorize();
+    while (!protocol.requests.some(function (request) { return request.method === 'hello'; })) {
+        await new Promise(function (resolve) { setImmediate(resolve); });
+    }
+    assert.equal(client.status().state, 'authenticating');
+    await assert.rejects(
+        client.negotiate({ deadlineUnixMs: Date.now() + 40 }),
+        { code: 'DEADLINE_EXCEEDED', retryable: true },
+    );
+    assert.equal(client.status().state, 'authenticating');
+});
+
+test('CEP client bounds the initial pairing challenge by the Core absolute deadline', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        requestTimeoutMs: 2000,
+    });
+    t.after(function () { return client.close(); });
+    await assert.rejects(
+        client.beginPairing(Date.now() + 40),
+        { code: 'DEADLINE_EXCEEDED', retryable: true },
+    );
+    assert.equal(client.status().state, 'pairing-pending');
 });
 
 for (const fixture of [
@@ -317,7 +497,16 @@ for (const fixture of [
         protocol.authorize();
         await client.waitUntilConnected();
         await client.capabilities();
-        await assert.rejects(client.projectSummary(), { code: 'INVALID_REQUEST', retryable: false });
+        await assert.rejects(client.projectSummary(), function (error) {
+            assert.equal(error.code, 'NATIVE_CONTRACT_MISMATCH');
+            assert.equal(error.retryable, false);
+            assert.equal(error.sideEffect, 'not-started');
+            assert.deepEqual(error.recovery, {
+                action: 'refresh-capabilities',
+                hint: 'Refresh the authenticated native contract before retrying.',
+            });
+            return true;
+        });
     });
 }
 

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -25,6 +25,7 @@ const blocked = new Set();
 // Self-reported label of the panel's own diagnostic /exec probes. Must match
 // the x-ae-mcp-client header in plugin/panel/src/cep/diagnostics.js.
 const INTERNAL_CLIENT = 'panel-diagnostics/internal';
+const NATIVE_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 
 function setRuntimeDependencies(dependencies) {
     if (!dependencies || typeof dependencies.express !== 'function') {
@@ -122,8 +123,9 @@ function makeNativeAegpClient() {
     if (!nativeAegpClient
         || typeof nativeAegpClient.beginPairing !== 'function'
         || typeof nativeAegpClient.waitUntilConnected !== 'function'
+        || typeof nativeAegpClient.negotiate !== 'function'
         || typeof nativeAegpClient.capabilities !== 'function'
-        || typeof nativeAegpClient.projectSummary !== 'function'
+        || typeof nativeAegpClient.invoke !== 'function'
         || typeof nativeAegpClient.status !== 'function'
         || typeof nativeAegpClient.close !== 'function') {
         nativeAegpClient = null;
@@ -158,19 +160,95 @@ function setNativeAegpRuntime(runtime) {
 function nativeErrorPayload(error) {
     const code = typeof error?.code === 'string' && /^[A-Z][A-Z0-9_]{2,63}$/.test(error.code)
         ? error.code : 'NATIVE_UNAVAILABLE';
-    return {
+    const policies = {
+        NATIVE_UNAVAILABLE: [true, 'not-started', 'reconnect'],
+        NATIVE_UNSUPPORTED: [false, 'not-started', 'refresh-capabilities'],
+        NATIVE_CONTRACT_MISMATCH: [false, 'not-started', 'refresh-capabilities'],
+        AUTH_REQUIRED: [false, 'not-started', 'approve-pairing'],
+        WIRE_VERSION_MISMATCH: [false, 'not-started', 'reconnect'],
+        INVALID_REQUEST: [false, 'not-started', 'none'],
+        INVALID_ARGUMENT: [false, 'not-started', 'change-arguments'],
+        DUPLICATE_REQUEST: [false, 'not-started', 'inspect-state'],
+        PRECONDITION_FAILED: [false, 'not-started', 'open-project'],
+        STALE_LOCATOR: [true, 'not-started', 'refresh-locator'],
+        DEADLINE_EXCEEDED: [true, 'not-started', 'retry'],
+        CANCELLED: [false, 'not-started', 'none'],
+        QUEUE_FULL: [true, 'not-started', 'retry'],
+        AE_SHUTTING_DOWN: [true, 'not-started', 'reconnect'],
+        SESSION_STALE: [true, 'not-started', 'reconnect'],
+        CAPABILITY_FAILED: [false, 'not-started', 'inspect-state'],
+        POSSIBLY_SIDE_EFFECTING_FAILURE: [false, 'may-have-occurred', 'inspect-state'],
+        NATIVE_PAIRING_REQUIRED: [true, 'not-started', 'approve-pairing'],
+    };
+    const policy = policies[code] || policies.NATIVE_UNAVAILABLE;
+    const fixedContractMismatch = code === 'NATIVE_CONTRACT_MISMATCH';
+    const recovery = !fixedContractMismatch
+        && error?.recovery && typeof error.recovery === 'object'
+        ? { ...error.recovery }
+        : {
+            action: policy[2],
+            hint: fixedContractMismatch
+                ? 'Refresh the authenticated native contract before retrying.'
+                : code === 'NATIVE_PAIRING_REQUIRED' || code === 'AUTH_REQUIRED'
+                ? 'Approve the matching fingerprint in After Effects, then retry.'
+                : 'Follow the recovery action before retrying the native request.',
+        };
+    const payload = {
         code,
-        message: code === 'NATIVE_PAIRING_REQUIRED'
+        message: typeof error?.message === 'string' && error.message.length > 0
+            ? error.message : code === 'NATIVE_PAIRING_REQUIRED'
             ? 'Approve the matching fingerprint from the After Effects AE MCP menu, then retry.'
             : 'Native AEGP request failed with ' + code + '.',
-        retryable: error?.retryable === true || code === 'NATIVE_UNAVAILABLE',
+        retryable: fixedContractMismatch
+            ? false : typeof error?.retryable === 'boolean' ? error.retryable : policy[0],
+        sideEffect: fixedContractMismatch
+            ? 'not-started' : typeof error?.sideEffect === 'string' ? error.sideEffect : policy[1],
+        recovery,
+    };
+    if (code === 'NATIVE_PAIRING_REQUIRED' && error?.pairing) {
+        payload.details = {
+            pairingFingerprint: error.pairing.fingerprint,
+            pairingExpiresInMs: error.pairing.expiresInMs,
+            hostInstanceId: error.pairing.hostInstanceId,
+            sourceCommit: error.pairing.sourceCommit,
+        };
+    } else if (error?.details && typeof error.details === 'object' && !Array.isArray(error.details)) {
+        payload.details = { ...error.details };
+    }
+    return payload;
+}
+
+function exactBody(value, required, optional) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+    const allowed = new Set(required.concat(optional || []));
+    return required.every(function (key) { return Object.hasOwn(value, key); })
+        && Object.keys(value).every(function (key) { return allowed.has(key); });
+}
+
+function validDeadline(value) {
+    return Number.isSafeInteger(value) && value > 0;
+}
+
+function nativeGateError(code, message, retryable, action, hint) {
+    return {
+        code,
+        message,
+        retryable,
+        sideEffect: 'not-started',
+        recovery: { action, hint },
     };
 }
 
 function nativeRequestGate(req, res) {
     const provided = req.get(authToken.HEADER);
     if (!authToken.tokenMatches(provided, execToken)) {
-        res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'unauthorized', retryable: false } });
+        res.status(401).json({
+            ok: false,
+            error: nativeGateError(
+                'UNAUTHORIZED', 'unauthorized', false, 'reconnect',
+                'Reload the shared loopback token before reconnecting.',
+            ),
+        });
         return null;
     }
     const client = req.get('x-ae-mcp-client') || 'unknown';
@@ -181,7 +259,10 @@ function nativeRequestGate(req, res) {
         activity.record({ client, engine: 'native-aegp', ok: false, denied: 'blocked' });
         res.status(403).json({
             ok: false,
-            error: { code: 'CLIENT_BLOCKED', message: 'this client is blocked in the panel', retryable: false },
+            error: nativeGateError(
+                'CLIENT_BLOCKED', 'this client is blocked in the panel', false, 'none',
+                'A user must unblock this client in the panel before another request.',
+            ),
         });
         return null;
     }
@@ -189,15 +270,18 @@ function nativeRequestGate(req, res) {
         activity.record({ client, engine: 'native-aegp', ok: false, denied: 'paused' });
         res.status(503).json({
             ok: false,
-            error: { code: 'ACTIONS_PAUSED', message: 'AI actions are paused in the panel', retryable: true },
+            error: nativeGateError(
+                'ACTIONS_PAUSED', 'AI actions are paused in the panel', true, 'retry',
+                'Resume AI actions in the panel before retrying.',
+            ),
         });
         return null;
     }
     return client;
 }
 
-async function nativePairingRequired(client) {
-    const pending = await client.beginPairing();
+async function nativePairingRequired(client, deadlineUnixMs) {
+    const pending = await client.beginPairing(deadlineUnixMs);
     const error = new Error('native AEGP pairing requires an After Effects decision');
     error.code = 'NATIVE_PAIRING_REQUIRED';
     error.retryable = true;
@@ -205,15 +289,15 @@ async function nativePairingRequired(client) {
     throw error;
 }
 
-async function connectedNativeClient() {
+async function connectedNativeClient(deadlineUnixMs) {
     const client = makeNativeAegpClient();
     const status = client.status();
     if (status.state === 'connected') return client;
     if (status.state === 'authenticating') {
-        await client.waitUntilConnected();
+        await client.waitUntilConnected(deadlineUnixMs);
         return client;
     }
-    return nativePairingRequired(client);
+    return nativePairingRequired(client, deadlineUnixMs);
 }
 
 function sendNativeFailure(res, error) {
@@ -411,54 +495,151 @@ function buildApp() {
         }
     });
 
-    a.post('/native/invoke', async (req, res) => {
+    a.post('/native/negotiate', async (req, res) => {
         const clientLabel = nativeRequestGate(req, res);
         if (clientLabel === null) return;
         const body = req.body || {};
-        if (!body || typeof body !== 'object' || Array.isArray(body)
-            || JSON.stringify(Object.keys(body).sort()) !== JSON.stringify([
-                'arguments', 'capabilityId', 'capabilityVersion',
-            ])
-            || body.capabilityId !== 'ae.project.summary'
-            || body.capabilityVersion !== 1
-            || !body.arguments || typeof body.arguments !== 'object'
-            || Array.isArray(body.arguments) || Object.keys(body.arguments).length !== 0) {
+        if (!exactBody(body, ['deadlineUnixMs']) || !validDeadline(body.deadlineUnixMs)) {
             return res.status(400).json({
                 ok: false,
-                error: { code: 'INVALID_ARGUMENT', message: 'native invoke parameters are invalid', retryable: false },
+                error: nativeErrorPayload(Object.assign(
+                    new Error('native negotiation parameters are invalid'),
+                    { code: 'INVALID_ARGUMENT', retryable: false },
+                )),
             });
         }
         const startedAt = Date.now();
         try {
-            const client = await connectedNativeClient();
-            await client.capabilities('full');
-            const result = await client.projectSummary();
-            const runtime = client.status();
+            const client = await connectedNativeClient(body.deadlineUnixMs);
+            const hello = await client.negotiate({ deadlineUnixMs: body.deadlineUnixMs });
+            const result = {
+                selectedWireVersion: hello.selectedWireVersion,
+                pluginVersion: hello.pluginVersion,
+                compiledSdkVersion: hello.compiledSdk.version,
+                sourceCommit: hello.sourceCommit,
+                hostInstanceId: hello.host.instanceId,
+                hostPlatform: hello.host.platform,
+                sessionId: hello.sessionId,
+                sessionGeneration: hello.sessionGeneration,
+                capabilitiesDigest: hello.capabilitiesDigest,
+            };
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'negotiate',
+                ok: true,
+                hostInstanceId: result.hostInstanceId,
+                sessionGeneration: result.sessionGeneration,
+                durationMs: Date.now() - startedAt,
+            });
+            res.json({ ok: true, result });
+        } catch (error) {
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'negotiate',
+                ok: false,
+                error: nativeErrorPayload(error).code,
+                durationMs: Date.now() - startedAt,
+            });
+            sendNativeFailure(res, error);
+        }
+    });
+
+    a.post('/native/capabilities', async (req, res) => {
+        const clientLabel = nativeRequestGate(req, res);
+        if (clientLabel === null) return;
+        const body = req.body || {};
+        const validIds = !Object.hasOwn(body, 'ids')
+            || (Array.isArray(body.ids) && body.ids.length >= 1 && body.ids.length <= 32
+                && body.ids.every(function (id) { return typeof id === 'string' && id.length > 0; })
+                && new Set(body.ids).size === body.ids.length);
+        if (!exactBody(body, ['detail', 'limit', 'deadlineUnixMs'], ['ids'])
+            || body.detail !== 'full'
+            || !Number.isSafeInteger(body.limit) || body.limit < 1 || body.limit > 100
+            || !validDeadline(body.deadlineUnixMs) || !validIds) {
+            return res.status(400).json({
+                ok: false,
+                error: nativeErrorPayload(Object.assign(
+                    new Error('native capabilities parameters are invalid'),
+                    { code: 'INVALID_ARGUMENT', retryable: false },
+                )),
+            });
+        }
+        const startedAt = Date.now();
+        try {
+            const client = await connectedNativeClient(body.deadlineUnixMs);
+            const query = {
+                detail: body.detail,
+                limit: body.limit,
+                deadlineUnixMs: body.deadlineUnixMs,
+            };
+            // ids=None is represented by omission across both HTTP and UDS.
+            if (Object.hasOwn(body, 'ids')) query.ids = body.ids;
+            const nativeResult = await client.capabilities(query);
+            const result = { sessionId: client.status().sessionId, ...nativeResult };
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'capabilities',
+                ok: true,
+                itemCount: result.items.length,
+                durationMs: Date.now() - startedAt,
+            });
+            res.json({ ok: true, result });
+        } catch (error) {
+            activity.record({
+                client: clientLabel,
+                engine: 'native-aegp',
+                operation: 'capabilities',
+                ok: false,
+                error: nativeErrorPayload(error).code,
+                durationMs: Date.now() - startedAt,
+            });
+            sendNativeFailure(res, error);
+        }
+    });
+
+    a.post('/native/invoke', async (req, res) => {
+        const clientLabel = nativeRequestGate(req, res);
+        if (clientLabel === null) return;
+        const body = req.body || {};
+        if (!exactBody(body, [
+            'requestId', 'capabilityId', 'capabilityVersion', 'arguments', 'deadlineUnixMs',
+        ])
+            || typeof body.requestId !== 'string' || !NATIVE_REQUEST_ID_PATTERN.test(body.requestId)
+            || body.capabilityId !== 'ae.project.summary'
+            || body.capabilityVersion !== 1
+            || !body.arguments || typeof body.arguments !== 'object'
+            || Array.isArray(body.arguments) || Object.keys(body.arguments).length !== 0
+            || !validDeadline(body.deadlineUnixMs)) {
+            return res.status(400).json({
+                ok: false,
+                error: nativeErrorPayload(Object.assign(
+                    new Error('native invoke parameters are invalid'),
+                    { code: 'INVALID_ARGUMENT', retryable: false },
+                )),
+            });
+        }
+        const startedAt = Date.now();
+        try {
+            const client = await connectedNativeClient(body.deadlineUnixMs);
+            const result = await client.invoke(body);
             activity.record({
                 client: clientLabel,
                 engine: 'native-aegp',
                 capabilityId: body.capabilityId,
+                requestId: body.requestId,
                 ok: true,
                 durationMs: Date.now() - startedAt,
             });
-            res.json({
-                ok: true,
-                capabilityId: body.capabilityId,
-                engine: 'native-aegp',
-                result,
-                runtime: {
-                    hostInstanceId: runtime.hostInstanceId,
-                    sourceCommit: runtime.sourceCommit,
-                    sessionGeneration: runtime.sessionGeneration,
-                    capabilitiesDigest: runtime.capabilitiesDigest,
-                    projectSummaryContractDigest: runtime.projectSummaryContractDigest,
-                },
-            });
+            res.json({ ok: true, result });
         } catch (error) {
             activity.record({
                 client: clientLabel,
                 engine: 'native-aegp',
                 capabilityId: body.capabilityId,
+                requestId: body.requestId,
                 ok: false,
                 error: nativeErrorPayload(error).code,
                 durationMs: Date.now() - startedAt,

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -8,6 +8,9 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const bundledExpressFixture = require('express');
+const brokerFailureFixtures = Object.values(require(
+    '../../native/ae-plugin/protocol/fixtures/broker-http-errors.json'
+));
 
 const authToken = require('./auth-token');
 
@@ -154,6 +157,11 @@ async function startNativeApp(nativeClient) {
     server.activity._reset();
     server.setPaused(false);
     server._setExecToken('known-secret-token');
+    server.setCSInterface({
+        evalScript: function () {
+            throw new Error('native HTTP routes must never call evalScript');
+        },
+    });
     server._setNativeAegpClientForTest(nativeClient);
     const app = server.buildApp();
     const srv = await new Promise((resolve) => {
@@ -172,17 +180,45 @@ function fakeNativeClient() {
         hostInstanceId: '22222222-2222-4222-8222-222222222222',
         sourceCommit: 'a'.repeat(40),
     };
+    const sessionId = '11111111-1111-4111-8111-111111111111';
     return {
         beginPairing: async function () { calls.push('pair'); state = 'pairing-decision'; return pending; },
-        waitUntilConnected: async function () { calls.push('wait'); state = 'connected'; return {}; },
-        capabilities: async function (detail) { calls.push('capabilities:' + detail); return { items: [] }; },
-        projectSummary: async function () {
-            calls.push('projectSummary');
+        waitUntilConnected: async function (deadlineUnixMs) {
+            calls.push(['wait', deadlineUnixMs]);
+            state = 'connected';
+            return {};
+        },
+        negotiate: async function (options) {
+            calls.push(['negotiate', options]);
+            return {
+                selectedWireVersion: 1,
+                pluginVersion: '0.1.0-dev',
+                compiledSdk: { version: '25.6.61' },
+                sourceCommit: pending.sourceCommit,
+                host: { instanceId: pending.hostInstanceId, platform: 'macos-arm64' },
+                sessionId,
+                sessionGeneration: 7,
+                capabilitiesDigest: 'd'.repeat(64),
+            };
+        },
+        capabilities: async function (options) {
+            calls.push(['capabilities', options]);
+            return {
+                detail: 'full',
+                items: [],
+                nextCursor: null,
+                queryDigest: 'f'.repeat(64),
+                capabilitiesDigest: 'd'.repeat(64),
+            };
+        },
+        invoke: async function (request) {
+            calls.push(['invoke', request]);
             return {
                 capabilityId: 'ae.project.summary',
                 capabilityVersion: 1,
                 engine: 'native-aegp',
                 evidence: {
+                    requestId: request.requestId,
                     requestDigest: 'b'.repeat(64),
                     postcondition: { verified: true, digest: 'c'.repeat(64) },
                 },
@@ -194,6 +230,7 @@ function fakeNativeClient() {
                 state,
                 hostInstanceId: pending.hostInstanceId,
                 sourceCommit: pending.sourceCommit,
+                sessionId: state === 'connected' ? sessionId : null,
                 sessionGeneration: state === 'connected' ? 7 : null,
                 capabilitiesDigest: 'd'.repeat(64),
                 projectSummaryContractDigest: 'e'.repeat(64),
@@ -201,6 +238,7 @@ function fakeNativeClient() {
         },
         close: async function () { closed += 1; state = 'closed'; },
         authorize: function () { state = 'connected'; },
+        authenticate: function () { state = 'authenticating'; },
         calls,
         closed: function () { return closed; },
     };
@@ -215,6 +253,8 @@ test('native routes require the shared token and reject an open-ended invoke env
         });
         assert.strictEqual(unauthorized.status, 401);
         assert.strictEqual(unauthorized.body.error.code, 'UNAUTHORIZED');
+        assert.strictEqual(unauthorized.body.error.sideEffect, 'not-started');
+        assert.strictEqual(unauthorized.body.error.recovery.action, 'reconnect');
 
         const arbitrary = await post(port, '/native/invoke', {
             'X-AE-MCP-Token': 'known-secret-token',
@@ -225,6 +265,30 @@ test('native routes require the shared token and reject an open-ended invoke env
         });
         assert.strictEqual(arbitrary.status, 400);
         assert.strictEqual(arbitrary.body.error.code, 'INVALID_ARGUMENT');
+
+        const explicitNullIds = await post(port, '/native/capabilities', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, {
+            ids: null,
+            detail: 'full',
+            limit: 100,
+            deadlineUnixMs: Date.now() + 10000,
+        });
+        assert.strictEqual(explicitNullIds.status, 400);
+        assert.strictEqual(explicitNullIds.body.error.code, 'INVALID_ARGUMENT');
+
+        const oversizedRequestId = await post(port, '/native/invoke', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, {
+            requestId: 'r'.repeat(65),
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: {},
+            deadlineUnixMs: Date.now() + 10000,
+        });
+        assert.strictEqual(oversizedRequestId.status, 400);
+        assert.strictEqual(oversizedRequestId.body.error.code, 'INVALID_ARGUMENT');
+        assert.doesNotMatch(JSON.stringify(server.activity.list()), /r{65}/);
         assert.deepStrictEqual(nativeClient.calls, []);
     } finally {
         srv.close();
@@ -232,7 +296,7 @@ test('native routes require the shared token and reject an open-ended invoke env
     }
 });
 
-test('native route exposes pairing without logging its fingerprint, then invokes hello-capabilities-read session', async () => {
+test('native routes expose pairing then preserve Core negotiation, registry, and invoke fields', async () => {
     const nativeClient = fakeNativeClient();
     const { server, srv, port } = await startNativeApp(nativeClient);
     const headers = {
@@ -240,27 +304,58 @@ test('native route exposes pairing without logging its fingerprint, then invokes
         'x-ae-mcp-client': 'stdio-mcp/test',
     };
     try {
-        const pairing = await post(port, '/native/invoke', headers, {
-            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+        const deadlineUnixMs = Date.now() + 10000;
+        const pairing = await post(port, '/native/negotiate', headers, {
+            deadlineUnixMs,
         });
         assert.strictEqual(pairing.status, 409);
         assert.strictEqual(pairing.body.error.code, 'NATIVE_PAIRING_REQUIRED');
+        assert.strictEqual(pairing.body.error.recovery.action, 'approve-pairing');
+        assert.deepStrictEqual(pairing.body.error.details, {
+            pairingFingerprint: '12AB-34CD',
+            pairingExpiresInMs: 60000,
+            hostInstanceId: '22222222-2222-4222-8222-222222222222',
+            sourceCommit: 'a'.repeat(40),
+        });
         assert.strictEqual(pairing.body.pairing.fingerprint, '12AB-34CD');
         assert.strictEqual(pairing.body.pairing.sourceCommit, 'a'.repeat(40));
         assert.doesNotMatch(JSON.stringify(server.activity.list()), /12AB-34CD/);
 
         nativeClient.authorize();
+        const negotiated = await post(port, '/native/negotiate', headers, {
+            deadlineUnixMs,
+        });
+        assert.strictEqual(negotiated.status, 200);
+        assert.strictEqual(negotiated.body.result.sourceCommit, 'a'.repeat(40));
+        assert.strictEqual(negotiated.body.result.compiledSdkVersion, '25.6.61');
+
+        const capabilities = await post(port, '/native/capabilities', headers, {
+            detail: 'full', limit: 100, deadlineUnixMs,
+        });
+        assert.strictEqual(capabilities.status, 200);
+        assert.strictEqual(capabilities.body.result.sessionId, '11111111-1111-4111-8111-111111111111');
+
         const invoked = await post(port, '/native/invoke', headers, {
-            capabilityId: 'ae.project.summary', capabilityVersion: 1, arguments: {},
+            requestId: 'core-project-summary-1',
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: {},
+            deadlineUnixMs,
         });
         assert.strictEqual(invoked.status, 200);
-        assert.strictEqual(invoked.body.engine, 'native-aegp');
         assert.strictEqual(invoked.body.result.value.itemCount, 2);
         assert.strictEqual(invoked.body.result.evidence.postcondition.verified, true);
-        assert.strictEqual(invoked.body.runtime.sourceCommit, 'a'.repeat(40));
-        assert.strictEqual(invoked.body.runtime.projectSummaryContractDigest, 'e'.repeat(64));
         assert.deepStrictEqual(nativeClient.calls, [
-            'pair', 'capabilities:full', 'projectSummary',
+            'pair',
+            ['negotiate', { deadlineUnixMs }],
+            ['capabilities', { detail: 'full', limit: 100, deadlineUnixMs }],
+            ['invoke', {
+                requestId: 'core-project-summary-1',
+                capabilityId: 'ae.project.summary',
+                capabilityVersion: 1,
+                arguments: {},
+                deadlineUnixMs,
+            }],
         ]);
     } finally {
         srv.close();
@@ -280,6 +375,8 @@ test('native routes preserve panel pause and client-block controls and close the
         }, body);
         assert.strictEqual(paused.status, 503);
         assert.strictEqual(paused.body.error.code, 'ACTIONS_PAUSED');
+        assert.strictEqual(paused.body.error.sideEffect, 'not-started');
+        assert.strictEqual(paused.body.error.recovery.action, 'retry');
         server.setPaused(false);
 
         server.setClientBlocked('blocked/test', true);
@@ -289,6 +386,8 @@ test('native routes preserve panel pause and client-block controls and close the
         }, body);
         assert.strictEqual(blocked.status, 403);
         assert.strictEqual(blocked.body.error.code, 'CLIENT_BLOCKED');
+        assert.strictEqual(blocked.body.error.sideEffect, 'not-started');
+        assert.strictEqual(blocked.body.error.recovery.action, 'none');
         assert.deepStrictEqual(nativeClient.calls, []);
     } finally {
         server.setPaused(false);
@@ -297,6 +396,112 @@ test('native routes preserve panel pause and client-block controls and close the
         server.stop();
     }
     assert.strictEqual(nativeClient.closed(), 1);
+});
+
+test('native invoke preserves complete structured native failures over HTTP', async () => {
+    const nativeClient = fakeNativeClient();
+    nativeClient.authorize();
+    nativeClient.invoke = async function () {
+        const error = new Error('project summary failed');
+        error.code = 'CAPABILITY_FAILED';
+        error.retryable = false;
+        error.sideEffect = 'not-started';
+        error.recovery = { action: 'inspect-state', hint: 'Inspect the project state.' };
+        error.details = { capabilityId: 'ae.project.summary' };
+        throw error;
+    };
+    const { server, srv, port } = await startNativeApp(nativeClient);
+    try {
+        const response = await post(port, '/native/invoke', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, {
+            requestId: 'core-project-summary-error',
+            capabilityId: 'ae.project.summary',
+            capabilityVersion: 1,
+            arguments: {},
+            deadlineUnixMs: Date.now() + 10000,
+        });
+        assert.strictEqual(response.status, 503);
+        assert.deepStrictEqual(response.body.error, {
+            code: 'CAPABILITY_FAILED',
+            message: 'project summary failed',
+            retryable: false,
+            sideEffect: 'not-started',
+            recovery: { action: 'inspect-state', hint: 'Inspect the project state.' },
+            details: { capabilityId: 'ae.project.summary' },
+        });
+    } finally {
+        srv.close();
+        server.stop();
+    }
+});
+
+for (const failureFixture of brokerFailureFixtures.concat([
+    {
+        name: 'actual native INVALID_REQUEST',
+        status: 503,
+        body: {
+            ok: false,
+            error: {
+                code: 'INVALID_REQUEST',
+                message: 'native request was invalid',
+                retryable: false,
+                sideEffect: 'not-started',
+                recovery: { action: 'none', hint: 'Do not retry this request.' },
+            },
+        },
+    },
+])) {
+    test('native invoke preserves ' + failureFixture.name + ' over HTTP', async () => {
+        const expectedError = failureFixture.body.error;
+        const nativeClient = fakeNativeClient();
+        nativeClient.authorize();
+        nativeClient.invoke = async function () {
+            const error = new Error(expectedError.message);
+            error.code = expectedError.code;
+            error.retryable = expectedError.retryable;
+            error.sideEffect = expectedError.sideEffect;
+            error.recovery = expectedError.recovery;
+            throw error;
+        };
+        const { server, srv, port } = await startNativeApp(nativeClient);
+        try {
+            const response = await post(port, '/native/invoke', {
+                'X-AE-MCP-Token': 'known-secret-token',
+            }, {
+                requestId: 'core-error-classification',
+                capabilityId: 'ae.project.summary',
+                capabilityVersion: 1,
+                arguments: {},
+                deadlineUnixMs: Date.now() + 10000,
+            });
+            assert.strictEqual(response.status, failureFixture.status);
+            assert.deepStrictEqual(response.body, failureFixture.body);
+        } finally {
+            srv.close();
+            server.stop();
+        }
+    });
+}
+
+test('native negotiation forwards the Core deadline while authentication is pending', async () => {
+    const nativeClient = fakeNativeClient();
+    nativeClient.authenticate();
+    const { server, srv, port } = await startNativeApp(nativeClient);
+    const deadlineUnixMs = Date.now() + 10000;
+    try {
+        const response = await post(port, '/native/negotiate', {
+            'X-AE-MCP-Token': 'known-secret-token',
+        }, { deadlineUnixMs });
+        assert.strictEqual(response.status, 200);
+        assert.deepStrictEqual(nativeClient.calls, [
+            ['wait', deadlineUnixMs],
+            ['negotiate', { deadlineUnixMs }],
+        ]);
+    } finally {
+        srv.close();
+        server.stop();
+    }
 });
 
 test('/exec returns 401 without a token', async () => {


### PR DESCRIPTION
## Summary

Expose the verified `ae.project.summary@1` AEGP capability through the model-visible public MCP tool `ae_projectSummary`.

This change adds the concrete Core-to-CEP native transport, preserves the typed negotiate/capabilities/invoke contract and structured failure policy, and explicitly prevents JSX fallback after native selection. The existing broader JSX `ae.overview` tool is unchanged.

Closes #76  
Part of #61  
Feeds #78

## Public path

The captured real-host call used the public MCP protocol, not an internal helper:

```text
initialize
  -> tools/list (ae_projectSummary advertised)
  -> tools/call ae_projectSummary
  -> Core typed native backend
  -> authenticated CEP broker
  -> native RPC
  -> AEGP main-thread dispatcher
  -> After Effects
  -> typed result + provenance + audit/evidence
```

## Real-host evidence

The original real-host candidate was `8bee48fe2fae9ef108f26813a65485755bd757a3`. The rebased head `e49503ad2eecad2c996074c43e4422b93eb9b648` was then rebuilt from the pinned SDK, transactionally installed with its matching CEP tree, loaded in After Effects, paired by an exact local fingerprint comparison, and exercised again through the public MCP surface.

- Public `tools/call` completed with MCP `isError: false` and payload `ok: true` against the installed After Effects host.
- The original gate reported an open disposable project with `0` items; the exact-rebased-head smoke independently reported an open project with `0` items.
- Implementation and execution evidence both reported `engine: native-aegp`, capability `ae.project.summary@1`, `effect: none`, and a verified `project-summary` postcondition using `sha256-rfc8785-jcs-v1`.
- Provenance recorded wire version `1`, plug-in version `0.1.0-dev`, compiled SDK `25.6.61`, and installed native source commit `e49503ad2eecad2c996074c43e4422b93eb9b648`. Host/session identifiers and digests were captured for verification but are intentionally omitted here.
- The panel activity delta contained exactly three successful `native-aegp` records: negotiation, capability discovery, and invoke. It contained no JSX or `/exec` activity.
- Native evidence recorded plug-in load, successful hello, successful capability discovery, queued invoke, and terminal success.
- `lsof` showed exactly one mapped ae-mcp native binary from the canonical `AeMcpNative.plugin` installation and no staged, backup, or legacy ae-mcp plug-in mapping.
- A separate real-host unauthenticated observation sent `POST /native/negotiate` without the shared token and received HTTP `401 / UNAUTHORIZED`; panel activity did not advance and the native log line count remained unchanged. This negative observation was not separately archived in the evidence bundle.
- With the panel UI paused, the same public MCP call returned structured `NATIVE_ACTIONS_PAUSED` with `sideEffect: not-started`. Filtering native JSONL from the transcript `startedAt` timestamp produced zero records, proving the request was stopped before native dispatch.
- After resuming actions in the UI, the same public MCP call immediately passed again without rebuilding pairing or the native session.

## Tests

- Python workspace: `702 passed, 4 skipped, 25 deselected`
- Host Node suite: `95 passed`
- Rebased-head Python focus suite: `146 passed`
- Rebased-head host Node suite: `51 passed` (unchanged command passed outside the socket-restricted sandbox)
- Rebased-head protocol suite: `28 passed`
- `git diff --check`: clean
- Independent rebased-diff review: **CLEAN**, with no blocker for the public native read path

Coverage includes public handler exposure/dispatch, strict typed transcript mapping, token/pause/block gates, pairing outcomes, malformed and tampered evidence, closed HTTP failure envelopes, structured recovery policy, deadline/cancellation-before-dispatch, and no-JSX/no-fallback behavior.

## Boundaries

Release-grade multi-instance/peer-identity hardening, restart-race recovery, dynamic AEGP/JSX selection, Windows native support, signing/notarization, and the first native write remain out of scope here.

## Merge gate

#78 has now proved the downstream real, audited, undoable native write in a disposable project, including verified `native-aegp` provenance, duplicate-request rejection, AE Undo/Redo, restart/reconnect, and no fallback while AE is unavailable. Merge this PR only after fresh CI succeeds for rebased head `e49503ad2eecad2c996074c43e4422b93eb9b648`; then repeat the public read on the squash-merged `main` before starting the #78 merge.
