### PR TITLE
chore(repo): enforce delivery rules and reconcile worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,5 +162,8 @@ jobs:
       - name: Run packaging contract tests
         run: node --test scripts/package/test/*.test.mjs
 
+      - name: Enforce repository delivery rules and audited worktree baseline
+        run: node scripts/check-repository-governance.mjs
+
       - name: Run release contract tests
         run: node --test scripts/release/test/*.test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ Thumbs.db
 # Local-only artifacts
 .rnd
 .worktrees/
+.local-workspace-archive/
 .superpowers/sdd/
 plugin/panel/ae_viewer_*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# Repository Development and Delivery Rules
+
+These rules apply to human developers and coding agents working in this repository. They exist to keep engineering effort aligned with observable After Effects functionality. When an issue plan, reviewer suggestion, or local preference conflicts with these rules, stop and resolve the conflict in favor of the user-visible acceptance outcome unless the user explicitly changes the priority.
+
+## 1. Measure outcomes, not activity
+
+- The primary P0 measure is a working capability through the public MCP surface. Lines changed, tests added, commits, PRs, protocol completeness, and CI status are supporting evidence, not delivery.
+- Prefer the smallest real vertical slice over a sequence of horizontal infrastructure layers.
+- A build, mock, isolated RPC test, internal function call, or ping-only result does not prove an AE capability works.
+- Do not describe a capability as complete until its observable AE result has been verified on the target machine.
+
+## 2. Prioritize by dependency and user value
+
+- Do not implement issues by issue number or creation order. Maintain P0/P1/P2/P3 priorities based on dependency and user value.
+- Work on one dependent P0 issue at a time. Do not start or stack the next dependent issue before the current issue has completed its full closure loop.
+- The closure loop is: implement -> automated tests -> independent diff review -> CI -> exact-build hardware validation -> merge -> rebuild/reinstall from `main` -> hardware revalidation -> close the issue and update its parent epic.
+- Parallel work is allowed only when it is genuinely independent and cannot cause mixed builds, shared-fixture conflicts, or premature assumptions about an unmerged interface.
+
+## 3. Define the public vertical-slice acceptance test first
+
+For AE-native work, write the executable acceptance path before expanding the implementation:
+
+```text
+public MCP tool
+  -> Core handler/backend
+  -> native RPC
+  -> AEGP main-thread dispatcher
+  -> After Effects state
+  -> typed result
+  -> audit evidence
+```
+
+- A read capability must return real AE state and include enough provenance and postcondition evidence to distinguish it from cached, replayed, mocked, or JSX-derived data.
+- A write capability must use a disposable fixture, record before/after AE state, return structured provenance, produce an audit record, and demonstrate a real Undo followed by state verification.
+- Use the public MCP tool name and request shape that a model will see. Internal calls may diagnose a failure but cannot replace end-to-end acceptance.
+- AEGP expands the capability ceiling; it is not a mechanical routing rule. Do not design a complex AEGP/JSX resolver until the real AEGP execution plane and useful native capability set are working.
+
+## 4. Hardware validation is a merge gate
+
+- Any change whose acceptance depends on AE loading, lifecycle, GUI state, main-thread behavior, CEP/native communication, or project mutation requires real-machine validation before merge.
+- Automated tests and CI never substitute for hardware validation.
+- Build, install, and test the exact candidate commit. Core, CEP host, native plugin, protocol metadata, and test evidence must report the same full commit SHA. Abort validation on any mismatch.
+- After merge, repeat the relevant public MCP smoke test from a clean `main` build. Do not rely on the pre-merge installation.
+- Use a dedicated disposable AE project. Never use the user's production project for write testing.
+- Prepare GUI access, permissions, pairing, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
+
+## 5. Keep review feedback from expanding P0
+
+Classify every newly discovered risk or reviewer comment before implementing it:
+
+1. **Current P0 blocker:** reproduced on the acceptance path, or demonstrably prevents correctness, recovery, auditability, or safe use of the current capability.
+2. **Follow-up:** credible hardening or product work that does not block the current vertical slice. Record it as a separate P1/P2 issue and keep it out of the active PR.
+3. **Not in scope:** hypothetical, unsupported, duplicated, or contrary to the current product decision. Document the disposition without implementing it.
+
+- Do not silently promote concurrency hardening, power-loss behavior, installer edge cases, signing, notarization, cross-platform expansion, or generalized framework work into P0.
+- Timebox investigations of non-reproduced edge cases. Once the current acceptance path is safe and reliable, defer the rest.
+- A reviewer finding is evidence to evaluate, not an automatic change request or priority override.
+
+## 6. Treat writes and uncertain failures explicitly
+
+- A transport timeout or disconnect after dispatch does not prove that a write did not occur.
+- Every native write should have a stable operation/request ID, bounded retry behavior, a queryable outcome when feasible, and a postcondition that can be checked independently.
+- On an indeterminate result such as `POSSIBLY_SIDE_EFFECTING_FAILURE`, inspect AE state and the audit trail before retrying. Never blindly repeat a possibly completed write.
+- Report Undo availability and Undo verification as separate facts. `available=true` must not imply that Undo has been executed and its postcondition verified.
+- Success requires agreement between the typed response, AE state, provenance, audit record, and verification result.
+
+## 7. Preserve build and workspace identity
+
+- Use one worktree and one branch for each issue. Know which worktree owns every build, install, test artifact, and running process.
+- Before building or deploying, record `git rev-parse HEAD`, dirty state, artifact hashes, installed paths, and runtime-reported source commit.
+- Never mix Core, CEP, native plugin, or protocol files from different commits. A convenient partial redeploy is not valid evidence.
+- Keep backup, staging, rollback, and evidence directories outside Adobe's plugin scan roots.
+- Keep disposable projects, generated scripts, logs, and smoke outputs out of tracked source paths unless they are intentional fixtures.
+- Do not use a stale or dirty root checkout as an implicit source for another issue's build.
+
+## 8. Minimize human interruption during hardware work
+
+- Consolidate all known permissions and GUI prerequisites into one preflight.
+- Once the user has authorized routine AE/macOS GUI control, perform normal focus, open/save/close, pairing, restart, disposable-project, and test Undo/Redo operations without repeatedly asking them to click.
+- Pause only for a genuinely required system confirmation, credential/license decision, destructive action outside the disposable fixture, or a product choice that changes the result.
+- When blocked, report the single concrete blocker and the evidence already gathered; do not offload ordinary debugging steps to the user.
+
+### 8.1 Reuse the proven Skip -> Continue recovery
+
+When macOS, the GUI-control layer, or an unrelated application interrupts an already authorized hardware-validation step, reuse the following recovery before starting a new investigation:
+
+1. Read the prompt and identify which application and permission it belongs to. Do not confuse an unrelated prompt with an AE, CEP, native-plugin, or MCP failure.
+2. If the permission is optional for the current acceptance path, click **Skip**. A known example is an unexpected Shadowrocket proxy/network permission prompt during local AE work; local AE validation must not be blocked on granting that unrelated permission.
+3. Click **Continue** in the controlling workflow to dismiss the interruption and return control to the active task.
+4. Read the screen again, restore focus to the exact target application, and resume from the last verified checkpoint. Do not restart the entire install, pairing, fixture, or acceptance sequence merely because the UI was interrupted.
+5. Retry the originally intended, idempotent click at most once after confirming the expected screen is visible. For a write or an operation with uncertain side effects, inspect AE state and audit evidence before any retry.
+
+Treat this Skip -> Continue sequence as established project knowledge. Do not repeatedly ask the user how to handle the same optional prompt, and do not turn it into a new P0 investigation.
+
+### 8.2 Recover from a genuine system-level block
+
+- First try the already authorized normal GUI path. If automation can click the required control safely, click it and continue without asking the user.
+- If macOS presents a protected confirmation that automation genuinely cannot operate, stop repeated or blind clicking. Record the exact prompt text, owning application, required button, and last verified checkpoint.
+- Ask the user for only the one unavoidable confirmation. Do not ask them to repeat ordinary focus, navigation, pairing, save, close, restart, or test-fixture steps.
+- After the user confirms completion, take a fresh UI observation, verify that the prompt is gone or the permission changed, restore the exact target application and fixture, and continue from the saved checkpoint immediately.
+- If the system block disappears without the requested permission being necessary, use **Skip** and **Continue** and resume. Do not broaden permissions merely to make the warning disappear.
+- A recovered GUI interruption is not evidence that the product operation succeeded. Continue the original public-MCP acceptance path and collect the same AE state, provenance, audit, and postcondition evidence required before the interruption.
+
+## 9. Completion evidence
+
+An issue completion report must include:
+
+- issue and PR links, exact tested commit, and merge commit;
+- the public MCP request and structured response;
+- AE state evidence before and after the operation;
+- native/AEGP provenance and matching source commit;
+- audit evidence with sensitive values and private paths redacted;
+- Undo and recovery evidence for writes;
+- CI/review status and the clean-`main` hardware revalidation;
+- remaining risks and their follow-up issue classification.
+
+Do not claim completion using only "tests passed", "CI is green", "the plugin compiled", or "the PR merged".
+
+## 10. Stop conditions before starting the next issue
+
+Do not proceed to the next dependent issue when any of the following is true:
+
+- the current public MCP acceptance test has not passed on real AE;
+- the installed components do not share an exact source commit;
+- a write produced an indeterminate result whose AE state and audit outcome are unreconciled;
+- the PR is merged but clean `main` has not been rebuilt, reinstalled, and reverified;
+- the test fixture, logs, or workspace state cannot distinguish the tested build from an older installation;
+- a new task would hide or work around the current failure instead of resolving it.
+
+These stop conditions are delivery controls, not reasons to add unrelated hardening. Fix the narrow blocking path, preserve the evidence, and resume the closure loop.

--- a/docs/checkpoints/2026-07-16-worktree-audit.md
+++ b/docs/checkpoints/2026-07-16-worktree-audit.md
@@ -1,0 +1,80 @@
+# Worktree and root-workspace audit — 2026-07-16
+
+Issue: [#109](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/109)
+
+Parent: [#61](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/61)
+
+Initial registered worktrees: **26**
+
+This inventory was captured after #103 closed at `2532da2763d01a3e17c31c0db85f6e047bb77105`. Paths are normalized so the audit does not publish a developer account name. Removal means `git worktree remove` only after checking tracked dirt, unpushed commits, merged ancestry, associated Issue/PR, ignored build material, and rollback purpose. Branch refs are not deleted by this cleanup.
+
+## Initial inventory and disposition
+
+| Path | State at audit | Issue / purpose | Disposition |
+| --- | --- | --- | --- |
+| `<repo-root>` | dirty; branch `codex/macos-header-tools-release-design`; 4 unique commits | historical release-design work plus local user artifacts | retain, archive local artifacts losslessly, preserve branch ref, then return root to clean `main` |
+| `<tmp>/ae-mcp-issue99-main-verify-1e6668a` | clean; detached; ancestor of `main` | #99 clean-main verification | remove-completed |
+| `<tmp>/ae-mcp-main-101-final-e075a70` | clean; detached; ancestor of `main` | #101 clean-main verification | remove-completed |
+| `<tmp>/ae-mcp-main-93-deploy` | clean; detached; ancestor of `main` | #93 deployment verification | remove-completed |
+| `<tmp>/ae-mcp-main-94-final-6c890776` | clean; detached; ancestor of `main` | #94 clean-main verification | remove-completed |
+| `<tmp>/ae-mcp-main-96-deploy` | clean; detached; ancestor of `main` | #96 deployment verification | remove-completed |
+| `<tmp>/ae-mcp-main-p0-verify` | clean; detached; duplicate ancestor | historical P0 verification | remove-completed |
+| `<tmp>/ae-mcp-rollback-29e7931` | clean; detached; one commit not in `main` | #73 rollback snapshot | retain and move to `<repo-root>/.worktrees/issue-73-rollback-29e7931` |
+| `<repo-root>/.worktrees/issue-101-native-layer-properties` | clean; PR #102 merged | #101 implementation | remove-completed |
+| `<repo-root>/.worktrees/issue-104-clean-main-2a166552` | clean; detached; ancestor | #104 clean-main verification | remove-completed |
+| `<repo-root>/.worktrees/issue-104-native-composition-time` | clean; PR #105 merged | #104 implementation | remove-completed |
+| `<repo-root>/.worktrees/issue-106-native-selected-layers` | clean; PR #107 merged | #106 implementation | remove-completed |
+| `<repo-root>/.worktrees/issue-109-repo-governance` | active; branch `codex/issue-109-repo-governance` | #109 implementation | retain-active |
+| `<repo-root>/.worktrees/issue-71-sdk-intake` | clean; PR #84 merged | #71 SDK intake | remove-completed |
+| `<repo-root>/.worktrees/issue-72-native-rpc` | clean; PR #85 merged | #72 protocol | remove-completed |
+| `<repo-root>/.worktrees/issue-73-native-plugin` | clean; PR #87 merged | #73 native plugin | remove-completed |
+| `<repo-root>/.worktrees/issue-74-authenticated-ipc` | clean; PR #91 merged | #74 authenticated IPC | remove-completed |
+| `<repo-root>/.worktrees/issue-75-native-core-backend` | clean; PR #92 merged | #75 Core backend | remove-completed |
+| `<repo-root>/.worktrees/issue-76-public-native-read` | clean; PR #93 merged | #76 public read | remove-completed |
+| `<repo-root>/.worktrees/issue-78-native-undoable-write` | clean; PR #94 squash-merged; six branch commits remain patch-distinct from `origin/main` | #78 public write history | retain branch worktree; deletion requires a separate explicit risk decision |
+| `<repo-root>/.worktrees/issue-95-cep-scan-root` | clean; PR #96 merged | #95 CEP scan-root fix | remove-completed |
+| `<repo-root>/.worktrees/issue-97-native-artifact-stage` | clean; PR #98 squash-merged; two branch commits remain patch-distinct from `origin/main` | #97 artifact staging history | retain branch worktree; deletion requires a separate explicit risk decision |
+| `<repo-root>/.worktrees/issue-99-native-project-graph` | clean; PR #100 merged | #99 project graph | remove-completed |
+| `<repo-root>/.worktrees/macos-provider-integration` | clean; PR #53 merged | macOS provider integration | remove-completed |
+| `<repo-root>/.worktrees/platform-contracts` | retain-dirty; 2 unique commits; PR #52 closed unmerged | superseded platform contract history, four untracked alternates, SDD and build evidence | retain-dirty |
+| `<repo-root>/.worktrees/post107-main-5261cea9d735` | clean; detached; ancestor | post-#107 clean-main verification | remove-completed |
+
+## Preserved unique content
+
+- Root branch `codex/macos-header-tools-release-design` remains as a branch ref. Its unique commits are not rewritten or deleted.
+- The #73 rollback snapshot at `29e7931fc9b1243896c1ff473b7c7ceb61b68825` remains a registered worktree under the repository's ignored `.worktrees` directory.
+- `<repo-root>/.worktrees/platform-contracts` remains untouched. It has two commits absent from `main`, four untracked `* 2` alternates, ignored `.superpowers/sdd` material, and ignored macOS helper build evidence.
+- The clean #78 and #97 worktrees remain registered because squash merging preserved their product result but not their individual branch commits as `origin/main` ancestors. Their branch refs and working trees are retained instead of treating PR state alone as proof that no unique history exists.
+- Root tracked dirt is archived as a patch before restoration. Disposable AEPs, autosaves, temporary JSX/Python helpers, and the obsolete smoke shell script are moved—not deleted—to `.local-workspace-archive/2026-07-16/root-pre-main/` with SHA-256 metadata.
+
+## Root artifact manifest before archival
+
+| Source | Bytes | SHA-256 | Classification |
+| --- | ---: | --- | --- |
+| `AEMCP_P0_78_DISPOSABLE.aep` | 9427 | `5fe1aad13146ba540ae0d468bc8445d81ac476ad773aecc571f7bc7235589c55` | disposable AE fixture; archive |
+| `Adobe After Effects 自动保存/AEMCP_P0_78_DISPOSABLE自动保存 1.aep` | 10533 | `b21651687ad3db670fe24ef61f6821839db2637cc58d266d30fab63cba886a83` | autosave; archive |
+| `Adobe After Effects 自动保存/AEMCP_P0_78_DISPOSABLE自动保存 2.aep` | 10723 | `48b0971ea8c6c28d4202681aba2dbccf57b0d689a1b64e6ca3d2caf897c0923c` | autosave; archive |
+| `scripts/create_timer_display.jsx` | 2604 | `3a85a7b6ad42d78e18ace0b3e50ab052c0713bc719cfef7d7fa2a2cd80f4c95b` | one-off JSX helper; archive |
+| `scripts/run_timer_display.py` | 1749 | `c640607d871d6f0bafdf1b6e2f85aed6d10a855adfb6746b858709611b3d1663` | one-off direct `/exec` helper; archive |
+| `scripts/smoke-test-macos.sh` | 5634 | `446d13fc1c9a45256f934b0d877abf9a67866aaacbf13dbd36a370d71999e2f7` | obsolete/manual smoke script; archive |
+| `packages/core/ae_mcp/schemas.py` tracked diff | one-line change | recorded as patch | preserve local edit, then restore worktree file |
+
+## Final retained registry target
+
+| Path | Required final state | Purpose |
+| --- | --- | --- |
+| `<repo-root>` | clean `main`, synchronized with `origin/main` | canonical integration checkout |
+| `<repo-root>/.worktrees/issue-109-repo-governance` | clean while PR is active; remove after closure | #109 isolated delivery worktree |
+| `<repo-root>/.worktrees/issue-73-rollback-29e7931` | clean detached snapshot | explicit #73 rollback evidence |
+| `<repo-root>/.worktrees/issue-78-native-undoable-write` | clean | retained patch-distinct #78 squash-merge history |
+| `<repo-root>/.worktrees/issue-97-native-artifact-stage` | clean | retained patch-distinct #97 squash-merge history |
+| `<repo-root>/.worktrees/platform-contracts` | retain-dirty | unmerged/superseded platform history and evidence |
+
+The local `--worktrees` governance check rejects undocumented live worktrees and rejects dirty worktrees unless this document explicitly marks their normalized path `retain-dirty`. CI runs the deterministic tracked-file contract; live worktree state remains a local closure gate because CI cannot see a developer machine's worktree registry.
+
+## Cleanup execution record
+
+- 20 completed or historical verification worktrees were removed from the Git registry after the pre-removal checks above. Branch refs were deliberately left intact.
+- Two removals (#99 and macOS provider integration) unregistered correctly but could not remove directories containing ignored dependencies. The now-unregistered orphan directories were deleted only after confirming their `.git` pointers targeted absent registry entries and their branch refs remained preserved.
+- Six worktrees remain registered during #109: root, active #109, #73 rollback, clean patch-distinct #78 history, clean patch-distinct #97 history, and dirty/unmerged `platform-contracts` history.
+- Root artifacts were archived with matching post-move SHA-256 values. Root tracked dirt was restored only after its patch was written to the ignored archive.

--- a/docs/checkpoints/2026-07-16-worktree-audit.md
+++ b/docs/checkpoints/2026-07-16-worktree-audit.md
@@ -47,6 +47,50 @@ This inventory was captured after #103 closed at `2532da2763d01a3e17c31c0db85f6e
 - The clean #78 and #97 worktrees remain registered because squash merging preserved their product result but not their individual branch commits as `origin/main` ancestors. Their branch refs and working trees are retained instead of treating PR state alone as proof that no unique history exists.
 - Root tracked dirt is archived as a patch before restoration. Disposable AEPs, autosaves, temporary JSX/Python helpers, and the obsolete smoke shell script are moved—not deleted—to `.local-workspace-archive/2026-07-16/root-pre-main/` with SHA-256 metadata.
 
+## Versioned HEAD, upstream, and patch inventory
+
+`main-only/branch-only` is `git rev-list --left-right --count origin/main...HEAD` at the `2532da2763d01a3e17c31c0db85f6e047bb77105` baseline. `patch + / -` is the count from `git cherry origin/main HEAD`; a plus is patch-distinct, while a minus has a patch-equivalent change on `origin/main`.
+
+| Path | Exact HEAD at audit | Branch / upstream at audit | main-only / branch-only | patch + / - | Dirty state |
+| --- | --- | --- | ---: | ---: | --- |
+| `<repo-root>` | `036d45ff6bb63294696fbab227bcb7ddb7721cb1` | `codex/macos-header-tools-release-design`; no upstream | 14 / 5 | 4 / 0 | 1 tracked + 7 untracked |
+| `<tmp>/ae-mcp-issue99-main-verify-1e6668a` | `1e6668a683eb08f4f6326b9ed76c5b704a7b7413` | detached | 4 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-main-101-final-e075a70` | `e075a70a5797aaee93d6f9a6b818144dba548484` | detached | 3 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-main-93-deploy` | `a7f7b2453fb62325d9a40ac22edbc05377882222` | detached | 8 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-main-94-final-6c890776` | `6c890776a24b901559e57de3b7b8822ba4fea3fe` | detached | 6 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-main-96-deploy` | `3c8204827fe546b4cc1a778934ac5ceea183c896` | detached | 7 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-main-p0-verify` | `a7f7b2453fb62325d9a40ac22edbc05377882222` | detached | 8 / 0 | 0 / 0 | clean |
+| `<tmp>/ae-mcp-rollback-29e7931` | `29e7931fc9b1243896c1ff473b7c7ceb61b68825` | detached | 14 / 3 | 1 / 2 | clean |
+| `<repo-root>/.worktrees/issue-101-native-layer-properties` | `e600e371033f026b0f538934a66ef147c7d188b1` | `origin/codex/issue-101-native-layer-properties`; 0 / 0 | 4 / 4 | 4 / 0 | clean |
+| `<repo-root>/.worktrees/issue-104-clean-main-2a166552` | `2a166552c15f51b57e7ab662f61ae6cd7cfe4997` | detached | 2 / 0 | 0 / 0 | clean |
+| `<repo-root>/.worktrees/issue-104-native-composition-time` | `88916f8b3186b354c8e7aa3f3bbef5d1b48f6fe7` | `origin/codex/issue-104-native-composition-time`; 0 / 0 | 3 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-106-native-selected-layers` | `56e2ec348b1fa25d66739d790b6c3bf2886ca5bb` | `origin/codex/issue-106-native-selected-layers`; 0 / 0 | 2 / 4 | 4 / 0 | clean |
+| `<repo-root>/.worktrees/issue-109-repo-governance` | `2532da2763d01a3e17c31c0db85f6e047bb77105` | new branch; no upstream | 0 / 0 | 0 / 0 | clean |
+| `<repo-root>/.worktrees/issue-71-sdk-intake` | `8d0ce5865ce1509dfb0d372238be8dbae262e7a3` | `origin/codex/issue-71-sdk-intake`; 0 / 0 | 14 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-72-native-rpc` | `f7f97218a3349e72c3305e33eba3bbcc48c730f6` | `origin/codex/issue-72-native-rpc-contract`; 0 / 0 | 13 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-73-native-plugin` | `d31e3acb3038577dd2cf5d9ef5fb7cc9405bd7d4` | `origin/codex/issue-73-native-plugin-host`; 0 / 0 | 12 / 4 | 4 / 0 | clean |
+| `<repo-root>/.worktrees/issue-74-authenticated-ipc` | `fb1ea7f476ab9f80fc76247406da58db90e0075f` | `origin/codex/issue-74-authenticated-ipc`; 0 / 0 | 11 / 2 | 2 / 0 | clean |
+| `<repo-root>/.worktrees/issue-75-native-core-backend` | `a7e24f8bcf25c1e449493a3c0c4115c01b8a047f` | `origin/codex/issue-75-native-core-backend`; 0 / 0 | 10 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-76-public-native-read` | `e49503ad2eecad2c996074c43e4422b93eb9b648` | `origin/codex/issue-76-public-native-read`; 0 / 0 | 9 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-78-native-undoable-write` | `70c9cd9192cde1ae891e29cdb26fdfdb23d14374` | `origin/codex/issue-78-native-undoable-write`; 0 / 0 | 7 / 6 | 6 / 0 | clean |
+| `<repo-root>/.worktrees/issue-95-cep-scan-root` | `b7d71b2d48012647ba72d4dec114849ab733a011` | `origin/codex/issue-95-cep-scan-root`; 0 / 0 | 8 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/issue-97-native-artifact-stage` | `7f52a841313b5c794efb92f7dfcf41e57451b0db` | `origin/codex/issue-97-native-artifact-stage`; 0 / 0 | 6 / 2 | 2 / 0 | clean |
+| `<repo-root>/.worktrees/issue-99-native-project-graph` | `533eae65a24ecc235cee37994779edf5acfb54d3` | `origin/codex/issue-99-native-project-graph`; 0 / 0 | 5 / 1 | 0 / 1 | clean |
+| `<repo-root>/.worktrees/macos-provider-integration` | `7afc85342ed9ddc95251b3df8c4205e82e0ae4fa` | upstream gone | 42 / 0 | 0 / 0 | clean |
+| `<repo-root>/.worktrees/platform-contracts` | `c8393232d4c372a18c10f3afddc7c882f8d0a9c1` | upstream gone | 69 / 18 | 2 / 16 | 4 untracked |
+| `<repo-root>/.worktrees/post107-main-5261cea9d735` | `5261cea9d735e2b043a4d331a9e80445663a0e26` | detached | 1 / 0 | 0 / 0 | clean |
+
+### Retained dirty-file identity
+
+The retained `platform-contracts` worktree was not modified. Its four untracked files at audit are:
+
+| Relative path | SHA-256 |
+| --- | --- |
+| `docs/superpowers/plans/2026-07-10-tool-library 2.md` | `b83a0c40bd36a08f3740753fc1abff6f3064827dbf93d9fcb1e547b1268c4745` |
+| `packages/core/ae_mcp/skill_store 2.py` | `14a7b3242150e1e20e2fdaaf97f0c77cf673d04cf8460c4df90a556a7fff278e` |
+| `packages/core/tests/test_skill_store 2.py` | `85e17af64c71f6188153dbd5affa67d8ef829f8b27ce2a7eeb49514d9a36edfb` |
+| `plugin/client/dist/app 2.js` | `74b8959381e575653363a0e6f301df708ded6e2a8cb429b72c8a5c9a1a7f1b7f` |
+
 ## Root artifact manifest before archival
 
 | Source | Bytes | SHA-256 | Classification |
@@ -59,18 +103,17 @@ This inventory was captured after #103 closed at `2532da2763d01a3e17c31c0db85f6e
 | `scripts/smoke-test-macos.sh` | 5634 | `446d13fc1c9a45256f934b0d877abf9a67866aaacbf13dbd36a370d71999e2f7` | obsolete/manual smoke script; archive |
 | `packages/core/ae_mcp/schemas.py` tracked diff | one-line change | recorded as patch | preserve local edit, then restore worktree file |
 
-## Final retained registry target
+## Final retained registry
 
 | Path | Required final state | Purpose |
 | --- | --- | --- |
 | `<repo-root>` | clean `main`, synchronized with `origin/main` | canonical integration checkout |
-| `<repo-root>/.worktrees/issue-109-repo-governance` | clean while PR is active; remove after closure | #109 isolated delivery worktree |
 | `<repo-root>/.worktrees/issue-73-rollback-29e7931` | clean detached snapshot | explicit #73 rollback evidence |
 | `<repo-root>/.worktrees/issue-78-native-undoable-write` | clean | retained patch-distinct #78 squash-merge history |
 | `<repo-root>/.worktrees/issue-97-native-artifact-stage` | clean | retained patch-distinct #97 squash-merge history |
 | `<repo-root>/.worktrees/platform-contracts` | retain-dirty | unmerged/superseded platform history and evidence |
 
-The local `--worktrees` governance check rejects undocumented live worktrees and rejects dirty worktrees unless this document explicitly marks their normalized path `retain-dirty`. CI runs the deterministic tracked-file contract; live worktree state remains a local closure gate because CI cannot see a developer machine's worktree registry.
+While a branch is under review, the worktree invoking the check is the sole allowed addition to this final set. Therefore candidate validation accepts the active #109 worktree, while the post-merge check invoked from root `main` rejects it until it is removed. The local `--worktrees` governance check rejects all other live worktree drift and rejects dirty worktrees unless the final table explicitly gives their state as `retain-dirty`. CI runs the deterministic tracked-file contract; live worktree state remains a local closure gate because CI cannot see a developer machine's worktree registry.
 
 ## Cleanup execution record
 

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const GOVERNANCE_PATH = 'AGENTS.md';
+export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
+
+const REQUIRED_RULES = [
+  '# Repository Development and Delivery Rules',
+  '## 1. Measure outcomes, not activity',
+  'public MCP surface',
+  '## 4. Hardware validation is a merge gate',
+  'Core, CEP host, native plugin',
+  'POSSIBLY_SIDE_EFFECTING_FAILURE',
+  'one worktree and one branch for each issue',
+  '## 9. Completion evidence',
+  '## 10. Stop conditions before starting the next issue',
+];
+
+const INITIAL_WORKTREES = [
+  '<repo-root>',
+  '<tmp>/ae-mcp-issue99-main-verify-1e6668a',
+  '<tmp>/ae-mcp-main-101-final-e075a70',
+  '<tmp>/ae-mcp-main-93-deploy',
+  '<tmp>/ae-mcp-main-94-final-6c890776',
+  '<tmp>/ae-mcp-main-96-deploy',
+  '<tmp>/ae-mcp-main-p0-verify',
+  '<tmp>/ae-mcp-rollback-29e7931',
+  '<repo-root>/.worktrees/issue-101-native-layer-properties',
+  '<repo-root>/.worktrees/issue-104-clean-main-2a166552',
+  '<repo-root>/.worktrees/issue-104-native-composition-time',
+  '<repo-root>/.worktrees/issue-106-native-selected-layers',
+  '<repo-root>/.worktrees/issue-109-repo-governance',
+  '<repo-root>/.worktrees/issue-71-sdk-intake',
+  '<repo-root>/.worktrees/issue-72-native-rpc',
+  '<repo-root>/.worktrees/issue-73-native-plugin',
+  '<repo-root>/.worktrees/issue-74-authenticated-ipc',
+  '<repo-root>/.worktrees/issue-75-native-core-backend',
+  '<repo-root>/.worktrees/issue-76-public-native-read',
+  '<repo-root>/.worktrees/issue-78-native-undoable-write',
+  '<repo-root>/.worktrees/issue-95-cep-scan-root',
+  '<repo-root>/.worktrees/issue-97-native-artifact-stage',
+  '<repo-root>/.worktrees/issue-99-native-project-graph',
+  '<repo-root>/.worktrees/macos-provider-integration',
+  '<repo-root>/.worktrees/platform-contracts',
+  '<repo-root>/.worktrees/post107-main-5261cea9d735',
+];
+
+export function validateGovernance({ agentsText, inventoryText, trackedPaths }) {
+  const errors = [];
+  for (const required of REQUIRED_RULES) {
+    if (!agentsText.includes(required)) errors.push(`${GOVERNANCE_PATH} is missing required rule: ${required}`);
+  }
+  if (!trackedPaths.has(GOVERNANCE_PATH)) errors.push(`${GOVERNANCE_PATH} must be tracked by git`);
+  if (!trackedPaths.has(INVENTORY_PATH)) errors.push(`${INVENTORY_PATH} must be tracked by git`);
+  if (!inventoryText.includes('Initial registered worktrees: **26**')) {
+    errors.push(`${INVENTORY_PATH} must record the 26-worktree baseline`);
+  }
+  for (const worktree of INITIAL_WORKTREES) {
+    if (!inventoryText.includes(`\`${worktree}\``)) errors.push(`${INVENTORY_PATH} is missing ${worktree}`);
+  }
+  return errors;
+}
+
+export function parseWorktreePorcelain(text) {
+  return text.trim().split(/\n\n+/).filter(Boolean).map((block) => {
+    const fields = Object.fromEntries(block.split('\n').map((line) => {
+      const separator = line.indexOf(' ');
+      return separator === -1 ? [line, true] : [line.slice(0, separator), line.slice(separator + 1)];
+    }));
+    return fields;
+  });
+}
+
+export function normalizeWorktreePath(worktreePath, repoRoot) {
+  if (worktreePath === repoRoot) return '<repo-root>';
+  if (worktreePath.startsWith(`${repoRoot}${path.sep}`)) {
+    return `<repo-root>/${path.relative(repoRoot, worktreePath).split(path.sep).join('/')}`;
+  }
+  if (worktreePath.startsWith(`/private/tmp${path.sep}`)) return `<tmp>/${path.basename(worktreePath)}`;
+  return `<external>/${path.basename(worktreePath)}`;
+}
+
+function git(repoRoot, args) {
+  return execFileSync('git', ['-C', repoRoot, ...args], { encoding: 'utf8' });
+}
+
+export function inspectLiveWorktrees(repoRoot, inventoryText, canonicalRoot = repoRoot) {
+  const errors = [];
+  const rows = parseWorktreePorcelain(git(repoRoot, ['worktree', 'list', '--porcelain'])).map((entry) => {
+    const normalized = normalizeWorktreePath(entry.worktree, canonicalRoot);
+    const status = git(entry.worktree, ['status', '--porcelain', '--untracked-files=normal']).trim();
+    const dirty = status.length > 0;
+    if (!inventoryText.includes(`\`${normalized}\``)) errors.push(`live worktree is undocumented: ${normalized}`);
+    if (dirty && !inventoryText.includes(`\`${normalized}\` | retain-dirty`)) {
+      errors.push(`dirty worktree lacks an explicit retain-dirty disposition: ${normalized}`);
+    }
+    return { path: normalized, head: entry.HEAD, branch: entry.branch ?? 'detached', dirty };
+  });
+  return { errors, rows };
+}
+
+function main() {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(scriptPath), '..');
+  const agentsText = fs.readFileSync(path.join(repoRoot, GOVERNANCE_PATH), 'utf8');
+  const inventoryText = fs.readFileSync(path.join(repoRoot, INVENTORY_PATH), 'utf8');
+  const trackedPaths = new Set(git(repoRoot, ['ls-files']).trim().split('\n'));
+  const errors = validateGovernance({ agentsText, inventoryText, trackedPaths });
+  let rows = [];
+  if (process.argv.includes('--worktrees')) {
+    const commonDir = git(repoRoot, ['rev-parse', '--path-format=absolute', '--git-common-dir']).trim();
+    const canonicalRoot = path.dirname(commonDir);
+    const live = inspectLiveWorktrees(repoRoot, inventoryText, canonicalRoot);
+    errors.push(...live.errors);
+    rows = live.rows;
+  }
+  if (errors.length > 0) {
+    for (const error of errors) process.stderr.write(`ERROR: ${error}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(`Repository governance check passed (${INITIAL_WORKTREES.length} audited baseline worktrees).\n`);
+  for (const row of rows) {
+    process.stdout.write(`${row.dirty ? 'DIRTY' : 'clean'} ${row.path} ${row.head.slice(0, 12)} ${row.branch}\n`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -19,6 +19,18 @@ const REQUIRED_RULES = [
   'one worktree and one branch for each issue',
   '## 9. Completion evidence',
   '## 10. Stop conditions before starting the next issue',
+  'Do not implement issues by issue number or creation order.',
+  'Automated tests and CI never substitute for hardware validation.',
+  'After merge, repeat the relevant public MCP smoke test from a clean `main` build.',
+  'Never blindly repeat a possibly completed write.',
+];
+
+const FINAL_WORKTREES = [
+  '<repo-root>',
+  '<repo-root>/.worktrees/issue-73-rollback-29e7931',
+  '<repo-root>/.worktrees/issue-78-native-undoable-write',
+  '<repo-root>/.worktrees/issue-97-native-artifact-stage',
+  '<repo-root>/.worktrees/platform-contracts',
 ];
 
 const INITIAL_WORKTREES = [
@@ -63,7 +75,22 @@ export function validateGovernance({ agentsText, inventoryText, trackedPaths }) 
   for (const worktree of INITIAL_WORKTREES) {
     if (!inventoryText.includes(`\`${worktree}\``)) errors.push(`${INVENTORY_PATH} is missing ${worktree}`);
   }
+  const finalRows = extractFinalRetainedWorktrees(inventoryText);
+  const actualFinal = [...finalRows.keys()].sort();
+  const expectedFinal = [...FINAL_WORKTREES].sort();
+  if (JSON.stringify(actualFinal) !== JSON.stringify(expectedFinal)) {
+    errors.push(`${INVENTORY_PATH} final retained worktree set does not match the reviewed contract`);
+  }
   return errors;
+}
+
+export function extractFinalRetainedWorktrees(inventoryText) {
+  const section = inventoryText.match(/## Final retained registry\n([\s\S]*?)(?:\n## |$)/)?.[1] ?? '';
+  const rows = new Map();
+  for (const match of section.matchAll(/^\| `([^`]+)` \| ([^|]+) \|/gm)) {
+    rows.set(match[1], match[2].trim());
+  }
+  return rows;
 }
 
 export function parseWorktreePorcelain(text) {
@@ -91,12 +118,16 @@ function git(repoRoot, args) {
 
 export function inspectLiveWorktrees(repoRoot, inventoryText, canonicalRoot = repoRoot) {
   const errors = [];
+  const finalRows = extractFinalRetainedWorktrees(inventoryText);
   const rows = parseWorktreePorcelain(git(repoRoot, ['worktree', 'list', '--porcelain'])).map((entry) => {
     const normalized = normalizeWorktreePath(entry.worktree, canonicalRoot);
     const status = git(entry.worktree, ['status', '--porcelain', '--untracked-files=normal']).trim();
     const dirty = status.length > 0;
-    if (!inventoryText.includes(`\`${normalized}\``)) errors.push(`live worktree is undocumented: ${normalized}`);
-    if (dirty && !inventoryText.includes(`\`${normalized}\` | retain-dirty`)) {
+    const isInvokingWorktree = path.resolve(entry.worktree) === path.resolve(repoRoot);
+    if (!finalRows.has(normalized) && !isInvokingWorktree) {
+      errors.push(`live worktree is outside the final retained set: ${normalized}`);
+    }
+    if (dirty && finalRows.get(normalized) !== 'retain-dirty') {
       errors.push(`dirty worktree lacks an explicit retain-dirty disposition: ${normalized}`);
     }
     return { path: normalized, head: entry.HEAD, branch: entry.branch ?? 'detached', dirty };

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import { execFileSync } from 'node:child_process';
@@ -8,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
+export const GOVERNANCE_SHA256 = '48f64cbdeff4618367a3770ebbf6ae234e70ea16f375427764a1967b17c05fc0';
 
 const REQUIRED_RULES = [
   '# Repository Development and Delivery Rules',
@@ -25,7 +27,7 @@ const REQUIRED_RULES = [
   'Never blindly repeat a possibly completed write.',
 ];
 
-const FINAL_WORKTREES = [
+export const FINAL_WORKTREES = [
   '<repo-root>',
   '<repo-root>/.worktrees/issue-73-rollback-29e7931',
   '<repo-root>/.worktrees/issue-78-native-undoable-write',
@@ -64,6 +66,10 @@ const INITIAL_WORKTREES = [
 
 export function validateGovernance({ agentsText, inventoryText, trackedPaths }) {
   const errors = [];
+  const agentsSha256 = createHash('sha256').update(agentsText).digest('hex');
+  if (agentsSha256 !== GOVERNANCE_SHA256) {
+    errors.push(`${GOVERNANCE_PATH} content changed; review and update the locked SHA-256 deliberately`);
+  }
   for (const required of REQUIRED_RULES) {
     if (!agentsText.includes(required)) errors.push(`${GOVERNANCE_PATH} is missing required rule: ${required}`);
   }
@@ -132,7 +138,15 @@ export function inspectLiveWorktrees(repoRoot, inventoryText, canonicalRoot = re
     }
     return { path: normalized, head: entry.HEAD, branch: entry.branch ?? 'detached', dirty };
   });
+  const livePaths = new Set(rows.map((row) => row.path));
+  for (const missing of missingFinalWorktrees(livePaths)) {
+    errors.push(`required retained worktree is missing: ${missing}`);
+  }
   return { errors, rows };
+}
+
+export function missingFinalWorktrees(livePaths) {
+  return FINAL_WORKTREES.filter((worktree) => !livePaths.has(worktree));
 }
 
 function main() {

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import {
+  GOVERNANCE_PATH,
+  INVENTORY_PATH,
+  normalizeWorktreePath,
+  parseWorktreePorcelain,
+  validateGovernance,
+} from '../../check-repository-governance.mjs';
+
+test('tracked repository rules and worktree baseline pass the governance contract', () => {
+  const agentsText = fs.readFileSync(GOVERNANCE_PATH, 'utf8');
+  const inventoryText = fs.readFileSync(INVENTORY_PATH, 'utf8');
+  const errors = validateGovernance({
+    agentsText,
+    inventoryText,
+    trackedPaths: new Set([GOVERNANCE_PATH, INVENTORY_PATH]),
+  });
+  assert.deepEqual(errors, []);
+});
+
+test('missing delivery rules and untracked governance files fail closed', () => {
+  const errors = validateGovernance({ agentsText: '', inventoryText: '', trackedPaths: new Set() });
+  assert.ok(errors.some((error) => error.includes('public MCP surface')));
+  assert.ok(errors.some((error) => error.includes('must be tracked by git')));
+  assert.ok(errors.some((error) => error.includes('26-worktree baseline')));
+});
+
+test('worktree porcelain parsing and path normalization are deterministic', () => {
+  const parsed = parseWorktreePorcelain([
+    'worktree /repo',
+    `HEAD ${'a'.repeat(40)}`,
+    'branch refs/heads/main',
+    '',
+    'worktree /private/tmp/verify',
+    `HEAD ${'b'.repeat(40)}`,
+    'detached',
+    '',
+  ].join('\n'));
+  assert.equal(parsed.length, 2);
+  assert.equal(parsed[1].detached, true);
+  assert.equal(normalizeWorktreePath('/repo/.worktrees/issue-1', '/repo'), '<repo-root>/.worktrees/issue-1');
+  assert.equal(normalizeWorktreePath('/private/tmp/verify', '/repo'), '<tmp>/verify');
+});

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -3,9 +3,11 @@ import { test } from 'node:test';
 import fs from 'node:fs';
 import {
   GOVERNANCE_PATH,
+  FINAL_WORKTREES,
   INVENTORY_PATH,
   extractFinalRetainedWorktrees,
   normalizeWorktreePath,
+  missingFinalWorktrees,
   parseWorktreePorcelain,
   validateGovernance,
 } from '../../check-repository-governance.mjs';
@@ -37,11 +39,25 @@ test('semantic rule reversal and final retained-set removal fail closed', () => 
     'Automated tests and CI fully substitute for hardware validation.',
   );
   assert.ok(validateGovernance({ agentsText: weakened, inventoryText, trackedPaths })
-    .some((error) => error.includes('never substitute')));
+    .some((error) => error.includes('locked SHA-256')));
+  const otherWeakening = agentsText.replace(
+    'Use one worktree and one branch for each issue.',
+    'Do not use one worktree and one branch for each issue.',
+  );
+  assert.ok(validateGovernance({ agentsText: otherWeakening, inventoryText, trackedPaths })
+    .some((error) => error.includes('locked SHA-256')));
   const withoutFinalSet = inventoryText.replace(/## Final retained registry[\s\S]*?(?=\n## Cleanup execution record)/, '');
   assert.ok(validateGovernance({ agentsText, inventoryText: withoutFinalSet, trackedPaths })
     .some((error) => error.includes('final retained worktree set')));
   assert.equal(extractFinalRetainedWorktrees(withoutFinalSet).size, 0);
+});
+
+test('live registry validation rejects a missing required retained worktree', () => {
+  assert.deepEqual(missingFinalWorktrees(new Set(FINAL_WORKTREES)), []);
+  assert.deepEqual(
+    missingFinalWorktrees(new Set(FINAL_WORKTREES.slice(1))),
+    [FINAL_WORKTREES[0]],
+  );
 });
 
 test('worktree porcelain parsing and path normalization are deterministic', () => {

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import {
   GOVERNANCE_PATH,
   INVENTORY_PATH,
+  extractFinalRetainedWorktrees,
   normalizeWorktreePath,
   parseWorktreePorcelain,
   validateGovernance,
@@ -25,6 +26,22 @@ test('missing delivery rules and untracked governance files fail closed', () => 
   assert.ok(errors.some((error) => error.includes('public MCP surface')));
   assert.ok(errors.some((error) => error.includes('must be tracked by git')));
   assert.ok(errors.some((error) => error.includes('26-worktree baseline')));
+});
+
+test('semantic rule reversal and final retained-set removal fail closed', () => {
+  const agentsText = fs.readFileSync(GOVERNANCE_PATH, 'utf8');
+  const inventoryText = fs.readFileSync(INVENTORY_PATH, 'utf8');
+  const trackedPaths = new Set([GOVERNANCE_PATH, INVENTORY_PATH]);
+  const weakened = agentsText.replace(
+    'Automated tests and CI never substitute for hardware validation.',
+    'Automated tests and CI fully substitute for hardware validation.',
+  );
+  assert.ok(validateGovernance({ agentsText: weakened, inventoryText, trackedPaths })
+    .some((error) => error.includes('never substitute')));
+  const withoutFinalSet = inventoryText.replace(/## Final retained registry[\s\S]*?(?=\n## Cleanup execution record)/, '');
+  assert.ok(validateGovernance({ agentsText, inventoryText: withoutFinalSet, trackedPaths })
+    .some((error) => error.includes('final retained worktree set')));
+  assert.equal(extractFinalRetainedWorktrees(withoutFinalSet).size, 0);
 });
 
 test('worktree porcelain parsing and path normalization are deterministic', () => {


### PR DESCRIPTION
Closes #109\n\nParent Epic: #61\nPriority: P1 delivery integrity (follows completed #103)\n\nOutcome:\n- tracks repository delivery rules in AGENTS.md\n- adds a fail-closed governance contract and CI step\n- records the complete 26-worktree baseline, merge/dirty/rollback decisions, and final retained registry\n- archives root AEP/autosave/script/schema artifacts losslessly under the ignored local archive\n- removes 20 completed verification/merged worktrees while preserving patch-distinct and dirty/unmerged histories\n- returns the canonical root checkout to clean, synchronized main\n\nVerification:\n- repository governance check passed\n- live worktree governance check passed\n- packaging contract suite: 318 tests / 380 assertions, 0 failures, 6 skipped\n- git diff check passed\n- candidate: 3d1b4cf66ce4fd4bb925b8af472b19df72f770a2\n\nThis repository-governance change does not alter AE runtime behavior, so the hardware/public-MCP gate is not applicable.