### PR TITLE
fix(native-locators): invalidate graph across atomic same-path reopen

### DIFF
--- a/native/ae-plugin/include/aemcp_native/host_dispatcher.hpp
+++ b/native/ae-plugin/include/aemcp_native/host_dispatcher.hpp
@@ -34,6 +34,11 @@ inline constexpr std::string_view kCompositionTimeReadCapability =
     "ae.composition.time.read";
 inline constexpr std::string_view kLayerPropertiesListCapability =
     "ae.layer.properties.list";
+// Authenticated broker control-plane operation. This is deliberately omitted
+// from model-facing capability discovery and can only fence native locator
+// cache state; it never changes the After Effects project.
+inline constexpr std::string_view kProjectGraphInvalidateControl =
+    "internal.project-graph.invalidate";
 inline constexpr std::size_t kNativePageValueBudgetBytes = 48U * 1024U;
 
 // Selects the logical effective AEGP name: a non-empty layer override, then a
@@ -102,6 +107,11 @@ struct ProjectBitDepthChanged {
   bool changed{true};
   std::int32_t before_bits_per_channel{0};
   std::int32_t after_bits_per_channel{0};
+};
+
+struct ProjectGraphInvalidation {
+  bool invalidated{false};
+  std::uint64_t generation{0};
 };
 
 struct ObjectLocator {
@@ -356,6 +366,18 @@ struct HostLayerPropertiesResult {
       std::string code, std::string detail, std::string field = {});
 };
 
+struct HostProjectGraphInvalidationResult {
+  bool ok{false};
+  ProjectGraphInvalidation value;
+  std::string error_code;
+  std::string message;
+
+  [[nodiscard]] static HostProjectGraphInvalidationResult success(
+      ProjectGraphInvalidation result);
+  [[nodiscard]] static HostProjectGraphInvalidationResult failure(
+      std::string code, std::string detail);
+};
+
 class HostApi {
  public:
   virtual ~HostApi() = default;
@@ -374,6 +396,8 @@ class HostApi {
       const CompositionTimeQuery& query, TimePoint work_deadline);
   [[nodiscard]] virtual HostLayerPropertiesResult list_layer_properties(
       const LayerPropertiesQuery& query, TimePoint work_deadline);
+  [[nodiscard]] virtual HostProjectGraphInvalidationResult invalidate_project_graph(
+      TimePoint work_deadline);
 };
 
 struct Request {
@@ -476,6 +500,7 @@ struct Completion {
   CompositionLayersPage composition_selected_layers_result;
   CompositionTimeRead composition_time_result;
   LayerPropertiesPage layer_properties_result;
+  ProjectGraphInvalidation project_graph_invalidation_result;
   // Internal fence correlation only; never serialized or logged.
   std::string idempotency_key;
   std::string error_code;

--- a/native/ae-plugin/include/aemcp_native/project_epoch.hpp
+++ b/native/ae-plugin/include/aemcp_native/project_epoch.hpp
@@ -28,12 +28,18 @@ class ProjectEpochTracker final {
       throw std::invalid_argument("project identity is unavailable");
     }
     if (present_ && observation == observation_) return false;
-    if (generation_ >= kMaxGeneration) {
-      throw std::runtime_error("project locator generation exhausted");
-    }
+    advance_generation();
     present_ = true;
     observation_ = std::move(observation);
-    ++generation_;
+    return true;
+  }
+
+  // A command hook can invalidate every locator immediately before AE handles
+  // a command without claiming that the command is a project lifecycle event.
+  // Keep the last observation so the next identical poll does not rotate twice.
+  [[nodiscard]] bool invalidate() {
+    if (!present_) return false;
+    advance_generation();
     return true;
   }
 
@@ -44,9 +50,17 @@ class ProjectEpochTracker final {
     return true;
   }
 
+  [[nodiscard]] bool present() const noexcept { return present_; }
   [[nodiscard]] std::uint64_t generation() const noexcept { return generation_; }
 
  private:
+  void advance_generation() {
+    if (generation_ >= kMaxGeneration) {
+      throw std::runtime_error("project locator generation exhausted");
+    }
+    ++generation_;
+  }
+
   bool present_{false};
   ProjectObservation observation_;
   std::uint64_t generation_{0};

--- a/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
+++ b/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
@@ -39,7 +39,7 @@ class CodecError final : public std::runtime_error {
   CodecErrorKind kind_;
 };
 
-enum class RpcMethod { kHello, kCapabilities, kInvoke, kCancel };
+enum class RpcMethod { kHello, kCapabilities, kInvoke, kCancel, kInvalidateGraph };
 enum class ClientComponent { kCoreBroker, kDevelopmentSmoke };
 enum class CapabilityDetail { kSummary, kFull };
 
@@ -81,7 +81,18 @@ struct CancelParams {
   std::string target_request_id;
 };
 
-using RequestParams = std::variant<HelloParams, CapabilitiesParams, InvokeParams, CancelParams>;
+struct InvalidateGraphParams {
+  // Closed v1 reason allowlist. Kept typed so future lifecycle sources cannot
+  // silently acquire this authenticated main-thread fence.
+  enum class Reason { kCepJsx } reason{Reason::kCepJsx};
+};
+
+using RequestParams = std::variant<
+    HelloParams,
+    CapabilitiesParams,
+    InvokeParams,
+    CancelParams,
+    InvalidateGraphParams>;
 
 struct ParsedRequest {
   RpcMethod method{RpcMethod::kHello};
@@ -417,6 +428,13 @@ struct CancelSuccess {
   bool terminal_response_expected{false};
 };
 
+struct ProjectGraphInvalidateSuccess {
+  std::string request_id;
+  std::string session_id;
+  bool invalidated{false};
+  std::uint64_t generation{0};
+};
+
 enum class RpcErrorCode {
   kNativeUnavailable,
   kNativeUnsupported,
@@ -476,6 +494,8 @@ struct ErrorResponse {
     const LayerPropertiesSuccess& response);
 [[nodiscard]] std::vector<std::uint8_t> encode_cancel_success(
     const CancelSuccess& response);
+[[nodiscard]] std::vector<std::uint8_t> encode_project_graph_invalidate_success(
+    const ProjectGraphInvalidateSuccess& response);
 [[nodiscard]] std::vector<std::uint8_t> encode_error_response(const ErrorResponse& response);
 
 }  // namespace aemcp::native::rpc

--- a/native/ae-plugin/protocol/README.md
+++ b/native/ae-plugin/protocol/README.md
@@ -57,7 +57,7 @@ Adobe approval or completed host validation.
    SDK identity, actual AE host identity, instance/session IDs, limits, and a
    capability digest. No overlap returns `WIRE_VERSION_MISMATCH`.
 3. The broker requests compact capability summaries by default. It can request
-   full, bounded contracts for selected IDs. Version 1 has five compile-time
+   full, bounded contracts for selected IDs. Version 1 has eight compile-time
    capabilities. Capability discovery deliberately does not support pagination:
    `cursor` is rejected and `nextCursor` must be null. If the effective limit is smaller than the
    number of matching descriptors, the plug-in fails closed instead of returning
@@ -76,9 +76,29 @@ Adobe approval or completed host validation.
    bounded schemas; a generic argument bag or field-name blacklist is never a
    security boundary. Arbitrary C++, JSX, shell text, command lines, pointers,
    native handles, and unknown nested data are rejected before dispatch.
-5. Zero or more ordered `progress` events may precede exactly one terminal
+5. `invalidateGraph` is an authenticated, internal lifecycle method used when the
+   trusted CEP host already has a connected native session and is about to start
+   accepted `/exec` JSX. The acknowledgment is a main-thread fence: in that
+   connected state, JSX is not evaluated unless the complete old locator namespace
+   has already been invalidated. This deliberately invalidates locators even when
+   the JSX later makes no project change or fails. With no native client, or after
+   that client disconnects, `/exec` keeps its legacy behavior; no native namespace
+   exists yet in the former case, while reconnecting establishes a new session that
+   makes locators from the disconnected session stale in the latter.
+   Its request params are exactly
+   `{ "reason": "cep-jsx" }`. The plug-in atomically invalidates the complete
+   project/item/composition/layer/stream locator namespace and returns exactly
+   `{ "generation": <safe nonnegative integer>, "invalidated": <boolean> }`.
+   When `invalidated` is true, `generation` is the resulting positive monotonic
+   graph generation. When no locator namespace was active, `invalidated` is
+   false and `generation` is the zero sentinel. The response is
+   bound to the authenticated session and request ID and is never replayed.
+   This method is not a capability descriptor, is never returned by
+   `capabilities`, and is not a model-facing or public MCP tool. No other reason
+   value or additional field is accepted.
+6. Zero or more ordered `progress` events may precede exactly one terminal
    response. Results include `engine=native-aegp` and machine-verifiable evidence.
-6. `cancel` is explicit. A timeout never implies that a dispatched mutation
+7. `cancel` is explicit. A timeout never implies that a dispatched mutation
    stopped, and an ambiguous mutation failure is never retried through JSX.
 
 Request IDs are unique per session. An in-flight or content-mismatched duplicate
@@ -154,6 +174,33 @@ Project objects use server-issued UUID locators bound to host instance, native
 session, project, and generation. A locator never contains or encodes an AEGP
 handle, pointer, address, or process-local object. Any host/session/project or
 generation mismatch returns `STALE_LOCATOR` before suite dispatch.
+An accepted `invalidateGraph` lifecycle boundary makes every previously issued
+locator stale as one atomic namespace transition; callers must rediscover fresh
+locators before the next graph operation.
+
+The lifecycle coverage is deliberately conservative because the fixed-SDK audit
+found neither an immutable project-instance identifier nor a documented project
+open/close notification:
+
+- Before After Effects handles a menu command, the registered
+  `AEGP_HP_BeforeAE` / `AEGP_Command_ALL` hook invalidates the active namespace.
+  This covers manual close, open, reopen, Undo, and Redo commands, while accepting
+  harmless false-positive invalidation for commands that do not replace a project.
+- When the trusted CEP `/exec` bridge has a connected native session, it waits for
+  an authenticated `invalidateGraph` main-thread acknowledgment before evaluating
+  JSX. If that connected-session fence fails, the JSX is not started. This covers
+  an atomic close-and-same-path-reopen carried by one bridge call, even if no graph
+  request observes the empty interval. An absent client has issued no native
+  namespace, and locators from a disconnected client are fenced by the new session
+  established on reconnect.
+- A native host/session restart continues to invalidate all locators through the
+  existing host and session binding.
+
+Scripts or plug-ins that mutate project lifecycle outside both the registered AE
+command path and the authenticated CEP `/exec` path are not claimed as covered.
+They must integrate an equivalent invalidation boundary before exposing native
+graph reads. Handle, root-item ID, and path equality alone are explicitly not
+treated as project-instance proof.
 
 ## Error and recovery contract
 

--- a/native/ae-plugin/protocol/aegp-rpc.schema.json
+++ b/native/ae-plugin/protocol/aegp-rpc.schema.json
@@ -28,7 +28,8 @@
     "defaultTerminalCacheEntries": 128,
     "defaultTerminalCacheTtlMs": 60000,
     "terminalObservationClockToleranceMs": 0,
-    "cancelDecision": "atomic-one-use-controller-receipt"
+    "cancelDecision": "atomic-one-use-controller-receipt",
+    "graphInvalidation": "authenticated-internal-cep-jsx-boundary"
   },
   "x-digests": {
     "algorithm": "sha256",
@@ -92,7 +93,7 @@
       "enum": ["macos-arm64", "windows-x64"]
     },
     "method": {
-      "enum": ["hello", "capabilities", "invoke", "cancel"]
+      "enum": ["hello", "capabilities", "invoke", "invalidateGraph", "cancel"]
     },
     "wireRange": {
       "type": "object",
@@ -1001,6 +1002,14 @@
         "targetRequestId": { "$ref": "#/$defs/requestId" }
       }
     },
