### PR TITLE
build(native-plugin/macos): bind AEGP artifact into verified unsigned stage

### DIFF
--- a/native/ae-plugin/build-macos.mjs
+++ b/native/ae-plugin/build-macos.mjs
@@ -16,6 +16,9 @@ import { verifyMacPlugin } from './verify-macos.mjs';
 const MODULE_PATH = fileURLToPath(import.meta.url);
 const MODULE_ROOT = path.dirname(MODULE_PATH);
 const REPO_ROOT = path.resolve(MODULE_ROOT, '../..');
+const PRODUCT_MANIFEST_PATH = 'plugin/host/package.json';
+const PRODUCT_VERSION_PATTERN = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+const PRODUCT_VERSION_TOKEN = Buffer.from('__AE_MCP_PRODUCT_VERSION__', 'ascii');
 
 function buildError(code, message) {
   const error = new Error(message);
@@ -74,6 +77,50 @@ function gitFileBytes(sourceCommit, relativePath) {
   return commandBytes('/usr/bin/git', [
     '-C', REPO_ROOT, 'show', `${sourceCommit}:${relativePath}`,
   ], [REPO_ROOT]);
+}
+
+function productVersionFromCommit(sourceCommit) {
+  const bytes = gitFileBytes(sourceCommit, PRODUCT_MANIFEST_PATH);
+  if (bytes.length === 0 || bytes.length > 64 * 1024) {
+    throw buildError(
+      'AE_PLUGIN_PRODUCT_VERSION_INVALID',
+      'repository product manifest is not a bounded file',
+    );
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw buildError(
+      'AE_PLUGIN_PRODUCT_VERSION_INVALID',
+      'repository product manifest is not valid JSON',
+    );
+  }
+  const productVersion = manifest?.version;
+  if (typeof productVersion !== 'string'
+      || productVersion.length > 64
+      || !PRODUCT_VERSION_PATTERN.test(productVersion)) {
+    throw buildError(
+      'AE_PLUGIN_PRODUCT_VERSION_INVALID',
+      'repository product manifest does not declare a numeric semantic version',
+    );
+  }
+  return productVersion;
+}
+
+function replaceExactlyOnce(bytes, token, replacement, label) {
+  const offset = bytes.indexOf(token);
+  if (offset < 0 || bytes.indexOf(token, offset + token.length) >= 0) {
+    throw buildError(
+      'AE_PLUGIN_PRODUCT_VERSION_INVALID',
+      `${label} must contain exactly one product version token`,
+    );
+  }
+  return Buffer.concat([
+    bytes.subarray(0, offset),
+    replacement,
+    bytes.subarray(offset + token.length),
+  ]);
 }
 
 async function snapshotProductFile(sourceCommit, relativePath, snapshotRoot) {
@@ -255,12 +302,14 @@ async function writeReceipt(
   stage,
   verification,
   sourceCommit,
+  productVersion,
   sdkVerification,
   schemaBytes,
 ) {
   const receipt = {
     schemaVersion: 1,
     artifact: verification,
+    productVersion,
     sourceCommit,
     source: {
       commit: sourceCommit,
@@ -301,6 +350,7 @@ async function buildMacPluginInternal({
     throw buildError('AE_PLUGIN_PLATFORM_UNSUPPORTED', 'macOS arm64 is required for this development build');
   }
   const sourceCommit = readCleanSourceCommit();
+  const productVersion = productVersionFromCommit(sourceCommit);
   const boundaries = await repositoryBoundaries();
   const policy = await loadAeSdkPolicy();
   const verification = await verifyAeSdkInput({
@@ -428,11 +478,21 @@ async function buildMacPluginInternal({
     await fs.promises.mkdir(path.join(contents, 'MacOS'), { recursive: true, mode: 0o700 });
     await fs.promises.mkdir(path.join(contents, 'Resources'), { recursive: true, mode: 0o700 });
     await fs.promises.mkdir(objects, { mode: 0o700 });
-    await fs.promises.copyFile(
+    const infoPlist = path.join(contents, 'Info.plist');
+    const infoTemplate = await fs.promises.readFile(
       productInputs.get('native/ae-plugin/resources/Info.plist'),
-      path.join(contents, 'Info.plist'),
-      fs.constants.COPYFILE_EXCL,
     );
+    await fs.promises.writeFile(
+      infoPlist,
+      replaceExactlyOnce(
+        infoTemplate,
+        PRODUCT_VERSION_TOKEN,
+        Buffer.from(productVersion, 'ascii'),
+        'native Info.plist template',
+      ),
+      { flag: 'wx', mode: 0o600 },
+    );
+    await fs.promises.chmod(infoPlist, 0o644);
     await fs.promises.writeFile(
       path.join(contents, 'PkgInfo'),
       Buffer.from('AEgxFXTC', 'ascii'),
@@ -452,6 +512,7 @@ async function buildMacPluginInternal({
       '-std=c++20', '-stdlib=libc++', '-arch', 'arm64', '-mmacosx-version-min=14.0',
       '-isysroot', sysroot,
       `-DAE_MCP_SOURCE_COMMIT="${sourceCommit}"`,
+      `-DAE_MCP_PRODUCT_VERSION="${productVersion}"`,
       '-pthread', '-fPIC', '-fvisibility=hidden', '-fvisibility-inlines-hidden',
       '-Wall', '-Wextra', '-Wpedantic', '-Werror', '-O0',
       ...includes,
@@ -502,12 +563,20 @@ async function buildMacPluginInternal({
     await fs.promises.rm(sourceSnapshot, { recursive: true });
     await fs.promises.rm(sdkSnapshot, { recursive: true });
     command('/usr/bin/codesign', ['--force', '--sign', '-', '--timestamp=none', bundle], redactions);
-    const artifactVerification = await verifyMacPlugin({ bundlePath: bundle });
+    const artifactVerification = await verifyMacPlugin({
+      bundlePath: bundle,
+      expectedProductVersion: productVersion,
+    });
     if (readCleanSourceCommit() !== sourceCommit) {
       throw buildError('AE_PLUGIN_SOURCE_CHANGED', 'repository HEAD changed during native build');
     }
     const receipt = await writeReceipt(
-      stage, artifactVerification, sourceCommit, verification, schemaBytes,
+      stage,
+      artifactVerification,
+      sourceCommit,
+      productVersion,
+      verification,
+      schemaBytes,
     );
     await fs.promises.rename(stage, canonicalOutput);
     return Object.freeze({
@@ -516,6 +585,7 @@ async function buildMacPluginInternal({
       bundle: path.join(canonicalOutput, 'AeMcpNative.plugin'),
       receipt: path.join(canonicalOutput, 'build-receipt.json'),
       artifact: artifactVerification,
+      productVersion: receipt.productVersion,
       sourceCommit: receipt.sourceCommit,
       runtimeEvidence: false,
     });

--- a/native/ae-plugin/install-dev-macos.mjs
+++ b/native/ae-plugin/install-dev-macos.mjs
@@ -25,6 +25,7 @@ const MAX_JSON_BYTES = 64 * 1024;
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const SHA256 = /^[0-9a-f]{64}$/u;
 const COMMIT_SHA = /^[0-9a-f]{40}$/u;
+const PRODUCT_VERSION = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
 const MANAGED_BUNDLE_NAME = /^\.AeMcpNative\.(?:stage|backup|failed|replaced)\.([0-9a-f-]+)\.disabled$/u;
 const TRANSACTION_FILE_NAME = /^\.AeMcpNative\.transaction\.([0-9a-f-]+)\.json$/u;
 const STALE_LOCK_FILE_NAME = /^\.AeMcpNative\.stale-lock\.([0-9a-f-]+)\.json$/u;
@@ -120,6 +121,7 @@ function validateReceipt(value) {
     [
       'artifact',
       'build',
+      'productVersion',
       'protocolSchemaSha256',
       'schemaVersion',
       'sdk',
@@ -158,6 +160,9 @@ function validateReceipt(value) {
       || !COMMIT_SHA.test(value.sourceCommit)
       || value.source.commit !== value.sourceCommit
       || value.source.repositoryClean !== true
+      || typeof value.productVersion !== 'string'
+      || value.productVersion.length > 64
+      || !PRODUCT_VERSION.test(value.productVersion ?? '')
       || !SHA256.test(value.protocolSchemaSha256)
       || value.sdk.name !== 'Adobe After Effects C/C++ Plug-in SDK'
       || value.sdk.claimedVersion !== '25.6.61'
@@ -301,7 +306,10 @@ async function loadSourceArtifact(artifactDir, dependencies) {
     throw installerError('AE_PLUGIN_RECEIPT_INVALID', 'build receipt is not valid JSON');
   }
   const observed = validateArtifact(
-    await dependencies.verifyBundle({ bundlePath }),
+    await dependencies.verifyBundle({
+      bundlePath,
+      expectedProductVersion: receipt.productVersion,
+    }),
     'verified source artifact',
   );
   if (!isDeepStrictEqual(observed, receipt.artifact)) {
@@ -1597,6 +1605,7 @@ export async function installDevMacPlugin({
         action: 'install',
         transactionId,
         target,
+        productVersion: source.receipt.productVersion,
         sourceCommit: source.receipt.sourceCommit,
         artifact: source.receipt.artifact,
         previous: {

--- a/native/ae-plugin/resources/Info.plist
+++ b/native/ae-plugin/resources/Info.plist
@@ -19,7 +19,7 @@
   <key>CFBundleSignature</key>
   <string>FXTC</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>__AE_MCP_PRODUCT_VERSION__</string>
   <key>CFBundleSupportedPlatforms</key>
   <array><string>MacOSX</string></array>
   <key>CFBundleVersion</key>

--- a/native/ae-plugin/src/aegp/plugin_entry.cpp
+++ b/native/ae-plugin/src/aegp/plugin_entry.cpp
@@ -44,6 +44,10 @@
 #error "AE_MCP_SOURCE_COMMIT must bind the native binary to a clean repository commit"
 #endif
 
+#ifndef AE_MCP_PRODUCT_VERSION
+#error "AE_MCP_PRODUCT_VERSION must bind the native binary to the repository product version"
+#endif
+
 namespace {
 
 using namespace std::chrono_literals;
@@ -73,7 +77,7 @@ using aemcp::native::kProjectBitDepthReadCapability;
 using aemcp::native::kProjectBitDepthSetCapability;
 using aemcp::native::kProjectSummaryCapability;
 
-constexpr std::string_view kPluginVersion = "0.1.0-dev";
+constexpr std::string_view kPluginVersion = AE_MCP_PRODUCT_VERSION;
 constexpr std::string_view kSdkVersion = "25.6.61";
 constexpr std::uint64_t kSdkBuild = 61;
 constexpr std::string_view kSourceCommit = AE_MCP_SOURCE_COMMIT;

--- a/native/ae-plugin/verify-macos.mjs
+++ b/native/ae-plugin/verify-macos.mjs
@@ -19,6 +19,8 @@ const MAX_DIRECTORY_DEPTH = 8;
 const MAX_ENTRIES = 32;
 const MAX_FILE_BYTES = 128 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 160 * 1024 * 1024;
+const PRODUCT_VERSION_PATTERN = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/u;
+const PIPL_COMPATIBILITY_VERSION = 0x00010000;
 
 function verificationError(code, message) {
   const error = new Error(message);
@@ -144,7 +146,17 @@ function plistValue(plist, key) {
 export async function verifyMacPlugin({
   bundlePath,
   allowManagedDisabledName = false,
+  expectedProductVersion,
 }) {
+  if (expectedProductVersion !== undefined
+      && (typeof expectedProductVersion !== 'string'
+        || expectedProductVersion.length > 64
+        || !PRODUCT_VERSION_PATTERN.test(expectedProductVersion))) {
+    throw verificationError(
+      'AE_PLUGIN_ARGUMENT_INVALID',
+      'expected product version must be a numeric semantic version',
+    );
+  }
   const bundleName = bundlePath ? path.basename(bundlePath) : '';
   const nameIsAllowed = bundleName === 'AeMcpNative.plugin'
     || (allowManagedDisabledName && MANAGED_DISABLED_BUNDLE.test(bundleName));
@@ -175,7 +187,6 @@ export async function verifyMacPlugin({
     CFBundleIdentifier: 'dev.aemcp.native-plugin',
     CFBundlePackageType: 'AEgx',
     CFBundleSignature: 'FXTC',
-    CFBundleShortVersionString: '0.1.0',
     CFBundleVersion: '1',
     LSMinimumSystemVersion: '14.0',
   };
@@ -183,6 +194,19 @@ export async function verifyMacPlugin({
     if (plistValue(plist, key) !== expected) {
       throw verificationError('AE_PLUGIN_PLIST_INVALID', `unexpected ${key} in native plug-in`);
     }
+  }
+  const productVersion = plistValue(plist, 'CFBundleShortVersionString');
+  if (productVersion.length > 64 || !PRODUCT_VERSION_PATTERN.test(productVersion)) {
+    throw verificationError(
+      'AE_PLUGIN_PRODUCT_VERSION_INVALID',
+      'native plug-in product version is not numeric semantic version text',
+    );
+  }
+  if (expectedProductVersion !== undefined && productVersion !== expectedProductVersion) {
+    throw verificationError(
+      'AE_PLUGIN_PRODUCT_VERSION_MISMATCH',
+      'native plug-in product version does not match the exact repository build version',
+    );
   }
   if (!(await fs.promises.readFile(pkgInfo)).equals(Buffer.from('AEgxFXTC', 'ascii'))) {
     throw verificationError('AE_PLUGIN_PLIST_INVALID', 'native plug-in PkgInfo is invalid');
@@ -197,6 +221,13 @@ export async function verifyMacPlugin({
   if (JSON.stringify(exported) !== JSON.stringify(['_AeMcpNativeMain'])) {
     throw verificationError('AE_PLUGIN_EXPORT_INVALID', 'native plug-in exports an unexpected symbol set');
   }
+  const executableBytes = await fs.promises.readFile(executable);
+  if (!executableBytes.includes(Buffer.from(productVersion, 'ascii'))) {
+    throw verificationError(
+      'AE_PLUGIN_PRODUCT_VERSION_MISMATCH',
+      'native executable does not embed the Info.plist product version used by runtime provenance',
+    );
+  }
 
   const deRez = command('/usr/bin/xcrun', ['--find', 'DeRez']).trim();
   const resourceDump = command(deRez, ['-useDF', resource]);
@@ -205,6 +236,9 @@ export async function verifyMacPlugin({
     throw verificationError('AE_PLUGIN_PIPL_INVALID', 'native plug-in PiPL is missing required metadata');
   }
   assertPiplProperty(resourceBytes, 'kind', Buffer.from('AEgx', 'ascii'));
+  const piplCompatibilityVersion = Buffer.alloc(4);
+  piplCompatibilityVersion.writeUInt32BE(PIPL_COMPATIBILITY_VERSION);
+  assertPiplProperty(resourceBytes, 'vers', piplCompatibilityVersion);
   const entryPoint = Buffer.from('AeMcpNativeMain', 'ascii');
   assertPiplProperty(
     resourceBytes,

--- a/packaging/schemas/bundle-manifest.schema.json
+++ b/packaging/schemas/bundle-manifest.schema.json
@@ -47,6 +47,17 @@
         "manifestSha256": { "$ref": "#/$defs/sha256" }
       }
     },
+    "nativePlugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifestPath", "manifestSha256"],
+      "properties": {
+        "manifestPath": {
+          "const": "artifacts/native-plugin/macos-arm64/native-plugin-manifest.json"
+        },
+        "manifestSha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
     "files": {
       "type": "array",
       "minItems": 1,
@@ -58,6 +69,16 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": { "required": ["nativePlugin"] },
+      "then": {
+        "properties": {
+          "platform": { "const": "macos-arm64" }
+        }
+      }
+    }
+  ],
   "$defs": {
     "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
     "baseEntry": {

--- a/packaging/schemas/native-plugin-manifest.schema.json
+++ b/packaging/schemas/native-plugin-manifest.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NativePluginManifestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "productVersion",
+    "sourceCommitSha",
+    "platform",
+    "architecture",
+    "artifact",
+    "sdk",
+    "protocol",
+    "build"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "productVersion": { "$ref": "#/$defs/semver" },
+    "sourceCommitSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "platform": { "const": "macos-arm64" },
+    "architecture": { "const": "arm64" },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "payloadRoot",
+        "bundlePath",
+        "receiptPath",
+        "receiptSha256",
+        "bundleName",
+        "bundleIdentifier",
+        "bundleType",
+        "entryPoint",
+        "fileCount",
+        "bundleTreeSha256",
+        "executablePath",
+        "executableSha256",
+        "piplPath",
+        "piplResourceId",
+        "piplCompatibilityVersion",
+        "piplSha256"
+      ],
+      "properties": {
+        "payloadRoot": { "const": "payload" },
+        "bundlePath": { "const": "payload/AeMcpNative.plugin" },
+        "receiptPath": { "const": "payload/build-receipt.json" },
+        "receiptSha256": { "$ref": "#/$defs/sha256" },
+        "bundleName": { "const": "AeMcpNative.plugin" },
+        "bundleIdentifier": { "const": "dev.aemcp.native-plugin" },
+        "bundleType": { "const": "AEgx" },
+        "entryPoint": { "const": "AeMcpNativeMain" },
+        "fileCount": { "const": 5 },
+        "bundleTreeSha256": { "$ref": "#/$defs/sha256" },
+        "executablePath": {
+          "const": "payload/AeMcpNative.plugin/Contents/MacOS/AeMcpNative"
+        },
+        "executableSha256": { "$ref": "#/$defs/sha256" },
+        "piplPath": {
+          "const": "payload/AeMcpNative.plugin/Contents/Resources/AeMcpNative.rsrc"
+        },
+        "piplResourceId": { "const": 16000 },
+        "piplCompatibilityVersion": { "const": 65536 },
+        "piplSha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "sdk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "claimedVersion",
+        "claimedBuild",
+        "policySha256",
+        "archiveSha256",
+        "rootContentSha256",
+        "verification",
+        "materialIncluded"
+      ],
+      "properties": {
+        "name": { "const": "Adobe After Effects C/C++ Plug-in SDK" },
+        "claimedVersion": { "const": "25.6.61" },
+        "claimedBuild": { "const": 61 },
+        "policySha256": { "$ref": "#/$defs/sha256" },
+        "archiveSha256": { "$ref": "#/$defs/sha256" },
+        "rootContentSha256": { "$ref": "#/$defs/sha256" },
+        "verification": {
+          "const": "archive-byte-identity-plus-canonical-root-content"
+        },
+        "materialIncluded": { "const": false }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaSha256"],
+      "properties": {
+        "schemaSha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "configuration",
+        "signing",
+        "signatureVerification",
+        "distributionApproved"
+      ],
+      "properties": {
+        "configuration": { "const": "development" },
+        "signing": { "const": "ad-hoc" },
+        "signatureVerification": { "const": "ad-hoc-verified" },
+        "distributionApproved": { "const": false }
+      }
+    }
+  },
+  "$defs": {
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/scripts/package/lib/manifest.mjs
+++ b/scripts/package/lib/manifest.mjs
@@ -6,6 +6,7 @@ export const PLATFORM_IDS = new Set(['macos-arm64', 'windows-x64']);
 export const SOURCE_SHA_PATTERN = /^[0-9a-f]{40}$/;
 export const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 export const SEMVER_PATTERN = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+export const NATIVE_PLUGIN_MANIFEST_PATH = 'artifacts/native-plugin/macos-arm64/native-plugin-manifest.json';
 
 export function bundleError(code, message) {
   const error = new Error(message);
@@ -295,7 +296,10 @@ export function validateBundleManifest(value) {
     throw bundleError('BUNDLE_MANIFEST_INVALID', 'bundle manifest must be an object');
   }
   const exactTop = ['files', 'helper', 'platform', 'runtime', 'schemaVersion', 'sourceCommitSha', 'version'];
-  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(exactTop)) {
+  const observedTop = Object.keys(value).sort();
+  const expectedTop = Object.hasOwn(value, 'nativePlugin')
+    ? [...exactTop, 'nativePlugin'].sort() : exactTop;
+  if (JSON.stringify(observedTop) !== JSON.stringify(expectedTop)) {
     throw bundleError('BUNDLE_MANIFEST_INVALID', 'bundle manifest has unexpected fields');
   }
   if (value.schemaVersion !== 1
@@ -326,6 +330,16 @@ export function validateBundleManifest(value) {
       || value.helper.helperId !== 'com.junkdoge.ae-mcp.platform-helper'
       || !SHA256_PATTERN.test(value.helper.manifestSha256 ?? '')) {
     throw bundleError('BUNDLE_MANIFEST_INVALID', 'bundle helper identity is invalid');
+  }
+  if (Object.hasOwn(value, 'nativePlugin')) {
+    if (value.platform !== 'macos-arm64'
+        || !value.nativePlugin
+        || JSON.stringify(Object.keys(value.nativePlugin).sort())
+          !== JSON.stringify(['manifestPath', 'manifestSha256'])
+        || value.nativePlugin.manifestPath !== NATIVE_PLUGIN_MANIFEST_PATH
+        || !SHA256_PATTERN.test(value.nativePlugin.manifestSha256 ?? '')) {
+      throw bundleError('BUNDLE_MANIFEST_INVALID', 'bundle native plug-in reference is invalid');
+    }
   }
   if (!Array.isArray(value.files) || value.files.length === 0) {
     throw bundleError('BUNDLE_MANIFEST_INVALID', 'bundle file inventory is empty');

--- a/scripts/package/lib/native-plugin-manifest.mjs
+++ b/scripts/package/lib/native-plugin-manifest.mjs
@@ -1,0 +1,605 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { verifyMacPlugin } from '../../../native/ae-plugin/verify-macos.mjs';
+import {
+  NATIVE_PLUGIN_MANIFEST_PATH,
+  SHA256_PATTERN,
+  SOURCE_SHA_PATTERN,
+  bundleError,
+  canonicalJson,
+  copyRegularFileStable,
+  copyTree,
+  readCanonicalJsonFile,
+  readJsonFile,
+  sha256Bytes,
+  sha256File,
+  writeCanonicalJson,
+} from './manifest.mjs';
+
+export const NATIVE_PLUGIN_ROOT = path.posix.dirname(NATIVE_PLUGIN_MANIFEST_PATH);
+export const NATIVE_PLUGIN_MANIFEST_NAME = path.posix.basename(NATIVE_PLUGIN_MANIFEST_PATH);
+export const NATIVE_PLUGIN_PAYLOAD_ROOT = 'payload';
+export const NATIVE_PLUGIN_BUNDLE_NAME = 'AeMcpNative.plugin';
+export const NATIVE_PLUGIN_RECEIPT_NAME = 'build-receipt.json';
+
+const NATIVE_PLUGIN_MANIFEST_RELATIVE = NATIVE_PLUGIN_MANIFEST_PATH;
+const BUNDLE_RELATIVE = NATIVE_PLUGIN_PAYLOAD_ROOT + '/' + NATIVE_PLUGIN_BUNDLE_NAME;
+const RECEIPT_RELATIVE = NATIVE_PLUGIN_PAYLOAD_ROOT + '/' + NATIVE_PLUGIN_RECEIPT_NAME;
+const EXECUTABLE_RELATIVE =
+  BUNDLE_RELATIVE + '/Contents/MacOS/AeMcpNative';
+const PIPL_RELATIVE =
+  BUNDLE_RELATIVE + '/Contents/Resources/AeMcpNative.rsrc';
+const PIPL_COMPATIBILITY_VERSION = 0x00010000;
+const SDK_NAME = 'Adobe After Effects C/C++ Plug-in SDK';
+const SDK_VERSION = '25.6.61';
+const SDK_BUILD = 61;
+const PRODUCT_VERSION_PATTERN =
+  /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+
+function nativeError(code, message) {
+  return bundleError(code, message);
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value,
+  expected,
+  label,
+  code = 'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID',
+) {
+  if (!isRecord(value)
+      || JSON.stringify(Object.keys(value).sort())
+        !== JSON.stringify([...expected].sort())) {
+    throw nativeError(
+      code,
+      label + ' has an unexpected shape',
+    );
+  }
+}
+
+function validateNativeArtifact(value, label) {
+  assertExactKeys(
+    value,
+    [
+      'architecture',
+      'bundleName',
+      'bundleTreeSha256',
+      'bundleType',
+      'codeSignature',
+      'entryPoint',
+      'executableSha256',
+      'fileCount',
+      'piplSha256',
+      'platform',
+      'schemaVersion',
+    ],
+    label,
+    'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+  );
+  if (value.schemaVersion !== 1
+      || value.bundleName !== NATIVE_PLUGIN_BUNDLE_NAME
+      || value.platform !== 'macos-arm64'
+      || value.architecture !== 'arm64'
+      || value.bundleType !== 'AEgx'
+      || value.entryPoint !== 'AeMcpNativeMain'
+      || value.codeSignature !== 'ad-hoc-verified'
+      || value.fileCount !== 5
+      || !SHA256_PATTERN.test(value.bundleTreeSha256 ?? '')
+      || !SHA256_PATTERN.test(value.executableSha256 ?? '')
+      || !SHA256_PATTERN.test(value.piplSha256 ?? '')) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      label + ' is not a supported macOS AEGP artifact',
+    );
+  }
+  return value;
+}
+
+export function validateNativeBuildReceipt(value) {
+  assertExactKeys(
+    value,
+    [
+      'artifact',
+      'build',
+      'productVersion',
+      'protocolSchemaSha256',
+      'schemaVersion',
+      'sdk',
+      'source',
+      'sourceCommit',
+    ],
+    'native build receipt',
+    'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+  );
+  assertExactKeys(
+    value.source,
+    ['commit', 'repositoryClean'],
+    'native build receipt source',
+    'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+  );
+  assertExactKeys(
+    value.sdk,
+    [
+      'archiveVerification',
+      'claimedBuild',
+      'claimedVersion',
+      'inputProvenance',
+      'materialIncluded',
+      'name',
+      'rootVerification',
+    ],
+    'native build receipt SDK evidence',
+    'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+  );
+  assertExactKeys(
+    value.build,
+    [
+      'compatibilityEvidence',
+      'configuration',
+      'distributionApproved',
+      'runtimeEvidence',
+      'signing',
+    ],
+    'native build receipt build evidence',
+    'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+  );
+  validateNativeArtifact(value.artifact, 'native build receipt artifact');
+  if (value.schemaVersion !== 1
+      || !PRODUCT_VERSION_PATTERN.test(value.productVersion ?? '')
+      || !SOURCE_SHA_PATTERN.test(value.sourceCommit ?? '')
+      || value.source.commit !== value.sourceCommit
+      || value.source.repositoryClean !== true
+      || !SHA256_PATTERN.test(value.protocolSchemaSha256 ?? '')
+      || value.sdk.name !== SDK_NAME
+      || value.sdk.claimedVersion !== SDK_VERSION
+      || value.sdk.claimedBuild !== SDK_BUILD
+      || value.sdk.materialIncluded !== false
+      || value.sdk.archiveVerification !== 'sha256-verified'
+      || value.sdk.rootVerification !== 'layout-and-content-verified'
+      || value.sdk.inputProvenance
+        !== 'archive-byte-identity-plus-canonical-root-content'
+      || value.build.configuration !== 'development'
+      || value.build.signing !== 'ad-hoc'
+      || value.build.distributionApproved !== false
+      || value.build.runtimeEvidence !== false
+      || value.build.compatibilityEvidence !== false) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+      'native build receipt evidence is invalid',
+    );
+  }
+  return value;
+}
+
+export function validateNativePluginManifest(value) {
+  assertExactKeys(
+    value,
+    [
+      'architecture',
+      'artifact',
+      'build',
+      'platform',
+      'productVersion',
+      'protocol',
+      'schemaVersion',
+      'sdk',
+      'sourceCommitSha',
+    ],
+    'native plug-in manifest',
+  );
+  assertExactKeys(
+    value.artifact,
+    [
+      'bundleIdentifier',
+      'bundleName',
+      'bundlePath',
+      'bundleTreeSha256',
+      'bundleType',
+      'entryPoint',
+      'executablePath',
+      'executableSha256',
+      'fileCount',
+      'payloadRoot',
+      'piplCompatibilityVersion',
+      'piplPath',
+      'piplResourceId',
+      'piplSha256',
+      'receiptPath',
+      'receiptSha256',
+    ],
+    'native plug-in manifest artifact',
+  );
+  assertExactKeys(
+    value.sdk,
+    [
+      'archiveSha256',
+      'claimedBuild',
+      'claimedVersion',
+      'materialIncluded',
+      'name',
+      'policySha256',
+      'rootContentSha256',
+      'verification',
+    ],
+    'native plug-in manifest SDK evidence',
+  );
+  assertExactKeys(value.protocol, ['schemaSha256'], 'native plug-in protocol evidence');
+  assertExactKeys(
+    value.build,
+    ['configuration', 'distributionApproved', 'signatureVerification', 'signing'],
+    'native plug-in build evidence',
+  );
+  if (value.schemaVersion !== 1
+      || !PRODUCT_VERSION_PATTERN.test(value.productVersion ?? '')
+      || !SOURCE_SHA_PATTERN.test(value.sourceCommitSha ?? '')
+      || value.platform !== 'macos-arm64'
+      || value.architecture !== 'arm64'
+      || value.artifact.payloadRoot !== NATIVE_PLUGIN_PAYLOAD_ROOT
+      || value.artifact.bundlePath !== BUNDLE_RELATIVE
+      || value.artifact.receiptPath !== RECEIPT_RELATIVE
+      || !SHA256_PATTERN.test(value.artifact.receiptSha256 ?? '')
+      || value.artifact.bundleName !== NATIVE_PLUGIN_BUNDLE_NAME
+      || value.artifact.bundleIdentifier !== 'dev.aemcp.native-plugin'
+      || value.artifact.bundleType !== 'AEgx'
+      || value.artifact.entryPoint !== 'AeMcpNativeMain'
+      || value.artifact.fileCount !== 5
+      || !SHA256_PATTERN.test(value.artifact.bundleTreeSha256 ?? '')
+      || value.artifact.executablePath !== EXECUTABLE_RELATIVE
+      || !SHA256_PATTERN.test(value.artifact.executableSha256 ?? '')
+      || value.artifact.piplPath !== PIPL_RELATIVE
+      || value.artifact.piplResourceId !== 16000
+      || value.artifact.piplCompatibilityVersion !== PIPL_COMPATIBILITY_VERSION
+      || !SHA256_PATTERN.test(value.artifact.piplSha256 ?? '')
+      || value.sdk.name !== SDK_NAME
+      || value.sdk.claimedVersion !== SDK_VERSION
+      || value.sdk.claimedBuild !== SDK_BUILD
+      || !SHA256_PATTERN.test(value.sdk.policySha256 ?? '')
+      || !SHA256_PATTERN.test(value.sdk.archiveSha256 ?? '')
+      || !SHA256_PATTERN.test(value.sdk.rootContentSha256 ?? '')
+      || value.sdk.verification
+        !== 'archive-byte-identity-plus-canonical-root-content'
+      || value.sdk.materialIncluded !== false
+      || !SHA256_PATTERN.test(value.protocol.schemaSha256 ?? '')
+      || value.build.configuration !== 'development'
+      || value.build.signing !== 'ad-hoc'
+      || value.build.signatureVerification !== 'ad-hoc-verified'
+      || value.build.distributionApproved !== false) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID',
+      'native plug-in manifest identity is invalid',
+    );
+  }
+  return value;
+}
+
+async function assertExactDirectoryEntries(directory, expected, label) {
+  const metadata = await fs.promises.lstat(directory).catch(() => null);
+  if (!metadata?.isDirectory() || metadata.isSymbolicLink()) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_INPUT_MISSING',
+      label + ' directory is missing or symbolic',
+    );
+  }
+  const entries = (await fs.promises.readdir(directory)).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(entries) !== JSON.stringify(wanted)) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH',
+      label + ' file set is not exact',
+    );
+  }
+}
+
+async function candidateEvidence(repoRoot) {
+  const policyPath = path.join(repoRoot, 'packaging', 'ae-sdk-inputs.json');
+  const protocolPath = path.join(
+    repoRoot,
+    'native',
+    'ae-plugin',
+    'protocol',
+    'aegp-rpc.schema.json',
+  );
+  const policy = await readJsonFile(policyPath, 'BUNDLE_NATIVE_PLUGIN_SDK_INVALID');
+  const mac = policy?.sdk?.platforms?.['macos-arm64'];
+  if (policy?.schemaVersion !== 1
+      || policy.sdk?.name !== SDK_NAME
+      || policy.sdk?.claimedVersion !== SDK_VERSION
+      || policy.sdk?.claimedBuild !== SDK_BUILD
+      || !SHA256_PATTERN.test(mac?.archive?.sha256 ?? '')
+      || mac?.rootContentLock?.status !== 'canonical-file-tree-verified'
+      || !SHA256_PATTERN.test(mac?.rootContentLock?.sha256 ?? '')) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_SDK_INVALID',
+      'candidate SDK policy does not contain the locked macOS SDK evidence',
+    );
+  }
+  return Object.freeze({
+    policySha256: sha256Bytes(Buffer.from(canonicalJson(policy), 'utf8')),
+    archiveSha256: mac.archive.sha256,
+    rootContentSha256: mac.rootContentLock.sha256,
+    protocolSchemaSha256: await sha256File(protocolPath),
+  });
+}
+
+function assertReceiptMatchesCandidate(
+  receipt,
+  expectedVersion,
+  expectedSourceCommit,
+  evidence,
+) {
+  if (receipt.productVersion !== expectedVersion) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
+      'native product version does not match the platform bundle',
+    );
+  }
+  if (receipt.sourceCommit !== expectedSourceCommit) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
+      'native source commit does not match the platform bundle',
+    );
+  }
+  if (receipt.protocolSchemaSha256 !== evidence.protocolSchemaSha256) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_PROTOCOL_MISMATCH',
+      'native RPC protocol digest does not match the candidate schema',
+    );
+  }
+}
+
+function verifierFrom(dependencies) {
+  const verifier = dependencies?.verifyMacPlugin ?? verifyMacPlugin;
+  if (typeof verifier !== 'function') {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_VERIFIER_INVALID',
+      'native plug-in verifier dependency is invalid',
+    );
+  }
+  return verifier;
+}
+
+function sameCanonical(left, right) {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+async function assertEmbeddedSourceCommit(bundlePath, sourceCommit) {
+  const executable = path.join(bundlePath, 'Contents', 'MacOS', 'AeMcpNative');
+  const metadata = await fs.promises.lstat(executable).catch(() => null);
+  if (!metadata?.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1
+      || metadata.size <= 0 || metadata.size > 128 * 1024 * 1024) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      'native executable is not a bounded regular file',
+    );
+  }
+  const bytes = await fs.promises.readFile(executable);
+  if (!bytes.includes(Buffer.from(sourceCommit, 'ascii'))) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
+      'native executable does not embed the exact source commit',
+    );
+  }
+}
+
+function manifestFor(receipt, receiptSha256, evidence) {
+  return validateNativePluginManifest({
+    schemaVersion: 1,
+    productVersion: receipt.productVersion,
+    sourceCommitSha: receipt.sourceCommit,
+    platform: 'macos-arm64',
+    architecture: 'arm64',
+    artifact: {
+      payloadRoot: NATIVE_PLUGIN_PAYLOAD_ROOT,
+      bundlePath: BUNDLE_RELATIVE,
+      receiptPath: RECEIPT_RELATIVE,
+      receiptSha256,
+      bundleName: NATIVE_PLUGIN_BUNDLE_NAME,
+      bundleIdentifier: 'dev.aemcp.native-plugin',
+      bundleType: receipt.artifact.bundleType,
+      entryPoint: receipt.artifact.entryPoint,
+      fileCount: receipt.artifact.fileCount,
+      bundleTreeSha256: receipt.artifact.bundleTreeSha256,
+      executablePath: EXECUTABLE_RELATIVE,
+      executableSha256: receipt.artifact.executableSha256,
+      piplPath: PIPL_RELATIVE,
+      piplResourceId: 16000,
+      piplCompatibilityVersion: PIPL_COMPATIBILITY_VERSION,
+      piplSha256: receipt.artifact.piplSha256,
+    },
+    sdk: {
+      name: SDK_NAME,
+      claimedVersion: SDK_VERSION,
+      claimedBuild: SDK_BUILD,
+      policySha256: evidence.policySha256,
+      archiveSha256: evidence.archiveSha256,
+      rootContentSha256: evidence.rootContentSha256,
+      verification: 'archive-byte-identity-plus-canonical-root-content',
+      materialIncluded: false,
+    },
+    protocol: {
+      schemaSha256: evidence.protocolSchemaSha256,
+    },
+    build: {
+      configuration: receipt.build.configuration,
+      signing: receipt.build.signing,
+      signatureVerification: receipt.artifact.codeSignature,
+      distributionApproved: receipt.build.distributionApproved,
+    },
+  });
+}
+
+function assertManifestMatchesReceipt(manifest, receipt, evidence) {
+  const expected = manifestFor(receipt, manifest.artifact.receiptSha256, evidence);
+  if (!sameCanonical(manifest, expected)) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_EVIDENCE_MISMATCH',
+      'native manifest does not match the build receipt and candidate evidence',
+    );
+  }
+}
+
+async function verifyArtifact(bundlePath, receipt, dependencies) {
+  const actual = validateNativeArtifact(
+    await verifierFrom(dependencies)({
+      bundlePath,
+      expectedProductVersion: receipt.productVersion,
+    }),
+    'observed native artifact',
+  );
+  if (!sameCanonical(actual, receipt.artifact)) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_ARTIFACT_MISMATCH',
+      'observed native artifact does not match its build receipt',
+    );
+  }
+  await assertEmbeddedSourceCommit(bundlePath, receipt.sourceCommit);
+  return actual;
+}
+
+export async function verifyNativePluginStage({
+  root,
+  productVersion,
+  sourceCommitSha,
+  candidateRepoRoot,
+  dependencies = {},
+} = {}) {
+  const nativeRoot = path.resolve(String(root ?? ''));
+  await assertExactDirectoryEntries(
+    nativeRoot,
+    [NATIVE_PLUGIN_MANIFEST_NAME, NATIVE_PLUGIN_PAYLOAD_ROOT],
+    'native plug-in stage',
+  );
+  const payloadRoot = path.join(nativeRoot, NATIVE_PLUGIN_PAYLOAD_ROOT);
+  await assertExactDirectoryEntries(
+    payloadRoot,
+    [NATIVE_PLUGIN_BUNDLE_NAME, NATIVE_PLUGIN_RECEIPT_NAME],
+    'native plug-in payload',
+  );
+  const manifestPath = path.join(nativeRoot, NATIVE_PLUGIN_MANIFEST_NAME);
+  const manifest = validateNativePluginManifest(
+    await readCanonicalJsonFile(manifestPath),
+  );
+  if (manifest.productVersion !== productVersion) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
+      'native manifest version does not match the platform bundle',
+    );
+  }
+  if (manifest.sourceCommitSha !== sourceCommitSha) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
+      'native manifest source does not match the platform bundle',
+    );
+  }
+  const evidence = await candidateEvidence(path.resolve(String(candidateRepoRoot ?? '')));
+  const receiptPath = path.join(payloadRoot, NATIVE_PLUGIN_RECEIPT_NAME);
+  if (await sha256File(receiptPath) !== manifest.artifact.receiptSha256) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_HASH_MISMATCH',
+      'native build receipt digest does not match its manifest',
+    );
+  }
+  const receipt = validateNativeBuildReceipt(
+    await readJsonFile(receiptPath, 'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID'),
+  );
+  assertReceiptMatchesCandidate(receipt, productVersion, sourceCommitSha, evidence);
+  assertManifestMatchesReceipt(manifest, receipt, evidence);
+  await verifyArtifact(
+    path.join(payloadRoot, NATIVE_PLUGIN_BUNDLE_NAME),
+    receipt,
+    dependencies,
+  );
+  return manifest;
+}
+
+export async function stageNativePluginArtifact({
+  sourceRoot,
+  destinationRoot,
+  productVersion,
+  sourceCommitSha,
+  candidateRepoRoot,
+  dependencies = {},
+} = {}) {
+  if (!PRODUCT_VERSION_PATTERN.test(productVersion ?? '')) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
+      'native stage requires a semantic product version',
+    );
+  }
+  if (!SOURCE_SHA_PATTERN.test(sourceCommitSha ?? '')) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
+      'native stage requires a full source commit',
+    );
+  }
+  const source = path.resolve(String(sourceRoot ?? ''));
+  const destination = path.resolve(String(destinationRoot ?? ''));
+  await assertExactDirectoryEntries(
+    source,
+    [NATIVE_PLUGIN_BUNDLE_NAME, NATIVE_PLUGIN_RECEIPT_NAME],
+    'native build output',
+  );
+  const evidence = await candidateEvidence(path.resolve(String(candidateRepoRoot ?? '')));
+  const sourceReceipt = validateNativeBuildReceipt(
+    await readJsonFile(
+      path.join(source, NATIVE_PLUGIN_RECEIPT_NAME),
+      'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+    ),
+  );
+  assertReceiptMatchesCandidate(
+    sourceReceipt,
+    productVersion,
+    sourceCommitSha,
+    evidence,
+  );
+  await verifyArtifact(
+    path.join(source, NATIVE_PLUGIN_BUNDLE_NAME),
+    sourceReceipt,
+    dependencies,
+  );
+  const existing = await fs.promises.lstat(destination).catch(() => null);
+  if (existing) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_OUTPUT_EXISTS',
+      'native stage output already exists',
+    );
+  }
+  try {
+    const payloadRoot = path.join(destination, NATIVE_PLUGIN_PAYLOAD_ROOT);
+    await fs.promises.mkdir(payloadRoot, { recursive: true });
+    await copyTree(
+      path.join(source, NATIVE_PLUGIN_BUNDLE_NAME),
+      path.join(payloadRoot, NATIVE_PLUGIN_BUNDLE_NAME),
+    );
+    await copyRegularFileStable(
+      path.join(source, NATIVE_PLUGIN_RECEIPT_NAME),
+      path.join(payloadRoot, NATIVE_PLUGIN_RECEIPT_NAME),
+    );
+    const receiptSha256 = await sha256File(
+      path.join(payloadRoot, NATIVE_PLUGIN_RECEIPT_NAME),
+    );
+    const manifest = manifestFor(sourceReceipt, receiptSha256, evidence);
+    const manifestPath = path.join(destination, NATIVE_PLUGIN_MANIFEST_NAME);
+    await writeCanonicalJson(manifestPath, manifest);
+    await verifyNativePluginStage({
+      root: destination,
+      productVersion,
+      sourceCommitSha,
+      candidateRepoRoot,
+      dependencies,
+    });
+    return Object.freeze({
+      manifest,
+      manifestPath,
+      manifestRelativePath: NATIVE_PLUGIN_MANIFEST_RELATIVE,
+      manifestSha256: await sha256File(manifestPath),
+    });
+  } catch (error) {
+    await fs.promises.rm(destination, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/scripts/package/stage-platform-bundle.mjs
+++ b/scripts/package/stage-platform-bundle.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   PLATFORM_IDS,
+  NATIVE_PLUGIN_MANIFEST_PATH,
   SEMVER_PATTERN,
   SOURCE_SHA_PATTERN,
   assertPortableRelativePath,
@@ -17,6 +18,10 @@ import {
   validateBundleManifest,
   writeCanonicalJson,
 } from './lib/manifest.mjs';
+import {
+  NATIVE_PLUGIN_ROOT,
+  stageNativePluginArtifact,
+} from './lib/native-plugin-manifest.mjs';
 import { validateRuntimeManifest } from './lib/runtime-manifest.mjs';
 import { verifyPlatformBundle } from './verify-platform-bundle.mjs';
 
@@ -134,6 +139,7 @@ export async function stagePlatformBundle({
   repoRoot,
   sourceCommitSha,
   inputs = {},
+  dependencies = {},
 } = {}) {
   if (!PLATFORM_IDS.has(platform)) throw bundleError('BUNDLE_PLATFORM_INVALID', `unsupported platform: ${platform}`);
   if (!SEMVER_PATTERN.test(version ?? '')) throw bundleError('BUNDLE_VERSION_INVALID', `invalid semver: ${version}`);
@@ -156,6 +162,14 @@ export async function stagePlatformBundle({
     ?? path.join(resolvedRepoRoot, 'packages', 'core', 'ae_mcp', 'skills_bundled'));
   const supportMatrixPath = path.resolve(inputs.supportMatrixPath
     ?? path.join(resolvedRepoRoot, 'packaging', 'support-matrix.json'));
+  const nativePluginRoot = inputs.nativePluginRoot === undefined
+    ? undefined : path.resolve(inputs.nativePluginRoot);
+  if (nativePluginRoot !== undefined && platform !== 'macos-arm64') {
+    throw bundleError(
+      'BUNDLE_NATIVE_PLUGIN_PLATFORM_INVALID',
+      'the AEGP native plug-in artifact is only valid for macos-arm64',
+    );
+  }
   await requiredDirectory(pluginRoot, 'plugin');
   await requiredDirectory(runtimeRoot, 'runtime');
   await requiredDirectory(helperRoot, 'helper');
@@ -187,6 +201,16 @@ export async function stagePlatformBundle({
       path.join(temporary, 'metadata', 'support-matrix.json'),
       fs.constants.COPYFILE_EXCL,
     );
+    const nativePlugin = nativePluginRoot === undefined
+      ? undefined
+      : await stageNativePluginArtifact({
+        sourceRoot: nativePluginRoot,
+        destinationRoot: path.join(temporary, ...NATIVE_PLUGIN_ROOT.split('/')),
+        productVersion: version,
+        sourceCommitSha,
+        candidateRepoRoot: resolvedRepoRoot,
+        dependencies,
+      });
     const runtimeManifestPath = path.join(temporary, 'runtime', platform, 'runtime-manifest.json');
     const runtimeSbomPath = path.join(temporary, 'runtime', platform, 'sbom.spdx.json');
     const licenseInventoryPath = path.join(
@@ -201,6 +225,12 @@ export async function stagePlatformBundle({
       version,
       platform,
       sourceCommitSha,
+      ...(nativePlugin ? {
+        nativePlugin: {
+          manifestPath: NATIVE_PLUGIN_MANIFEST_PATH,
+          manifestSha256: nativePlugin.manifestSha256,
+        },
+      } : {}),
       runtime: {
         nodeVersion: runtimeManifest.node.version,
         pythonVersion: runtimeManifest.python.version,
@@ -215,7 +245,14 @@ export async function stagePlatformBundle({
       files: await collectManifestEntries(temporary),
     });
     await writeCanonicalJson(path.join(temporary, 'bundle-manifest.json'), manifest);
-    await verifyPlatformBundle({ root: temporary, platform, version, sourceCommitSha });
+    await verifyPlatformBundle({
+      root: temporary,
+      platform,
+      version,
+      sourceCommitSha,
+      candidateRepoRoot: resolvedRepoRoot,
+      dependencies,
+    });
     await fs.promises.rename(temporary, destination);
     return { root: destination, manifestPath: path.join(destination, 'bundle-manifest.json') };
   } catch (error) {
@@ -274,7 +311,12 @@ export async function resolveCliSourceCommit(repoRoot, environment = process.env
 
 function parseArgs(argv) {
   const values = new Map();
-  const allowed = new Set(['--platform', '--version', '--out']);
+  const allowed = new Set([
+    '--native-plugin-artifact',
+    '--out',
+    '--platform',
+    '--version',
+  ]);
   for (let index = 0; index < argv.length; index += 1) {
     const item = argv[index];
     const equal = item.indexOf('=');
@@ -283,12 +325,18 @@ function parseArgs(argv) {
     if (!allowed.has(key) || !value || values.has(key)) throw new Error(`invalid argument: ${item}`);
     values.set(key, value);
   }
-  for (const key of allowed) if (!values.has(key)) throw new Error(`${key} is required`);
-  return {
+  for (const key of ['--platform', '--version', '--out']) {
+    if (!values.has(key)) throw new Error(`${key} is required`);
+  }
+  const parsed = {
     platform: values.get('--platform'),
     version: values.get('--version'),
     outDir: values.get('--out'),
   };
+  if (values.has('--native-plugin-artifact')) {
+    parsed.inputs = { nativePluginRoot: values.get('--native-plugin-artifact') };
+  }
+  return parsed;
 }
 
 async function main() {

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -7,6 +7,19 @@ import { canonicalJson } from '../../lib/manifest.mjs';
 import { buildLicenseInventory, buildRuntimeSpdx } from '../../lib/runtime-evidence.mjs';
 
 export const SOURCE_COMMIT_SHA = '0123456789abcdef0123456789abcdef01234567';
+export const PRODUCT_VERSION = '0.9.2';
+
+const NATIVE_PLUGIN_ROOT = 'artifacts/native-plugin/macos-arm64';
+const NATIVE_PLUGIN_MANIFEST = `${NATIVE_PLUGIN_ROOT}/native-plugin-manifest.json`;
+const NATIVE_PLUGIN_PAYLOAD = `${NATIVE_PLUGIN_ROOT}/payload`;
+const NATIVE_PLUGIN_RECEIPT = `${NATIVE_PLUGIN_PAYLOAD}/build-receipt.json`;
+const NATIVE_PLUGIN_BUNDLE = `${NATIVE_PLUGIN_PAYLOAD}/AeMcpNative.plugin`;
+const NATIVE_EXECUTABLE = `${NATIVE_PLUGIN_BUNDLE}/Contents/MacOS/AeMcpNative`;
+
+const FIXTURE_PROTOCOL = canonicalJson({
+  schemaVersion: 1,
+  title: 'Synthetic AEGP RPC fixture',
+});
 
 export function sha256Bytes(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -238,6 +251,165 @@ async function writePackaging(repoRoot) {
     'packages/core/ae_mcp/skills_bundled/fixture.json',
     '{"name":"fixture-tool"}\n',
   );
+  await writeFixtureFile(
+    repoRoot,
+    'packaging/ae-sdk-inputs.json',
+    canonicalJson({
+      schemaVersion: 1,
+      sdk: {
+        name: 'Adobe After Effects C/C++ Plug-in SDK',
+        claimedVersion: '25.6.61',
+        claimedBuild: 61,
+        platforms: {
+          'macos-arm64': {
+            archive: { sha256: 'd'.repeat(64) },
+            rootContentLock: {
+              status: 'canonical-file-tree-verified',
+              sha256: 'e'.repeat(64),
+            },
+          },
+        },
+      },
+    }),
+  );
+  await writeFixtureFile(
+    repoRoot,
+    'native/ae-plugin/protocol/aegp-rpc.schema.json',
+    FIXTURE_PROTOCOL,
+  );
+}
+
+async function writeNativePluginFixture(h) {
+  const nativePluginRoot = path.join(h.root, 'native-plugin-build');
+  const bundleRoot = path.join(nativePluginRoot, 'AeMcpNative.plugin');
+  const executableBytes = Buffer.concat([
+    machoArm64Bytes(),
+    Buffer.from(`fixture:${SOURCE_COMMIT_SHA}`, 'ascii'),
+  ]);
+  const piplBytes = Buffer.from(
+    'fixture-pipl:16000:AEgx:AeMcpNativeMain:compatibility=65536',
+    'ascii',
+  );
+  const bundleFiles = [
+    ['Contents/Info.plist', [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<plist version="1.0"><dict>',
+      '<key>CFBundleIdentifier</key><string>dev.aemcp.native-plugin</string>',
+      '<key>CFBundleShortVersionString</key><string>0.9.2</string>',
+      '<key>CFBundleExecutable</key><string>AeMcpNative</string>',
+      '<key>CFBundlePackageType</key><string>AEgx</string>',
+      '</dict></plist>',
+      '',
+    ].join('\n'), 0o644],
+    ['Contents/MacOS/AeMcpNative', executableBytes, 0o755],
+    ['Contents/PkgInfo', Buffer.from('AEgxFXTC', 'ascii'), 0o644],
+    ['Contents/Resources/AeMcpNative.rsrc', piplBytes, 0o644],
+    ['Contents/_CodeSignature/CodeResources', 'synthetic ad-hoc signature\n', 0o644],
+  ];
+  for (const [relative, bytes, mode] of bundleFiles) {
+    await writeFixtureFile(bundleRoot, relative, bytes, mode);
+  }
+
+  const executableSha256 = sha256Bytes(executableBytes);
+  const piplSha256 = sha256Bytes(piplBytes);
+  const artifact = {
+    schemaVersion: 1,
+    bundleName: 'AeMcpNative.plugin',
+    platform: 'macos-arm64',
+    architecture: 'arm64',
+    bundleType: 'AEgx',
+    entryPoint: 'AeMcpNativeMain',
+    fileCount: 5,
+    bundleTreeSha256: sha256Bytes(Buffer.from(canonicalJson(
+      bundleFiles.map(([relative, bytes, mode]) => ({
+        path: relative,
+        sha256: sha256Bytes(Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes)),
+        mode,
+      })),
+    ), 'utf8')),
+    executableSha256,
+    piplSha256,
+    codeSignature: 'ad-hoc-verified',
+  };
+  const receipt = {
+    schemaVersion: 1,
+    productVersion: PRODUCT_VERSION,
+    artifact,
+    sourceCommit: SOURCE_COMMIT_SHA,
+    source: {
+      commit: SOURCE_COMMIT_SHA,
+      repositoryClean: true,
+    },
+    protocolSchemaSha256: sha256Bytes(Buffer.from(FIXTURE_PROTOCOL, 'utf8')),
+    sdk: {
+      name: 'Adobe After Effects C/C++ Plug-in SDK',
+      claimedVersion: '25.6.61',
+      claimedBuild: 61,
+      materialIncluded: false,
+      archiveVerification: 'sha256-verified',
+      rootVerification: 'layout-and-content-verified',
+      inputProvenance: 'archive-byte-identity-plus-canonical-root-content',
+    },
+    build: {
+      configuration: 'development',
+      signing: 'ad-hoc',
+      distributionApproved: false,
+      runtimeEvidence: false,
+      compatibilityEvidence: false,
+    },
+  };
+  await writeFixtureFile(
+    nativePluginRoot,
+    'build-receipt.json',
+    `${JSON.stringify(receipt, null, 2)}\n`,
+    0o600,
+  );
+
+  const verifyMacPlugin = async ({ bundlePath, expectedProductVersion }) => {
+    if (path.basename(bundlePath) !== 'AeMcpNative.plugin'
+        || expectedProductVersion !== PRODUCT_VERSION
+        || await sha256File(path.join(bundlePath, 'Contents/MacOS/AeMcpNative'))
+          !== executableSha256
+        || await sha256File(path.join(
+          bundlePath,
+          'Contents/Resources/AeMcpNative.rsrc',
+        )) !== piplSha256) {
+      const error = new Error('synthetic native verifier rejected the bundle');
+      error.code = 'AE_PLUGIN_FIXTURE_INVALID';
+      throw error;
+    }
+    return structuredClone(artifact);
+  };
+
+  h.nativePluginRoot = nativePluginRoot;
+  h.input.inputs = { ...h.input.inputs, nativePluginRoot };
+  h.input.dependencies = { verifyMacPlugin };
+  h.verifyInput = {
+    ...h.verifyInput,
+    candidateRepoRoot: h.repoRoot,
+    dependencies: { verifyMacPlugin },
+  };
+  h.nativePath = (relative = '') => path.join(
+    h.outDir,
+    ...NATIVE_PLUGIN_ROOT.split('/'),
+    ...(relative ? relative.split('/') : []),
+  );
+  h.nativeManifest = () => JSON.parse(
+    fs.readFileSync(path.join(h.outDir, ...NATIVE_PLUGIN_MANIFEST.split('/')), 'utf8'),
+  );
+  h.mutateNativeReceipt = async (mutate) => {
+    const receiptPath = path.join(h.outDir, ...NATIVE_PLUGIN_RECEIPT.split('/'));
+    const receipt = JSON.parse(await fs.promises.readFile(receiptPath, 'utf8'));
+    mutate(receipt);
+    await fs.promises.writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+    const manifestPath = path.join(h.outDir, ...NATIVE_PLUGIN_MANIFEST.split('/'));
+    const manifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8'));
+    manifest.artifact.receiptSha256 = await sha256File(receiptPath);
+    await fs.promises.writeFile(manifestPath, canonicalJson(manifest));
+    await rewriteStageManifests(h);
+  };
+  h.nativeExecutablePath = path.join(h.outDir, ...NATIVE_EXECUTABLE.split('/'));
+  return h;
 }
 
 export async function makeStageHarness(t, platform = 'macos-arm64', overrides = {}) {
@@ -252,7 +424,7 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
   const helperRoot = await writeHelper(repoRoot, platform);
   const input = {
     platform,
-    version: '0.9.2',
+    version: PRODUCT_VERSION,
     outDir,
     repoRoot,
     sourceCommitSha: SOURCE_COMMIT_SHA,
@@ -265,7 +437,7 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
     runtimeRoot,
     helperRoot,
     input,
-    verifyInput: { root: outDir, platform, version: '0.9.2' },
+    verifyInput: { root: outDir, platform, version: PRODUCT_VERSION },
     exists(relative) {
       return fs.existsSync(path.join(outDir, ...relative.split('/')));
     },
@@ -279,6 +451,10 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
       await fs.promises.writeFile(target, bytes);
     },
   };
+}
+
+export async function makeNativeStageHarness(t, platform = 'macos-arm64', overrides = {}) {
+  return writeNativePluginFixture(await makeStageHarness(t, platform, overrides));
 }
 
 export async function inventoryFixtureTree(root, omitted = new Set()) {
@@ -313,6 +489,11 @@ export async function rewriteStageManifests(h, { helper = false } = {}) {
     path.join(runtimeRoot, 'license-inventory.json'),
   );
   bundleManifest.helper.manifestSha256 = await sha256File(helperManifestPath);
+  if (bundleManifest.nativePlugin) {
+    bundleManifest.nativePlugin.manifestSha256 = await sha256File(
+      path.join(h.outDir, ...NATIVE_PLUGIN_MANIFEST.split('/')),
+    );
+  }
   bundleManifest.files = await inventory(h.outDir, new Set(['bundle-manifest.json']));
   await fs.promises.writeFile(bundleManifestPath, canonicalJson(bundleManifest));
 }

--- a/scripts/package/test/native-aegp-build-contract.test.mjs
+++ b/scripts/package/test/native-aegp-build-contract.test.mjs
@@ -10,6 +10,14 @@ const PLUGIN_ENTRY = await fs.promises.readFile(
   'native/ae-plugin/src/aegp/plugin_entry.cpp',
   'utf8',
 );
+const INFO_PLIST = await fs.promises.readFile(
+  'native/ae-plugin/resources/Info.plist',
+  'utf8',
+);
+const VERIFIER = await fs.promises.readFile(
+  'native/ae-plugin/verify-macos.mjs',
+  'utf8',
+);
 
 test('native mac build consumes both locked SDK inputs and records combined evidence', () => {
   assert.match(BUILD_SCRIPT, /verifyAeSdkInput\(\{/u);
@@ -49,15 +57,45 @@ test('native mac build compiles product Git blobs from a private minimal SDK sna
   assert.doesNotMatch(BUILD_SCRIPT, /cleanup did not complete.*stage/u);
 });
 
+test('native product version is derived from the exact commit and bound across the artifact', () => {
+  assert.match(BUILD_SCRIPT, /PRODUCT_MANIFEST_PATH = 'plugin\/host\/package\.json'/u);
+  assert.match(
+    BUILD_SCRIPT,
+    /gitFileBytes\(sourceCommit, PRODUCT_MANIFEST_PATH\)/u,
+  );
+  assert.match(BUILD_SCRIPT, /PRODUCT_VERSION_TOKEN/u);
+  assert.match(BUILD_SCRIPT, /replaceExactlyOnce\(/u);
+  assert.match(BUILD_SCRIPT, /-DAE_MCP_PRODUCT_VERSION=/u);
+  assert.match(BUILD_SCRIPT, /expectedProductVersion: productVersion/u);
+  assert.doesNotMatch(BUILD_SCRIPT, /AE_MCP_PRODUCT_VERSION[^\n]*(?:process\.env|environment)/u);
+  assert.doesNotMatch(BUILD_SCRIPT, /--product-version/u);
+
+  assert.equal(
+    INFO_PLIST.match(/__AE_MCP_PRODUCT_VERSION__/gu)?.length,
+    1,
+    'Info.plist must contain exactly one deterministic product version token',
+  );
+  assert.match(PLUGIN_ENTRY, /#ifndef AE_MCP_PRODUCT_VERSION/u);
+  assert.match(PLUGIN_ENTRY, /kPluginVersion = AE_MCP_PRODUCT_VERSION/u);
+  assert.match(VERIFIER, /CFBundleShortVersionString/u);
+  assert.match(VERIFIER, /PIPL_COMPATIBILITY_VERSION = 0x00010000/u);
+  assert.match(VERIFIER, /JSON\.stringify\(exported\).*\['_AeMcpNativeMain'\]/u);
+  assert.match(VERIFIER, /data 'PiPL' \(16000\)/u);
+  assert.match(
+    VERIFIER,
+    /assertPiplProperty\(resourceBytes, 'vers', piplCompatibilityVersion\)/u,
+  );
+
+  for (const source of [BUILD_SCRIPT, INFO_PLIST, PLUGIN_ENTRY, VERIFIER]) {
+    assert.doesNotMatch(source, /0\.1\.0(?:-dev)?/u);
+  }
+});
+
 test('native mac build emits the AE-recognized AEGP package metadata', async () => {
-  const [verifier, plist] = await Promise.all([
-    fs.promises.readFile('native/ae-plugin/verify-macos.mjs', 'utf8'),
-    fs.promises.readFile('native/ae-plugin/resources/Info.plist', 'utf8'),
-  ]);
-  assert.match(plist, /<key>CFBundleSignature<\/key>\s*<string>FXTC<\/string>/u);
+  assert.match(INFO_PLIST, /<key>CFBundleSignature<\/key>\s*<string>FXTC<\/string>/u);
   assert.match(BUILD_SCRIPT, /Buffer\.from\('AEgxFXTC', 'ascii'\)/u);
-  assert.match(verifier, /'Contents\/PkgInfo'/u);
-  assert.match(verifier, /Buffer\.from\('AEgxFXTC', 'ascii'\)/u);
+  assert.match(VERIFIER, /'Contents\/PkgInfo'/u);
+  assert.match(VERIFIER, /Buffer\.from\('AEgxFXTC', 'ascii'\)/u);
 });
 
 test('native idle hook drains only real authenticated requests', () => {

--- a/scripts/package/test/native-aegp-dev-install.test.mjs
+++ b/scripts/package/test/native-aegp-dev-install.test.mjs
@@ -29,6 +29,7 @@ const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, '../../..');
 const installerPath = path.join(repoRoot, 'native/ae-plugin/install-dev-macos.mjs');
 const SOURCE_COMMIT = 'a'.repeat(40);
+const PRODUCT_VERSION = '0.9.2';
 const TX1 = '00000000-0000-4000-8000-000000000001';
 const TX2 = '00000000-0000-4000-8000-000000000002';
 
@@ -52,7 +53,10 @@ function artifactFor(payload) {
   };
 }
 
-async function makeArtifact(root, name, payload, { receiptArtifact } = {}) {
+async function makeArtifact(root, name, payload, {
+  receiptArtifact,
+  receiptProductVersion = PRODUCT_VERSION,
+} = {}) {
   const artifactDir = path.join(root, name);
   const bundle = path.join(artifactDir, 'AeMcpNative.plugin');
   await mkdir(path.join(bundle, 'Contents', 'MacOS'), { recursive: true });
@@ -65,6 +69,7 @@ async function makeArtifact(root, name, payload, { receiptArtifact } = {}) {
   const receipt = {
     schemaVersion: 1,
     artifact: receiptArtifact ?? artifactFor(payload),
+    productVersion: receiptProductVersion,
     sourceCommit: SOURCE_COMMIT,
     source: {
       commit: SOURCE_COMMIT,
@@ -111,7 +116,11 @@ async function fixture(t) {
 }
 
 function fakeVerifier(calls = []) {
-  return async ({ bundlePath, allowManagedDisabledName = false }) => {
+  return async ({
+    bundlePath,
+    allowManagedDisabledName = false,
+    expectedProductVersion,
+  }) => {
     const name = path.basename(bundlePath);
     const disabled = /^\.AeMcpNative\.(?:stage|backup|failed|replaced)\..+\.disabled$/u;
     if (name !== 'AeMcpNative.plugin' && !(allowManagedDisabledName && disabled.test(name))) {
@@ -120,7 +129,12 @@ function fakeVerifier(calls = []) {
       throw error;
     }
     const payload = await readFile(path.join(bundlePath, 'payload.txt'), 'utf8');
-    calls.push({ allowManagedDisabledName, name, payload });
+    if (expectedProductVersion !== undefined && expectedProductVersion !== PRODUCT_VERSION) {
+      const error = new Error('unexpected product version');
+      error.code = 'AE_PLUGIN_PRODUCT_VERSION_MISMATCH';
+      throw error;
+    }
+    calls.push({ allowManagedDisabledName, expectedProductVersion, name, payload });
     return artifactFor(payload);
   };
 }
@@ -331,6 +345,7 @@ test('fresh install is receipt-bound, triple-gated, and rolls back without delet
   });
   assert.equal(gateCalls, 3);
   assert.equal(installed.transactionId, TX1);
+  assert.equal(installed.productVersion, PRODUCT_VERSION);
   assert.equal(installed.previous.present, false);
   assert.equal(await payloadAt(state.target), 'one');
   await assertScanRootExactly(state, true);
@@ -389,6 +404,41 @@ test('upgrade keeps a hash-bound disabled backup and rollback restores it', asyn
   });
   assert.equal(result.restoredPrevious, true);
   assert.equal(await payloadAt(state.target), 'one');
+  await assertScanRootExactly(state, true);
+});
+
+test('a committed #94 artifact-v1 transaction and current pointer remain upgrade-compatible', async (t) => {
+  const state = await fixture(t);
+  const first = await makeArtifact(state.root, 'issue-94-build', 'one');
+  const second = await makeArtifact(state.root, 'issue-97-build', 'two');
+  await installDevMacPlugin({
+    artifactDir: first,
+    mediaCoreRoot: state.mediaCoreRoot,
+    dependencies: dependencies({ transactionId: TX1 }),
+  });
+
+  const transaction = JSON.parse(await readFile(
+    path.join(state.stateStore, `.AeMcpNative.transaction.${TX1}.json`),
+    'utf8',
+  ));
+  const current = JSON.parse(await readFile(
+    path.join(state.stateStore, '.AeMcpNative.current.json'),
+    'utf8',
+  ));
+  assert.equal(transaction.status, 'committed');
+  assert.equal(current.transactionId, TX1);
+  assert.deepEqual(transaction.installedArtifact, artifactFor('one'));
+  assert.equal(Object.hasOwn(transaction.installedArtifact, 'productVersion'), false);
+  assert.equal(Object.hasOwn(transaction.installedArtifact, 'piplCompatibilityVersion'), false);
+
+  const upgraded = await installDevMacPlugin({
+    artifactDir: second,
+    mediaCoreRoot: state.mediaCoreRoot,
+    dependencies: dependencies({ transactionId: TX2 }),
+  });
+  assert.equal(upgraded.transactionId, TX2);
+  assert.equal(upgraded.productVersion, PRODUCT_VERSION);
+  assert.equal(await payloadAt(state.target), 'two');
   await assertScanRootExactly(state, true);
 });
 
@@ -711,6 +761,24 @@ test('complete artifact receipt comparison rejects a single changed hash', async
       dependencies: dependencies(),
     }),
     { code: 'AE_PLUGIN_RECEIPT_MISMATCH' },
+  );
+});
+
+test('receipt product version is bound to the verified native bundle identity', async (t) => {
+  const state = await fixture(t);
+  const artifactDir = await makeArtifact(
+    state.root,
+    'build-version-mismatch',
+    'one',
+    { receiptProductVersion: '0.1.0' },
+  );
+  await assert.rejects(
+    installDevMacPlugin({
+      artifactDir,
+      mediaCoreRoot: state.mediaCoreRoot,
+      dependencies: dependencies(),
+    }),
+    { code: 'AE_PLUGIN_PRODUCT_VERSION_MISMATCH' },
   );
 });
 

--- a/scripts/package/test/native-plugin-manifest.test.mjs
+++ b/scripts/package/test/native-plugin-manifest.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+
+import {
+  validateNativePluginManifest,
+} from '../lib/native-plugin-manifest.mjs';
+import { stagePlatformBundle } from '../stage-platform-bundle.mjs';
+import {
+  makeNativeStageHarness,
+} from './helpers/platform-bundle-fixture.mjs';
+
+test('native plug-in schema and runtime validator enforce the exact generated shape', async (t) => {
+  const h = await makeNativeStageHarness(t);
+  await stagePlatformBundle(h.input);
+  const manifest = h.nativeManifest();
+  const schema = JSON.parse(await fs.promises.readFile(
+    'packaging/schemas/native-plugin-manifest.schema.json',
+    'utf8',
+  ));
+
+  assert.equal(schema.additionalProperties, false);
+  assert.deepEqual([...schema.required].sort(), Object.keys(manifest).sort());
+  for (const key of ['artifact', 'sdk', 'protocol', 'build']) {
+    assert.equal(schema.properties[key].additionalProperties, false, key);
+    assert.deepEqual(
+      [...schema.properties[key].required].sort(),
+      Object.keys(manifest[key]).sort(),
+      key,
+    );
+  }
+  assert.doesNotThrow(() => validateNativePluginManifest(manifest));
+
+  const unknownTop = structuredClone(manifest);
+  unknownTop.unreviewed = true;
+  assert.throws(
+    () => validateNativePluginManifest(unknownTop),
+    { code: 'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID' },
+  );
+
+  const unknownNested = structuredClone(manifest);
+  unknownNested.artifact.unreviewed = true;
+  assert.throws(
+    () => validateNativePluginManifest(unknownNested),
+    { code: 'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID' },
+  );
+
+  const abbreviatedSource = structuredClone(manifest);
+  abbreviatedSource.sourceCommitSha = abbreviatedSource.sourceCommitSha.slice(0, 12);
+  assert.throws(
+    () => validateNativePluginManifest(abbreviatedSource),
+    { code: 'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID' },
+  );
+
+  for (const mutate of [
+    (value) => { value.artifact.bundleIdentifier = 'dev.aemcp.wrong'; },
+    (value) => { value.artifact.piplResourceId = 16001; },
+    (value) => { value.artifact.piplCompatibilityVersion = 1; },
+    (value) => { value.build.signatureVerification = 'developer-id'; },
+  ]) {
+    const wrongIdentity = structuredClone(manifest);
+    mutate(wrongIdentity);
+    assert.throws(
+      () => validateNativePluginManifest(wrongIdentity),
+      { code: 'BUNDLE_NATIVE_PLUGIN_MANIFEST_INVALID' },
+    );
+  }
+});

--- a/scripts/package/test/stage-platform-bundle.test.mjs
+++ b/scripts/package/test/stage-platform-bundle.test.mjs
@@ -9,7 +9,13 @@ import {
   resolveCliSourceCommit,
   stagePlatformBundle,
 } from '../stage-platform-bundle.mjs';
-import { makeStageHarness, SOURCE_COMMIT_SHA } from './helpers/platform-bundle-fixture.mjs';
+import { verifyPlatformBundle } from '../verify-platform-bundle.mjs';
+import {
+  makeNativeStageHarness,
+  makeStageHarness,
+  PRODUCT_VERSION,
+  SOURCE_COMMIT_SHA,
+} from './helpers/platform-bundle-fixture.mjs';
 
 test('stage contains one platform and omits development files', async (t) => {
   const h = await makeStageHarness(t, 'macos-arm64');
@@ -27,6 +33,80 @@ test('stage contains one platform and omits development files', async (t) => {
   assert.equal(h.exists('bundled-tools/fixture.json'), true);
   assert.equal(h.exists('platform/macos-arm64/helper-manifest.json'), true);
   assert.equal(h.manifest().files.some((entry) => entry.path.endsWith('.node')), false);
+  assert.equal(Object.hasOwn(h.manifest(), 'nativePlugin'), false);
+  assert.equal(h.exists('artifacts/native-plugin'), false);
+});
+
+test('macOS stage explicitly opts in a verified native plug-in artifact', async (t) => {
+  const h = await makeNativeStageHarness(t);
+
+  await stagePlatformBundle(h.input);
+  const bundleManifest = h.manifest();
+  const nativeManifest = h.nativeManifest();
+
+  assert.deepEqual(Object.keys(bundleManifest.nativePlugin).sort(), [
+    'manifestPath',
+    'manifestSha256',
+  ]);
+  assert.equal(
+    bundleManifest.nativePlugin.manifestPath,
+    'artifacts/native-plugin/macos-arm64/native-plugin-manifest.json',
+  );
+  assert.equal(nativeManifest.productVersion, PRODUCT_VERSION);
+  assert.equal(nativeManifest.sourceCommitSha, SOURCE_COMMIT_SHA);
+  assert.equal(nativeManifest.platform, 'macos-arm64');
+  assert.equal(nativeManifest.artifact.bundleName, 'AeMcpNative.plugin');
+  assert.equal(nativeManifest.sdk.materialIncluded, false);
+  assert.equal(bundleManifest.files.some(({ path: relative }) => (
+    /AfterEffectsSDK_|ae25\.6_61\.64bit\.AfterEffectsSDK|AE_GeneralPlug|PiPLtool|\.pdf$/iu
+      .test(relative)
+  )), false);
+  assert.equal(h.exists(
+    'artifacts/native-plugin/macos-arm64/payload/AeMcpNative.plugin/Contents/MacOS/AeMcpNative',
+  ), true);
+  assert.equal(h.exists(
+    'artifacts/native-plugin/macos-arm64/payload/build-receipt.json',
+  ), true);
+  await assert.doesNotReject(verifyPlatformBundle(h.verifyInput));
+});
+
+test('identical native inputs produce byte-identical native and bundle manifests', async (t) => {
+  const left = await makeNativeStageHarness(t);
+  const right = await makeNativeStageHarness(t);
+  await stagePlatformBundle(left.input);
+  await stagePlatformBundle(right.input);
+
+  for (const relative of [
+    'bundle-manifest.json',
+    'artifacts/native-plugin/macos-arm64/native-plugin-manifest.json',
+  ]) {
+    assert.deepEqual(
+      await fs.promises.readFile(path.join(left.outDir, ...relative.split('/'))),
+      await fs.promises.readFile(path.join(right.outDir, ...relative.split('/'))),
+      relative,
+    );
+  }
+});
+
+test('Windows stage rejects the macOS-only native plug-in input', async (t) => {
+  const h = await makeNativeStageHarness(t, 'windows-x64');
+
+  await assert.rejects(
+    stagePlatformBundle(h.input),
+    { code: 'BUNDLE_NATIVE_PLUGIN_PLATFORM_INVALID' },
+  );
+  assert.equal(fs.existsSync(h.outDir), false);
+});
+
+test('native stage rejects an incomplete build output and publishes nothing', async (t) => {
+  const h = await makeNativeStageHarness(t);
+  await fs.promises.rm(path.join(h.nativePluginRoot, 'build-receipt.json'));
+
+  await assert.rejects(
+    stagePlatformBundle(h.input),
+    { code: 'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH' },
+  );
+  assert.equal(fs.existsSync(h.outDir), false);
 });
 
 test('stage rejects a noncanonical source commit SHA', async (t) => {
@@ -215,6 +295,20 @@ test('CLI candidate resolution requires exact clean HEAD and strict arguments', 
       '--platform=macos-arm64', '--version', '0.9.2', '--out', 'build/stage',
     ]),
     { platform: 'macos-arm64', version: '0.9.2', outDir: 'build/stage' },
+  );
+  assert.deepEqual(
+    parseStagePlatformBundleArgs([
+      '--platform', 'macos-arm64',
+      '--version', '0.9.2',
+      '--out', 'build/stage',
+      '--native-plugin-artifact', '/private/tmp/native-build',
+    ]),
+    {
+      platform: 'macos-arm64',
+      version: '0.9.2',
+      outDir: 'build/stage',
+      inputs: { nativePluginRoot: '/private/tmp/native-build' },
+    },
   );
   assert.throws(
     () => parseStagePlatformBundleArgs([

--- a/scripts/package/test/verify-platform-bundle.test.mjs
+++ b/scripts/package/test/verify-platform-bundle.test.mjs
@@ -220,6 +220,10 @@ test('verification rejects representative Adobe SDK material paths from the stag
   for (const relative of [
     'AfterEffectsSDK_25.6_61_mac.zip',
     'sdk/Examples/Headers/AE_GeneralPlug.h',
+    'sdk/Examples/AEGP/Commando/main.cpp',
+    'sdk/Examples/Other/sample.txt',
+    'sdk/AE_IO.h',
+    'sdk/AE_General.r',
     'sdk/PiPLtool',
     'sdk/documentation.pdf',
     'tools/ae-sdk-extract-zstd',

--- a/scripts/package/test/verify-platform-bundle.test.mjs
+++ b/scripts/package/test/verify-platform-bundle.test.mjs
@@ -10,6 +10,7 @@ import { buildLicenseInventory, buildRuntimeSpdx } from '../lib/runtime-evidence
 import {
   SOURCE_COMMIT_SHA,
   machoX64Bytes,
+  makeNativeStageHarness,
   makeStageHarness,
   rewriteStageManifests,
 } from './helpers/platform-bundle-fixture.mjs';
@@ -21,8 +22,221 @@ test('verification accepts an untouched platform bundle without network access',
   globalThis.fetch = async () => { throw new Error('network access is forbidden'); };
   try {
     await verifyPlatformBundle(h.verifyInput);
+    assert.equal(Object.hasOwn(h.manifest(), 'nativePlugin'), false);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test('verification rejects missing and extra native payload entries after outer rehash', async (t) => {
+  await t.test('missing receipt', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    await fs.promises.rm(h.nativePath('payload/build-receipt.json'));
+    await rewriteStageManifests(h);
+
+    await assert.rejects(
+      verifyPlatformBundle(h.verifyInput),
+      { code: 'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH' },
+    );
+  });
+
+  await t.test('extra native stage file', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    await fs.promises.writeFile(h.nativePath('unexpected.txt'), 'unexpected\n');
+    await rewriteStageManifests(h);
+
+    await assert.rejects(
+      verifyPlatformBundle(h.verifyInput),
+      { code: 'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH' },
+    );
+  });
+});
+
+test('native payload and its top-level reference are a bidirectional invariant', async (t) => {
+  await t.test('referenced payload cannot be made unreferenced', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    const manifestPath = path.join(h.outDir, 'bundle-manifest.json');
+    const manifest = h.manifest();
+    delete manifest.nativePlugin;
+    await fs.promises.writeFile(manifestPath, canonicalJson(manifest));
+
+    await assert.rejects(
+      verifyPlatformBundle(h.verifyInput),
+      { code: 'BUNDLE_NATIVE_PLUGIN_REFERENCE_MISSING' },
+    );
+  });
+
+  await t.test('unreferenced native namespace content is rejected', async (subtest) => {
+    const h = await makeStageHarness(subtest, 'macos-arm64');
+    await stagePlatformBundle(h.input);
+    const unbound = path.join(h.outDir, 'artifacts', 'native-plugin', 'unbound.txt');
+    await fs.promises.mkdir(path.dirname(unbound), { recursive: true });
+    await fs.promises.writeFile(unbound, 'unbound native payload\n');
+    await rewriteStageManifests(h);
+
+    await assert.rejects(
+      verifyPlatformBundle(h.verifyInput),
+      { code: 'BUNDLE_NATIVE_PLUGIN_REFERENCE_MISSING' },
+    );
+  });
+
+  await t.test('referenced platform payload excludes sibling namespace files', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    const sibling = path.join(h.outDir, 'artifacts', 'native-plugin', 'unbound.txt');
+    await fs.promises.writeFile(sibling, 'unexpected native sibling\n');
+    await rewriteStageManifests(h);
+
+    await assert.rejects(
+      verifyPlatformBundle(h.verifyInput),
+      { code: 'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH' },
+    );
+  });
+});
+
+test('verification rejects a tampered native executable byte', async (t) => {
+  const h = await makeNativeStageHarness(t);
+  await stagePlatformBundle(h.input);
+  const executable = await fs.promises.readFile(h.nativeExecutablePath);
+  executable[executable.length - 1] ^= 0xff;
+  await fs.promises.writeFile(h.nativeExecutablePath, executable);
+
+  await assert.rejects(
+    verifyPlatformBundle(h.verifyInput),
+    { code: 'BUNDLE_HASH_MISMATCH' },
+  );
+});
+
+test('verification rejects native semantic drift after outer digests are refreshed', async (t) => {
+  const cases = [
+    {
+      name: 'source commit',
+      code: 'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
+      mutate(receipt) {
+        receipt.sourceCommit = 'f'.repeat(40);
+        receipt.source.commit = receipt.sourceCommit;
+      },
+    },
+    {
+      name: 'product version',
+      code: 'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
+      mutate(receipt) {
+        receipt.productVersion = '0.1.0';
+      },
+    },
+    {
+      name: 'RPC protocol digest',
+      code: 'BUNDLE_NATIVE_PLUGIN_PROTOCOL_MISMATCH',
+      mutate(receipt) {
+        receipt.protocolSchemaSha256 = 'f'.repeat(64);
+      },
+    },
+    {
+      name: 'SDK build evidence',
+      code: 'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID',
+      mutate(receipt) {
+        receipt.sdk.claimedBuild = 60;
+      },
+    },
+    {
+      name: 'plug-in entry point identity',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.entryPoint = 'WrongNativeMain';
+      },
+    },
+    {
+      name: 'native plug-in architecture',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.architecture = 'x86_64';
+      },
+    },
+    {
+      name: 'native bundle type',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.bundleType = 'eFKT';
+      },
+    },
+    {
+      name: 'development signature identity',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.codeSignature = 'developer-id';
+      },
+    },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(fixture.name, async (subtest) => {
+      const h = await makeNativeStageHarness(subtest);
+      await stagePlatformBundle(h.input);
+      await h.mutateNativeReceipt(fixture.mutate);
+
+      await assert.rejects(
+        verifyPlatformBundle(h.verifyInput),
+        { code: fixture.code },
+      );
+    });
+  }
+});
+
+test('verification detects the staged AEGP executable architecture from bytes', async (t) => {
+  const h = await makeNativeStageHarness(t);
+  await stagePlatformBundle(h.input);
+  const executableBytes = Buffer.concat([
+    machoX64Bytes(),
+    Buffer.from(SOURCE_COMMIT_SHA, 'ascii'),
+  ]);
+  await fs.promises.writeFile(h.nativeExecutablePath, executableBytes);
+
+  const receiptPath = h.nativePath('payload/build-receipt.json');
+  const receipt = JSON.parse(await fs.promises.readFile(receiptPath, 'utf8'));
+  receipt.artifact.executableSha256 = await sha256File(h.nativeExecutablePath);
+  await fs.promises.writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+
+  const manifestPath = h.nativePath('native-plugin-manifest.json');
+  const nativeManifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8'));
+  nativeManifest.artifact.executableSha256 = receipt.artifact.executableSha256;
+  nativeManifest.artifact.bundleTreeSha256 = receipt.artifact.bundleTreeSha256;
+  nativeManifest.artifact.receiptSha256 = await sha256File(receiptPath);
+  await fs.promises.writeFile(manifestPath, canonicalJson(nativeManifest));
+  await rewriteStageManifests(h);
+
+  h.verifyInput.dependencies.verifyMacPlugin = async () => (
+    structuredClone(JSON.parse(await fs.promises.readFile(receiptPath, 'utf8')).artifact)
+  );
+  await assert.rejects(
+    verifyPlatformBundle(h.verifyInput),
+    { code: 'BUNDLE_ARCH_MISMATCH' },
+  );
+});
+
+test('verification rejects representative Adobe SDK material paths from the stage', async (t) => {
+  for (const relative of [
+    'AfterEffectsSDK_25.6_61_mac.zip',
+    'sdk/Examples/Headers/AE_GeneralPlug.h',
+    'sdk/PiPLtool',
+    'sdk/documentation.pdf',
+    'tools/ae-sdk-extract-zstd',
+  ]) {
+    await t.test(relative, async (subtest) => {
+      const h = await makeNativeStageHarness(subtest);
+      await stagePlatformBundle(h.input);
+      const material = path.join(h.outDir, ...relative.split('/'));
+      await fs.promises.mkdir(path.dirname(material), { recursive: true });
+      await fs.promises.writeFile(material, 'synthetic forbidden SDK material\n');
+      await rewriteStageManifests(h);
+
+      await assert.rejects(
+        verifyPlatformBundle(h.verifyInput),
+        { code: 'BUNDLE_ADOBE_SDK_MATERIAL_FORBIDDEN' },
+      );
+    });
   }
 });
 

--- a/scripts/package/verify-platform-bundle.mjs
+++ b/scripts/package/verify-platform-bundle.mjs
@@ -10,6 +10,7 @@ import {
 } from './lib/runtime-evidence.mjs';
 import { validateRuntimeManifest } from './lib/runtime-manifest.mjs';
 import {
+  NATIVE_PLUGIN_MANIFEST_PATH,
   PLATFORM_IDS,
   SHA256_PATTERN,
   assertPortableRelativePath,
@@ -22,6 +23,18 @@ import {
   sha256File,
   validateBundleManifest,
 } from './lib/manifest.mjs';
+import {
+  NATIVE_PLUGIN_ROOT,
+  verifyNativePluginStage,
+} from './lib/native-plugin-manifest.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ADOBE_SDK_LOCKED_FILE_DIGESTS = new Set([
+  'c6abccd52ae25936b819b78c4fea2858bd161f216f72f75184fe9ec55a49756e',
+  'e02fa2b488c3cceb238866b648eb9a2526d308a260744367915a2f173663c36c',
+  '3d3a39175a09d07f6f9734284636f9eadce968b05161650e3cba097a95905330',
+  '640b513bfdfdab264057f3fce0356ced468cdb6d3bd3e2666e6743ec8be1fdba',
+]);
 
 function validateHelperManifest(value, platform) {
   const expectedTop = ['entrypoints', 'files', 'helperId', 'platform', 'schemaVersion'];
@@ -304,9 +317,31 @@ function assertProductionFileSet(entries, platform) {
     : /(?:darwin-|macos-|linux-|win32-arm64)/i;
   const foreignEntry = entries.find((entry) => foreign.test(entry.path));
   if (foreignEntry) throw bundleError('BUNDLE_FOREIGN_PLATFORM', `foreign platform payload: ${foreignEntry.path}`);
+  const adobeSdkMaterial = entries.find((entry) => (
+    ADOBE_SDK_LOCKED_FILE_DIGESTS.has(entry.sha256)
+    || /(?:^|\/)(?:AfterEffectsSDK[^/]*|ae[0-9._]+\.AfterEffectsSDK)(?:\/|$)/iu.test(entry.path)
+    || /(?:^|\/)Examples\/(?:Headers|Resources|Util)(?:\/|$)/u.test(entry.path)
+    || /(?:^|\/)(?:AE_GeneralPlug(?:Old)?|AEGP_SuiteHandler|SPBasic)\.h$/iu.test(entry.path)
+    || /(?:^|\/)(?:PiPLtool|AdobePIPL)(?:\.exe)?$/iu.test(entry.path)
+    || /(?:^|\/)(?:documentation|after.?effects[^/]*sdk[^/]*)\.pdf$/iu.test(entry.path)
+    || /(?:^|\/)ae-sdk-(?:extract|unpack)[^/]*$/iu.test(entry.path)
+  ));
+  if (adobeSdkMaterial) {
+    throw bundleError(
+      'BUNDLE_ADOBE_SDK_MATERIAL_FORBIDDEN',
+      `Adobe SDK material is forbidden in the staged product: ${adobeSdkMaterial.path}`,
+    );
+  }
 }
 
-export async function verifyPlatformBundle({ root, platform, version, sourceCommitSha } = {}) {
+export async function verifyPlatformBundle({
+  root,
+  platform,
+  version,
+  sourceCommitSha,
+  candidateRepoRoot = REPO_ROOT,
+  dependencies = {},
+} = {}) {
   if (!PLATFORM_IDS.has(platform)) throw bundleError('BUNDLE_PLATFORM_INVALID', `unsupported platform: ${platform}`);
   const resolvedRoot = path.resolve(String(root ?? ''));
   const manifestPath = path.join(resolvedRoot, 'bundle-manifest.json');
@@ -327,6 +362,45 @@ export async function verifyPlatformBundle({ root, platform, version, sourceComm
     throw bundleError('BUNDLE_FILE_SET_MISMATCH', 'bundle file set does not match manifest');
   }
   for (const entry of manifest.files) await verifyEntry(entry, actualByPath.get(entry.path));
+  const nativeNamespace = path.posix.dirname(NATIVE_PLUGIN_ROOT);
+  const nativeNamespaceEntries = actual.filter((entry) => (
+    entry.path === nativeNamespace
+    || entry.path.startsWith(`${nativeNamespace}/`)
+  ));
+  if (!manifest.nativePlugin && nativeNamespaceEntries.length > 0) {
+    throw bundleError(
+      'BUNDLE_NATIVE_PLUGIN_REFERENCE_MISSING',
+      'native plug-in payload exists without a top-level manifest reference',
+    );
+  }
+  if (manifest.nativePlugin) {
+    const unexpectedNativeEntry = nativeNamespaceEntries.find((entry) => (
+      entry.path !== NATIVE_PLUGIN_ROOT
+      && !entry.path.startsWith(`${NATIVE_PLUGIN_ROOT}/`)
+    ));
+    if (unexpectedNativeEntry) {
+      throw bundleError(
+        'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH',
+        `unexpected native plug-in namespace entry: ${unexpectedNativeEntry.path}`,
+      );
+    }
+    const nativeManifestEntry = actualByPath.get(NATIVE_PLUGIN_MANIFEST_PATH);
+    if (!nativeManifestEntry
+        || nativeManifestEntry.type !== 'file'
+        || nativeManifestEntry.sha256 !== manifest.nativePlugin.manifestSha256) {
+      throw bundleError(
+        'BUNDLE_NATIVE_PLUGIN_HASH_MISMATCH',
+        'native plug-in manifest reference does not match the staged file',
+      );
+    }
+    await verifyNativePluginStage({
+      root: path.join(resolvedRoot, ...NATIVE_PLUGIN_ROOT.split('/')),
+      productVersion: manifest.version,
+      sourceCommitSha: manifest.sourceCommitSha,
+      candidateRepoRoot,
+      dependencies,
+    });
+  }
 
   const runtimeManifestPath = path.join(resolvedRoot, 'runtime', platform, 'runtime-manifest.json');
   if (await sha256File(runtimeManifestPath) !== manifest.runtime.manifestSha256) {

--- a/scripts/package/verify-platform-bundle.mjs
+++ b/scripts/package/verify-platform-bundle.mjs
@@ -320,8 +320,9 @@ function assertProductionFileSet(entries, platform) {
   const adobeSdkMaterial = entries.find((entry) => (
     ADOBE_SDK_LOCKED_FILE_DIGESTS.has(entry.sha256)
     || /(?:^|\/)(?:AfterEffectsSDK[^/]*|ae[0-9._]+\.AfterEffectsSDK)(?:\/|$)/iu.test(entry.path)
-    || /(?:^|\/)Examples\/(?:Headers|Resources|Util)(?:\/|$)/u.test(entry.path)
-    || /(?:^|\/)(?:AE_GeneralPlug(?:Old)?|AEGP_SuiteHandler|SPBasic)\.h$/iu.test(entry.path)
+    || /(?:^|\/)Examples(?:\/|$)/u.test(entry.path)
+    || /(?:^|\/)(?:AE_GeneralPlug(?:Old)?|AE_IO|AEGP_SuiteHandler|SPBasic)\.h$/iu.test(entry.path)
+    || /(?:^|\/)AE_General\.r$/iu.test(entry.path)
     || /(?:^|\/)(?:PiPLtool|AdobePIPL)(?:\.exe)?$/iu.test(entry.path)
     || /(?:^|\/)(?:documentation|after.?effects[^/]*sdk[^/]*)\.pdf$/iu.test(entry.path)
     || /(?:^|\/)ae-sdk-(?:extract|unpack)[^/]*$/iu.test(entry.path)

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -104,6 +104,36 @@ test('Panel source, generated bundle, and CEP manifest use the release version',
   assert.equal(manifest.match(/<Host Name="AEFT" Version="([^"]+)"/)?.[1], '[25.0,26.9]');
 });
 
+test('native product version is injected from the exact repository product manifest', async () => {
+  const [build, entry, infoPlist, installer, verifier] = await Promise.all([
+    text('native/ae-plugin/build-macos.mjs'),
+    text('native/ae-plugin/src/aegp/plugin_entry.cpp'),
+    text('native/ae-plugin/resources/Info.plist'),
+    text('native/ae-plugin/install-dev-macos.mjs'),
+    text('native/ae-plugin/verify-macos.mjs'),
+  ]);
+
+  assert.match(build, /PRODUCT_MANIFEST_PATH = 'plugin\/host\/package\.json'/u);
+  assert.match(build, /gitFileBytes\(sourceCommit, PRODUCT_MANIFEST_PATH\)/u);
+  assert.match(build, /-DAE_MCP_PRODUCT_VERSION=/u);
+  assert.match(entry, /kPluginVersion = AE_MCP_PRODUCT_VERSION/u);
+  assert.equal(infoPlist.match(/__AE_MCP_PRODUCT_VERSION__/gu)?.length, 1);
+  assert.match(build, /expectedProductVersion: productVersion/u);
+  assert.match(verifier, /PIPL_COMPATIBILITY_VERSION = 0x00010000/u);
+  assert.match(build, /productVersion,/u);
+  assert.match(installer, /expectedProductVersion: receipt\.productVersion/u);
+  assert.match(installer, /productVersion: source\.receipt\.productVersion/u);
+
+  for (const [relativePath, source] of [
+    ['native/ae-plugin/build-macos.mjs', build],
+    ['native/ae-plugin/src/aegp/plugin_entry.cpp', entry],
+    ['native/ae-plugin/resources/Info.plist', infoPlist],
+    ['native/ae-plugin/verify-macos.mjs', verifier],
+  ]) {
+    assert.doesNotMatch(source, /0\.1\.0(?:-dev)?/u, relativePath);
+  }
+});
+
 test('user docs describe the v0.9.2 platform assets and optional AI channel CLIs', async () => {
   for (const relativePath of USER_DOCS) {
     const body = await text(relativePath);


### PR DESCRIPTION
Closes #97

## Outcome

- adds a dedicated, fail-closed macOS AEGP artifact manifest and validator
- binds the native bundle, receipt, Info.plist, runtime provenance, PiPL, SDK evidence, RPC protocol, and top-level platform manifest to the same full source SHA and product version
- stages the already-verified native payload under `artifacts/native-plugin/macos-arm64` and enforces a bidirectional top-level manifest reference
- rejects Adobe SDK archives, headers, examples, PDFs, PiPLtool, and extraction tools from staged product content
- keeps the existing development installer transaction model and remains optional for fixture-only/non-native platform stages

## Exact candidate

- source: `7f52a841313b5c794efb92f7dfcf41e57451b0db`
- product: `0.9.2`
- SDK: `25.6.61`, archive SHA-256 `c6abccd...56e` (developer-supplied; no SDK material is committed or staged)
- native bundle tree: `bcb70768d06922db24de1daa52e9ba0bd8b18a9c140a57a5c55e1276ca744051`
- executable: `0a089aa249d05ce3e67cea1f8428ccadd776a190eb19060b063c9e944a5c938e`
- PiPL: `4c439de251ad7d3d8f49bb54967e420152063d06909db29612c7eac60722c665`
- staged native manifest: `b8ffec28a957573837b4bc7bae22dbc2d21c683fb324906179ce072f5d144979`
- staged receipt: `67ebe1a485f6344c8abdc19a736b223f1ab3207b60700b33ed6f1eeee09d83e4`

The staged `payload/` was reverified with the production verifier and installed through the existing macOS development installer. The prior #94 installed-state format upgraded successfully.

## Automated verification

- targeted packaging/release regression: 143/143
- final SDK-material verifier regression: 53/53
- full `scripts/package/test/*.test.mjs`: pass
- full `scripts/release/test/*.test.mjs`: pass
- host tests: 98/98
- sidecar tests: 32/32
- panel production build: pass and generated tracked output unchanged
- independent manifest-contract, acceptance, and diff reviews: no P0/P1 blocker
- `git diff --check`: pass

## Formal AE real-host gate

Only `/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app` was launched. Both runs hard-validated:

- bundle ID `com.adobe.AfterEffects.application`
- host `26.3.0` build `87`; Beta not running
- native load `pluginVersion=0.9.2`, source `7f52a841313b5c794efb92f7dfcf41e57451b0db`
- matching exact-source CEP/Core and canonical native mapping only (`lsof` showed no backup/staging mapping)
- disposable project open with one real AE item

Public MCP `ae_projectSummary {}` passed before and after a full AE quit/restart and fresh pairing. Both responses reported `engine=native-aegp`, exact source/version provenance, real project state, `effect=none`, verified `project-summary` postcondition, and matching request/postcondition digests across audit and evidence. Native terminal audit events also reported `ok=true`.

## Existing release-environment constraint

The production portable-runtime build still fails closed because the repository's trusted redistribution approvals contain no approval for `LicenseRef-Node-ICU-Bundle`. This PR does not invent or broaden that legal approval. The native stage, its production verifier, activation path, and public MCP hardware gate are real; the surrounding complete portable-runtime assembly remains blocked by that pre-existing release-policy input rather than by this diff.
