### PR TITLE
chore(repo): reconcile post-#126 worktree governance

### DIFF
--- a/docs/checkpoints/2026-07-16-worktree-audit.md
+++ b/docs/checkpoints/2026-07-16-worktree-audit.md
@@ -108,12 +108,9 @@ The retained `platform-contracts` worktree was not modified. Its four untracked 
 | Path | Required final state | Purpose |
 | --- | --- | --- |
 | `<repo-root>` | clean `main`, synchronized with `origin/main` | canonical integration checkout |
-| `<repo-root>/.worktrees/issue-73-rollback-29e7931` | clean detached snapshot | explicit #73 rollback evidence |
-| `<repo-root>/.worktrees/issue-78-native-undoable-write` | clean | retained patch-distinct #78 squash-merge history |
-| `<repo-root>/.worktrees/issue-97-native-artifact-stage` | clean | retained patch-distinct #97 squash-merge history |
 | `<repo-root>/.worktrees/platform-contracts` | retain-dirty | unmerged/superseded platform history and evidence |
 
-While a branch is under review, the worktree invoking the check is the sole allowed addition to this final set. Therefore candidate validation accepts the active #109 worktree, while the post-merge check invoked from root `main` rejects it until it is removed. The local `--worktrees` governance check rejects all other live worktree drift and rejects dirty worktrees unless the final table explicitly gives their state as `retain-dirty`. CI runs the deterministic tracked-file contract; live worktree state remains a local closure gate because CI cannot see a developer machine's worktree registry.
+While a branch is under review, the worktree invoking the check is the sole allowed addition to this final set. Candidate validation therefore accepts the active Issue worktree, while the post-merge check invoked from root `main` rejects it until it is removed. The local `--worktrees` governance check rejects all other live worktree drift and rejects dirty worktrees unless the final table explicitly gives their state as `retain-dirty`. CI runs the deterministic tracked-file contract; live worktree state remains a local closure gate because CI cannot see a developer machine's worktree registry.
 
 ## Cleanup execution record
 