+    "invalidateGraphParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "const": "cep-jsx" }
+      }
+    },
     "requestBase": {
       "type": "object",
       "additionalProperties": false,
@@ -1057,6 +1066,19 @@
         }
       ]
     },
+    "invalidateGraphRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/requestBase" },
+        {
+          "type": "object",
+          "required": ["sessionId"],
+          "properties": {
+            "method": { "const": "invalidateGraph" },
+            "params": { "$ref": "#/$defs/invalidateGraphParams" }
+          }
+        }
+      ]
+    },
     "cancelRequest": {
       "allOf": [
         { "$ref": "#/$defs/requestBase" },
@@ -1075,6 +1097,7 @@
         { "$ref": "#/$defs/helloRequest" },
         { "$ref": "#/$defs/capabilitiesRequest" },
         { "$ref": "#/$defs/invokeRequest" },
+        { "$ref": "#/$defs/invalidateGraphRequest" },
         { "$ref": "#/$defs/cancelRequest" }
       ]
     },
@@ -1907,6 +1930,16 @@
         "terminalResponseExpected": { "type": "boolean" }
       }
     },
+    "invalidateGraphResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation", "invalidated"],
+      "properties": {
+        "generation": { "$ref": "#/$defs/safeNonnegativeInteger" },
+        "invalidated": { "type": "boolean" }
+      },
+      "x-invariant": "invalidated-implies-positive-generation;not-invalidated-implies-zero-generation"
+    },
     "errorCode": {
       "enum": [
         "NATIVE_UNAVAILABLE",
@@ -2196,6 +2229,21 @@
         "result": { "$ref": "#/$defs/cancelResult" }
       }
     },
