### PR TITLE
fix(macos): keep CEP installer state off scan root

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,7 +66,7 @@ macOS 请把 `<USER>` 替换为实际账户名。Windows 请把 `command` 改成
 
 ### 开发安装
 
-开发 checkout 才需要 `uv`、Node/npm 和本地编译/签名工具。它不是普通用户安装路径。运行脚本前必须关闭全部 After Effects / AfterFX 进程。脚本会先预检必须文件，在目标同一 CEP 父目录建立唯一 staging，完成整树复制与复验后再原子 rename；旧安装保留为唯一 backup，任何交换失败都会自动恢复，成功时会打印绝对恢复命令。
+开发 checkout 才需要 `uv`、Node/npm 和本地编译/签名工具。它不是普通用户安装路径。运行脚本前必须关闭全部 After Effects / AfterFX 进程。macOS 脚本会先预检必须文件，并把旧版安装器遗留且名称严格匹配的 transaction artifact 非破坏性迁出 Adobe CEP 扫描根；随后在私有 `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/` 中建立唯一 staging，完成整树复制与复验后再原子 rename。扫描根中只保留生效的 `com.aemcp.panel`。旧安装作为唯一 backup 保存在同一私有状态目录中，任何交换失败都会自动恢复，成功时会打印绝对恢复命令。Windows 脚本仍使用目标旁的事务目录和同样的回滚契约。
 
 ```bash
 uv sync --all-packages --group dev
@@ -168,7 +168,7 @@ This is the final v0.9.2 stable-launcher contract. The current Panel config gene
 
 ### Developer Install
 
-Only a development checkout requires `uv`, Node/npm, and local build/signing tools. This is not the normal-user install path. Close every After Effects / AfterFX process first. Each script preflights required source files, copies and verifies a unique staging tree beside the target, then performs same-parent atomic renames. It retains the old panel as a unique backup, restores it automatically on swap failure, and prints an absolute restore command after success.
+Only a development checkout requires `uv`, Node/npm, and local build/signing tools. This is not the normal-user install path. Close every After Effects / AfterFX process first. On macOS, the script preflights required source files and non-destructively moves strictly named transaction artifacts left by older installers out of Adobe's CEP scan root. It then creates its unique staging tree in the private off-scan state directory `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/`. After copying and verifying the complete tree, it atomically renames the candidate into place; the scan root retains only the active `com.aemcp.panel`. The old panel remains as the unique backup in that private state directory, is restored automatically on swap failure, and is named in an absolute restore command after success. The Windows script continues to use transaction directories beside its target with the same rollback contract.
 
 ```bash
 uv sync --all-packages --group dev

--- a/scripts/install-plugin-dev-macos.sh
+++ b/scripts/install-plugin-dev-macos.sh
@@ -19,6 +19,7 @@ plugin_src="${repo_root}/plugin"
 cep_parent="${HOME}/Library/Application Support/Adobe/CEP/extensions"
 extension_id='com.aemcp.panel'
 cep_dir="${cep_parent}/${extension_id}"