@@ -121,3 +118,20 @@ While a branch is under review, the worktree invoking the check is the sole allo
 - Two removals (#99 and macOS provider integration) unregistered correctly but could not remove directories containing ignored dependencies. The now-unregistered orphan directories were deleted only after confirming their `.git` pointers targeted absent registry entries and their branch refs remained preserved.
 - Six worktrees remain registered during #109: root, active #109, #73 rollback, clean patch-distinct #78 history, clean patch-distinct #97 history, and dirty/unmerged `platform-contracts` history.
 - Root artifacts were archived with matching post-move SHA-256 values. Root tracked dirt was restored only after its patch was written to the ignored archive.
+
+## Post-#126 reconciliation — Issue #130
+
+The #109 table above remains the immutable 26-worktree audit record. Issue #130 rechecked the live registry after the #124/#126 native capability closures and reconciled the machine gate with subsequent, separately authorized cleanup.
+
+| Path before #130 cleanup | Exact HEAD | State and upstream | Issue / PR mapping | Disposition |
+| --- | --- | --- | --- | --- |
+| `<repo-root>` | `5ebb77b09f4990339852fcf17698184018c5d32f` | clean `main`; synchronized with `origin/main` | #126 / PR #129 clean-main acceptance source | retain |
+| `<repo-root>/.worktrees/issue-124-native-apply-effect` | `4375ac0d966f48d04141e15b4e9829ce5402b541` | clean; upstream synchronized; branch tree is the current main feature minus the later #126 fix | #124 / PR #125 merged | remove completed worktree; retain branch ref |
+| `<repo-root>/.worktrees/issue-126-effect-undo-identity` | `c9dcf064b6b0389296c3db640918029d3e159ce7` | clean; upstream synchronized; fully merged into `main` | #126 / PR #129 merged | remove completed worktree; retain branch ref |
+| `<repo-root>/.worktrees/platform-contracts` | `c8393232d4c372a18c10f3afddc7c882f8d0a9c1` | retain-dirty; upstream gone; 18 branch-only commits and four untracked files | PR #52 closed unmerged and superseded by merged PR #53; Tool Library WIP excluded from #53 | retain unchanged |
+
+The three historical worktrees that #109 initially retained (#73 rollback, #78 squash history, and #97 squash history) were later unregistered. Review of #130 found that the exact #73 rollback commit was still present only through reflog/object retention and was not reachable from the issue-73 branch. Before accepting the cleanup, #130 created the durable annotated tag `archive/rollback/issue-73-29e7931-20260716` at exact commit `29e7931fc9b1243896c1ff473b7c7ceb61b68825`; the local `--worktrees` gate now fails if that tag is absent or peels to another commit. The #78 and #97 commits remain reachable through their remote-tracking branches. Issue #130 does not delete or rewrite any of those refs.
+
+The four `platform-contracts` untracked-file hashes still match the **Retained dirty-file identity** table exactly. Their corresponding tracked filenames are content-distinct: the Tool Library plan differs by 3 insertions/3 deletions, `skill_store 2.py` by 411 insertions/39 deletions, `test_skill_store 2.py` by 75 insertions/1 deletion, and `app 2.js` has a distinct binary hash. This WIP is not disposable.
+
+The ignored root archive remains at `.local-workspace-archive/2026-07-16/root-pre-main/` with the fixture, two autosaves, three one-off scripts, the governance-source copy, the tracked `schemas.py` patch, and its manifest. No archived user content was deleted. After removing the two completed worktrees, the persistent live registry is exactly the clean root plus retained-dirty `platform-contracts`; the active #130 worktree is permitted only while this Issue is under review.

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -29,11 +29,12 @@ const REQUIRED_RULES = [
 
 export const FINAL_WORKTREES = [
   '<repo-root>',
-  '<repo-root>/.worktrees/issue-73-rollback-29e7931',
-  '<repo-root>/.worktrees/issue-78-native-undoable-write',
-  '<repo-root>/.worktrees/issue-97-native-artifact-stage',
   '<repo-root>/.worktrees/platform-contracts',
 ];
+
+export const REQUIRED_ARCHIVE_REFS = new Map([
+  ['archive/rollback/issue-73-29e7931-20260716', '29e7931fc9b1243896c1ff473b7c7ceb61b68825'],
+]);
 
 const INITIAL_WORKTREES = [
   '<repo-root>',
@@ -142,7 +143,25 @@ export function inspectLiveWorktrees(repoRoot, inventoryText, canonicalRoot = re
   for (const missing of missingFinalWorktrees(livePaths)) {
     errors.push(`required retained worktree is missing: ${missing}`);
   }
+  errors.push(...validateArchiveRefs((ref) => git(repoRoot, ['rev-parse', `${ref}^{commit}`]).trim()));
   return { errors, rows };
+}
+
+export function validateArchiveRefs(resolveRef) {
+  const errors = [];
+  for (const [ref, expected] of REQUIRED_ARCHIVE_REFS) {
+    let actual;
+    try {
+      actual = resolveRef(ref);
+    } catch {
+      errors.push(`required archive ref is missing: ${ref}`);
+      continue;
+    }
+    if (actual !== expected) {
+      errors.push(`required archive ref points to ${actual}, expected ${expected}: ${ref}`);
+    }
+  }
+  return errors;
 }
 
 export function missingFinalWorktrees(livePaths) {

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -5,10 +5,12 @@ import {
   GOVERNANCE_PATH,
   FINAL_WORKTREES,
   INVENTORY_PATH,
+  REQUIRED_ARCHIVE_REFS,
   extractFinalRetainedWorktrees,
   normalizeWorktreePath,
   missingFinalWorktrees,
   parseWorktreePorcelain,
+  validateArchiveRefs,
   validateGovernance,
 } from '../../check-repository-governance.mjs';
 
@@ -58,6 +60,23 @@ test('live registry validation rejects a missing required retained worktree', ()
     missingFinalWorktrees(new Set(FINAL_WORKTREES.slice(1))),
     [FINAL_WORKTREES[0]],
   );
+});
+
+test('post-#126 retained set keeps only root and the dirty platform WIP', () => {
+  assert.deepEqual(FINAL_WORKTREES, [
+    '<repo-root>',
+    '<repo-root>/.worktrees/platform-contracts',
+  ]);
+});
+
+test('rollback archive ref must exist and peel to the audited commit', () => {
+  const [[ref, sha]] = REQUIRED_ARCHIVE_REFS;
+  assert.deepEqual(validateArchiveRefs((candidate) => {
+    assert.equal(candidate, ref);
+    return sha;
+  }), []);
+  assert.match(validateArchiveRefs(() => '0'.repeat(40))[0], /expected/u);
+  assert.match(validateArchiveRefs(() => { throw new Error('missing'); })[0], /missing/u);
 });
 
 test('worktree porcelain parsing and path normalization are deterministic', () => {


### PR DESCRIPTION
Closes #130

## Outcome

- removes the already-cleaned #73/#78/#97 worktrees from the persistent live retained-set contract without deleting their history
- removes completed #124/#126 worktrees while retaining their branch refs
- preserves the dirty `platform-contracts` worktree and records its four content-distinct untracked WIP files
- adds a durable archive tag for the otherwise-unreferenced #73 rollback SHA
- makes the local live gate require that tag to peel to the exact audited rollback commit
- leaves the original 26-worktree audit immutable and appends the post-#126 reconciliation

## Exact candidate

- commit: `46c3150fca68eaeef8e3ba7390f00ba33c117c3a`
- rollback archive tag: `archive/rollback/issue-73-29e7931-20260716`
- tagged commit: `29e7931fc9b1243896c1ff473b7c7ceb61b68825`

## Verification

- `node scripts/check-repository-governance.mjs --worktrees`: pass
  - clean root `main`
  - clean active #130 candidate
  - retained-dirty `platform-contracts`
- `node --test scripts/package/test/repository-governance.test.mjs`: 7/7 pass
- `git diff --check main...HEAD`: pass
- root archive and four dirty WIP hashes rechecked; no user content deleted
- independent read-only Codex review of exact candidate: no findings; it confirmed the retained-set and rollback-ref validation are correct

This change does not touch AE runtime or a public MCP capability, so hardware validation is not applicable. Clean-main live-governance revalidation remains required after merge.