+    "invalidateGraphSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wireVersion", "kind", "sessionId", "requestId", "method", "ok", "replayed", "result"],
+      "properties": {
+        "wireVersion": { "$ref": "#/$defs/wireVersion" },
+        "kind": { "const": "response" },
+        "sessionId": { "$ref": "#/$defs/uuid" },
+        "requestId": { "$ref": "#/$defs/requestId" },
+        "method": { "const": "invalidateGraph" },
+        "ok": { "const": true },
+        "replayed": { "const": false },
+        "result": { "$ref": "#/$defs/invalidateGraphResult" }
+      }
+    },
     "failureBase": {
       "type": "object",
       "additionalProperties": false,
@@ -2237,7 +2285,7 @@
           "type": "object",
           "required": ["sessionId"],
           "properties": {
-            "method": { "enum": ["capabilities", "invoke", "cancel"] },
+            "method": { "enum": ["capabilities", "invoke", "invalidateGraph", "cancel"] },
             "error": {
               "properties": {
                 "code": { "not": { "const": "WIRE_VERSION_MISMATCH" } }
@@ -2252,6 +2300,7 @@
         { "$ref": "#/$defs/helloSuccess" },
         { "$ref": "#/$defs/capabilitiesSuccess" },
         { "$ref": "#/$defs/invokeSuccess" },
+        { "$ref": "#/$defs/invalidateGraphSuccess" },
         { "$ref": "#/$defs/cancelSuccess" },
         { "$ref": "#/$defs/helloFailure" },
         { "$ref": "#/$defs/sessionFailure" }

--- a/native/ae-plugin/protocol/conformance.mjs
+++ b/native/ae-plugin/protocol/conformance.mjs
@@ -31,7 +31,7 @@ export const ERROR_POLICIES = Object.freeze({
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/u;
-const METHODS = new Set(['hello', 'capabilities', 'invoke', 'cancel']);
+const METHODS = new Set(['hello', 'capabilities', 'invoke', 'invalidateGraph', 'cancel']);
 const PROGRESS_PHASE = Object.freeze({ queued: 0, dispatched: 1, running: 2, validating: 3 });
 const VALID_REPLAY_RECEIPTS = new WeakSet();
 const VALID_CANCEL_DECISIONS = new WeakSet();
@@ -675,6 +675,13 @@ export function classifyRequest(message) {
           || !Number.isSafeInteger(args.limit) || args.limit < 1 || args.limit > 25) {
         return { ok: false, errorCode: 'INVALID_ARGUMENT' };
       }
+    }
+    return { ok: true };
+  }
+  if (message.method === 'invalidateGraph') {
+    const params = message.params;
+    if (!exactKeys(params, new Set(['reason']), ['reason']) || params.reason !== 'cep-jsx') {
+      return { ok: false, errorCode: 'INVALID_ARGUMENT' };
     }
     return { ok: true };
   }
@@ -1735,6 +1742,24 @@ export function validateCancelResult(result, schema) {
     'not-found': false,
   }[result?.state];
   return expected !== undefined && result.terminalResponseExpected === expected;
+}
+
+export function validateInvalidateGraphExchange(helloContext, request, response, schema) {
+  const result = response?.result;
+  return validateHelloContext(helloContext, schema)
+    && validateRequestComposite(request, schema).ok === true
+    && request.method === 'invalidateGraph'
+    && request.sessionId === helloContext.response.sessionId
+    && validateResponseShape(response, schema)
+    && response?.ok === true
+    && response.kind === 'response'
+    && response.method === 'invalidateGraph'
+    && response.sessionId === request.sessionId
+    && response.requestId === request.requestId
+    && response.wireVersion === request.wireVersion
+    && response.replayed === false
+    && schemaAccepts(schema?.$defs?.invalidateGraphResult, result, schema)
+    && (result.invalidated ? result.generation >= 1 : result.generation === 0);
 }
 
 export function validateProgressEvent(message, request, schema) {

--- a/native/ae-plugin/protocol/fixtures/invalidate-graph.json
+++ b/native/ae-plugin/protocol/fixtures/invalidate-graph.json
@@ -1,0 +1,30 @@
+{
+  "_fixture": {
+    "classification": "synthetic-contract-vector",
+    "runtimeEvidence": false,
+    "compatibilityEvidence": false
+  },
+  "request": {
+    "wireVersion": 1,
+    "kind": "request",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "invalidate-graph-1",
+    "method": "invalidateGraph",
+    "params": {
+      "reason": "cep-jsx"
+    }
+  },
+  "response": {
+    "wireVersion": 1,
+    "kind": "response",
+    "sessionId": "11111111-1111-4111-8111-111111111111",
+    "requestId": "invalidate-graph-1",
+    "method": "invalidateGraph",
+    "ok": true,
+    "replayed": false,
+    "result": {
+      "generation": 9,
+      "invalidated": true
+    }
+  }
+}

--- a/native/ae-plugin/protocol/protocol.test.mjs
+++ b/native/ae-plugin/protocol/protocol.test.mjs
@@ -51,6 +51,7 @@ import {
   validateHelloFailure,
   validateHelloExchange,
   validateIdempotencyContract,
+  validateInvalidateGraphExchange,
   validateLocator,
   validateProgressEvent,
   validateRequestComposite,
@@ -183,7 +184,13 @@ test('schema locks strict framing, bounded defaults, rate limits, and native pro
   assert.equal(schema['x-lifecycle'].pagination, 'capability-owned-offset-limit-v1');
   assert.equal(schema['x-lifecycle'].terminalObservationClockToleranceMs, 0);
   assert.equal(schema['x-digests'].propertyNameSort, 'utf-16-code-units');
-  assert.deepEqual(schema.$defs.method.enum, ['hello', 'capabilities', 'invoke', 'cancel']);
+  assert.deepEqual(schema.$defs.method.enum, [
+    'hello', 'capabilities', 'invoke', 'invalidateGraph', 'cancel',
+  ]);
+  assert.equal(
+    schema['x-lifecycle'].graphInvalidation,
+    'authenticated-internal-cep-jsx-boundary',
+  );
   assert.equal(schema.$defs.executionEvidence.properties.engine.const, 'native-aegp');
   assert.equal(schema.$defs.negotiatedLimits.required.includes('maxRequestsPerSecond'), true);
   assert.equal(schema.$defs.negotiatedLimits.required.includes('maxBurst'), true);
@@ -217,6 +224,7 @@ test('all checked-in vectors are synthetic and contain no host or Adobe suite cl
     'invoke-composition-selected-layers-list.json',
     'invoke-composition-time-read.json',
     'invoke-layer-properties-list.json',
+    'invalidate-graph.json',
     'cancel.json',
     'errors.json',
     'negative-corpus.json',
@@ -252,6 +260,7 @@ test('golden requests, events, responses, and bound error policies validate', ()
     'invoke-composition-selected-layers-list.json',
     'invoke-composition-time-read.json',
     'invoke-layer-properties-list.json',
+    'invalidate-graph.json',
     'cancel.json',
   ]) {
     const fixture = golden(name);
@@ -456,6 +465,7 @@ test('schema shape and composite request validation have an explicit differentia
     golden('invoke-composition-selected-layers-list.json').request,
     golden('invoke-composition-time-read.json').request,
     golden('invoke-layer-properties-list.json').request,
+    golden('invalidate-graph.json').request,
     golden('cancel.json').request,
   ];
   for (const request of validRequests) {
@@ -515,6 +525,69 @@ test('schema shape and composite request validation have an explicit differentia
   assert.equal(schemaAccepts(schema.$defs.progressEvent, wrongSession), true);
   assert.equal(validateProgressEvent(wrongSession, invoke.request, schema), false,
     'composite validation adds request/session binding');
+});
+
+test('graph invalidation is an exact authenticated internal lifecycle exchange', () => {
+  const hello = golden('hello.json');
+  const fixture = golden('invalidate-graph.json');
+  assert.equal(validateInvalidateGraphExchange(
+    hello, fixture.request, fixture.response, schema,
+  ), true);
+
+  const noSession = structuredClone(fixture.request);
+  delete noSession.sessionId;
+  assert.equal(schemaAccepts(schema.$defs.request, noSession), false);
+  assert.deepEqual(classifyRequest(noSession), { ok: false, errorCode: 'SESSION_STALE' });
+
+  const wrongReason = structuredClone(fixture.request);
+  wrongReason.params.reason = 'manual';
+  const extraParam = structuredClone(fixture.request);
+  extraParam.params.extra = true;
+  const missingReason = structuredClone(fixture.request);
+  delete missingReason.params.reason;
+  for (const request of [wrongReason, extraParam, missingReason]) {
+    assert.equal(schemaAccepts(schema.$defs.request, request), false);
+    assert.deepEqual(classifyRequest(request), { ok: false, errorCode: 'INVALID_ARGUMENT' });
+  }
+
+  const noActiveNamespace = structuredClone(fixture.response);
+  noActiveNamespace.result = { generation: 0, invalidated: false };
+  assert.equal(validateInvalidateGraphExchange(
+    hello, fixture.request, noActiveNamespace, schema,
+  ), true);
+
+  const wrongSession = structuredClone(fixture.response);
+  wrongSession.sessionId = '77777777-7777-4777-8777-777777777777';
+  const replayed = { ...fixture.response, replayed: true };
+  const negativeGeneration = structuredClone(fixture.response);
+  negativeGeneration.result.generation = -1;
+  const unsafeGeneration = structuredClone(fixture.response);
+  unsafeGeneration.result.generation = 9007199254740992;
+  const zeroInvalidationGeneration = structuredClone(fixture.response);
+  zeroInvalidationGeneration.result.generation = 0;
+  const nonzeroNoopGeneration = structuredClone(noActiveNamespace);
+  nonzeroNoopGeneration.result.generation = 9;
+  const extraResult = structuredClone(fixture.response);
+  extraResult.result.extra = true;
+  const missingInvalidated = structuredClone(fixture.response);
+  delete missingInvalidated.result.invalidated;
+  for (const response of [
+    wrongSession, replayed, negativeGeneration, unsafeGeneration, zeroInvalidationGeneration,
+    nonzeroNoopGeneration, extraResult, missingInvalidated,
+  ]) {
+    assert.equal(validateInvalidateGraphExchange(
+      hello, fixture.request, response, schema,
+    ), false);
+  }
+
+  assert.equal(nativeCapabilityRegistry(schema).length, 8);
+  assert.doesNotMatch(JSON.stringify(golden('capabilities.json')), /invalidateGraph/u);
+  const disguisedInvoke = structuredClone(golden('invoke-project-summary.json').request);
+  disguisedInvoke.params.capabilityId = 'ae.invalidateGraph';
+  assert.equal(schemaAccepts(schema.$defs.request, disguisedInvoke), false);
+  assert.deepEqual(classifyRequest(disguisedInvoke), {
+    ok: false, errorCode: 'INVALID_ARGUMENT',
+  });
 });
 
 test('response and event decode composites enforce closed root shapes before semantics', () => {

--- a/native/ae-plugin/src/aegp/plugin_entry.cpp
+++ b/native/ae-plugin/src/aegp/plugin_entry.cpp
@@ -66,6 +66,7 @@ using aemcp::native::HostCompositionTimeResult;
 using aemcp::native::HostDispatcher;
 using aemcp::native::HostReadResult;
 using aemcp::native::HostProjectItemsResult;
+using aemcp::native::HostProjectGraphInvalidationResult;
 using aemcp::native::HostLayerPropertiesResult;
 using aemcp::native::MacEndpointRegistry;
 using aemcp::native::MacIpcServer;
@@ -93,6 +94,7 @@ using aemcp::native::kCompositionSelectedLayersListCapability;
 using aemcp::native::kCompositionTimeReadCapability;
 using aemcp::native::kProjectItemsListCapability;
 using aemcp::native::kLayerPropertiesListCapability;
+using aemcp::native::kProjectGraphInvalidateControl;
 
 constexpr std::string_view kPluginVersion = AE_MCP_PRODUCT_VERSION;
 constexpr std::string_view kSdkVersion = "25.6.61";
@@ -513,6 +515,20 @@ class ProjectGraphRegistry final {
     clear_objects();
   }
 
+  [[nodiscard]] bool invalidate_project() {
+    if (!epoch_.present()) return false;
+
+    // Prepare every potentially-throwing value before advancing the epoch so
+    // callers never observe a new generation with the old locator registry.
+    std::string next_project_id = aemcp::native::secure_uuid_v4();
+    std::string next_project_object_id = aemcp::native::secure_uuid_v4();
+    if (!epoch_.invalidate()) return false;
+    project_id_ = std::move(next_project_id);
+    project_object_id_ = std::move(next_project_object_id);
+    clear_objects();
+    return true;
+  }
+
   void observe_project(
       std::uintptr_t identity,
       std::uintptr_t root_item_identity,
@@ -637,6 +653,10 @@ class ProjectGraphRegistry final {
         && locator.session_id == session && locator.project_id == project_id_
         && locator.generation == epoch_.generation()
         && locator.object_id == project_object_id_;
+  }
+
+  [[nodiscard]] std::uint64_t generation() const noexcept {
+    return epoch_.generation();
   }
 
   [[nodiscard]] std::optional<A_long> resolve_composition(
@@ -850,6 +870,24 @@ class AegpHostApi final : public HostApi {
   AegpHostApi(
       SPBasicSuite* basic, AEGP_PluginID plugin_id, ProjectGraphRegistry& graph)
       : basic_(basic), plugin_id_(plugin_id), graph_(graph) {}
+
+  [[nodiscard]] HostProjectGraphInvalidationResult invalidate_project_graph(
+      TimePoint work_deadline) override {
+    if (std::chrono::steady_clock::now() >= work_deadline) {
+      return HostProjectGraphInvalidationResult::failure(
+          "DEADLINE_EXCEEDED", "project graph invalidation budget elapsed");
+    }
+    try {
+      const bool invalidated = graph_.invalidate_project();
+      return HostProjectGraphInvalidationResult::success({
+          invalidated,
+          invalidated ? graph_.generation() : 0,
+      });
+    } catch (...) {
+      return HostProjectGraphInvalidationResult::failure(
+          "NATIVE_UNAVAILABLE", "could not invalidate the native project graph");
+    }
+  }
 
   [[nodiscard]] HostReadResult read_project_summary(TimePoint work_deadline) override {
     const auto budget_expired = [work_deadline] {
@@ -2597,7 +2635,13 @@ void log_completion(
            << ",\"completedAtUnixMs\":" << completed_at_unix_ms;
   }
   if (completion.ok) {
-    if (completion.capability_id == kProjectBitDepthSetCapability) {
+    if (completion.capability_id == kProjectGraphInvalidateControl) {
+      output << ",\"result\":{\"invalidated\":"
+             << (completion.project_graph_invalidation_result.invalidated
+                    ? "true" : "false")
+             << ",\"generation\":"
+             << completion.project_graph_invalidation_result.generation;
+    } else if (completion.capability_id == kProjectBitDepthSetCapability) {
       output << ",\"result\":{\"changed\":"
              << (completion.bit_depth_change_result.changed ? "true" : "false")
              << ",\"beforeBitsPerChannel\":"
@@ -2789,9 +2833,18 @@ A_Err command_hook(
     A_Boolean* handled) noexcept {
   try {
     auto* state = reinterpret_cast<PluginState*>(global_refcon);
-    if (state == nullptr || handled == nullptr || command != state->pairing_command) {
+    if (state == nullptr) return A_Err_GENERIC;
+    if (command != state->pairing_command) {
+      const bool invalidated = state->project_graph.invalidate_project();
+      state->log.append(event_prefix(*state, "project.command-invalidation")
+          + ",\"command\":" + std::to_string(command)
+          + ",\"phase\":\"before-ae\",\"invalidated\":"
+          + (invalidated ? "true" : "false")
+          + ",\"generation\":"
+          + std::to_string(state->project_graph.generation()) + "}");
       return A_Err_NONE;
     }
+    if (handled == nullptr) return A_Err_GENERIC;
     *handled = TRUE;
     const auto pending = state->ipc_server
         ? state->ipc_server->pending_pairing() : std::nullopt;

--- a/native/ae-plugin/src/core/host_dispatcher.cpp
+++ b/native/ae-plugin/src/core/host_dispatcher.cpp
@@ -250,6 +250,22 @@ HostLayerPropertiesResult HostLayerPropertiesResult::failure(
   return result;
 }
 
+HostProjectGraphInvalidationResult HostProjectGraphInvalidationResult::success(
+    ProjectGraphInvalidation value) {
+  HostProjectGraphInvalidationResult result;
+  result.ok = true;
+  result.value = value;
+  return result;
+}
+
+HostProjectGraphInvalidationResult HostProjectGraphInvalidationResult::failure(
+    std::string code, std::string detail) {
+  HostProjectGraphInvalidationResult result;
+  result.error_code = std::move(code);
+  result.message = std::move(detail);
+  return result;
+}
+
 HostBitDepthReadResult HostApi::read_project_bit_depth(TimePoint) {
   return HostBitDepthReadResult::failure(
       "NATIVE_UNSUPPORTED", "project bit-depth reads are unavailable");
@@ -288,6 +304,11 @@ HostLayerPropertiesResult HostApi::list_layer_properties(
     const LayerPropertiesQuery&, TimePoint) {
   return HostLayerPropertiesResult::failure(
       "NATIVE_UNSUPPORTED", "layer property reads are unavailable");
+}
+
+HostProjectGraphInvalidationResult HostApi::invalidate_project_graph(TimePoint) {
+  return HostProjectGraphInvalidationResult::failure(
+      "NATIVE_UNSUPPORTED", "project graph invalidation is unavailable");
 }
 
 std::size_t HostDispatcher::RequestKeyHash::operator()(const RequestKey& key) const noexcept {
@@ -335,11 +356,28 @@ EnqueueResult HostDispatcher::enqueue(Request request) {
       request.capability_id == kCompositionTimeReadCapability;
   const bool layer_properties_list =
       request.capability_id == kLayerPropertiesListCapability;
+  const bool project_graph_invalidate =
+      request.capability_id == kProjectGraphInvalidateControl;
   if (!project_summary && !project_bit_depth_read && !project_bit_depth_set
       && !project_items_list && !composition_layers_list
       && !composition_selected_layers_list && !composition_time_read
-      && !layer_properties_list) {
+      && !layer_properties_list && !project_graph_invalidate) {
     return {EnqueueCode::kUnsupportedCapability, "NATIVE_UNSUPPORTED"};
+  }
+  if (project_graph_invalidate
+      && (request.target_depth != 0 || !request.idempotency_key.empty()
+          || !request.arguments_fingerprint_sha256.empty()
+          || !request.host_instance_id.empty() || !request.session_id.empty()
+          || request.offset != 0 || request.limit != 0
+          || request.project_locator.has_value()
+          || request.composition_locator.has_value()
+          || request.layer_locator.has_value()
+          || request.parent_property_locator.has_value())) {
+    return {
+        EnqueueCode::kInvalidRequest,
+        "INVALID_ARGUMENT",
+        "project graph invalidation parameters are not closed",
+        "params"};
   }
   if ((project_summary || project_bit_depth_read)
       && (request.target_depth != 0 || !request.idempotency_key.empty()
@@ -691,7 +729,33 @@ DrainBatch HostDispatcher::drain(HostApi& host) {
       completion = expired(request, false);
     } else {
       try {
-        if (request.capability_id == kProjectSummaryCapability) {
+        if (request.capability_id == kProjectGraphInvalidateControl) {
+          HostProjectGraphInvalidationResult host_result =
+              host.invalidate_project_graph(std::min(request.deadline, idle_deadline));
+          if (clock_.now() > request.deadline) {
+            completion = expired(request, true);
+          } else if (!host_result.ok) {
+            completion = failure_for(
+                request,
+                host_result.error_code.empty() ? "CAPABILITY_FAILED" : host_result.error_code,
+                host_result.message.empty()
+                    ? "native graph invalidation failed" : host_result.message);
+          } else if (host_result.value.invalidated
+              ? host_result.value.generation < 1
+              : host_result.value.generation != 0) {
+            completion = failure_for(
+                request,
+                "CAPABILITY_FAILED",
+                "native graph invalidation result was inconsistent");
+          } else {
+            completion.request_id = request.request_id;
+            completion.capability_id = request.capability_id;
+            completion.route_id = request.route_id;
+            completion.session_generation = request.session_generation;
+            completion.ok = true;
+            completion.project_graph_invalidation_result = host_result.value;
+          }
+        } else if (request.capability_id == kProjectSummaryCapability) {
           HostReadResult host_result = host.read_project_summary(
               std::min(request.deadline, idle_deadline));
           if (clock_.now() > request.deadline) {

--- a/native/ae-plugin/src/core/native_rpc_connection.cpp
+++ b/native/ae-plugin/src/core/native_rpc_connection.cpp
@@ -28,6 +28,7 @@ using rpc::RpcMethod;
 constexpr std::chrono::milliseconds kSocketWriteTimeout{1500};
 
 struct ActiveEvidence {
+  RpcMethod method{RpcMethod::kInvoke};
   std::string request_digest;
   std::uint64_t started_at_unix_ms{0};
 };
@@ -240,11 +241,19 @@ void NativeRpcConnectionHandler::serve(
         const std::uint64_t completed_at = session_clock_.now_unix_ms();
         const std::string& request_digest = evidence->second.request_digest;
         const std::uint64_t started_at = evidence->second.started_at_unix_ms;
+        const bool graph_invalidation =
+            completion.capability_id == kProjectGraphInvalidateControl;
         std::string postcondition_digest;
         bool evidence_valid = valid_timing_evidence(evidence->second, completed_at);
         if (completion.ok && evidence_valid) {
           try {
-            if (completion.capability_id == kProjectSummaryCapability) {
+            if (graph_invalidation) {
+              evidence_valid = completion.project_graph_invalidation_result.invalidated
+                  ? completion.project_graph_invalidation_result.generation >= 1
+                    && completion.project_graph_invalidation_result.generation
+                      <= rpc::kMaxSafeInteger
+                  : completion.project_graph_invalidation_result.generation == 0;
+            } else if (completion.capability_id == kProjectSummaryCapability) {
               if (completion.result.item_count < 0
                   || static_cast<std::uint64_t>(completion.result.item_count)
                       > rpc::kMaxSafeInteger) {
@@ -291,7 +300,8 @@ void NativeRpcConnectionHandler::serve(
           completion.ok = false;
           const bool mutating = completion.capability_id == kProjectBitDepthSetCapability;
           completion.error_code = mutating
-              ? "POSSIBLY_SIDE_EFFECTING_FAILURE" : "CAPABILITY_FAILED";
+              ? "POSSIBLY_SIDE_EFFECTING_FAILURE"
+              : graph_invalidation ? "NATIVE_UNAVAILABLE" : "CAPABILITY_FAILED";
           completion.message = "native result evidence failed validation";
           postcondition_digest.clear();
           if (mutating) {
@@ -312,7 +322,14 @@ void NativeRpcConnectionHandler::serve(
         }
         std::vector<std::uint8_t> response;
         if (completion.ok) {
-          if (completion.capability_id == kProjectSummaryCapability) {
+          if (graph_invalidation) {
+            response = rpc::encode_project_graph_invalidate_success({
+                completion.request_id,
+                connection.session_id,
+                completion.project_graph_invalidation_result.invalidated,
+                completion.project_graph_invalidation_result.generation,
+            });
+          } else if (completion.capability_id == kProjectSummaryCapability) {
             response = rpc::encode_project_summary_success({
                 completion.request_id,
                 connection.session_id,
@@ -416,14 +433,17 @@ void NativeRpcConnectionHandler::serve(
           }
         } else {
           ParsedRequest synthetic;
-          synthetic.method = RpcMethod::kInvoke;
+          synthetic.method = evidence->second.method;
           synthetic.request_id = completion.request_id;
+          const std::string capability = graph_invalidation
+              ? std::string{} : completion.capability_id;
           response = rpc::encode_error_response(error_for(
               synthetic,
               connection.session_id,
-              completion.error_code,
+              graph_invalidation && completion.error_code == "CAPABILITY_FAILED"
+                  ? "NATIVE_UNAVAILABLE" : completion.error_code,
               completion.message.empty() ? "native request failed" : completion.message,
-              completion.capability_id,
+              capability,
               completion.error_field));
         }
         if (!write_frame(connection.socket_fd, response)) {
@@ -602,33 +622,48 @@ void NativeRpcConnectionHandler::serve(
         const std::uint64_t effective_deadline = *ingress.effective_deadline_unix_ms;
         const std::uint64_t ttl = effective_deadline > now_unix
             ? effective_deadline - now_unix : 0;
-        const auto& invoke = std::get<rpc::InvokeParams>(request.params);
-        const EnqueueResult enqueued = dispatcher_.enqueue({
-            request.request_id,
-            invoke.capability_id,
-            dispatcher_clock_.now() + std::chrono::milliseconds(ttl),
-            connection.peer.connection_id,
-            connection.session_generation,
-            invoke.target_depth,
-            invoke.idempotency_key,
-            invoke.arguments_fingerprint_sha256,
-            runtime_.host_instance_id,
-            connection.session_id,
-            invoke.offset,
-            invoke.limit,
-            invoke.project_locator,
-            invoke.composition_locator,
-            invoke.layer_locator,
-            invoke.parent_property_locator,
-        });
+        Request dispatch_request;
+        if (request.method == RpcMethod::kInvalidateGraph) {
+          dispatch_request = {
+              request.request_id,
+              std::string(kProjectGraphInvalidateControl),
+              dispatcher_clock_.now() + std::chrono::milliseconds(ttl),
+              connection.peer.connection_id,
+              connection.session_generation,
+          };
+        } else {
+          const auto& invoke = std::get<rpc::InvokeParams>(request.params);
+          dispatch_request = {
+              request.request_id,
+              invoke.capability_id,
+              dispatcher_clock_.now() + std::chrono::milliseconds(ttl),
+              connection.peer.connection_id,
+              connection.session_generation,
+              invoke.target_depth,
+              invoke.idempotency_key,
+              invoke.arguments_fingerprint_sha256,
+              runtime_.host_instance_id,
+              connection.session_id,
+              invoke.offset,
+              invoke.limit,
+              invoke.project_locator,
+              invoke.composition_locator,
+              invoke.layer_locator,
+              invoke.parent_property_locator,
+          };
+        }
+        const std::string dispatched_capability = dispatch_request.capability_id;
+        const EnqueueResult enqueued = dispatcher_.enqueue(std::move(dispatch_request));
         if (enqueued.code != EnqueueCode::kAccepted) {
+          const std::string capability = request.method == RpcMethod::kInvoke
+              ? dispatched_capability : std::string{};
           if (!write_frame(connection.socket_fd, rpc::encode_error_response(error_for(
                   request,
                   connection.session_id,
                   enqueued.error_code,
                   enqueued.message.empty()
                       ? "native dispatcher rejected the request" : enqueued.message,
-                  invoke.capability_id,
+                  capability,
                   enqueued.error_field)))) {
             connected = false;
             break;
@@ -637,6 +672,7 @@ void NativeRpcConnectionHandler::serve(
           continue;
         }
         active.emplace(request.request_id, ActiveEvidence{
+            request.method,
             request.request_fingerprint_sha256,
             now_unix,
         });
@@ -651,7 +687,10 @@ void NativeRpcConnectionHandler::serve(
           connected = false;
           break;
         }
-        observer_.on_rpc_event("invoke", request.request_id, "queued");
+        observer_.on_rpc_event(
+            request.method == RpcMethod::kInvalidateGraph ? "invalidateGraph" : "invoke",
+            request.request_id,
+            "queued");
         observer_.on_rpc_event(
             "dispatch.wake",
             request.request_id,

--- a/native/ae-plugin/src/core/rpc_codec.cpp
+++ b/native/ae-plugin/src/core/rpc_codec.cpp
@@ -453,6 +453,7 @@ std::string method_name(RpcMethod method) {
     case RpcMethod::kCapabilities: return "capabilities";
     case RpcMethod::kInvoke: return "invoke";
     case RpcMethod::kCancel: return "cancel";
+    case RpcMethod::kInvalidateGraph: return "invalidateGraph";
   }
   invalid_argument("unknown RPC method");
 }
@@ -625,6 +626,14 @@ std::string canonical_request(const ParsedRequest& request) {
       params = "{\"targetRequestId\":" + json_string(value.target_request_id) + "}";
       break;
     }
+    case RpcMethod::kInvalidateGraph: {
+      const auto& value = std::get<InvalidateGraphParams>(request.params);
+      if (value.reason != InvalidateGraphParams::Reason::kCepJsx) {
+        invalid_argument("unknown project graph invalidation reason");
+      }
+      params = "{\"reason\":\"cep-jsx\"}";
+      break;
+    }
   }
   std::vector<std::string> members;
   if (request.deadline_unix_ms.has_value()) {
@@ -732,6 +741,7 @@ ParsedRequest classify_request(const JsonValue& root) {
   else if (method == "capabilities") request.method = RpcMethod::kCapabilities;
   else if (method == "invoke") request.method = RpcMethod::kInvoke;
   else if (method == "cancel") request.method = RpcMethod::kCancel;
+  else if (method == "invalidateGraph") request.method = RpcMethod::kInvalidateGraph;
   else invalid_request("unknown RPC method");
 
   if (const JsonValue* value = member(*envelope, "deadlineUnixMs")) {
@@ -929,7 +939,7 @@ ParsedRequest classify_request(const JsonValue& root) {
         invalid_argument("invoke is not in the compile-time allowlist");
       }
       request.params = std::move(result);
-    } else {
+    } else if (request.method == RpcMethod::kCancel) {
       if (!exact_keys(*params, {"targetRequestId"}, {"targetRequestId"})) {
         invalid_argument("invalid cancel params");
       }
@@ -938,6 +948,13 @@ ParsedRequest classify_request(const JsonValue& root) {
           *params, "targetRequestId", CodecErrorKind::kInvalidArgument);
       if (!valid_request_id(result.target_request_id)) invalid_argument("invalid cancel target ID");
       request.params = std::move(result);
+    } else {
+      if (!exact_keys(*params, {"reason"}, {"reason"})
+          || required_string(*params, "reason", CodecErrorKind::kInvalidArgument)
+              != "cep-jsx") {
+        invalid_argument("invalid project graph invalidation params");
+      }
+      request.params = InvalidateGraphParams{};
     }
   }
   request.request_fingerprint_sha256 = sha256_hex(canonical_request(request));
@@ -1631,7 +1648,9 @@ SessionIngressResult RpcSessionFrontDoor::admit(const ParsedRequest& request) {
       || (request.method == RpcMethod::kInvoke
         && std::holds_alternative<InvokeParams>(request.params))
       || (request.method == RpcMethod::kCancel
-        && std::holds_alternative<CancelParams>(request.params));
+        && std::holds_alternative<CancelParams>(request.params))
+      || (request.method == RpcMethod::kInvalidateGraph
+        && std::holds_alternative<InvalidateGraphParams>(request.params));
   if (!params_match) {
     return {SessionIngressCode::kInvalidRequest, "INVALID_REQUEST", std::nullopt, false};
   }
@@ -2599,6 +2618,24 @@ std::vector<std::uint8_t> encode_cancel_success(const CancelSuccess& response) {
       + (response.terminal_response_expected ? "true" : "false")
       + "},\"sessionId\":" + json_string(response.session_id)
       + ",\"wireVersion\":1}";
+  return frame_output(std::move(json));
+}
+
+std::vector<std::uint8_t> encode_project_graph_invalidate_success(
+    const ProjectGraphInvalidateSuccess& response) {
+  require_request_id(response.request_id);
+  require_uuid(response.session_id, "session ID");
+  if (response.invalidated
+      ? response.generation < 1 || response.generation > kMaxSafeInteger
+      : response.generation != 0) {
+    invalid_argument("invalid project graph invalidation result");
+  }
+  std::string json = "{\"kind\":\"response\",\"method\":\"invalidateGraph\","
+      "\"ok\":true,\"replayed\":false,\"requestId\":"
+      + json_string(response.request_id) + ",\"result\":{\"generation\":"
+      + std::to_string(response.generation) + ",\"invalidated\":"
+      + (response.invalidated ? "true" : "false") + "},\"sessionId\":"
+      + json_string(response.session_id) + ",\"wireVersion\":1}";
   return frame_output(std::move(json));
 }
 

--- a/native/ae-plugin/tests/host_dispatcher_test.cpp
+++ b/native/ae-plugin/tests/host_dispatcher_test.cpp
@@ -183,20 +183,29 @@ void project_epoch_fences_reused_aegp_handles() {
   require(!tracker.observe(saved) && tracker.generation() == 1,
       "an unchanged project observation rotated its generation");
 
+  require(tracker.present() && tracker.invalidate() && tracker.generation() == 2,
+      "a command invalidation did not rotate the active project generation");
+  require(!tracker.observe(saved) && tracker.generation() == 2,
+      "command invalidation discarded the current project observation");
+  require(tracker.invalidate() && tracker.generation() == 3,
+      "a second command invalidation did not remain monotonic");
+
   const ProjectObservation empty{
       saved.project_identity, saved.root_item_identity, saved.root_item_id, {}};
-  require(tracker.observe(empty) && tracker.generation() == 2,
+  require(tracker.observe(empty) && tracker.generation() == 4,
       "saved-to-empty project path transition was hidden by reused AEGP handles");
-  require(tracker.observe(saved) && tracker.generation() == 3,
+  require(tracker.observe(saved) && tracker.generation() == 5,
       "empty-to-reopened project path transition did not rotate its generation");
 
   const ProjectObservation replaced_root{
       saved.project_identity, 0x3000U, saved.root_item_id, saved.project_path};
-  require(tracker.observe(replaced_root) && tracker.generation() == 4,
+  require(tracker.observe(replaced_root) && tracker.generation() == 6,
       "a replaced root AEGP handle did not rotate the project generation");
   require(tracker.close() && !tracker.close(),
       "project close observation was not idempotent");
-  require(tracker.observe(replaced_root) && tracker.generation() == 5,
+  require(!tracker.present() && !tracker.invalidate() && tracker.generation() == 6,
+      "a command invalidation rotated an absent project generation");
+  require(tracker.observe(replaced_root) && tracker.generation() == 7,
       "reopening the same observed handles after close reused the old generation");
 }
 

--- a/native/ae-plugin/tests/native_rpc_connection_test.cpp
+++ b/native/ae-plugin/tests/native_rpc_connection_test.cpp
@@ -34,6 +34,7 @@ using aemcp::native::HostCompositionTimeResult;
 using aemcp::native::HostDispatcher;
 using aemcp::native::HostIdleSignal;
 using aemcp::native::HostLayerPropertiesResult;
+using aemcp::native::HostProjectGraphInvalidationResult;
 using aemcp::native::HostReadResult;
 using aemcp::native::HostProjectItemsResult;
 using aemcp::native::NativeRpcConnectionHandler;
@@ -44,6 +45,7 @@ using aemcp::native::ProjectSummary;
 using aemcp::native::Request;
 using aemcp::native::TimePoint;
 using aemcp::native::kProjectBitDepthSetCapability;
+using aemcp::native::kProjectGraphInvalidateControl;
 using aemcp::native::kProjectSummaryCapability;
 using aemcp::native::rpc::SessionClock;
 
@@ -256,6 +258,13 @@ class FakeHost final : public HostApi {
     return HostLayerPropertiesResult::success(std::move(page));
   }
 
+  [[nodiscard]] HostProjectGraphInvalidationResult invalidate_project_graph(
+      TimePoint) override {
+    ++project_graph_invalidation_calls;
+    project_graph_invalidation_thread = std::this_thread::get_id();
+    return HostProjectGraphInvalidationResult::success({true, 9});
+  }
+
   [[nodiscard]] static aemcp::native::ObjectLocator locator(
       std::string kind,
       std::string object_id,
@@ -284,6 +293,8 @@ class FakeHost final : public HostApi {
   int composition_selected_layers_calls{0};
   int composition_time_calls{0};
   int layer_properties_calls{0};
+  int project_graph_invalidation_calls{0};
+  std::thread::id project_graph_invalidation_thread;
 };
 
 struct EventRecord {
@@ -494,6 +505,14 @@ std::string invoke_json(
       + "\",\"method\":\"invoke\",\"deadlineUnixMs\":1900000005000,"
         "\"params\":{\"capabilityId\":\"ae.project.summary\","
         "\"capabilityVersion\":1,\"arguments\":{}}}";
+}
+
+std::string invalidate_graph_json(
+    std::string_view request_id = "invalidate-graph-1") {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"" + std::string(request_id)
+      + "\",\"method\":\"invalidateGraph\","
+        "\"params\":{\"reason\":\"cep-jsx\"}}";
 }
 
 std::string bit_depth_read_invoke_json(std::string_view request_id) {
@@ -1090,6 +1109,103 @@ void hello_capabilities_invoke_cancel_and_fencing_work() {
   (void)dispatcher.shutdown();
 }
 
+void invalidate_graph_runs_only_on_owner_dispatcher_and_is_fenced() {
+  FakeDispatcherClock dispatcher_clock;
+  FakeSessionClock session_clock;
+  const std::thread::id owner_thread = std::this_thread::get_id();
+  HostDispatcher dispatcher(owner_thread, dispatcher_clock);
+  RecordingObserver observer;
+  RecordingIdleSignal idle_signal;
+  NativeRpcConnectionHandler handler(
+      dispatcher, dispatcher_clock, session_clock, runtime(), observer, idle_signal);
+  std::array<int, 2> sockets{};
+  require(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets.data()) == 0,
+      "invalidateGraph socketpair failed");
+  const AuthenticatedConnection authenticated =
+      connection(sockets[1], "route-invalidate", 11);
+  std::thread worker([&] { handler.serve(authenticated); });
+
+  send_json(sockets[0], hello_json());
+  require_contains(read_body(sockets[0]), "\"ok\":true", "invalidateGraph hello");
+
+  FakeHost host;
+  const std::string request = invalidate_graph_json();
+  send_json(sockets[0], request);
+  const std::string progress = read_body(sockets[0]);
+  require_contains(progress, "\"event\":\"progress\"", "invalidateGraph progress");
+  require_contains(progress, "\"phase\":\"queued\"", "invalidateGraph progress");
+  wait_until([&] { return dispatcher.queued() == 1; }, "queued invalidateGraph request");
+  wait_until([&] { return idle_signal.calls() == 1; }, "invalidateGraph idle wake");
+  require(host.project_graph_invalidation_calls == 0,
+      "invalidateGraph reached HostApi before dispatcher drain");
+  require(observer.has_event("invalidateGraph", "invalidate-graph-1", "queued")
+          && observer.has_event(
+              "dispatch.wake", "invalidate-graph-1", "scheduled"),
+      "invalidateGraph did not emit its queued and wake audit events");
+
+  bool wrong_thread = false;
+  std::size_t wrong_thread_completions = 0;
+  std::thread non_owner([&] {
+    const auto batch = dispatcher.drain(host);
+    wrong_thread = batch.wrong_thread;
+    wrong_thread_completions = batch.completions.size();
+  });
+  non_owner.join();
+  require(wrong_thread && wrong_thread_completions == 0
+          && host.project_graph_invalidation_calls == 0
+          && dispatcher.queued() == 1,
+      "non-owner dispatcher drain reached invalidateGraph HostApi");
+
+  const auto batch = dispatcher.drain(host);
+  require(batch.completions.size() == 1
+          && batch.completions[0].ok
+          && batch.completions[0].capability_id == kProjectGraphInvalidateControl
+          && batch.completions[0].project_graph_invalidation_result.invalidated
+          && batch.completions[0].project_graph_invalidation_result.generation == 9,
+      "owner dispatcher did not produce the typed invalidateGraph completion");
+  require(host.project_graph_invalidation_calls == 1
+          && host.project_graph_invalidation_thread == owner_thread,
+      "invalidateGraph HostApi call did not run exactly once on the owner thread");
+
+  const std::string acknowledgement = read_body(sockets[0]);
+  require_contains(
+      acknowledgement, "\"method\":\"invalidateGraph\"", "invalidateGraph response");
+  require_contains(acknowledgement, "\"ok\":true", "invalidateGraph response");
+  require_contains(acknowledgement,
+      "\"result\":{\"generation\":9,\"invalidated\":true}",
+      "invalidateGraph response");
+  require(acknowledgement.find("\"capabilityId\"") == std::string::npos,
+      "invalidateGraph response exposed its internal dispatcher capability");
+
+  wait_until([&] {
+    return !observer.terminal("invalidate-graph-1").request_id.empty();
+  }, "invalidateGraph terminal audit");
+  const TerminalRecord terminal = observer.terminal("invalidate-graph-1");
+  require(terminal.ok
+          && terminal.request_digest
+              == "0be932440057b1f2509aee30f414f8fb45d6a637d3327c76cc75d9ca84222bd3"
+          && terminal.request_digest.size() == 64
+          && terminal.postcondition_digest.empty(),
+      "invalidateGraph terminal audit did not preserve its request-only evidence");
+
+  send_json(sockets[0], request);
+  const std::string duplicate = read_body(sockets[0]);
+  require_contains(
+      duplicate, "\"method\":\"invalidateGraph\"", "duplicate invalidateGraph");
+  require_contains(
+      duplicate, "\"code\":\"DUPLICATE_REQUEST\"", "duplicate invalidateGraph");
+  require_contains(duplicate,
+      "\"sideEffect\":\"not-started\"", "duplicate invalidateGraph");
+  require(host.project_graph_invalidation_calls == 1
+          && dispatcher.queued() == 0
+          && idle_signal.calls() == 1
+          && !wait_readable(sockets[0], 100ms),
+      "duplicate invalidateGraph reached HostApi or emitted extra work");
+
+  finish_connection(sockets[0], sockets[1], worker);
+  (void)dispatcher.shutdown();
+}
+
 void invalid_postcondition_becomes_structured_failure() {
   FakeDispatcherClock dispatcher_clock;
   FakeSessionClock session_clock;
@@ -1199,6 +1315,7 @@ void construction_failure_is_contained_by_noexcept_boundary() {
 
 int main() {
   hello_capabilities_invoke_cancel_and_fencing_work();
+  invalidate_graph_runs_only_on_owner_dispatcher_and_is_fenced();
   invalid_postcondition_becomes_structured_failure();
   construction_failure_is_contained_by_noexcept_boundary();
   std::cout << "native_rpc_connection_test: PASS\n";

--- a/native/ae-plugin/tests/rpc_codec_test.cpp
+++ b/native/ae-plugin/tests/rpc_codec_test.cpp
@@ -31,12 +31,14 @@ using aemcp::native::rpc::ErrorResponse;
 using aemcp::native::rpc::FrameDecoder;
 using aemcp::native::rpc::HelloParams;
 using aemcp::native::rpc::HelloSuccess;
+using aemcp::native::rpc::InvalidateGraphParams;
 using aemcp::native::rpc::InvokeParams;
 using aemcp::native::rpc::ParsedRequest;
 using aemcp::native::rpc::ProgressEvent;
 using aemcp::native::rpc::ProgressPhase;
 using aemcp::native::rpc::ProjectBitDepthReadSuccess;
 using aemcp::native::rpc::ProjectBitDepthSetSuccess;
+using aemcp::native::rpc::ProjectGraphInvalidateSuccess;
 using aemcp::native::rpc::ProjectItemsSuccess;
 using aemcp::native::rpc::ProjectSummarySuccess;
 using aemcp::native::rpc::RpcErrorCode;
@@ -63,6 +65,7 @@ using aemcp::native::rpc::encode_hello_success;
 using aemcp::native::rpc::encode_progress_event;
 using aemcp::native::rpc::encode_project_bit_depth_read_success;
 using aemcp::native::rpc::encode_project_bit_depth_set_success;
+using aemcp::native::rpc::encode_project_graph_invalidate_success;
 using aemcp::native::rpc::encode_project_summary_success;
 using aemcp::native::rpc::encode_composition_layers_success;
 using aemcp::native::rpc::encode_composition_selected_layers_success;
@@ -162,6 +165,14 @@ std::string invoke_json(
       + "\",\"method\":\"invoke\",\"deadlineUnixMs\":" + std::to_string(deadline)
       + ",\"params\":{\"capabilityId\":\"ae.project.summary\","
         "\"capabilityVersion\":1,\"arguments\":" + std::string(arguments) + "}}";
+}
+
+std::string invalidate_graph_json(
+    std::string_view request_id = "invalidate-graph-1",
+    std::string_view params = "{\"reason\":\"cep-jsx\"}") {
+  return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
+      + std::string(kSession) + "\",\"requestId\":\"" + std::string(request_id)
+      + "\",\"method\":\"invalidateGraph\",\"params\":" + std::string(params) + "}";
 }
 
 std::string bit_depth_read_invoke_json(
@@ -409,6 +420,88 @@ void project_bit_depth_invokes_are_closed_and_explicitly_mapped() {
     (void)decode_request_frame(frame(bit_depth_set_invoke_json(
         "bit-depth-extra", "16", "bit-depth-intent-005", ",\"jsx\":\"x\"")));
   }, "INVALID_ARGUMENT", "unknown project bit-depth argument");
+}
+
+void invalidate_graph_requests_and_results_are_closed_and_deterministic() {
+  const std::string golden = invalidate_graph_json();
+  const ParsedRequest parsed = decode_request_frame(frame(golden));
+  require(parsed.method == RpcMethod::kInvalidateGraph
+          && parsed.session_id == kSession
+          && !parsed.deadline_unix_ms.has_value()
+          && std::holds_alternative<InvalidateGraphParams>(parsed.params)
+          && std::get<InvalidateGraphParams>(parsed.params).reason
+              == InvalidateGraphParams::Reason::kCepJsx,
+      "invalidateGraph request did not preserve its typed method and closed params");
+  require(parsed.request_fingerprint_sha256
+          == "0be932440057b1f2509aee30f414f8fb45d6a637d3327c76cc75d9ca84222bd3",
+      "invalidateGraph RFC 8785 request digest diverged from its fixture");
+  require(decode_request_frame(frame(" \n" + golden + "\t"))
+              .request_fingerprint_sha256 == parsed.request_fingerprint_sha256,
+      "invalidateGraph request digest changed across insignificant whitespace");
+
+  const std::string missing_params = "{\"wireVersion\":1,\"kind\":\"request\","
+      "\"sessionId\":\"" + std::string(kSession)
+      + "\",\"requestId\":\"invalidate-missing-params\","
+        "\"method\":\"invalidateGraph\"}";
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(missing_params));
+  }, "INVALID_REQUEST", "invalidateGraph missing params object");
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invalidate_graph_json("invalidate-missing-reason", "{}")));
+  }, "INVALID_ARGUMENT", "invalidateGraph missing reason");
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invalidate_graph_json(
+        "invalidate-wrong-type", "{\"reason\":true}")));
+  }, "INVALID_ARGUMENT", "invalidateGraph non-string reason");
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invalidate_graph_json(
+        "invalidate-wrong-reason", "{\"reason\":\"script\"}")));
+  }, "INVALID_ARGUMENT", "invalidateGraph unknown reason");
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(invalidate_graph_json(
+        "invalidate-extra", "{\"reason\":\"cep-jsx\",\"extra\":true}")));
+  }, "INVALID_ARGUMENT", "invalidateGraph extra param");
+
+  std::string wrong_method = golden;
+  wrong_method.replace(
+      wrong_method.find("invalidateGraph"), std::string_view("invalidateGraph").size(),
+      "invalidategraph");
+  expect_codec_error([&] {
+    (void)decode_request_frame(frame(wrong_method));
+  }, "INVALID_REQUEST", "invalidateGraph method case drift");
+
+  ProjectGraphInvalidateSuccess success{
+      "invalidate-graph-1", std::string(kSession), true, 9};
+  const std::string success_body = body(
+      encode_project_graph_invalidate_success(success));
+  require(success_body.find("\"method\":\"invalidateGraph\"") != std::string::npos
+          && success_body.find("\"replayed\":false") != std::string::npos
+          && success_body.find(
+              "\"result\":{\"generation\":9,\"invalidated\":true}")
+              != std::string::npos,
+      "invalidateGraph success encoder omitted its typed acknowledgement");
+
+  success.generation = 0;
+  expect_argument_error([&] {
+    (void)encode_project_graph_invalidate_success(success);
+  }, "invalidateGraph true result with generation zero");
+  success.generation = aemcp::native::rpc::kMaxSafeInteger + 1;
+  expect_argument_error([&] {
+    (void)encode_project_graph_invalidate_success(success);
+  }, "invalidateGraph true result with unsafe generation");
+
+  success.invalidated = false;
+  success.generation = 0;
+  const std::string no_project_body = body(
+      encode_project_graph_invalidate_success(success));
+  require(no_project_body.find(
+              "\"result\":{\"generation\":0,\"invalidated\":false}")
+              != std::string::npos,
+      "invalidateGraph no-project acknowledgement changed its zero-generation invariant");
+  success.generation = 1;
+  expect_argument_error([&] {
+    (void)encode_project_graph_invalidate_success(success);
+  }, "invalidateGraph false result with nonzero generation");
 }
 
 void project_graph_invokes_and_results_are_closed_and_deterministic() {
@@ -1312,6 +1405,7 @@ void fixed_seed_mutation_fuzz_is_bounded() {
 int main() {
   golden_requests_are_typed_and_closed();
   project_bit_depth_invokes_are_closed_and_explicitly_mapped();
+  invalidate_graph_requests_and_results_are_closed_and_deterministic();
   project_graph_invokes_and_results_are_closed_and_deterministic();
   framing_fragmentation_and_multiple_frames_work();
   strict_json_and_frame_limits_fail_closed();

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1725,6 +1725,33 @@ function createNativeAegpClient(options) {
         return result;
     }
 
+    async function invalidateProjectGraph(options) {
+        const call = options || {};
+        if (!exactKeys(call, ['deadlineUnixMs'])
+            || !Number.isSafeInteger(call.deadlineUnixMs) || call.deadlineUnixMs <= 0) {
+            throw nativeError(
+                'INVALID_ARGUMENT',
+                'native project graph invalidation request is invalid',
+                false,
+            );
+        }
+        if (state !== 'connected') await waitUntilConnected(call.deadlineUnixMs);
+        const result = await send(
+            'invalidateGraph',
+            { reason: 'cep-jsx' },
+            { deadlineUnixMs: call.deadlineUnixMs },
+        );
+        if (!exactKeys(result, ['generation', 'invalidated'])
+            || !Number.isSafeInteger(result.generation) || result.generation < 0
+            || typeof result.invalidated !== 'boolean'
+            || (result.invalidated ? result.generation < 1 : result.generation !== 0)) {
+            throw nativeContractMismatch(
+                'native project graph invalidation result was malformed',
+            );
+        }
+        return result;
+    }
+
     async function projectSummary() {
         return invoke({
             requestId: 'invoke-' + String(nextRequest++) + '-' + randomBytes(4).toString('hex'),
@@ -1748,6 +1775,7 @@ function createNativeAegpClient(options) {
         negotiate,
         capabilities,
         invoke,
+        invalidateProjectGraph,
         projectSummary,
         close,
         status: function () {

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -242,6 +242,11 @@ function installProtocol(server, options) {
                         nextCursor: null,
                         items: CAPABILITIES_VECTOR.items,
                     };
+                } else if (request.method === 'invalidateGraph') {
+                    result = input.invalidateResult || {
+                        generation: 8,
+                        invalidated: true,
+                    };
                 } else if (request.params.capabilityId === 'ae.project.items.list'
                     || request.params.capabilityId === 'ae.composition.layers.list'
                     || request.params.capabilityId === 'ae.composition.selected-layers.list'
@@ -355,7 +360,10 @@ function installProtocol(server, options) {
                     if (input.mutateInvoke) input.mutateInvoke(result, request);
                 }
                 if (input.suppressHello && request.method === 'hello') continue;
-                const responseError = request.method === 'invoke' ? input.invokeError : null;
+                const responseError = request.method === 'invoke'
+                    ? input.invokeError
+                    : request.method === 'invalidateGraph'
+                        ? input.invalidateError : null;
                 socket.write(frame({
                     wireVersion: 1,
                     kind: 'response',
@@ -437,6 +445,56 @@ test('discovery accepts only a private descriptor and socket owned by this user'
 
     fs.chmodSync(path.join(fixture.root, 'aemcp-n1', 'd-' + HOST + '.endpoint'), 0o644);
     assert.deepEqual(discoverNativeEndpoints({ runtimeRoot: fixture.root }), []);
+});
+
+test('CEP client sends the closed internal project-graph invalidation contract', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const ready = await readyNativeClient(t);
+    const result = await ready.client.invalidateProjectGraph({
+        deadlineUnixMs: 1900000002000,
+    });
+
+    assert.deepEqual(result, { generation: 8, invalidated: true });
+    const request = ready.protocol.requests.at(-1);
+    assert.equal(request.method, 'invalidateGraph');
+    assert.deepEqual(request.params, { reason: 'cep-jsx' });
+    assert.equal(request.sessionId, SESSION);
+    assert.equal(request.deadlineUnixMs, 1900000002000);
+    assert.deepEqual(Object.keys(request).sort(), [
+        'deadlineUnixMs', 'kind', 'method', 'params', 'requestId', 'sessionId', 'wireVersion',
+    ]);
+});
+
+test('CEP client rejects an open project-graph invalidation result', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const ready = await readyNativeClient(t, {
+        invalidateResult: { generation: 8, invalidated: true, extra: 'open-contract' },
+    });
+
+    await assert.rejects(
+        ready.client.invalidateProjectGraph({ deadlineUnixMs: 1900000002000 }),
+        (error) => error?.code === 'NATIVE_CONTRACT_MISMATCH'
+            && /invalidation result was malformed/.test(error.message),
+    );
+});
+
+test('CEP client rejects inconsistent project-graph invalidation evidence', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    for (const invalidateResult of [
+        { generation: 0, invalidated: true },
+        { generation: 8, invalidated: false },
+    ]) {
+        const ready = await readyNativeClient(t, { invalidateResult });
+        await assert.rejects(
+            ready.client.invalidateProjectGraph({ deadlineUnixMs: 1900000002000 }),
+            (error) => error?.code === 'NATIVE_CONTRACT_MISMATCH'
+                && /invalidation result was malformed/.test(error.message),
+        );
+        await ready.client.close();
+    }
 });
 
 test('CEP client verifies native project summary and bit-depth read/write capabilities', {

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -25,6 +25,7 @@ const blocked = new Set();
 // Self-reported label of the panel's own diagnostic /exec probes. Must match
 // the x-ae-mcp-client header in plugin/panel/src/cep/diagnostics.js.
 const INTERNAL_CLIENT = 'panel-diagnostics/internal';
+const NATIVE_MAX_REQUEST_WINDOW_MS = 30000;
 const NATIVE_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 const PROJECT_SUMMARY_CAPABILITY = 'ae.project.summary';
 const PROJECT_BIT_DEPTH_READ_CAPABILITY = 'ae.project.bit-depth.read';
@@ -135,6 +136,7 @@ function makeNativeAegpClient() {
         || typeof nativeAegpClient.negotiate !== 'function'
         || typeof nativeAegpClient.capabilities !== 'function'
         || typeof nativeAegpClient.invoke !== 'function'
+        || typeof nativeAegpClient.invalidateProjectGraph !== 'function'
         || typeof nativeAegpClient.status !== 'function'
         || typeof nativeAegpClient.close !== 'function') {
         nativeAegpClient = null;
@@ -144,6 +146,12 @@ function makeNativeAegpClient() {
         throw error;
     }
     return nativeAegpClient;
+}
+
+async function invalidateConnectedNativeProjectGraph(deadlineUnixMs) {
+    const client = nativeAegpClient;
+    if (!client || client.status()?.state !== 'connected') return;
+    await client.invalidateProjectGraph({ deadlineUnixMs });
 }
 
 function closeNativeAegpClient() {
@@ -782,6 +790,11 @@ function buildApp() {
 
         const startedAt = Date.now();
         try {
+            const invalidationDeadlineUnixMs = Math.min(
+                Number.MAX_SAFE_INTEGER,
+                startedAt + Math.min(Math.ceil(t), NATIVE_MAX_REQUEST_WINDOW_MS),
+            );
+            await invalidateConnectedNativeProjectGraph(invalidationDeadlineUnixMs);
             const encoded = await jsxBridge.evalScript(transported, t);
             const result = decodeEvalScriptTransportResult(encoded);
             activity.record({

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -189,6 +189,22 @@ async function startNativeApp(nativeClient) {
     return { server, srv, port: srv.address().port };
 }
 
+async function startExecAppWithNative(nativeClient, evalScript) {
+    delete require.cache[require.resolve('./server')];
+    delete require.cache[require.resolve('./jsx-bridge')];
+    const server = bindRuntimeDependencies(require('./server'));
+    server.activity._reset();
+    server.setPaused(false);
+    server._setExecToken('known-secret-token');
+    server.setCSInterface({ evalScript });
+    server._setNativeAegpClientForTest(nativeClient);
+    const app = server.buildApp();
+    const srv = await new Promise((resolve) => {
+        const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+    });
+    return { server, srv, port: srv.address().port };
+}
+
 function fakeNativeClient() {
     let state = 'disconnected';
     let closed = 0;
@@ -293,6 +309,10 @@ function fakeNativeClient() {
                 },
                 value: { projectOpen: true, projectName: 'Fixture.aep', itemCount: 2 },
             };
+        },
+        invalidateProjectGraph: async function (options) {
+            calls.push(['invalidateProjectGraph', options]);
+            return { generation: 8, invalidated: true };
         },
         status: function () {
             return {
@@ -877,6 +897,106 @@ test('/exec returns 200 with the correct token', async () => {
         assert.strictEqual(r.body.result, 'stub-result');
     } finally {
         srv.close();
+    }
+});
+
+test('/exec awaits connected native project-graph invalidation before evalScript', async () => {
+    const events = [];
+    let invalidationOptions;
+    const nativeClient = {
+        status: function () { return { state: 'connected' }; },
+        invalidateProjectGraph: async function (options) {
+            invalidationOptions = options;
+            events.push('invalidate:start');
+            await Promise.resolve();
+            events.push('invalidate:ack');
+            return { generation: 8, invalidated: true };
+        },
+        close: async function () {},
+    };
+    const running = await startExecAppWithNative(nativeClient, function (_jsx, cb) {
+        events.push('evalScript');
+        cb('{"ok":true,"result":"stub-result"}');
+    });
+    try {
+        const response = await post(
+            running.port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: '1', timeoutMs: 60000 },
+        );
+        assert.equal(response.status, 200);
+        assert.equal(response.body.ok, true);
+        assert.deepEqual(events, ['invalidate:start', 'invalidate:ack', 'evalScript']);
+        assert.deepEqual(Object.keys(invalidationOptions), ['deadlineUnixMs']);
+        assert.equal(Number.isSafeInteger(invalidationOptions.deadlineUnixMs), true);
+        assert.equal(invalidationOptions.deadlineUnixMs > 0, true);
+        assert.equal(invalidationOptions.deadlineUnixMs > Date.now(), true);
+        assert.equal(invalidationOptions.deadlineUnixMs <= Date.now() + 30000, true);
+    } finally {
+        running.srv.close();
+        running.server._setNativeAegpClientForTest(null);
+    }
+});
+
+test('/exec fails closed before evalScript when connected native invalidation fails', async () => {
+    let evalCalls = 0;
+    const nativeClient = {
+        status: function () { return { state: 'connected' }; },
+        invalidateProjectGraph: async function () {
+            const error = new Error('native graph fence failed');
+            error.code = 'NATIVE_UNAVAILABLE';
+            throw error;
+        },
+        close: async function () {},
+    };
+    const running = await startExecAppWithNative(nativeClient, function (_jsx, cb) {
+        evalCalls += 1;
+        cb('{"ok":true,"result":"must-not-run"}');
+    });
+    try {
+        const response = await post(
+            running.port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: 'app.project.close();' },
+        );
+        assert.equal(response.status, 200);
+        assert.equal(response.body.ok, false);
+        assert.match(response.body.error, /native graph fence failed/);
+        assert.equal(evalCalls, 0);
+    } finally {
+        running.srv.close();
+        running.server._setNativeAegpClientForTest(null);
+    }
+});
+
+test('/exec keeps legacy evalScript behavior when the existing native client is disconnected', async () => {
+    let invalidationCalls = 0;
+    let evalCalls = 0;
+    const nativeClient = {
+        status: function () { return { state: 'disconnected' }; },
+        invalidateProjectGraph: async function () { invalidationCalls += 1; },
+        close: async function () {},
+    };
+    const running = await startExecAppWithNative(nativeClient, function (_jsx, cb) {
+        evalCalls += 1;
+        cb('{"ok":true,"result":"legacy-result"}');
+    });
+    try {
+        const response = await post(
+            running.port,
+            '/exec',
+            { 'X-AE-MCP-Token': 'known-secret-token' },
+            { code: '1' },
+        );
+        assert.equal(response.status, 200);
+        assert.deepEqual(response.body, { ok: true, result: 'legacy-result' });
+        assert.equal(invalidationCalls, 0);
+        assert.equal(evalCalls, 1);
+    } finally {
+        running.srv.close();
+        running.server._setNativeAegpClientForTest(null);
     }
 });
 


### PR DESCRIPTION
Closes #103.

## What changed

- adds the authenticated internal `invalidateGraph` RPC boundary for CEP/JSX-driven project replacement;
- dispatches invalidation on the AE main thread and atomically clears project/item/composition/layer/stream locator state while monotonically rotating the project generation and project id;
- fences connected-native `/exec` before JSX starts, while preserving the legacy path when native is absent or disconnected;
- registers AE command-hook invalidation for manual project lifecycle commands;
- preserves public structured `STALE_LOCATOR` recovery and rejects mixed fresh/stale locator scopes in Core before native execution;
- caps the internal invalidation deadline to the native protocol's 30-second request window even when `/exec` is given a longer timeout.

## Why

AE can close and reopen the same `.aep` between native graph calls while reusing all observable SDK handles and the same path. Handle/path comparison cannot distinguish that ABA replacement. This change adds an explicit, authenticated project-graph replacement boundary instead of claiming undocumented SDK identity guarantees.

## Candidate validation

Exact candidate: `32f13d46e185021d5faf1a29428f09892372455a`.

- formal host preflight: `/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app`, bundle `com.adobe.AfterEffects.application`, version `26.3.0`, build `87`; Beta was not running;
- native bundle: SDK `25.6.61`, bundle tree `e3507297cf61413944f8efa2e46f66dda9ec6707f7387c0b7126dd94f8f03169`, executable `6f88bd034852aeae01f68ada8fca9f4c7538a472fe205061df3a1831b85166e6`;
- Core, CEP and native provenance all reported the exact candidate SHA; `lsof` mapped only the canonical installed plugin;
- matching pairing fingerprint `2E80-BD30` produced native `applied:true`, authorized session and `rpc.hello ok`;
- public MCP candidate gate created only `/private/tmp/ae-mcp-issue101-32f13d46e185.aep`, captured project/composition/layer/stream locators, closed and reopened that same file inside one public `ae_exec`, then verified:
  - one authenticated `internal.project-graph.invalidate` terminal audit with request digest and main-thread queue/wake evidence;
  - old project/composition/layer/stream locators each returned structured `STALE_LOCATOR` with refresh recovery;
  - a fresh layer combined with the old stream was rejected by Core with zero additional native invoke;
  - fresh discovery rotated generation/project id and read Opacity `73.25` with verified native postcondition/audit;
  - gate exited successfully.

## Automated validation

- protocol conformance: 32/32;
- CEP host tests: 93 tests;
- Core native contract tests: 43 tests;
- C++ `host_dispatcher`, `rpc_codec`, and `native_rpc_connection` tests compiled with C++20 and `-Werror` and passed;
- macOS SDK packaging/leak checks passed; no Adobe SDK material is tracked;
- `git diff --check` passed;
- independent C++ and JS/protocol reviews found no unresolved in-scope P0/P1 issue before the candidate gate.

## Remaining gate

After merge, rebuild and reinstall native/CEP/Core from clean `main`, repeat the formal-host public MCP gate, and only then close #103/update #77.