+state_dir="${HOME}/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1"
 
 required_files=(
   'CSXS/manifest.xml'
@@ -35,6 +36,7 @@ require_tool find
 require_tool realpath
 require_tool rsync
 require_tool mv
+require_tool chmod
 
 set +e
 pgrep -f 'Adobe After Effects|AfterFX' >/dev/null 2>&1
@@ -85,11 +87,53 @@ if [[ -e "$cep_dir" || -L "$cep_dir" ]]; then
     || fail "existing CEP target is not a regular directory: ${cep_dir}"
 fi
 
+mkdir -p "$state_dir"
+[[ -d "$state_dir" && ! -L "$state_dir" ]] \
+  || fail "CEP installer state is not a regular directory: ${state_dir}"
+chmod 700 "$state_dir" \
+  || fail "could not make CEP installer state private: ${state_dir}"
+state_dir="$(cd "$state_dir" && pwd -P)"
+case "$state_dir" in
+  "$cep_parent"|"$cep_parent"/*)
+    fail "CEP installer state must remain outside the Adobe extension scan root"
+    ;;
+esac
+
+# Older versions retained complete transaction artifacts beside the active
+# extension. Adobe may discover those directories even when their names begin
+# with a dot, so move only the installer-owned shapes out of the scan root
+# before creating the next transaction.
+legacy_artifacts=()
+legacy_destinations=()
+shopt -s nullglob
+for legacy_kind in staging backup failed replaced; do
+  legacy_prefix=".${extension_id}.${legacy_kind}."
+  for legacy_artifact in "${cep_parent}/${legacy_prefix}"*; do
+    legacy_name="${legacy_artifact##*/}"
+    legacy_suffix="${legacy_name#"$legacy_prefix"}"
+    [[ "$legacy_name" == "$legacy_prefix"* \
+      && "$legacy_suffix" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+      || fail "legacy CEP transaction artifact has an invalid name: ${legacy_artifact}"
+    [[ -d "$legacy_artifact" && ! -L "$legacy_artifact" ]] \
+      || fail "legacy CEP transaction artifact is not a regular directory: ${legacy_artifact}"
+    legacy_destination="${state_dir}/${legacy_name}"
+    [[ ! -e "$legacy_destination" && ! -L "$legacy_destination" ]] \
+      || fail "legacy CEP transaction destination already exists: ${legacy_destination}"
+    legacy_artifacts+=("$legacy_artifact")
+    legacy_destinations+=("$legacy_destination")
+  done
+done
+shopt -u nullglob
+for ((legacy_index = 0; legacy_index < ${#legacy_artifacts[@]}; legacy_index += 1)); do
+  mv "${legacy_artifacts[$legacy_index]}" "${legacy_destinations[$legacy_index]}" \
+    || fail "could not move legacy CEP transaction artifact out of the Adobe scan root"
+done
+
 install_id="$(date -u '+%Y%m%dT%H%M%SZ').$$.${RANDOM}"
-staging="${cep_parent}/.${extension_id}.staging.${install_id}"
-backup="${cep_parent}/.${extension_id}.backup.${install_id}"
-failed_install="${cep_parent}/.${extension_id}.failed.${install_id}"
-restore_replaced="${cep_parent}/.${extension_id}.replaced.${install_id}"
+staging="${state_dir}/.${extension_id}.staging.${install_id}"
+backup="${state_dir}/.${extension_id}.backup.${install_id}"
+failed_install="${state_dir}/.${extension_id}.failed.${install_id}"
+restore_replaced="${state_dir}/.${extension_id}.replaced.${install_id}"
 for generated in "$staging" "$backup" "$failed_install" "$restore_replaced"; do
   [[ ! -e "$generated" && ! -L "$generated" ]] \
     || fail "generated deployment path already exists: ${generated}"
@@ -144,7 +188,7 @@ verify_tree() {
   [[ -z "$changes" ]] || fail "staged plugin tree differs from source: ${destination}"
 }
 
-printf '[1/5] Staging the complete plugin tree beside the final target...\n'
+printf '[1/5] Staging the complete plugin tree outside the Adobe scan root...\n'
 mkdir -m 700 "$staging"
 rsync -a --delete "${plugin_src}/" "${staging}/" \
   || fail 'plugin copy into staging failed'

--- a/scripts/package/test/dev-install-contract.test.mjs
+++ b/scripts/package/test/dev-install-contract.test.mjs
@@ -62,9 +62,11 @@ exec /bin/mv "$@"
 `);
   }
 
-  const target = path.join(
+  const scanRoot = path.join(home, 'Library/Application Support/Adobe/CEP/extensions');
+  const target = path.join(scanRoot, 'com.aemcp.panel');
+  const stateDir = path.join(
     home,
-    'Library/Application Support/Adobe/CEP/extensions/com.aemcp.panel',
+    'Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1',
   );
   await mkdir(target, { recursive: true });
   await writeFile(path.join(target, 'old-install.txt'), 'preserve me\n', 'utf8');
@@ -77,6 +79,8 @@ exec /bin/mv "$@"
     fixtureRepo,
     installer,
     plugin,
+    scanRoot,
+    stateDir,
     target,
   };
 }
@@ -116,13 +120,78 @@ test('macOS dev install stages, verifies, swaps, and retains a restorable backup
   });
   assert.equal(await readFile(path.join(fixture.target, 'client/dist/app.js'), 'utf8'),
     'fixture:client/dist/app.js\n');
-  const parent = path.dirname(fixture.target);
-  const backups = (await readdir(parent)).filter((name) => name.includes('.backup.'));
+  const scanRootEntries = await readdir(path.dirname(fixture.target));
+  assert.deepEqual(scanRootEntries, ['com.aemcp.panel']);
+  const backups = (await readdir(fixture.stateDir)).filter((name) => name.includes('.backup.'));
   assert.equal(backups.length, 1);
-  assert.equal(await readFile(path.join(parent, backups[0], 'old-install.txt'), 'utf8'),
+  assert.equal(await readFile(path.join(fixture.stateDir, backups[0], 'old-install.txt'), 'utf8'),
     'preserve me\n');
+  assert.equal((await stat(fixture.stateDir)).mode & 0o077, 0);
   assert.match(stdout, /Restore command.*After Effects is closed/is);
   assert.match(stdout, new RegExp(backups[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('macOS dev install preserves legacy transaction artifacts outside the CEP scan root', async (t) => {
+  const fixture = await makeMacFixture(t);
+  const legacyName = '.com.aemcp.panel.backup.20260714T210715Z.54520.16325';
+  const legacyArtifact = path.join(fixture.scanRoot, legacyName);
+  await mkdir(legacyArtifact);
+  await writeFile(path.join(legacyArtifact, 'legacy-install.txt'), 'legacy bytes\n', 'utf8');
+
+  await execFileAsync(fixture.installer, [], {
+    cwd: fixture.fixtureRepo,
+    env: fixture.env,
+  });
+
+  assert.deepEqual(await readdir(fixture.scanRoot), ['com.aemcp.panel']);
+  assert.equal(
+    await readFile(path.join(fixture.stateDir, legacyName, 'legacy-install.txt'), 'utf8'),
+    'legacy bytes\n',
+  );
+});
+
+test('macOS dev install rejects symbolic or non-directory legacy transaction artifacts', async (t) => {
+  for (const kind of ['symlink', 'file']) {
+    await t.test(kind, async (child) => {
+      const fixture = await makeMacFixture(child);
+      const legacyName = `.com.aemcp.panel.failed.${kind}-fixture`;
+      const legacyArtifact = path.join(fixture.scanRoot, legacyName);
+      if (kind === 'symlink') await symlink(fixture.target, legacyArtifact);
+      else await writeFile(legacyArtifact, 'not a directory\n', 'utf8');
+
+      await assert.rejects(
+        execFileAsync(fixture.installer, [], {
+          cwd: fixture.fixtureRepo,
+          env: fixture.env,
+        }),
+        /legacy CEP transaction artifact is not a regular directory/i,
+      );
+      assert.equal(await readFile(path.join(fixture.target, 'old-install.txt'), 'utf8'),
+        'preserve me\n');
+    });
+  }
+});
+
+test('macOS dev install fails closed when a legacy artifact destination conflicts', async (t) => {
+  const fixture = await makeMacFixture(t);
+  const legacyName = '.com.aemcp.panel.replaced.conflict-fixture';
+  const legacyArtifact = path.join(fixture.scanRoot, legacyName);
+  await mkdir(legacyArtifact);
+  await writeFile(path.join(legacyArtifact, 'scan-root-copy.txt'), 'scan root\n', 'utf8');
+  await mkdir(fixture.stateDir, { recursive: true });
+  await mkdir(path.join(fixture.stateDir, legacyName));
+
+  await assert.rejects(
+    execFileAsync(fixture.installer, [], {
+      cwd: fixture.fixtureRepo,
+      env: fixture.env,
+    }),
+    /legacy CEP transaction destination already exists/i,
+  );
+  assert.equal(await readFile(path.join(legacyArtifact, 'scan-root-copy.txt'), 'utf8'),
+    'scan root\n');
+  assert.equal(await readFile(path.join(fixture.target, 'old-install.txt'), 'utf8'),
+    'preserve me\n');
 });
 
 test('macOS dev install restores the old panel when the second atomic rename fails', async (t) => {
@@ -131,11 +200,12 @@ test('macOS dev install restores the old panel when the second atomic rename fai
     execFileAsync(fixture.installer, [], { cwd: fixture.fixtureRepo, env: fixture.env }),
   );
   assert.equal(await readFile(path.join(fixture.target, 'old-install.txt'), 'utf8'), 'preserve me\n');
-  const siblings = await readdir(path.dirname(fixture.target));
-  assert.equal(siblings.some((name) => name.includes('.staging.')), false);
+  assert.deepEqual(await readdir(path.dirname(fixture.target)), ['com.aemcp.panel']);
+  const stateEntries = await readdir(fixture.stateDir);
+  assert.equal(stateEntries.some((name) => name.includes('.staging.')), false);
 });
 
-test('both dev installers encode preflight, same-parent staging, rollback, and no delete-first path', async () => {
+test('dev installers encode preflight, isolated macOS state, rollback, and no delete-first path', async () => {
   const mac = await readFile(path.join(repoRoot, 'scripts/install-plugin-dev-macos.sh'), 'utf8');
   const windows = await readFile(path.join(repoRoot, 'scripts/install-plugin-dev.ps1'), 'utf8');
 
@@ -146,6 +216,16 @@ test('both dev installers encode preflight, same-parent staging, rollback, and n
   assert.match(mac, /rsync[\s\S]*--delete/);
   assert.match(mac, /rsync[\s\S]*--checksum/);
   assert.match(mac, /restore/i);
+  assert.match(mac, /AfterEffectsMCP\/cep-panel-dev-v1/);
+  assert.match(mac, /state_dir=.*AfterEffectsMCP/);
+  assert.match(mac, /staging="\$\{state_dir\}/);
+  assert.match(mac, /backup="\$\{state_dir\}/);
+  assert.match(mac, /failed_install="\$\{state_dir\}/);
+  assert.match(mac, /restore_replaced="\$\{state_dir\}/);
+  assert.doesNotMatch(mac, /staging="\$\{cep_parent\}/);
+  assert.doesNotMatch(mac, /backup="\$\{cep_parent\}/);
+  assert.doesNotMatch(mac, /failed_install="\$\{cep_parent\}/);
+  assert.doesNotMatch(mac, /restore_replaced="\$\{cep_parent\}/);
   assert.ok(mac.indexOf('defaults write') < mac.indexOf('mv "$cep_dir" "$backup"'));
   for (const required of ['CSXS/manifest.xml', 'client/dist/app.js', 'host/server.js']) {
     assert.ok(mac.includes(required));


### PR DESCRIPTION
Closes #95

## What changed

- Store macOS CEP development installer staging, backup, failed-candidate, and replaced trees under the private off-scan state directory `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/`.
- Keep only the canonical `com.aemcp.panel` tree under Adobe's CEP `extensions` scan root.
- Non-destructively migrate legacy installer-owned hidden transaction directories out of the scan root; reject symlinks, non-directories, invalid names, and destination conflicts.
- Preserve the existing verified swap, rollback, and printed restore command.
- Update the focused installer contract tests and bilingual developer-install documentation.

## Root cause and impact

A real #94 hardware run loaded a retained hidden backup carrying the same CEP bundle/extension ID and version as the canonical panel. That mixed an exact new native plug-in with an old Host validator: the AEGP write committed, but the public MCP path reported `POSSIBLY_SIDE_EFFECTING_FAILURE`. Keeping every complete extension tree except the canonical one outside Adobe's scan root removes that ambiguity.

## Scope boundary

This is the narrow reproduced P0 blocker only. It does not add installer locks, concurrent-install handling, power-loss guarantees, signing, notarization, or production-installer work.

## Validation so far

Exact candidate: `b7d71b2d48012647ba72d4dec114849ab733a011`

- `bash -n scripts/install-plugin-dev-macos.sh`
- Focused installer tests: 12 passed
- Full packaging tests: 335 passed, 6 skipped
- `git diff --check`
- Independent blocker-only diff review: no blockers

## Pending merge gate

The PR remains Draft until the exact candidate is installed on the target Mac, the Adobe CEP scan root contains only the canonical extension, After Effects loads the matching Host/native source commit, and a public MCP native read succeeds. Clean-`main` rebuild/reinstall/reverification is also required after merge.

Sensitive pairing/runtime identifiers and private project paths will not be posted.