### PR TITLE
feat(tool-library): add safe agent-free direct run

### DIFF
--- a/packages/core/ae_mcp/approval_gate.py
+++ b/packages/core/ae_mcp/approval_gate.py
@@ -118,9 +118,11 @@ def plan_decision(tier: str, risk: str) -> PlanDecision:
     return "allow"
 
 
-def build_plan_elicitation_schema(plan: "ExecutionPlan") -> dict[str, object]:
+def build_plan_elicitation_schema(
+    plan: "ExecutionPlan", *, requested_scope: PlanAuthorization | None = None
+) -> dict[str, object]:
     decisions = ["once", "deny"]
-    if plan.risk == "write":
+    if plan.risk == "write" and requested_scope != "once":
         decisions.insert(1, "session")
     return {
         "type": "object",
@@ -137,7 +139,12 @@ def build_plan_elicitation_schema(plan: "ExecutionPlan") -> dict[str, object]:
     }
 
 
-async def authorize_plan(plan: "ExecutionPlan", ctx: Any) -> PlanAuthorization:
+async def authorize_plan(
+    plan: "ExecutionPlan",
+    ctx: Any,
+    *,
+    requested_scope: PlanAuthorization | None = None,
+) -> PlanAuthorization:
     decision = plan_decision(current_tool_tier(), plan.risk)
     if decision == "allow":
         return "once"
@@ -157,7 +164,9 @@ async def authorize_plan(plan: "ExecutionPlan", ctx: Any) -> PlanAuthorization:
     try:
         result = await elicit(
             message=f"Approve Tool Library action for {plan.artifact_id} ({plan.risk})?",
-            requestedSchema=build_plan_elicitation_schema(plan),
+            requestedSchema=build_plan_elicitation_schema(
+                plan, requested_scope=requested_scope
+            ),
             related_request_id=getattr(ctx, "request_id", None),
         )
     except Exception as exc:

--- a/packages/core/ae_mcp/client_identity.py
+++ b/packages/core/ae_mcp/client_identity.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 import contextvars
+from contextvars import Token
 
 HEADER = "x-ae-mcp-client"
 _client: contextvars.ContextVar[str] = contextvars.ContextVar(
     "ae_mcp_client",
     default="unknown",
+)
+_panel_developer: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "ae_mcp_panel_developer",
+    default=False,
 )
 
 
@@ -19,3 +24,17 @@ def set_client(name: str | None, version: str | None) -> None:
 
 def get_client() -> str:
     return _client.get()
+
+
+def set_panel_developer(enabled: bool) -> Token[bool]:
+    """Scope trusted Developer Tools visibility to one MCP request."""
+
+    return _panel_developer.set(bool(enabled))
+
+
+def reset_panel_developer(token: Token[bool]) -> None:
+    _panel_developer.reset(token)
+
+
+def panel_developer_enabled() -> bool:
+    return _panel_developer.get()

--- a/packages/core/ae_mcp/handlers/tools.py
+++ b/packages/core/ae_mcp/handlers/tools.py
@@ -17,7 +17,8 @@ from ae_mcp.tool_artifact import (
     ToolSummary,
 )
 from ae_mcp.tool_service import default_tool_service
-from ae_mcp.tool_store import ToolRevisionConflict, ToolStoreValidationError
+from ae_mcp.tool_execution import execution_capabilities
+from ae_mcp.tool_store import ToolNotFound, ToolRevisionConflict, ToolStoreValidationError
 
 
 def _error(exc: Exception) -> dict[str, Any]:
@@ -34,8 +35,11 @@ def _error(exc: Exception) -> dict[str, Any]:
     }
 
 
-def _summary(value: ToolSummary) -> dict[str, JsonValue]:
-    return {
+def _summary(
+    value: ToolSummary,
+    execution_capabilities: Mapping[str, JsonValue] | None = None,
+) -> dict[str, JsonValue]:
+    result: dict[str, JsonValue] = {
         "id": value.id,
         "name": value.name,
         "description": value.description,
@@ -51,9 +55,17 @@ def _summary(value: ToolSummary) -> dict[str, JsonValue]:
         "lastUsedAt": value.last_used_at,
         "sourceType": value.source_type,
     }
+    if execution_capabilities is not None:
+        result["executionCapabilities"] = cast(
+            JsonValue, dict(execution_capabilities)
+        )
+    return result
 
 
-def _artifact_summary(value: ToolArtifact) -> dict[str, JsonValue]:
+def _artifact_summary(
+    value: ToolArtifact,
+    execution_capabilities: Mapping[str, JsonValue] | None = None,
+) -> dict[str, JsonValue]:
     return _summary(
         ToolSummary(
             id=value.id,
@@ -70,8 +82,14 @@ def _artifact_summary(value: ToolArtifact) -> dict[str, JsonValue]:
             updated_at=value.updated_at,
             last_used_at=value.last_used_at,
             source_type=value.source.type,
-        )
+        ),
+        execution_capabilities,
     )
+
+
+def _summary_with_execution(service: Any, value: ToolSummary) -> dict[str, JsonValue]:
+    artifact = service.store.get(value.id, include_content=True)
+    return _summary(value, execution_capabilities(artifact))
 
 
 def _trusted_bundled(value: ToolArtifact) -> bool:
@@ -92,13 +110,23 @@ async def _run_tool_index(args: schemas.AeToolIndexArgs, ctx: Any) -> Any:
         statuses = set(args.statuses) if args.statuses is not None else {"saved", "pinned"}
         if args.include_candidates:
             statuses.add("candidate")
-        rows = default_tool_service().store.list(
-            kinds=None if args.kinds is None else set(args.kinds),
+        service = default_tool_service()
+        requested_kinds = None if args.kinds is None else set(args.kinds)
+        if not args.developer_mode:
+            allowed = {"jsx", "expression", "prompt-skill", "recipe", "diagnostic"}
+            requested_kinds = allowed if requested_kinds is None else requested_kinds & allowed
+        rows = service.store.list(
+            kinds=cast(Any, requested_kinds),
             statuses=cast(Any, statuses),
             source_types=None if args.source_types is None else set(args.source_types),
             limit=args.limit,
         )
-        return {"ok": True, "artifacts": [_summary(row) for row in rows]}
+        if not args.developer_mode:
+            rows = [row for row in rows if row.kind != "system-command"]
+        return {
+            "ok": True,
+            "artifacts": [_summary_with_execution(service, row) for row in rows],
+        }
     except Exception as exc:  # noqa: BLE001
         return _error(exc)
 
@@ -109,9 +137,14 @@ async def _run_tool_search(args: schemas.AeToolSearchArgs, ctx: Any) -> Any:
         statuses = (
             set(args.statuses) if args.statuses is not None else {"saved", "pinned"}
         )
-        rows, total = default_tool_service().store.search(
+        service = default_tool_service()
+        requested_kinds = None if args.kinds is None else set(args.kinds)
+        if not args.developer_mode:
+            allowed = {"jsx", "expression", "prompt-skill", "recipe", "diagnostic"}
+            requested_kinds = allowed if requested_kinds is None else requested_kinds & allowed
+        rows, total = service.store.search(
             args.query,
-            kinds=None if args.kinds is None else set(args.kinds),
+            kinds=cast(Any, requested_kinds),
             categories=None if args.categories is None else set(args.categories),
             tags=None if args.tags is None else set(args.tags),
             risks=None if args.risks is None else set(args.risks),
@@ -120,9 +153,13 @@ async def _run_tool_search(args: schemas.AeToolSearchArgs, ctx: Any) -> Any:
             offset=args.offset,
             limit=args.limit,
         )
+        if not args.developer_mode:
+            hidden_count = sum(row.kind == "system-command" for row in rows)
+            rows = [row for row in rows if row.kind != "system-command"]
+            total = max(0, total - hidden_count)
         return {
             "ok": True,
-            "artifacts": [_summary(row) for row in rows],
+            "artifacts": [_summary_with_execution(service, row) for row in rows],
             "total": total,
             "offset": args.offset,
             "limit": args.limit,
@@ -134,12 +171,17 @@ async def _run_tool_search(args: schemas.AeToolSearchArgs, ctx: Any) -> Any:
 async def _run_tool_inspect(args: schemas.AeToolInspectArgs, ctx: Any) -> Any:
     del ctx
     try:
-        artifact = default_tool_service().store.get(
+        service = default_tool_service()
+        artifact = service.store.get(
             args.artifact_id, include_content=True
         )
+        if artifact.kind == "system-command" and not args.developer_mode:
+            raise ToolNotFound()
+        wire = artifact.to_dict()
+        wire["executionCapabilities"] = execution_capabilities(artifact)
         return {
             "ok": True,
-            "artifact": artifact.to_dict(),
+            "artifact": wire,
             "trust": "signed-bundled" if _trusted_bundled(artifact) else "user-untrusted",
         }
     except Exception as exc:  # noqa: BLE001
@@ -171,10 +213,26 @@ async def _run_tool_use(args: schemas.AeToolUseArgs, ctx: Any) -> Any:
                 "scope": grant.scope,
                 "expiresAt": grant.expires_at,
             }
-        return await service.execution.execute(
-            cast(str, args.plan_hash),
-            cast(str, args.grant_id),
-            ctx=ctx,
+        if args.action == "execute":
+            return await service.execution.execute_tracked(
+                cast(str, args.plan_hash),
+                cast(str, args.grant_id),
+                ctx=ctx,
+                initiator=client_identity.get_client() or "mcp-client",
+            )
+        if args.action == "start":
+            return await service.execution.start_job(
+                cast(str, args.plan_hash),
+                cast(str, args.grant_id),
+                ctx=ctx,
+                initiator=client_identity.get_client() or "panel-direct",
+            )
+        if args.action == "status":
+            return service.execution.job_status(cast(str, args.execution_id))
+        if args.action == "cancel":
+            return service.execution.cancel_job(cast(str, args.execution_id))
+        return service.execution.job_history(
+            cast(str, args.artifact_id), limit=cast(int, args.limit)
         )
     except Exception as exc:  # noqa: BLE001
         return _error(exc)

--- a/packages/core/ae_mcp/handlers/tools.py
+++ b/packages/core/ae_mcp/handlers/tools.py
@@ -222,6 +222,7 @@ async def _run_tool_use(args: schemas.AeToolUseArgs, ctx: Any) -> Any:
             return await service.execution.execute_tracked(
                 cast(str, args.plan_hash),
                 cast(str, args.grant_id),
+                operation_id=cast(str, args.operation_id),
                 ctx=ctx,
                 initiator=client_identity.get_client() or "mcp-client",
             )

--- a/packages/core/ae_mcp/handlers/tools.py
+++ b/packages/core/ae_mcp/handlers/tools.py
@@ -112,7 +112,8 @@ async def _run_tool_index(args: schemas.AeToolIndexArgs, ctx: Any) -> Any:
             statuses.add("candidate")
         service = default_tool_service()
         requested_kinds = None if args.kinds is None else set(args.kinds)
-        if not args.developer_mode:
+        developer_mode = client_identity.panel_developer_enabled()
+        if not developer_mode:
             allowed = {"jsx", "expression", "prompt-skill", "recipe", "diagnostic"}
             requested_kinds = allowed if requested_kinds is None else requested_kinds & allowed
         rows = service.store.list(
@@ -121,7 +122,7 @@ async def _run_tool_index(args: schemas.AeToolIndexArgs, ctx: Any) -> Any:
             source_types=None if args.source_types is None else set(args.source_types),
             limit=args.limit,
         )
-        if not args.developer_mode:
+        if not developer_mode:
             rows = [row for row in rows if row.kind != "system-command"]
         return {
             "ok": True,
@@ -139,7 +140,8 @@ async def _run_tool_search(args: schemas.AeToolSearchArgs, ctx: Any) -> Any:
         )
         service = default_tool_service()
         requested_kinds = None if args.kinds is None else set(args.kinds)
-        if not args.developer_mode:
+        developer_mode = client_identity.panel_developer_enabled()
+        if not developer_mode:
             allowed = {"jsx", "expression", "prompt-skill", "recipe", "diagnostic"}
             requested_kinds = allowed if requested_kinds is None else requested_kinds & allowed
         rows, total = service.store.search(
@@ -153,7 +155,7 @@ async def _run_tool_search(args: schemas.AeToolSearchArgs, ctx: Any) -> Any:
             offset=args.offset,
             limit=args.limit,
         )
-        if not args.developer_mode:
+        if not developer_mode:
             hidden_count = sum(row.kind == "system-command" for row in rows)
             rows = [row for row in rows if row.kind != "system-command"]
             total = max(0, total - hidden_count)
@@ -175,7 +177,10 @@ async def _run_tool_inspect(args: schemas.AeToolInspectArgs, ctx: Any) -> Any:
         artifact = service.store.get(
             args.artifact_id, include_content=True
         )
-        if artifact.kind == "system-command" and not args.developer_mode:
+        if (
+            artifact.kind == "system-command"
+            and not client_identity.panel_developer_enabled()
+        ):
             raise ToolNotFound()
         wire = artifact.to_dict()
         wire["executionCapabilities"] = execution_capabilities(artifact)
@@ -224,6 +229,7 @@ async def _run_tool_use(args: schemas.AeToolUseArgs, ctx: Any) -> Any:
             return await service.execution.start_job(
                 cast(str, args.plan_hash),
                 cast(str, args.grant_id),
+                operation_id=cast(str, args.operation_id),
                 ctx=ctx,
                 initiator=client_identity.get_client() or "panel-direct",
             )

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -996,7 +996,15 @@ class AeToolUseArgs(_StrictModel):
     grant_id: Optional[str] = Field(None, min_length=1, max_length=256)
     grant_scope: Optional[Literal["once", "session"]] = None
     execution_id: Optional[str] = Field(None, min_length=1, max_length=256)
-    operation_id: Optional[str] = Field(None, min_length=16, max_length=128)
+    operation_id: Optional[str] = Field(
+        None,
+        min_length=16,
+        max_length=128,
+        description=(
+            "Stable caller-generated id for execute/start. Reuse it when a response "
+            "is lost; changing it authorizes a distinct execution."
+        ),
+    )
     limit: Optional[int] = Field(None, ge=1, le=100)
 
     @model_validator(mode="after")
@@ -1060,10 +1068,8 @@ class AeToolUseArgs(_StrictModel):
         elif self.action in {"execute", "start"}:
             if self.plan_hash is None or self.grant_id is None:
                 raise ValueError(f"{self.action} requires plan_hash and grant_id")
-            if self.action == "start" and self.operation_id is None:
-                raise ValueError("start requires operation_id")
-            if self.action == "execute" and self.operation_id is not None:
-                raise ValueError("execute forbids operation_id")
+            if self.operation_id is None:
+                raise ValueError(f"{self.action} requires operation_id")
             if any(
                 value is not None
                 for value in (

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -933,6 +933,9 @@ class AeSkillUseArgs(_StrictModel):
 
 
 ToolArtifactKind = Literal[
+    "jsx", "expression", "prompt-skill", "recipe", "diagnostic"
+]
+PanelToolArtifactKind = Literal[
     "jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"
 ]
 ToolArtifactStatus = Literal["candidate", "saved", "pinned", "archived", "deprecated"]
@@ -947,7 +950,6 @@ class AeToolIndexArgs(_StrictModel):
     statuses: Optional[List[ToolArtifactStatus]] = None
     source_types: Optional[List[ToolSourceType]] = None
     include_candidates: bool = False
-    developer_mode: bool = False
     limit: int = Field(100, ge=1, le=1000)
 
 
@@ -960,7 +962,6 @@ class AeToolSearchArgs(_StrictModel):
     risks: Optional[List[ToolArtifactRisk]] = None
     statuses: Optional[List[ToolArtifactStatus]] = None
     source_types: Optional[List[ToolSourceType]] = None
-    developer_mode: bool = False
     offset: int = Field(0, ge=0)
     limit: int = Field(50, ge=1, le=1000)
 
@@ -968,7 +969,18 @@ class AeToolSearchArgs(_StrictModel):
 class AeToolInspectArgs(_StrictModel):
     """ae.toolInspect — read one full Tool Library artifact as untrusted content."""
     artifact_id: str = Field(..., min_length=1, max_length=256)
-    developer_mode: bool = False
+
+
+class AePanelToolIndexArgs(AeToolIndexArgs):
+    """Private panel-only index schema; never advertised through tools/list."""
+
+    kinds: Optional[List[PanelToolArtifactKind]] = None
+
+
+class AePanelToolSearchArgs(AeToolSearchArgs):
+    """Private panel-only search schema; never advertised through tools/list."""
+
+    kinds: Optional[List[PanelToolArtifactKind]] = None
 
 
 class AeToolUseArgs(_StrictModel):
@@ -984,46 +996,126 @@ class AeToolUseArgs(_StrictModel):
     grant_id: Optional[str] = Field(None, min_length=1, max_length=256)
     grant_scope: Optional[Literal["once", "session"]] = None
     execution_id: Optional[str] = Field(None, min_length=1, max_length=256)
+    operation_id: Optional[str] = Field(None, min_length=16, max_length=128)
     limit: Optional[int] = Field(None, ge=1, le=100)
 
     @model_validator(mode="after")
     def validate_action_shape(self) -> "AeToolUseArgs":
         if self.action == "render":
-            if self.artifact_id is None or self.plan_hash is not None or self.grant_id is not None:
+            if (
+                self.artifact_id is None
+                or self.plan_hash is not None
+                or self.grant_id is not None
+            ):
                 raise ValueError("render requires artifact_id and forbids plan_hash/grant_id")
-            if self.grant_scope is not None or self.target or self.execution_id is not None or self.limit is not None:
-                raise ValueError("render forbids grant_scope/target/execution_id/limit")
+            if (
+                self.grant_scope is not None
+                or self.target
+                or self.execution_id is not None
+                or self.operation_id is not None
+                or self.limit is not None
+            ):
+                raise ValueError(
+                    "render forbids grant_scope/target/execution_id/operation_id/limit"
+                )
             if self.operation not in {None, "render"}:
                 raise ValueError("render operation must be render")
             self.operation = "render"
         elif self.action == "prepare":
             if self.artifact_id is None or self.operation is None:
                 raise ValueError("prepare requires artifact_id and operation")
-            if self.plan_hash is not None or self.grant_id is not None or self.grant_scope is not None or self.execution_id is not None or self.limit is not None:
-                raise ValueError("prepare forbids plan_hash/grant_id/grant_scope/execution_id/limit")
+            if any(
+                value is not None
+                for value in (
+                    self.plan_hash,
+                    self.grant_id,
+                    self.grant_scope,
+                    self.execution_id,
+                    self.operation_id,
+                    self.limit,
+                )
+            ):
+                raise ValueError(
+                    "prepare forbids plan_hash/grant_id/grant_scope/"
+                    "execution_id/operation_id/limit"
+                )
         elif self.action == "grant":
             if self.plan_hash is None or self.grant_scope is None:
                 raise ValueError("grant requires plan_hash and grant_scope")
-            if self.artifact_id is not None or self.grant_id is not None or self.execution_id is not None or self.limit is not None:
-                raise ValueError("grant forbids artifact_id/grant_id/execution_id/limit")
+            if any(
+                value is not None
+                for value in (
+                    self.artifact_id,
+                    self.grant_id,
+                    self.execution_id,
+                    self.operation_id,
+                    self.limit,
+                )
+            ):
+                raise ValueError(
+                    "grant forbids artifact_id/grant_id/execution_id/operation_id/limit"
+                )
             if self.operation is not None or self.args or self.target:
                 raise ValueError("grant forbids operation/args/target")
         elif self.action in {"execute", "start"}:
             if self.plan_hash is None or self.grant_id is None:
                 raise ValueError(f"{self.action} requires plan_hash and grant_id")
-            if self.artifact_id is not None or self.grant_scope is not None or self.execution_id is not None or self.limit is not None:
-                raise ValueError(f"{self.action} forbids artifact_id/grant_scope/execution_id/limit")
+            if self.action == "start" and self.operation_id is None:
+                raise ValueError("start requires operation_id")
+            if self.action == "execute" and self.operation_id is not None:
+                raise ValueError("execute forbids operation_id")
+            if any(
+                value is not None
+                for value in (
+                    self.artifact_id,
+                    self.grant_scope,
+                    self.execution_id,
+                    self.limit,
+                )
+            ):
+                raise ValueError(
+                    f"{self.action} forbids artifact_id/grant_scope/execution_id/limit"
+                )
             if self.operation is not None or self.args or self.target:
                 raise ValueError(f"{self.action} forbids operation/args/target")
         elif self.action in {"status", "cancel"}:
             if self.execution_id is None:
                 raise ValueError(f"{self.action} requires execution_id")
-            if any(value is not None for value in (self.artifact_id, self.operation, self.plan_hash, self.grant_id, self.grant_scope, self.limit)) or self.args or self.target:
+            if (
+                any(
+                    value is not None
+                    for value in (
+                        self.artifact_id,
+                        self.operation,
+                        self.plan_hash,
+                        self.grant_id,
+                        self.grant_scope,
+                        self.operation_id,
+                        self.limit,
+                    )
+                )
+                or self.args
+                or self.target
+            ):
                 raise ValueError(f"{self.action} accepts execution_id only")
         else:
             if self.artifact_id is None:
                 raise ValueError("history requires artifact_id")
-            if any(value is not None for value in (self.operation, self.plan_hash, self.grant_id, self.grant_scope, self.execution_id)) or self.args or self.target:
+            if (
+                any(
+                    value is not None
+                    for value in (
+                        self.operation,
+                        self.plan_hash,
+                        self.grant_id,
+                        self.grant_scope,
+                        self.execution_id,
+                        self.operation_id,
+                    )
+                )
+                or self.args
+                or self.target
+            ):
                 raise ValueError("history accepts artifact_id and limit only")
             if self.limit is None:
                 self.limit = 20

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -932,7 +932,9 @@ class AeSkillUseArgs(_StrictModel):
     execute: bool = Field(False, description="When true, execute rendered JSX in AE.")
 
 
-ToolArtifactKind = Literal["jsx", "expression", "prompt-skill", "recipe", "diagnostic"]
+ToolArtifactKind = Literal[
+    "jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"
+]
 ToolArtifactStatus = Literal["candidate", "saved", "pinned", "archived", "deprecated"]
 ToolArtifactRisk = Literal["read", "write", "destructive", "external"]
 ToolArtifactOperation = Literal["render", "execute", "apply"]
@@ -945,6 +947,7 @@ class AeToolIndexArgs(_StrictModel):
     statuses: Optional[List[ToolArtifactStatus]] = None
     source_types: Optional[List[ToolSourceType]] = None
     include_candidates: bool = False
+    developer_mode: bool = False
     limit: int = Field(100, ge=1, le=1000)
 
 
@@ -957,6 +960,7 @@ class AeToolSearchArgs(_StrictModel):
     risks: Optional[List[ToolArtifactRisk]] = None
     statuses: Optional[List[ToolArtifactStatus]] = None
     source_types: Optional[List[ToolSourceType]] = None
+    developer_mode: bool = False
     offset: int = Field(0, ge=0)
     limit: int = Field(50, ge=1, le=1000)
 
@@ -964,48 +968,65 @@ class AeToolSearchArgs(_StrictModel):
 class AeToolInspectArgs(_StrictModel):
     """ae.toolInspect — read one full Tool Library artifact as untrusted content."""
     artifact_id: str = Field(..., min_length=1, max_length=256)
+    developer_mode: bool = False
 
 
 class AeToolUseArgs(_StrictModel):
-    """ae.toolUse — render or run the prepare, grant, execute protocol."""
+    """ae.toolUse — render or run the hash-bound execution protocol."""
     artifact_id: Optional[str] = Field(None, min_length=1, max_length=256)
-    action: Literal["render", "prepare", "grant", "execute"]
+    action: Literal[
+        "render", "prepare", "grant", "execute", "start", "status", "cancel", "history"
+    ]
     operation: Optional[ToolArtifactOperation] = None
     args: Dict[str, Any] = Field(default_factory=dict)
     target: Dict[str, Any] = Field(default_factory=dict)
     plan_hash: Optional[str] = Field(None, min_length=1, max_length=256)
     grant_id: Optional[str] = Field(None, min_length=1, max_length=256)
     grant_scope: Optional[Literal["once", "session"]] = None
+    execution_id: Optional[str] = Field(None, min_length=1, max_length=256)
+    limit: Optional[int] = Field(None, ge=1, le=100)
 
     @model_validator(mode="after")
     def validate_action_shape(self) -> "AeToolUseArgs":
         if self.action == "render":
             if self.artifact_id is None or self.plan_hash is not None or self.grant_id is not None:
                 raise ValueError("render requires artifact_id and forbids plan_hash/grant_id")
-            if self.grant_scope is not None or self.target:
-                raise ValueError("render forbids grant_scope and target")
+            if self.grant_scope is not None or self.target or self.execution_id is not None or self.limit is not None:
+                raise ValueError("render forbids grant_scope/target/execution_id/limit")
             if self.operation not in {None, "render"}:
                 raise ValueError("render operation must be render")
             self.operation = "render"
         elif self.action == "prepare":
             if self.artifact_id is None or self.operation is None:
                 raise ValueError("prepare requires artifact_id and operation")
-            if self.plan_hash is not None or self.grant_id is not None or self.grant_scope is not None:
-                raise ValueError("prepare forbids plan_hash/grant_id/grant_scope")
+            if self.plan_hash is not None or self.grant_id is not None or self.grant_scope is not None or self.execution_id is not None or self.limit is not None:
+                raise ValueError("prepare forbids plan_hash/grant_id/grant_scope/execution_id/limit")
         elif self.action == "grant":
             if self.plan_hash is None or self.grant_scope is None:
                 raise ValueError("grant requires plan_hash and grant_scope")
-            if self.artifact_id is not None or self.grant_id is not None:
-                raise ValueError("grant forbids artifact_id/grant_id")
+            if self.artifact_id is not None or self.grant_id is not None or self.execution_id is not None or self.limit is not None:
+                raise ValueError("grant forbids artifact_id/grant_id/execution_id/limit")
             if self.operation is not None or self.args or self.target:
                 raise ValueError("grant forbids operation/args/target")
-        else:
+        elif self.action in {"execute", "start"}:
             if self.plan_hash is None or self.grant_id is None:
-                raise ValueError("execute requires plan_hash and grant_id")
-            if self.artifact_id is not None or self.grant_scope is not None:
-                raise ValueError("execute forbids artifact_id/grant_scope")
+                raise ValueError(f"{self.action} requires plan_hash and grant_id")
+            if self.artifact_id is not None or self.grant_scope is not None or self.execution_id is not None or self.limit is not None:
+                raise ValueError(f"{self.action} forbids artifact_id/grant_scope/execution_id/limit")
             if self.operation is not None or self.args or self.target:
-                raise ValueError("execute forbids operation/args/target")
+                raise ValueError(f"{self.action} forbids operation/args/target")
+        elif self.action in {"status", "cancel"}:
+            if self.execution_id is None:
+                raise ValueError(f"{self.action} requires execution_id")
+            if any(value is not None for value in (self.artifact_id, self.operation, self.plan_hash, self.grant_id, self.grant_scope, self.limit)) or self.args or self.target:
+                raise ValueError(f"{self.action} accepts execution_id only")
+        else:
+            if self.artifact_id is None:
+                raise ValueError("history requires artifact_id")
+            if any(value is not None for value in (self.operation, self.plan_hash, self.grant_id, self.grant_scope, self.execution_id)) or self.args or self.target:
+                raise ValueError("history accepts artifact_id and limit only")
+            if self.limit is None:
+                self.limit = 20
         return self
 
 

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -12,8 +12,10 @@ object surfaced via the request_context; it owns report_progress.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
+import os
 import re
 import time
 from typing import Any, List
@@ -25,7 +27,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import CallToolResult, TextContent, Tool
 from pydantic import ValidationError as PydanticValidationError
 
-from ae_mcp import approval_gate, client_identity
+from ae_mcp import approval_gate, client_identity, schemas
 from ae_mcp.annotations import VERB_ANNOTATIONS
 from ae_mcp.backends.native import NativeBackendError, NativeInvokeBackend
 from ae_mcp.error_hints import append_hint
@@ -41,6 +43,15 @@ from ae_mcp.tool_store import ToolStoreError
 
 log = logging.getLogger("ae_mcp.server")
 _history_scanner = RegexSecretScanner()
+_PANEL_CAPABILITY_ARGUMENT = "_ae_panel_capability"
+_PANEL_DEVELOPER_TOOLS = frozenset(
+    {"ae.toolIndex", "ae.toolSearch", "ae.toolInspect"}
+)
+_PANEL_DEVELOPER_SCHEMAS = {
+    "ae.toolIndex": schemas.AePanelToolIndexArgs,
+    "ae.toolSearch": schemas.AePanelToolSearchArgs,
+    "ae.toolInspect": schemas.AeToolInspectArgs,
+}
 
 # Matches a leading dotted verb token at the very start of a docstring, e.g.
 # "ae.init — bootstrap …". Only the leading token is rewritten so the rest of
@@ -52,6 +63,24 @@ def default_tool_service():
     from ae_mcp.tool_service import default_tool_service as resolve
 
     return resolve()
+
+
+def _panel_request(
+    canonical: str,
+    arguments: dict | None,
+) -> tuple[dict[str, Any], bool]:
+    """Consume the per-process panel capability without advertising it to models."""
+
+    values = dict(arguments or {})
+    supplied = values.pop(_PANEL_CAPABILITY_ARGUMENT, None)
+    expected = os.environ.get("AE_MCP_PANEL_CAPABILITY", "")
+    trusted = (
+        canonical in _PANEL_DEVELOPER_TOOLS
+        and isinstance(supplied, str)
+        and len(expected) >= 64
+        and hmac.compare_digest(supplied, expected)
+    )
+    return values, trusted
 
 
 def _filtered_tool_names() -> set:
@@ -752,14 +781,24 @@ def build_server() -> Server:
             )
         name = canonical
 
-        schema_cls, run_fn = HANDLERS[name]
+        arguments, panel_developer = _panel_request(canonical, arguments)
+        public_schema_cls, run_fn = HANDLERS[name]
+        schema_cls = (
+            _PANEL_DEVELOPER_SCHEMAS[canonical]
+            if panel_developer
+            else public_schema_cls
+        )
 
         # The SDK's default validation happens before this handler and reduces
         # every schema failure to unstructured text. Reapply the same
         # jsonschema validation here using the exact tools/list schema: the
         # native layer-property tool can then expose its structured recovery
         # contract, while established tools keep the SDK's original text error.
-        input_schema = advertised_input_schemas.get(expose_tool_name(name))
+        input_schema = (
+            schema_cls.model_json_schema()
+            if panel_developer
+            else advertised_input_schemas.get(expose_tool_name(name))
+        )
         if input_schema is not None:
             try:
                 validate_json_schema(
@@ -864,18 +903,22 @@ def build_server() -> Server:
                     isError=True,
                 )
 
+        developer_token = client_identity.set_panel_developer(panel_developer)
         try:
-            result = await run_fn(validated, ctx)
-        except NativeBackendError as e:
-            log.info("native handler %s failed with %s", name, e.code)
-            result = {"ok": False, "error": e.public_dict()}
-        except Exception as e:  # noqa: BLE001
-            log.exception("handler %s raised", name)
-            payload = _format_result({"ok": False, "error": append_hint(str(e))})
-            return CallToolResult(
-                content=[TextContent(type="text", text=payload)],
-                isError=True,
-            )
+            try:
+                result = await run_fn(validated, ctx)
+            except NativeBackendError as e:
+                log.info("native handler %s failed with %s", name, e.code)
+                result = {"ok": False, "error": e.public_dict()}
+            except Exception as e:  # noqa: BLE001
+                log.exception("handler %s raised", name)
+                payload = _format_result({"ok": False, "error": append_hint(str(e))})
+                return CallToolResult(
+                    content=[TextContent(type="text", text=payload)],
+                    isError=True,
+                )
+        finally:
+            client_identity.reset_panel_developer(developer_token)
 
         if isinstance(result, dict) and result.get("ok") is False and "error" in result:
             error = result["error"]

--- a/packages/core/ae_mcp/tool_archive.py
+++ b/packages/core/ae_mcp/tool_archive.py
@@ -28,7 +28,9 @@ from ae_mcp.tool_artifact import (
     ToolSource,
     ToolSummary,
     canonical_json_bytes,
+    compute_content_hash,
     max_risk,
+    new_user_artifact_id,
 )
 from ae_mcp.tool_secrets import SecretFinding, SecretScanner
 from ae_mcp.tool_store import ToolArtifactStore, ToolNotFound
@@ -82,6 +84,9 @@ _WINDOWS_RESERVED = frozenset(
 _LINK_BEARING_UNIX_EXTRAS = frozenset({0x000D, 0x5855, 0x756E, 0x7855, 0x7875})
 _NESTED_ARCHIVE_SUFFIXES = (".zip", ".aemcptools")
 _NESTED_ARCHIVE_MAGIC = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+_SYSTEM_COMMAND_SUFFIXES = frozenset(
+    {".ps1", ".psm1", ".bat", ".cmd", ".sh", ".command"}
+)
 
 
 @dataclass(frozen=True)
@@ -727,7 +732,10 @@ class ToolPackageManager:
             os.close(fd)
 
     def preview_import(self, archive_path: Path) -> ImportPreview:
-        archive_bytes = self._read_archive(Path(archive_path))
+        archive_path = Path(archive_path)
+        archive_bytes = self._read_archive(archive_path)
+        if archive_path.suffix.casefold() in _SYSTEM_COMMAND_SUFFIXES:
+            return self._preview_system_command(archive_path, archive_bytes)
         _validate_raw_zip_names(archive_bytes)
         package_sha256 = hashlib.sha256(archive_bytes).hexdigest()
         stack = contextlib.ExitStack()
@@ -815,6 +823,99 @@ class ToolPackageManager:
         except BaseException:
             stack.close()
             raise
+
+    def _preview_system_command(
+        self, source_path: Path, source_bytes: bytes
+    ) -> ImportPreview:
+        if len(source_bytes) > MAX_FILE_BYTES:
+            raise _error(
+                "ARCHIVE_LIMIT_EXCEEDED", "system-command asset exceeds the file limit"
+            )
+        _scan_all(self.scanner, {source_path.name: source_bytes})
+        try:
+            if source_bytes.startswith((b"\xff\xfe", b"\xfe\xff")):
+                content = source_bytes.decode("utf-16")
+            else:
+                content = source_bytes.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            raise _error(
+                "INVALID_SYSTEM_COMMAND", "system-command asset must be UTF text"
+            ) from None
+        if "\x00" in content:
+            raise _error(
+                "INVALID_SYSTEM_COMMAND", "system-command asset contains invalid text"
+            )
+        package_sha256 = hashlib.sha256(source_bytes).hexdigest()
+        now_ms = int(self._clock() * 1000)
+        suffix = source_path.suffix.casefold()
+        platforms = (
+            ["windows"] if suffix in {".ps1", ".psm1", ".bat", ".cmd"}
+            else ["macos", "linux"]
+        )
+        artifact_id = new_user_artifact_id(uuid4())
+        content_hash = compute_content_hash("system-command", content, {})
+        artifact = ToolArtifact(
+            id=artifact_id,
+            name=source_path.name,
+            description=(
+                "Developer-only quarantined system command. It cannot be run by "
+                "Tool Library or an MCP agent."
+            ),
+            kind="system-command",
+            category="developer-tools",
+            tags=("quarantined", "system-command"),
+            compatibility={"platforms": platforms, "runtime": "system-command"},
+            declared_risk="external",
+            source=ToolSource(
+                type="imported",
+                ref=source_path.name,
+                client=None,
+                product_version=None,
+                provenance={
+                    "packageSha256": package_sha256,
+                    "extension": suffix,
+                },
+            ),
+            status="candidate",
+            verified=False,
+            verification=None,
+            content=content,
+            args_schema={},
+            content_hash=content_hash,
+            schema_version=1,
+            revision=1,
+            created_at=now_ms,
+            updated_at=now_ms,
+            last_used_at=None,
+        )
+        store_revision = self.store.store_revision()
+        import_id = uuid4().hex
+        preview = ImportPreview(
+            import_id=import_id,
+            package_sha256=package_sha256,
+            artifacts=(
+                ImportItemPreview(
+                    summary=_summary(artifact),
+                    existing_id=None,
+                    metadata_changes={},
+                    content_changed=False,
+                    calculated_risk="external",
+                ),
+            ),
+            conflicts=(),
+            highest_risk="external",
+            expires_at=int(self._clock()) + IMPORT_TTL_SECONDS,
+        )
+        cleanup = contextlib.ExitStack()
+        self._pending[import_id] = _PendingImport(
+            preview=preview,
+            artifacts=(artifact,),
+            conflict_by_artifact_id={},
+            store_revision=store_revision,
+            root=Path(),
+            cleanup=cleanup,
+        )
+        return preview
 
     def commit_import(
         self,

--- a/packages/core/ae_mcp/tool_artifact.py
+++ b/packages/core/ae_mcp/tool_artifact.py
@@ -21,7 +21,7 @@ JsonValue: TypeAlias = (
     None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 )
 ArtifactKind: TypeAlias = Literal[
-    "jsx", "expression", "prompt-skill", "recipe", "diagnostic"
+    "jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"
 ]
 ArtifactStatus: TypeAlias = Literal[
     "candidate", "saved", "pinned", "archived", "deprecated"
@@ -56,7 +56,9 @@ class DiagnosticContent(TypedDict):
 ArtifactContent: TypeAlias = str | RecipeContent | DiagnosticContent
 
 
-_KINDS = frozenset({"jsx", "expression", "prompt-skill", "recipe", "diagnostic"})
+_KINDS = frozenset(
+    {"jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"}
+)
 _STATUSES = frozenset({"candidate", "saved", "pinned", "archived", "deprecated"})
 _RISKS = ("read", "write", "destructive", "external")
 _SOURCE_TYPES = frozenset({"user", "legacy", "bundled", "chat-tool-call", "imported"})
@@ -377,7 +379,7 @@ def _validate_recipe_tool(ref: str, args: Mapping[str, JsonValue]) -> None:
 
 
 def _validate_content(kind: ArtifactKind, value: Any) -> ArtifactContent:
-    if kind in {"jsx", "expression", "prompt-skill"}:
+    if kind in {"jsx", "expression", "prompt-skill", "system-command"}:
         if not isinstance(value, str):
             raise ValueError(f"{kind} content must be a string")
         return value
@@ -518,6 +520,8 @@ class ToolArtifact:
         risk = data["declaredRisk"]
         if risk not in _RISKS:
             raise ValueError("artifact declaredRisk is unsupported")
+        if kind == "system-command" and risk != "external":
+            raise ValueError("system-command artifacts must declare external risk")
         artifact_id = _string(
             data["id"], label="artifact id", max_length=256, allow_empty=False
         )
@@ -692,6 +696,8 @@ class ToolArtifactDraft:
         )
         if self.declared_risk not in _RISKS:
             raise ValueError("artifact declaredRisk is unsupported")
+        if self.kind == "system-command" and self.declared_risk != "external":
+            raise ValueError("system-command artifacts must declare external risk")
         if not isinstance(self.source, ToolSource):
             raise ValueError("artifact source must be a ToolSource")
         if self.status not in {"candidate", "saved"}:

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from ae_mcp.annotations import VERB_ANNOTATIONS
 from ae_mcp.approval_gate import PlanAuthorizationDenied, authorize_plan, plan_decision
+from ae_mcp.backends.native import NativeBackendError
 from ae_mcp.jsx_prelude import with_prelude
 from ae_mcp.tool_artifact import (
     ArtifactKind,
@@ -212,17 +213,43 @@ def execution_capabilities(artifact: ToolArtifact) -> dict[str, JsonValue]:
 
 
 class ToolExecutionError(RuntimeError):
-    def __init__(self, code: str, message: str) -> None:
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        error_details: Mapping[str, JsonValue] | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
+        self.error_details = dict(error_details or {})
+
+    def error_dict(self) -> dict[str, JsonValue]:
+        return {
+            "code": self.code,
+            "message": str(self),
+            **self.error_details,
+        }
 
     def public_dict(self) -> dict[str, object]:
-        return {"ok": False, "error": self.code, "message": str(self)}
+        return {
+            "ok": False,
+            "error": self.code,
+            "message": str(self),
+            **self.error_details,
+        }
 
 
 class _BackendExecutionError(ToolExecutionError):
-    def __init__(self, code: str, message: str, backend_name: str) -> None:
-        super().__init__(code, message)
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        backend_name: str,
+        *,
+        error_details: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        super().__init__(code, message, error_details=error_details)
         self.backend_name = backend_name
 
 
@@ -666,6 +693,7 @@ class _Analysis:
 @dataclass
 class _ExecutionJob:
     execution_id: str
+    operation_id: str
     artifact_id: str
     content_hash: str
     artifact_revision: int
@@ -678,8 +706,7 @@ class _ExecutionJob:
     finished_at: int | None = None
     cancel_requested: bool = False
     result: Mapping[str, JsonValue] | None = None
-    error_code: str | None = None
-    error_message: str | None = None
+    error: Mapping[str, JsonValue] | None = None
     audit: Mapping[str, JsonValue] | None = None
 
     def public_dict(self) -> dict[str, JsonValue]:
@@ -688,6 +715,7 @@ class _ExecutionJob:
         return {
             "ok": True,
             "executionId": self.execution_id,
+            "operationId": self.operation_id,
             "artifactId": self.artifact_id,
             "contentHash": self.content_hash,
             "artifactRevision": self.artifact_revision,
@@ -703,11 +731,7 @@ class _ExecutionJob:
             "startedAt": self.started_at,
             "finishedAt": self.finished_at,
             "result": None if self.result is None else dict(self.result),
-            "error": (
-                None
-                if self.error_code is None
-                else {"code": self.error_code, "message": self.error_message or self.error_code}
-            ),
+            "error": None if self.error is None else dict(self.error),
             "audit": None if self.audit is None else dict(self.audit),
         }
 
@@ -824,7 +848,7 @@ class ToolExecutionEngine:
         self.prepared_plans = prepared_plans or PreparedPlanStore(now=self._now)
         self.grants = grants or GrantStore(now=self._now)
         self._jobs: dict[str, _ExecutionJob] = {}
-        self._job_keys: dict[tuple[str, str], str] = {}
+        self._job_operations: dict[str, str] = {}
         self._job_tasks: dict[str, asyncio.Task[None]] = {}
         self._job_lock = threading.RLock()
         self._unsubscribe: Callable[[], None] | None = None
@@ -1167,24 +1191,41 @@ class ToolExecutionEngine:
         plan_hash: str,
         grant_id: str,
         *,
+        operation_id: str,
         ctx: Any,
         initiator: str,
     ) -> Mapping[str, JsonValue]:
-        key = (plan_hash, grant_id)
+        if not 16 <= len(operation_id) <= 128:
+            raise ToolExecutionError(
+                "tool_operation_id_invalid", "Operation id is invalid."
+            )
         with self._job_lock:
-            existing_id = self._job_keys.get(key)
+            existing_id = self._job_operations.get(operation_id)
             if existing_id is not None:
-                return self._jobs[existing_id].public_dict()
+                existing = self._jobs[existing_id]
+                if existing.plan_hash != plan_hash:
+                    raise ToolExecutionError(
+                        "tool_operation_conflict",
+                        "Operation id is already bound to a different execution plan.",
+                    )
+                return existing.public_dict()
         plan = self.prepared_plans.get(plan_hash)
         self.grants.peek(grant_id, plan)
         artifact, _analysis = self._assert_current(plan)
         with self._job_lock:
-            existing_id = self._job_keys.get(key)
+            existing_id = self._job_operations.get(operation_id)
             if existing_id is not None:
-                return self._jobs[existing_id].public_dict()
+                existing = self._jobs[existing_id]
+                if existing.plan_hash != plan_hash:
+                    raise ToolExecutionError(
+                        "tool_operation_conflict",
+                        "Operation id is already bound to a different execution plan.",
+                    )
+                return existing.public_dict()
             execution_id = uuid4().hex
             job = _ExecutionJob(
                 execution_id=execution_id,
+                operation_id=operation_id,
                 artifact_id=artifact.id,
                 content_hash=artifact.content_hash,
                 artifact_revision=artifact.revision,
@@ -1195,7 +1236,7 @@ class ToolExecutionEngine:
                 created_at=self._now(),
             )
             self._jobs[execution_id] = job
-            self._job_keys[key] = execution_id
+            self._job_operations[operation_id] = execution_id
             task = asyncio.create_task(
                 self._run_job(job, grant_id=grant_id, ctx=ctx),
                 name=f"ae-mcp-tool-{execution_id}",
@@ -1212,7 +1253,11 @@ class ToolExecutionEngine:
         initiator: str,
     ) -> Mapping[str, JsonValue]:
         started = await self.start_job(
-            plan_hash, grant_id, ctx=ctx, initiator=initiator
+            plan_hash,
+            grant_id,
+            operation_id=uuid4().hex,
+            ctx=ctx,
+            initiator=initiator,
         )
         execution_id = cast(str, started["executionId"])
         with self._job_lock:
@@ -1254,19 +1299,27 @@ class ToolExecutionEngine:
             result = await self.execute(job.plan_hash, grant_id, ctx=ctx)
         except ToolExecutionError as exc:
             with self._job_lock:
-                job.error_code = exc.code
-                job.error_message = str(exc)
+                error = exc.error_dict()
+                job.error = error
                 job.status = (
                     "outcome-unknown"
                     if exc.code == "tool_backend_timeout"
+                    or error.get("sideEffect") == "may-have-occurred"
                     else "failed"
                 )
                 job.finished_at = self._now()
                 job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
         except BaseException as exc:  # task shutdown must remain explicitly ambiguous
             with self._job_lock:
-                job.error_code = "tool_execution_interrupted"
-                job.error_message = "Execution tracking was interrupted; inspect AE state before retrying."
+                job.error = {
+                    "code": "tool_execution_interrupted",
+                    "message": "Execution tracking was interrupted; inspect AE state before retrying.",
+                    "sideEffect": "may-have-occurred",
+                    "recovery": {
+                        "action": "inspect-state",
+                        "hint": "Inspect AE state and the audit record before retrying.",
+                    },
+                }
                 job.status = "outcome-unknown"
                 job.finished_at = self._now()
                 job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
@@ -1390,7 +1443,11 @@ class ToolExecutionEngine:
             started_at=started_at,
             finished_at=self._now(),
             error_code=error_code,
-            engine=("maintained-jsx" if backend is not None else None),
+            engine=(
+                "native-aegp"
+                if backend == "native-aegp"
+                else "maintained-jsx" if backend is not None else None
+            ),
         )
         self.audit_log.append(record)
 
@@ -1590,6 +1647,8 @@ class ToolExecutionEngine:
                 self._assert_current(root_plan)
                 result = await run(schema.model_validate(normalized), ctx)
                 results.append(cast(JsonValue, _canonical_value(result, label="recipe result")))
+                if name in _NATIVE_AEGP_HANDLERS:
+                    backend_name = "native-aegp"
         return {"ok": True, "results": results}, backend_name
 
     async def execute(
@@ -1621,6 +1680,32 @@ class ToolExecutionEngine:
             )
             raise ToolExecutionError(
                 "tool_backend_timeout", "Tool execution timed out."
+            ) from exc
+        except NativeBackendError as exc:
+            public = cast(dict[str, JsonValue], exc.public_dict())
+            error_details = {
+                key: value
+                for key, value in public.items()
+                if key not in {"code", "message"}
+            }
+            outcome = (
+                "outcome-unknown"
+                if public.get("sideEffect") == "may-have-occurred"
+                else "backend-error"
+            )
+            self._audit(
+                plan,
+                grant=grant,
+                backend="native-aegp",
+                outcome=outcome,
+                started_at=started_at,
+                error_code=exc.code,
+            )
+            raise _BackendExecutionError(
+                exc.code,
+                str(exc),
+                "native-aegp",
+                error_details=error_details,
             ) from exc
         except ToolExecutionError as exc:
             backend_name = cast(

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -8,12 +8,14 @@ import hashlib
 import json
 import os
 import re
+import sys
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from string import Template
 from typing import Any, Callable, Literal, Mapping, Sequence, cast
+from uuid import uuid4
 
 from ae_mcp.annotations import VERB_ANNOTATIONS
 from ae_mcp.approval_gate import PlanAuthorizationDenied, authorize_plan, plan_decision
@@ -61,10 +63,152 @@ _PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _BLOCKED_STATUSES = frozenset({"candidate", "archived", "deprecated"})
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 _TEMPLATES_DIR = Path(__file__).resolve().parent / "jsx_templates"
+_NATIVE_AEGP_HANDLERS = frozenset(
+    {
+        "ae.projectSummary",
+        "ae.getProjectBitDepth",
+        "ae.setProjectBitDepth",
+        "ae.listProjectItems",
+        "ae.listCompositionLayers",
+        "ae.listSelectedLayers",
+        "ae.getCompositionTime",
+        "ae.setCompositionTime",
+        "ae.createComposition",
+        "ae.createCompositionLayer",
+        "ae.applyLayerEffect",
+        "ae.listLayerProperties",
+        "ae.listLayerPropertyKeyframes",
+        "ae.setLayerPropertyValue",
+    }
+)
 
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
+
+
+def _current_platform() -> str:
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("win"):
+        return "windows"
+    return "linux"
+
+
+def _artifact_runtime(artifact: ToolArtifact) -> str:
+    if artifact.kind == "system-command":
+        return "system-command"
+    if artifact.kind in {"jsx", "expression"}:
+        return "jsx"
+    if artifact.kind == "prompt-skill":
+        return "render-only"
+    if artifact.kind == "diagnostic":
+        return "core-handler"
+    content = cast(Mapping[str, Any], artifact.content)
+    tool_steps = [
+        cast(str, step["ref"])
+        for step in content["steps"]
+        if step["refType"] == "tool"
+    ]
+    if tool_steps and all(name in _NATIVE_AEGP_HANDLERS for name in tool_steps):
+        return "native-aegp"
+    return "core-recipe"
+
+
+def _supported_operations(kind: ArtifactKind) -> tuple[ArtifactOperation, ...]:
+    if kind == "system-command":
+        return ()
+    if kind == "jsx":
+        return ("render", "execute")
+    if kind == "expression":
+        return ("render", "apply")
+    if kind == "prompt-skill":
+        return ("render",)
+    if kind in {"recipe", "diagnostic"}:
+        return ("render", "execute")
+    return ()
+
+
+def execution_capabilities(artifact: ToolArtifact) -> dict[str, JsonValue]:
+    """Return the authoritative, fail-closed direct-execution contract."""
+
+    runtime = _artifact_runtime(artifact)
+    operations = _supported_operations(artifact.kind)
+    platform = _current_platform()
+    compatible = True
+    disabled_code: str | None = None
+    disabled_message: str | None = None
+    constraints = artifact.compatibility
+    raw_platforms = constraints.get("platforms")
+    if raw_platforms is not None:
+        if (
+            not isinstance(raw_platforms, list)
+            or not raw_platforms
+            or not all(item in {"macos", "windows", "linux"} for item in raw_platforms)
+        ):
+            compatible = False
+            disabled_code = "tool_compatibility_invalid"
+            disabled_message = "Artifact platform compatibility metadata is invalid."
+        elif platform not in raw_platforms:
+            compatible = False
+            disabled_code = "tool_platform_incompatible"
+            disabled_message = f"Artifact is not compatible with {platform}."
+    required_runtime = constraints.get("runtime")
+    if compatible and required_runtime is not None:
+        if not isinstance(required_runtime, str) or required_runtime != runtime:
+            compatible = False
+            disabled_code = "tool_runtime_incompatible"
+            disabled_message = "Artifact runtime compatibility does not match the server route."
+    if compatible and any(
+        key in constraints for key in ("aeVersion", "aeMinVersion", "aeMaxVersion")
+    ):
+        compatible = False
+        disabled_code = "tool_ae_compatibility_unverified"
+        disabled_message = (
+            "After Effects version constraints require a verified live host identity."
+        )
+    if artifact.kind == "system-command":
+        disabled_code = "tool_system_command_denied"
+        disabled_message = "System-command assets are quarantined and cannot execute."
+    elif artifact.status in _BLOCKED_STATUSES:
+        disabled_code = "tool_status_blocked"
+        disabled_message = "This artifact status cannot be executed."
+    elif not compatible and disabled_code is None:
+        disabled_code = "tool_compatibility_failed"
+        disabled_message = "Artifact compatibility could not be verified."
+
+    default_operation: ArtifactOperation | None = None
+    if artifact.kind == "expression":
+        default_operation = "apply"
+    elif artifact.kind in {"jsx", "recipe", "diagnostic"}:
+        default_operation = "execute"
+    direct_available = (
+        default_operation is not None
+        and default_operation in operations
+        and compatible
+        and disabled_code is None
+    )
+    return {
+        "runtime": runtime,
+        "operations": list(operations),
+        "compatibility": {
+            "compatible": compatible,
+            "platform": platform,
+            "constraints": dict(constraints),
+        },
+        "directRun": {
+            "available": direct_available,
+            "operation": default_operation,
+            "requiresTarget": default_operation == "apply",
+            "approvalScopes": ["once"],
+            "warningPolicy": "external" if artifact.declared_risk == "external" else "standard",
+            "disabledReason": (
+                None
+                if disabled_code is None
+                else {"code": disabled_code, "message": disabled_message or disabled_code}
+            ),
+        },
+    }
 
 
 class ToolExecutionError(RuntimeError):
@@ -475,6 +619,24 @@ class GrantStore:
                 )
             return grant
 
+    def peek(self, grant_id: str, plan: ExecutionPlan | str) -> ExecutionGrant:
+        expected_hash = plan.plan_hash if isinstance(plan, ExecutionPlan) else plan
+        with self._lock:
+            state = self._grants.get(grant_id)
+            if state is None:
+                raise ToolExecutionError(
+                    "tool_grant_invalid", "Execution grant is missing or already consumed."
+                )
+            grant = state.grant
+            if grant.expires_at <= self._now():
+                self._grants.pop(grant_id, None)
+                raise ToolExecutionError("tool_grant_expired", "Execution grant has expired.")
+            if grant.plan_hash != expected_hash:
+                raise ToolExecutionError(
+                    "tool_grant_mismatch", "Execution grant does not match this plan."
+                )
+            return grant
+
     def revoke_artifact(self, artifact_id: str) -> int:
         with self._lock:
             grants = [
@@ -499,6 +661,55 @@ class _Analysis:
     dependency_hashes: tuple[tuple[str, str], ...]
     risk: ArtifactRisk
     rendered: str | None
+
+
+@dataclass
+class _ExecutionJob:
+    execution_id: str
+    artifact_id: str
+    content_hash: str
+    artifact_revision: int
+    plan_hash: str
+    operation: ArtifactOperation
+    initiator: str
+    status: str
+    created_at: int
+    started_at: int | None = None
+    finished_at: int | None = None
+    cancel_requested: bool = False
+    result: Mapping[str, JsonValue] | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    audit: Mapping[str, JsonValue] | None = None
+
+    def public_dict(self) -> dict[str, JsonValue]:
+        terminal = self.status in {"succeeded", "failed", "cancelled", "outcome-unknown"}
+        progress = 100 if terminal else 25 if self.status == "running" else 0
+        return {
+            "ok": True,
+            "executionId": self.execution_id,
+            "artifactId": self.artifact_id,
+            "contentHash": self.content_hash,
+            "artifactRevision": self.artifact_revision,
+            "planHash": self.plan_hash,
+            "operation": self.operation,
+            "initiator": self.initiator,
+            "status": self.status,
+            "progress": progress,
+            "terminal": terminal,
+            "cancelRequested": self.cancel_requested,
+            "outcomeUnknown": self.status == "outcome-unknown",
+            "createdAt": self.created_at,
+            "startedAt": self.started_at,
+            "finishedAt": self.finished_at,
+            "result": None if self.result is None else dict(self.result),
+            "error": (
+                None
+                if self.error_code is None
+                else {"code": self.error_code, "message": self.error_message or self.error_code}
+            ),
+            "audit": None if self.audit is None else dict(self.audit),
+        }
 
 
 def _substitute_json(value: JsonValue, context: Mapping[str, JsonValue]) -> JsonValue:
@@ -612,6 +823,10 @@ class ToolExecutionEngine:
         self._now = now or _now_ms
         self.prepared_plans = prepared_plans or PreparedPlanStore(now=self._now)
         self.grants = grants or GrantStore(now=self._now)
+        self._jobs: dict[str, _ExecutionJob] = {}
+        self._job_keys: dict[tuple[str, str], str] = {}
+        self._job_tasks: dict[str, asyncio.Task[None]] = {}
+        self._job_lock = threading.RLock()
         self._unsubscribe: Callable[[], None] | None = None
         subscribe = getattr(store, "subscribe", None)
         if callable(subscribe):
@@ -621,6 +836,10 @@ class ToolExecutionEngine:
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None
+
+    @staticmethod
+    def describe(artifact: ToolArtifact) -> dict[str, JsonValue]:
+        return execution_capabilities(artifact)
 
     def _on_store_mutation(self, mutation: Any) -> None:
         if isinstance(mutation, Mapping):
@@ -767,6 +986,27 @@ class ToolExecutionEngine:
                 "tool_invalid_operation", "Tool operation is unsupported."
             )
         artifact = self._get_artifact(artifact_id)
+        capabilities = execution_capabilities(artifact)
+        if artifact.kind == "system-command":
+            raise ToolExecutionError(
+                "tool_system_command_denied",
+                "System-command assets are quarantined and cannot execute.",
+            )
+        operations = capabilities.get("operations", [])
+        if operation not in operations:
+            raise ToolExecutionError(
+                "tool_invalid_operation", "Tool operation is unsupported."
+            )
+        compatibility = capabilities.get("compatibility", {})
+        if not isinstance(compatibility, Mapping) or compatibility.get("compatible") is not True:
+            direct = capabilities.get("directRun", {})
+            reason = direct.get("disabledReason") if isinstance(direct, Mapping) else None
+            code = reason.get("code") if isinstance(reason, Mapping) else None
+            message = reason.get("message") if isinstance(reason, Mapping) else None
+            raise ToolExecutionError(
+                str(code or "tool_compatibility_failed"),
+                str(message or "Artifact compatibility could not be verified."),
+            )
         analysis = self._analyze(
             artifact,
             operation,
@@ -875,7 +1115,9 @@ class ToolExecutionEngine:
                 return existing
         started_at = self._now()
         try:
-            scope = await authorize_plan(plan, ctx)
+            scope = await authorize_plan(
+                plan, ctx, requested_scope=requested_scope
+            )
             if scope == "session":
                 if requested_scope != "session":
                     raise ToolExecutionError(
@@ -896,6 +1138,187 @@ class ToolExecutionEngine:
             if isinstance(exc, ToolExecutionError):
                 raise
             raise ToolExecutionError(exc.code, str(exc)) from exc
+
+    def _latest_audit(self, plan_hash: str, artifact_id: str) -> Mapping[str, JsonValue] | None:
+        if self.audit_log is None:
+            return None
+        for record in reversed(self.audit_log.list(limit=100, artifact_id=artifact_id)):
+            if record.plan_hash == plan_hash:
+                return record.public_dict()
+        return None
+
+    def _record_successful_use(self, plan: ExecutionPlan) -> None:
+        record_use = getattr(self.store, "record_use", None)
+        if not callable(record_use):
+            return
+        try:
+            record_use(
+                plan.artifact_id,
+                expected_content_hash=plan.content_hash,
+                used_at=self._now(),
+            )
+        except Exception:
+            # The AE action has already succeeded and was audited. A usage-metadata
+            # write failure must never invite a duplicate side-effecting retry.
+            return
+
+    async def start_job(
+        self,
+        plan_hash: str,
+        grant_id: str,
+        *,
+        ctx: Any,
+        initiator: str,
+    ) -> Mapping[str, JsonValue]:
+        key = (plan_hash, grant_id)
+        with self._job_lock:
+            existing_id = self._job_keys.get(key)
+            if existing_id is not None:
+                return self._jobs[existing_id].public_dict()
+        plan = self.prepared_plans.get(plan_hash)
+        self.grants.peek(grant_id, plan)
+        artifact, _analysis = self._assert_current(plan)
+        with self._job_lock:
+            existing_id = self._job_keys.get(key)
+            if existing_id is not None:
+                return self._jobs[existing_id].public_dict()
+            execution_id = uuid4().hex
+            job = _ExecutionJob(
+                execution_id=execution_id,
+                artifact_id=artifact.id,
+                content_hash=artifact.content_hash,
+                artifact_revision=artifact.revision,
+                plan_hash=plan_hash,
+                operation=plan.operation,
+                initiator=initiator or "unknown",
+                status="queued",
+                created_at=self._now(),
+            )
+            self._jobs[execution_id] = job
+            self._job_keys[key] = execution_id
+            task = asyncio.create_task(
+                self._run_job(job, grant_id=grant_id, ctx=ctx),
+                name=f"ae-mcp-tool-{execution_id}",
+            )
+            self._job_tasks[execution_id] = task
+            return job.public_dict()
+
+    async def execute_tracked(
+        self,
+        plan_hash: str,
+        grant_id: str,
+        *,
+        ctx: Any,
+        initiator: str,
+    ) -> Mapping[str, JsonValue]:
+        started = await self.start_job(
+            plan_hash, grant_id, ctx=ctx, initiator=initiator
+        )
+        execution_id = cast(str, started["executionId"])
+        with self._job_lock:
+            task = self._job_tasks.get(execution_id)
+        if task is not None:
+            await asyncio.shield(task)
+        status = self.job_status(execution_id)
+        if status["status"] == "succeeded":
+            result = status.get("result")
+            if isinstance(result, Mapping):
+                return cast(Mapping[str, JsonValue], result)
+            raise ToolExecutionError(
+                "tool_invalid_response", "Execution completed without a structured result."
+            )
+        error = status.get("error")
+        code = error.get("code") if isinstance(error, Mapping) else None
+        message = error.get("message") if isinstance(error, Mapping) else None
+        raise ToolExecutionError(
+            str(code or "tool_execution_failed"),
+            str(message or "Tool execution did not complete successfully."),
+        )
+
+    async def _run_job(self, job: _ExecutionJob, *, grant_id: str, ctx: Any) -> None:
+        await asyncio.sleep(0)
+        with self._job_lock:
+            if job.cancel_requested:
+                try:
+                    plan = self.prepared_plans.get(job.plan_hash)
+                    self.grants.consume(grant_id, plan)
+                except ToolExecutionError:
+                    pass
+                job.status = "cancelled"
+                job.finished_at = self._now()
+                self._job_tasks.pop(job.execution_id, None)
+                return
+            job.status = "running"
+            job.started_at = self._now()
+        try:
+            result = await self.execute(job.plan_hash, grant_id, ctx=ctx)
+        except ToolExecutionError as exc:
+            with self._job_lock:
+                job.error_code = exc.code
+                job.error_message = str(exc)
+                job.status = (
+                    "outcome-unknown"
+                    if exc.code == "tool_backend_timeout"
+                    else "failed"
+                )
+                job.finished_at = self._now()
+                job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
+        except BaseException as exc:  # task shutdown must remain explicitly ambiguous
+            with self._job_lock:
+                job.error_code = "tool_execution_interrupted"
+                job.error_message = "Execution tracking was interrupted; inspect AE state before retrying."
+                job.status = "outcome-unknown"
+                job.finished_at = self._now()
+                job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+        else:
+            with self._job_lock:
+                job.result = result
+                job.status = "succeeded"
+                job.finished_at = self._now()
+                job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
+        finally:
+            with self._job_lock:
+                self._job_tasks.pop(job.execution_id, None)
+
+    def job_status(self, execution_id: str) -> Mapping[str, JsonValue]:
+        with self._job_lock:
+            job = self._jobs.get(execution_id)
+            if job is None:
+                raise ToolExecutionError("tool_execution_not_found", "Execution was not found.")
+            return job.public_dict()
+
+    def cancel_job(self, execution_id: str) -> Mapping[str, JsonValue]:
+        with self._job_lock:
+            job = self._jobs.get(execution_id)
+            if job is None:
+                raise ToolExecutionError("tool_execution_not_found", "Execution was not found.")
+            if job.status == "queued":
+                job.cancel_requested = True
+                disposition = "cancelled-before-dispatch"
+            elif job.status == "running":
+                job.cancel_requested = True
+                disposition = "not-cancellable-after-dispatch"
+            else:
+                disposition = "already-terminal"
+            result = job.public_dict()
+            result["cancelDisposition"] = disposition
+            return result
+
+    def job_history(
+        self, artifact_id: str, *, limit: int = 20
+    ) -> Mapping[str, JsonValue]:
+        if not 1 <= limit <= 100:
+            raise ToolExecutionError("tool_invalid_input", "History limit is invalid.")
+        with self._job_lock:
+            rows = [job for job in self._jobs.values() if job.artifact_id == artifact_id]
+            rows.sort(key=lambda job: (job.created_at, job.execution_id), reverse=True)
+            return {
+                "ok": True,
+                "artifactId": artifact_id,
+                "executions": [job.public_dict() for job in rows[:limit]],
+            }
 
     def _scan_json(self, name: str, value: Mapping[str, JsonValue]) -> None:
         try:
@@ -1240,6 +1663,7 @@ class ToolExecutionEngine:
             outcome="success",
             started_at=started_at,
         )
+        self._record_successful_use(plan)
         return result
 
     async def execute_legacy_skill(
@@ -1388,6 +1812,7 @@ class ToolExecutionEngine:
             outcome="success",
             started_at=started_at,
         )
+        self._record_successful_use(plan)
         return {
             "ok": True,
             "name": record.skill.name,
@@ -1409,6 +1834,7 @@ __all__ = [
     "analyze_artifact_risk",
     "analyze_jsx",
     "compute_plan_hash",
+    "execution_capabilities",
     "normalize_args",
     "normalize_target",
 ]

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -1249,13 +1249,14 @@ class ToolExecutionEngine:
         plan_hash: str,
         grant_id: str,
         *,
+        operation_id: str,
         ctx: Any,
         initiator: str,
     ) -> Mapping[str, JsonValue]:
         started = await self.start_job(
             plan_hash,
             grant_id,
-            operation_id=uuid4().hex,
+            operation_id=operation_id,
             ctx=ctx,
             initiator=initiator,
         )
@@ -1275,9 +1276,24 @@ class ToolExecutionEngine:
         error = status.get("error")
         code = error.get("code") if isinstance(error, Mapping) else None
         message = error.get("message") if isinstance(error, Mapping) else None
+        error_details: dict[str, JsonValue] = {
+            key: cast(JsonValue, value)
+            for key, value in error.items()
+            if key not in {"code", "message"}
+        } if isinstance(error, Mapping) else {}
+        error_details.update(
+            {
+                "executionId": execution_id,
+                "operationId": operation_id,
+                "status": cast(JsonValue, status["status"]),
+                "outcomeUnknown": cast(JsonValue, status["outcomeUnknown"]),
+                "audit": cast(JsonValue, status.get("audit")),
+            }
+        )
         raise ToolExecutionError(
             str(code or "tool_execution_failed"),
             str(message or "Tool execution did not complete successfully."),
+            error_details=error_details,
         )
 
     async def _run_job(self, job: _ExecutionJob, *, grant_id: str, ctx: Any) -> None:

--- a/packages/core/ae_mcp/tool_legacy.py
+++ b/packages/core/ae_mcp/tool_legacy.py
@@ -574,6 +574,12 @@ class LegacySkillAdapter:
                 product_version=manifest.product_version,
                 provenance={"manifestSha256": digest},
             )
+            usage_metadata = self.metadata_store.get(
+                record.path,
+                content_hash,
+                default_risk=_default_risk(kind),
+                default_updated_at=file_updated_at,
+            )
             metadata = LegacyMetadata(
                 category="workflow",
                 tags=(),
@@ -584,7 +590,7 @@ class LegacySkillAdapter:
                 ),
                 compatibility={},
                 declared_risk=_default_risk(kind),
-                last_used_at=None,
+                last_used_at=usage_metadata.last_used_at,
                 revision=1,
                 updated_at=file_updated_at,
             )
@@ -655,6 +661,32 @@ class LegacySkillAdapter:
     def get(self, artifact_id: str) -> ToolArtifact:
         _record, artifact, _manifest = self._find(artifact_id)
         return artifact
+
+    def record_use(
+        self,
+        artifact_id: str,
+        *,
+        expected_content_hash: str,
+        used_at: int,
+    ) -> ToolArtifact:
+        from ae_mcp.tool_store import ToolRevisionConflict, ToolStoreValidationError
+
+        if isinstance(used_at, bool) or not isinstance(used_at, int) or used_at < 0:
+            raise ToolStoreValidationError()
+        record, artifact, _manifest = self._find(artifact_id)
+        if artifact.content_hash != expected_content_hash:
+            raise ToolRevisionConflict()
+        store_revision = self.metadata_store.store_revision()
+        _current_record, current, _current_manifest = self._find(artifact_id)
+        if current.content_hash != expected_content_hash:
+            raise ToolRevisionConflict()
+        self.metadata_store.compare_and_set(
+            record.path,
+            expected_content_hash,
+            {"lastUsedAt": max(current.last_used_at or 0, used_at)},
+            expected_revision=store_revision,
+        )
+        return self.get(artifact_id)
 
     def edit(
         self,

--- a/packages/core/ae_mcp/tool_service.py
+++ b/packages/core/ae_mcp/tool_service.py
@@ -186,6 +186,27 @@ class _ToolArtifactStoreView(ToolArtifactStore):
             return self.native.get(artifact_id, include_content=include_content)
         return self.legacy.get(artifact_id)
 
+    def record_use(
+        self,
+        artifact_id: str,
+        *,
+        expected_content_hash: str,
+        used_at: int,
+    ) -> ToolArtifact:
+        if self._is_native(artifact_id):
+            return self.native.record_use(
+                artifact_id,
+                expected_content_hash=expected_content_hash,
+                used_at=used_at,
+            )
+        updated = self.legacy.record_use(
+            artifact_id,
+            expected_content_hash=expected_content_hash,
+            used_at=used_at,
+        )
+        self._publish(StoreMutation("use", (artifact_id,), self.store_revision()))
+        return updated
+
     def create(
         self,
         draft: ToolArtifactDraft,

--- a/packages/core/ae_mcp/tool_store.py
+++ b/packages/core/ae_mcp/tool_store.py
@@ -743,6 +743,41 @@ class ToolArtifactStore:
     def store_revision(self) -> int:
         return cast(int, self._read_index()["revision"])
 
+    def record_use(
+        self,
+        artifact_id: str,
+        *,
+        expected_content_hash: str,
+        used_at: int,
+    ) -> ToolArtifact:
+        if isinstance(used_at, bool) or not isinstance(used_at, int) or used_at < 0:
+            raise ToolStoreValidationError()
+        with self._lock() as lock:
+            index = self._read_index()
+            position = self._entry_index(index, artifact_id)
+            current = self._load_artifact(artifact_id)
+            if current.content_hash != expected_content_hash:
+                raise ToolRevisionConflict()
+            value = current.to_dict()
+            value["lastUsedAt"] = max(current.last_used_at or 0, used_at)
+            updated = ToolArtifact.from_dict(value)
+            entries = list(self._entries(index))
+            entries[position] = _entry_from_artifact(updated)
+            next_revision = cast(int, index["revision"]) + 1
+            next_index: dict[str, JsonValue] = {
+                "schemaVersion": 1,
+                "revision": next_revision,
+                "artifacts": entries,
+            }
+            self._commit(
+                lock,
+                index_before=index,
+                index_after=next_index,
+                writes={self._artifact_path(artifact_id): self._scan_artifact(updated)},
+            )
+        self._publish(StoreMutation("use", (artifact_id,), next_revision))
+        return updated
+
     def create(
         self,
         draft: ToolArtifactDraft,

--- a/packages/core/ae_mcp/tool_store.py
+++ b/packages/core/ae_mcp/tool_store.py
@@ -327,7 +327,9 @@ _ENTRY_KEYS = frozenset(
         "sourceType",
     }
 )
-_KINDS = frozenset({"jsx", "expression", "prompt-skill", "recipe", "diagnostic"})
+_KINDS = frozenset(
+    {"jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"}
+)
 _STATUSES = frozenset({"candidate", "saved", "pinned", "archived", "deprecated"})
 _RISKS = frozenset({"read", "write", "destructive", "external"})
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")

--- a/packages/core/tests/test_approval_gate.py
+++ b/packages/core/tests/test_approval_gate.py
@@ -92,6 +92,9 @@ def _plan(risk="write"):
 def test_plan_elicitation_schema_allows_session_only_for_write():
     write_schema = build_plan_elicitation_schema(_plan("write"))
     destructive_schema = build_plan_elicitation_schema(_plan("destructive"))
+    direct_schema = build_plan_elicitation_schema(
+        _plan("write"), requested_scope="once"
+    )
 
     assert write_schema["properties"]["decision"]["enum"] == [
         "once",
@@ -102,6 +105,7 @@ def test_plan_elicitation_schema_allows_session_only_for_write():
         "once",
         "deny",
     ]
+    assert direct_schema["properties"]["decision"]["enum"] == ["once", "deny"]
     assert write_schema["additionalProperties"] is False
     assert write_schema["x-ae-mcp-plan"] == _plan("write").public_dict()
 

--- a/packages/core/tests/test_handlers_tools.py
+++ b/packages/core/tests/test_handlers_tools.py
@@ -166,8 +166,12 @@ class _Execution:
         self.calls.append(("execute", plan_hash, grant_id, ctx, initiator))
         return {"ok": True, "result": 1}
 
-    async def start_job(self, plan_hash, grant_id, *, ctx, initiator):
-        self.calls.append(("start", plan_hash, grant_id, ctx, initiator))
+    async def start_job(
+        self, plan_hash, grant_id, *, operation_id, ctx, initiator
+    ):
+        self.calls.append(
+            ("start", plan_hash, grant_id, operation_id, ctx, initiator)
+        )
         return {"ok": True, "executionId": "e", "status": "queued"}
 
     def job_status(self, execution_id):
@@ -411,15 +415,17 @@ async def test_system_commands_are_hidden_by_default_and_visible_only_as_develop
     ordinary_inspect = await handlers._run_tool_inspect(
         S.AeToolInspectArgs(artifact_id=service.store.artifact.id), None
     )
-    developer = await handlers._run_tool_index(
-        S.AeToolIndexArgs(developer_mode=True), None
-    )
-    developer_inspect = await handlers._run_tool_inspect(
-        S.AeToolInspectArgs(
-            artifact_id=service.store.artifact.id, developer_mode=True
-        ),
-        None,
-    )
+    token = handlers.client_identity.set_panel_developer(True)
+    try:
+        developer = await handlers._run_tool_index(
+            S.AePanelToolIndexArgs(), None
+        )
+        developer_inspect = await handlers._run_tool_inspect(
+            S.AeToolInspectArgs(artifact_id=service.store.artifact.id),
+            None,
+        )
+    finally:
+        handlers.client_identity.reset_panel_developer(token)
 
     assert ordinary["artifacts"] == []
     assert ordinary_search["artifacts"] == []
@@ -451,7 +457,12 @@ async def test_tool_use_dispatches_staged_protocol_exactly(service, action):
         ),
         "grant": dict(action="grant", plan_hash="p", grant_scope="once"),
         "execute": dict(action="execute", plan_hash="p", grant_id="g"),
-        "start": dict(action="start", plan_hash="p", grant_id="g"),
+        "start": dict(
+            action="start",
+            plan_hash="p",
+            grant_id="g",
+            operation_id="operation-handler-0001",
+        ),
         "status": dict(action="status", execution_id="e"),
         "cancel": dict(action="cancel", execution_id="e"),
         "history": dict(action="history", artifact_id="user:1", limit=10),

--- a/packages/core/tests/test_handlers_tools.py
+++ b/packages/core/tests/test_handlers_tools.py
@@ -162,8 +162,12 @@ class _Execution:
             grant_id="g", plan_hash=plan_hash, scope="once", expires_at=123
         )
 
-    async def execute_tracked(self, plan_hash, grant_id, *, ctx, initiator):
-        self.calls.append(("execute", plan_hash, grant_id, ctx, initiator))
+    async def execute_tracked(
+        self, plan_hash, grant_id, *, operation_id, ctx, initiator
+    ):
+        self.calls.append(
+            ("execute", plan_hash, grant_id, operation_id, ctx, initiator)
+        )
         return {"ok": True, "result": 1}
 
     async def start_job(
@@ -456,7 +460,12 @@ async def test_tool_use_dispatches_staged_protocol_exactly(service, action):
             target={},
         ),
         "grant": dict(action="grant", plan_hash="p", grant_scope="once"),
-        "execute": dict(action="execute", plan_hash="p", grant_id="g"),
+        "execute": dict(
+            action="execute",
+            plan_hash="p",
+            grant_id="g",
+            operation_id="operation-handler-execute",
+        ),
         "start": dict(
             action="start",
             plan_hash="p",

--- a/packages/core/tests/test_handlers_tools.py
+++ b/packages/core/tests/test_handlers_tools.py
@@ -162,9 +162,25 @@ class _Execution:
             grant_id="g", plan_hash=plan_hash, scope="once", expires_at=123
         )
 
-    async def execute(self, plan_hash, grant_id, *, ctx):
-        self.calls.append(("execute", plan_hash, grant_id, ctx))
+    async def execute_tracked(self, plan_hash, grant_id, *, ctx, initiator):
+        self.calls.append(("execute", plan_hash, grant_id, ctx, initiator))
         return {"ok": True, "result": 1}
+
+    async def start_job(self, plan_hash, grant_id, *, ctx, initiator):
+        self.calls.append(("start", plan_hash, grant_id, ctx, initiator))
+        return {"ok": True, "executionId": "e", "status": "queued"}
+
+    def job_status(self, execution_id):
+        self.calls.append(("status", execution_id))
+        return {"ok": True, "executionId": execution_id, "status": "running"}
+
+    def cancel_job(self, execution_id):
+        self.calls.append(("cancel", execution_id))
+        return {"ok": True, "executionId": execution_id, "cancelRequested": True}
+
+    def job_history(self, artifact_id, *, limit):
+        self.calls.append(("history", artifact_id, limit))
+        return {"ok": True, "artifactId": artifact_id, "executions": []}
 
 
 class _Packages:
@@ -343,6 +359,8 @@ async def test_index_and_search_return_summaries_without_content(service):
     assert index["ok"] is True
     assert index["artifacts"][0]["id"] == service.store.summary.id
     assert "content" not in index["artifacts"][0]
+    assert index["artifacts"][0]["executionCapabilities"]["runtime"] == "jsx"
+    assert index["artifacts"][0]["executionCapabilities"]["directRun"]["available"] is True
     assert search["total"] == 1
     assert "content" not in search["artifacts"][0]
 
@@ -364,11 +382,62 @@ async def test_inspect_only_marks_manifest_verified_bundled_content_as_signed(se
 
     assert trusted["trust"] == "signed-bundled"
     assert trusted["artifact"]["content"] == "return 1;"
+    assert trusted["artifact"]["executionCapabilities"]["runtime"] == "jsx"
     assert untrusted["trust"] == "user-untrusted"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("action", ["render", "prepare", "grant", "execute"])
+async def test_system_commands_are_hidden_by_default_and_visible_only_as_developer_metadata(service):
+    content = "Write-Output blocked"
+    digest = compute_content_hash("system-command", content, {})
+    service.store.artifact = replace(
+        service.store.artifact,
+        kind="system-command",
+        content=content,
+        declared_risk="external",
+        content_hash=digest,
+    )
+    service.store.summary = replace(
+        service.store.summary,
+        kind="system-command",
+        declared_risk="external",
+        content_hash=digest,
+    )
+
+    ordinary = await handlers._run_tool_index(S.AeToolIndexArgs(), None)
+    ordinary_search = await handlers._run_tool_search(
+        S.AeToolSearchArgs(query="blocked"), None
+    )
+    ordinary_inspect = await handlers._run_tool_inspect(
+        S.AeToolInspectArgs(artifact_id=service.store.artifact.id), None
+    )
+    developer = await handlers._run_tool_index(
+        S.AeToolIndexArgs(developer_mode=True), None
+    )
+    developer_inspect = await handlers._run_tool_inspect(
+        S.AeToolInspectArgs(
+            artifact_id=service.store.artifact.id, developer_mode=True
+        ),
+        None,
+    )
+
+    assert ordinary["artifacts"] == []
+    assert ordinary_search["artifacts"] == []
+    assert ordinary_inspect["ok"] is False
+    assert ordinary_inspect["error"] == "tool_not_found"
+    [row] = developer["artifacts"]
+    assert row["kind"] == "system-command"
+    assert row["executionCapabilities"]["directRun"]["available"] is False
+    assert developer_inspect["artifact"]["content"] == content
+    assert developer_inspect["artifact"]["executionCapabilities"]["directRun"][
+        "disabledReason"
+    ]["code"] == "tool_system_command_denied"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action", ["render", "prepare", "grant", "execute", "start", "status", "cancel", "history"]
+)
 async def test_tool_use_dispatches_staged_protocol_exactly(service, action):
     ctx = object()
     values = {
@@ -382,6 +451,10 @@ async def test_tool_use_dispatches_staged_protocol_exactly(service, action):
         ),
         "grant": dict(action="grant", plan_hash="p", grant_scope="once"),
         "execute": dict(action="execute", plan_hash="p", grant_id="g"),
+        "start": dict(action="start", plan_hash="p", grant_id="g"),
+        "status": dict(action="status", execution_id="e"),
+        "cancel": dict(action="cancel", execution_id="e"),
+        "history": dict(action="history", artifact_id="user:1", limit=10),
     }[action]
 
     result = await handlers._run_tool_use(S.AeToolUseArgs(**values), ctx)

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -587,17 +587,33 @@ def test_tool_use_enforces_the_staged_protocol():
     )
     S.AeToolUseArgs(action="grant", plan_hash="p", grant_scope="once")
     S.AeToolUseArgs(action="execute", plan_hash="p", grant_id="g")
+    S.AeToolUseArgs(
+        action="start",
+        plan_hash="p",
+        grant_id="g",
+        operation_id="operation-schema-0001",
+    )
 
     invalid = [
         {"action": "render"},
         {"action": "prepare", "artifact_id": "user:1"},
         {"action": "grant", "plan_hash": "p"},
         {"action": "execute", "plan_hash": "p"},
+        {"action": "start", "plan_hash": "p", "grant_id": "g"},
         {"action": "execute", "plan_hash": "p", "grant_id": "g", "artifact_id": "user:1"},
     ]
     for value in invalid:
         with pytest.raises(ValidationError):
             S.AeToolUseArgs(**value)
+
+
+def test_public_tool_discovery_schema_cannot_unlock_developer_commands():
+    for schema in (S.AeToolIndexArgs, S.AeToolSearchArgs, S.AeToolInspectArgs):
+        assert "developer_mode" not in schema.model_json_schema()["properties"]
+    public_kinds = S.AeToolIndexArgs.model_json_schema()["properties"]["kinds"]["anyOf"][0]["items"]["enum"]
+    assert "system-command" not in public_kinds
+    panel_kinds = S.AePanelToolIndexArgs.model_json_schema()["properties"]["kinds"]["anyOf"][0]["items"]["enum"]
+    assert "system-command" in panel_kinds
 
 
 def test_tool_mutations_require_cas_and_import_export_are_bounded():

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -586,7 +586,12 @@ def test_tool_use_enforces_the_staged_protocol():
         action="prepare", artifact_id="user:1", operation="execute"
     )
     S.AeToolUseArgs(action="grant", plan_hash="p", grant_scope="once")
-    S.AeToolUseArgs(action="execute", plan_hash="p", grant_id="g")
+    S.AeToolUseArgs(
+        action="execute",
+        plan_hash="p",
+        grant_id="g",
+        operation_id="operation-schema-execute",
+    )
     S.AeToolUseArgs(
         action="start",
         plan_hash="p",
@@ -599,6 +604,7 @@ def test_tool_use_enforces_the_staged_protocol():
         {"action": "prepare", "artifact_id": "user:1"},
         {"action": "grant", "plan_hash": "p"},
         {"action": "execute", "plan_hash": "p"},
+        {"action": "execute", "plan_hash": "p", "grant_id": "g"},
         {"action": "start", "plan_hash": "p", "grant_id": "g"},
         {"action": "execute", "plan_hash": "p", "grant_id": "g", "artifact_id": "user:1"},
     ]

--- a/packages/core/tests/test_tool_archive.py
+++ b/packages/core/tests/test_tool_archive.py
@@ -283,6 +283,43 @@ def saved_artifact() -> ToolArtifact:
 
 
 @pytest.mark.parametrize(
+    ("suffix", "platforms"),
+    [
+        (".ps1", ["windows"]),
+        (".psm1", ["windows"]),
+        (".bat", ["windows"]),
+        (".cmd", ["windows"]),
+        (".sh", ["macos", "linux"]),
+        (".command", ["macos", "linux"]),
+    ],
+)
+def test_system_command_import_is_classified_external_and_quarantined(
+    tmp_path: Path, suffix: str, platforms: list[str]
+) -> None:
+    store = FakeStore()
+    manager = make_manager(store, RegexSecretScanner(), tmp_path)
+    source = tmp_path / f"developer{suffix}"
+    source.write_text("echo blocked\n", encoding="utf-8")
+
+    preview = manager.preview_import(source)
+    item = preview.artifacts[0]
+    assert item.summary.kind == "system-command"
+    assert item.summary.declared_risk == "external"
+    assert item.calculated_risk == "external"
+    created = manager.commit_import(preview.import_id, {})
+    assert len(created) == 1
+    assert created[0].kind == "system-command"
+    assert created[0].status == "candidate"
+    assert created[0].declared_risk == "external"
+    assert created[0].compatibility == {
+        "platforms": platforms,
+        "runtime": "system-command",
+    }
+    assert created[0].source.ref == source.name
+    assert str(tmp_path) not in created[0].source.ref
+
+
+@pytest.mark.parametrize(
     "entry_name",
     [
         "../escape.json",

--- a/packages/core/tests/test_tool_archive.py
+++ b/packages/core/tests/test_tool_archive.py
@@ -319,6 +319,24 @@ def test_system_command_import_is_classified_external_and_quarantined(
     assert str(tmp_path) not in created[0].source.ref
 
 
+def test_system_command_import_remains_readable_after_persisting(tmp_path: Path) -> None:
+    root = tmp_path / "tools"
+    manager = make_manager(ToolArtifactStore(root), RegexSecretScanner(), tmp_path)
+    source = tmp_path / "developer.ps1"
+    source.write_text("Write-Output blocked\n", encoding="utf-8")
+
+    preview = manager.preview_import(source)
+    [created] = manager.commit_import(preview.import_id, {})
+
+    reopened = ToolArtifactStore(root)
+    [summary] = reopened.list(statuses={"candidate"})
+    persisted = reopened.get(created.id)
+    assert summary.kind == "system-command"
+    assert persisted.kind == "system-command"
+    assert persisted.declared_risk == "external"
+    assert persisted.content == "Write-Output blocked\n"
+
+
 @pytest.mark.parametrize(
     "entry_name",
     [

--- a/packages/core/tests/test_tool_archive.py
+++ b/packages/core/tests/test_tool_archive.py
@@ -323,7 +323,7 @@ def test_system_command_import_remains_readable_after_persisting(tmp_path: Path)
     root = tmp_path / "tools"
     manager = make_manager(ToolArtifactStore(root), RegexSecretScanner(), tmp_path)
     source = tmp_path / "developer.ps1"
-    source.write_text("Write-Output blocked\n", encoding="utf-8")
+    source.write_bytes(b"Write-Output blocked\n")
 
     preview = manager.preview_import(source)
     [created] = manager.commit_import(preview.import_id, {})

--- a/packages/core/tests/test_tool_artifact.py
+++ b/packages/core/tests/test_tool_artifact.py
@@ -333,3 +333,20 @@ def test_export_safe_source_omits_client_paths_and_arbitrary_provenance():
         "do-not-export",
     ):
         assert forbidden not in rendered
+
+
+def test_system_command_kind_requires_external_risk_and_round_trips_as_text():
+    with pytest.raises(ValueError, match="external risk"):
+        ToolArtifact.from_dict(
+            _artifact_wire(kind="system-command", content="echo blocked")
+        )
+    command = ToolArtifact.from_dict(
+        _artifact_wire(
+            kind="system-command",
+            content="echo blocked",
+            declaredRisk="external",
+        )
+    )
+    assert command.kind == "system-command"
+    assert command.declared_risk == "external"
+    assert command.to_dict()["content"] == "echo blocked"

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1011,21 +1011,42 @@ async def test_native_uncertain_write_keeps_recovery_and_is_never_blindly_retrie
     )
     plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
     grant = engine.grants.issue_once(plan)
-    started = await engine.start_job(
-        plan.plan_hash,
-        grant.grant_id,
-        operation_id="operation-native-uncertain",
-        ctx=None,
-        initiator="panel-direct",
-    )
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    with pytest.raises(ToolExecutionError) as first:
+        await engine.execute_tracked(
+            plan.plan_hash,
+            grant.grant_id,
+            operation_id="operation-native-uncertain",
+            ctx=None,
+            initiator="agent",
+        )
 
-    status = engine.job_status(started["executionId"])
+    public = first.value.public_dict()
+    assert public["error"] == "POSSIBLY_SIDE_EFFECTING_FAILURE"
+    assert public["operationId"] == "operation-native-uncertain"
+    assert public["outcomeUnknown"] is True
+    assert public["sideEffect"] == "may-have-occurred"
+    assert public["recovery"]["action"] == "inspect-state"
+    assert public["audit"]["outcome"] == "outcome-unknown"
+    assert public["audit"]["backend"] == "native-aegp"
+
+    status = engine.job_status(public["executionId"])
     assert status["status"] == "outcome-unknown"
     assert status["error"]["code"] == "POSSIBLY_SIDE_EFFECTING_FAILURE"
     assert status["error"]["sideEffect"] == "may-have-occurred"
     assert status["error"]["recovery"]["action"] == "inspect-state"
     assert status["audit"]["outcome"] == "outcome-unknown"
     assert status["audit"]["backend"] == "native-aegp"
+
+    # A lost agent response can be retried only with the same operation id.
+    # The server returns the existing terminal job and never dispatches again.
+    retry_grant = engine.grants.issue_once(plan)
+    with pytest.raises(ToolExecutionError) as second:
+        await engine.execute_tracked(
+            plan.plan_hash,
+            retry_grant.grant_id,
+            operation_id="operation-native-uncertain",
+            ctx=None,
+            initiator="agent",
+        )
+    assert second.value.public_dict()["executionId"] == public["executionId"]
     assert calls == 1

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import re
 from pathlib import Path
@@ -26,6 +27,7 @@ from ae_mcp.tool_execution import (
     analyze_artifact_risk,
     analyze_jsx,
     compute_plan_hash,
+    execution_capabilities,
     normalize_args,
     normalize_target,
 )
@@ -50,6 +52,7 @@ def _artifact(
     args_schema=None,
     declared_risk: str = "read",
     status: str = "saved",
+    compatibility=None,
 ) -> ToolArtifact:
     schema = {} if args_schema is None else args_schema
     return ToolArtifact(
@@ -59,7 +62,7 @@ def _artifact(
         kind=kind,
         category="workflow",
         tags=(),
-        compatibility={},
+        compatibility={} if compatibility is None else compatibility,
         declared_risk=declared_risk,
         source=_source(),
         status=status,
@@ -80,6 +83,7 @@ class _Store:
     def __init__(self, *artifacts: ToolArtifact) -> None:
         self.artifacts = {artifact.id: artifact for artifact in artifacts}
         self.callbacks = []
+        self.uses = []
 
     def get(self, artifact_id, *, include_content=True):
         return self.artifacts[artifact_id]
@@ -99,6 +103,16 @@ class _Store:
             event = StoreMutation("edit", (artifact.id,), 2)
             for callback in tuple(self.callbacks):
                 callback(event)
+
+    def record_use(self, artifact_id, *, expected_content_hash, used_at):
+        artifact = self.artifacts[artifact_id]
+        if artifact.content_hash != expected_content_hash:
+            raise RuntimeError("stale")
+        self.uses.append((artifact_id, expected_content_hash, used_at))
+        self.artifacts[artifact_id] = dataclasses.replace(
+            artifact, last_used_at=used_at
+        )
+        return self.artifacts[artifact_id]
 
 
 class _Backend:
@@ -266,6 +280,48 @@ def test_blocked_status_fails_before_backend_selection(status):
 
     assert caught.value.code == "tool_status_blocked"
     assert factory.calls == 0
+
+
+def test_server_execution_capabilities_identify_native_recipes_and_compatibility():
+    native = _artifact(
+        kind="recipe",
+        content={
+            "steps": [
+                {
+                    "refType": "tool",
+                    "ref": "ae.projectSummary",
+                    "operation": "call",
+                    "args": {},
+                    "target": {},
+                }
+            ]
+        },
+    )
+    described = execution_capabilities(native)
+    assert described["runtime"] == "native-aegp"
+    assert described["directRun"]["available"] is True
+    assert described["directRun"]["operation"] == "execute"
+    incompatible = dataclasses.replace(native, compatibility={"platforms": ["windows"]})
+    if execution_module.sys.platform == "darwin":
+        blocked = execution_capabilities(incompatible)
+        assert blocked["directRun"]["available"] is False
+        assert blocked["directRun"]["disabledReason"]["code"] == "tool_platform_incompatible"
+
+
+def test_system_commands_are_never_plannable_or_directly_executable():
+    command = _artifact(
+        kind="system-command",
+        content="Write-Output blocked",
+        declared_risk="external",
+    )
+    described = execution_capabilities(command)
+    assert described["operations"] == []
+    assert described["directRun"]["available"] is False
+    assert described["directRun"]["disabledReason"]["code"] == "tool_system_command_denied"
+    engine = ToolExecutionEngine(_Store(command), _Factory(_Backend()))
+    with pytest.raises(ToolExecutionError) as caught:
+        engine.prepare(command.id, operation="execute", args={}, target={})
+    assert caught.value.code == "tool_system_command_denied"
 
 
 def test_prompt_render_returns_untrusted_context_without_backend():
@@ -770,3 +826,114 @@ async def test_backend_failure_audit_keeps_backend_name_and_no_exception_text(
     assert record.engine == "maintained-jsx"
     assert record.outcome == "backend-error"
     assert private_error not in persisted
+
+
+@pytest.mark.asyncio
+async def test_execution_jobs_dedupe_report_history_audit_and_usage(tmp_path: Path):
+    artifact = _artifact()
+    store = _Store(artifact)
+    audit = ToolAuditLog(tmp_path)
+    engine = ToolExecutionEngine(store, _Backend(), audit_log=audit)
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+
+    first = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    duplicate = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    assert duplicate["executionId"] == first["executionId"]
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    status = engine.job_status(first["executionId"])
+    assert status["status"] == "succeeded"
+    assert status["terminal"] is True
+    assert status["audit"]["planHash"] == plan.plan_hash
+    assert status["audit"]["outcome"] == "success"
+    assert store.uses and store.uses[0][0] == artifact.id
+    late_duplicate = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    assert late_duplicate["executionId"] == first["executionId"]
+    history = engine.job_history(artifact.id)
+    assert [row["executionId"] for row in history["executions"]] == [
+        first["executionId"]
+    ]
+
+
+class _BlockingBackend(_Backend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def exec(self, code, **kwargs):
+        self.calls.append({"code": code, **kwargs})
+        self.started.set()
+        await self.release.wait()
+        return '{"ok":true}'
+
+
+@pytest.mark.asyncio
+async def test_running_cancel_never_claims_ae_stopped_and_late_success_wins():
+    artifact = _artifact()
+    backend = _BlockingBackend()
+    engine = ToolExecutionEngine(_Store(artifact), backend)
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    await backend.started.wait()
+
+    cancellation = engine.cancel_job(started["executionId"])
+    assert cancellation["cancelDisposition"] == "not-cancellable-after-dispatch"
+    assert cancellation["terminal"] is False
+    assert cancellation["cancelRequested"] is True
+    backend.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    completed = engine.job_status(started["executionId"])
+    assert completed["status"] == "succeeded"
+    assert completed["cancelRequested"] is True
+
+
+@pytest.mark.asyncio
+async def test_queued_cancel_prevents_dispatch_and_consumes_the_grant():
+    artifact = _artifact()
+    backend = _Backend()
+    engine = ToolExecutionEngine(_Store(artifact), backend)
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    cancellation = engine.cancel_job(started["executionId"])
+    assert cancellation["cancelDisposition"] == "cancelled-before-dispatch"
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert engine.job_status(started["executionId"])["status"] == "cancelled"
+    assert backend.calls == []
+    with pytest.raises(ToolExecutionError) as caught:
+        engine.grants.peek(grant.grant_id, plan)
+    assert caught.value.code == "tool_grant_invalid"
+
+
+@pytest.mark.asyncio
+async def test_job_timeout_is_reported_as_outcome_unknown_not_stopped():
+    artifact = _artifact()
+    backend = _Backend(asyncio.TimeoutError())
+    engine = ToolExecutionEngine(_Store(artifact), backend)
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    status = engine.job_status(started["executionId"])
+    assert status["status"] == "outcome-unknown"
+    assert status["outcomeUnknown"] is True
+    assert status["error"]["code"] == "tool_backend_timeout"

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -10,6 +10,8 @@ import pytest
 from mcp.types import ToolAnnotations
 
 from ae_mcp import tool_execution as execution_module
+from ae_mcp.backends.native import NativeBackendError
+from ae_mcp.handlers import HANDLERS, load_all
 from ae_mcp.tool_artifact import (
     ToolArtifact,
     ToolSource,
@@ -838,10 +840,18 @@ async def test_execution_jobs_dedupe_report_history_audit_and_usage(tmp_path: Pa
     grant = engine.grants.issue_once(plan)
 
     first = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-dedupe-0001",
+        ctx=None,
+        initiator="panel-direct",
     )
     duplicate = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-dedupe-0001",
+        ctx=None,
+        initiator="panel-direct",
     )
     assert duplicate["executionId"] == first["executionId"]
     await asyncio.sleep(0)
@@ -853,8 +863,13 @@ async def test_execution_jobs_dedupe_report_history_audit_and_usage(tmp_path: Pa
     assert status["audit"]["planHash"] == plan.plan_hash
     assert status["audit"]["outcome"] == "success"
     assert store.uses and store.uses[0][0] == artifact.id
+    replacement_grant = engine.grants.issue_once(plan)
     late_duplicate = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        replacement_grant.grant_id,
+        operation_id="operation-dedupe-0001",
+        ctx=None,
+        initiator="panel-direct",
     )
     assert late_duplicate["executionId"] == first["executionId"]
     history = engine.job_history(artifact.id)
@@ -884,7 +899,11 @@ async def test_running_cancel_never_claims_ae_stopped_and_late_success_wins():
     plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
     grant = engine.grants.issue_once(plan)
     started = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-cancel-running",
+        ctx=None,
+        initiator="panel-direct",
     )
     await backend.started.wait()
 
@@ -908,7 +927,11 @@ async def test_queued_cancel_prevents_dispatch_and_consumes_the_grant():
     plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
     grant = engine.grants.issue_once(plan)
     started = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-cancel-queued",
+        ctx=None,
+        initiator="panel-direct",
     )
     cancellation = engine.cancel_job(started["executionId"])
     assert cancellation["cancelDisposition"] == "cancelled-before-dispatch"
@@ -929,7 +952,11 @@ async def test_job_timeout_is_reported_as_outcome_unknown_not_stopped():
     plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
     grant = engine.grants.issue_once(plan)
     started = await engine.start_job(
-        plan.plan_hash, grant.grant_id, ctx=None, initiator="panel-direct"
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-timeout-unknown",
+        ctx=None,
+        initiator="panel-direct",
     )
     await asyncio.sleep(0)
     await asyncio.sleep(0)
@@ -937,3 +964,68 @@ async def test_job_timeout_is_reported_as_outcome_unknown_not_stopped():
     assert status["status"] == "outcome-unknown"
     assert status["outcomeUnknown"] is True
     assert status["error"]["code"] == "tool_backend_timeout"
+
+
+@pytest.mark.asyncio
+async def test_native_uncertain_write_keeps_recovery_and_is_never_blindly_retried(
+    tmp_path: Path,
+    monkeypatch,
+):
+    load_all()
+    schema, _original = HANDLERS["ae.ping"]
+    calls = 0
+
+    async def uncertain_native(_args, _ctx):
+        nonlocal calls
+        calls += 1
+        raise NativeBackendError(
+            "POSSIBLY_SIDE_EFFECTING_FAILURE",
+            "The native write may have completed.",
+            retryable=False,
+            side_effect="may-have-occurred",
+            recovery={
+                "action": "inspect-state",
+                "hint": "Inspect AE state and audit evidence before retrying.",
+            },
+        )
+
+    monkeypatch.setitem(HANDLERS, "ae.ping", (schema, uncertain_native))
+    artifact = _artifact(
+        kind="recipe",
+        content={
+            "steps": [
+                {
+                    "refType": "tool",
+                    "ref": "ae.ping",
+                    "operation": "call",
+                    "args": {},
+                    "target": {},
+                }
+            ]
+        },
+    )
+    engine = ToolExecutionEngine(
+        _Store(artifact),
+        _Backend(),
+        audit_log=ToolAuditLog(tmp_path),
+    )
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-native-uncertain",
+        ctx=None,
+        initiator="panel-direct",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    status = engine.job_status(started["executionId"])
+    assert status["status"] == "outcome-unknown"
+    assert status["error"]["code"] == "POSSIBLY_SIDE_EFFECTING_FAILURE"
+    assert status["error"]["sideEffect"] == "may-have-occurred"
+    assert status["error"]["recovery"]["action"] == "inspect-state"
+    assert status["audit"]["outcome"] == "outcome-unknown"
+    assert status["audit"]["backend"] == "native-aegp"
+    assert calls == 1

--- a/packages/core/tests/test_tool_names.py
+++ b/packages/core/tests/test_tool_names.py
@@ -215,6 +215,26 @@ async def test_call_tool_unknown_returns_structured_error():
     assert "unknown tool" in payload["error"]
 
 
+def test_panel_developer_capability_is_secret_bound_and_consumed(monkeypatch):
+    from ae_mcp import server as srv
+
+    secret = "ab" * 32
+    monkeypatch.setenv("AE_MCP_PANEL_CAPABILITY", secret)
+    values, trusted = srv._panel_request(
+        "ae.toolIndex",
+        {"_ae_panel_capability": secret, "kinds": ["system-command"]},
+    )
+    assert trusted is True
+    assert values == {"kinds": ["system-command"]}
+
+    public_values, public_trusted = srv._panel_request(
+        "ae.toolIndex",
+        {"_ae_panel_capability": "cd" * 32},
+    )
+    assert public_trusted is False
+    assert public_values == {}
+
+
 async def test_call_tool_schema_error_sets_iserror_true():
     """The direct dispatch path still marks pydantic validation failures."""
     load_all()

--- a/packages/core/tests/test_tool_store.py
+++ b/packages/core/tests/test_tool_store.py
@@ -112,6 +112,31 @@ def test_index_search_and_content_hash_lookup_never_return_content(tmp_path: Pat
     assert "TOP SECRET BODY" not in (store.root / "index.json").read_text("utf-8")
 
 
+def test_record_use_updates_usage_without_changing_content_revision(tmp_path: Path) -> None:
+    store = ToolArtifactStore(root=tmp_path / "tools")
+    created = store.create(draft())
+    observed = []
+    unsubscribe = store.subscribe(observed.append)
+    used = store.record_use(
+        created.id,
+        expected_content_hash=created.content_hash,
+        used_at=1234,
+    )
+    unsubscribe()
+
+    assert used.last_used_at == 1234
+    assert used.revision == created.revision
+    assert used.content_hash == created.content_hash
+    assert store.list()[0].last_used_at == 1234
+    assert observed[-1].kind == "use"
+    with pytest.raises(ToolRevisionConflict):
+        store.record_use(
+            created.id,
+            expected_content_hash="f" * 64,
+            used_at=1235,
+        )
+
+
 def test_reads_fail_closed_for_secret_bearing_legacy_index_and_artifact(
     tmp_path: Path,
 ) -> None:

--- a/plugin/client/dist/app.css
+++ b/plugin/client/dist/app.css
@@ -328,8 +328,32 @@ body {
   border: 0;
   border-bottom: 1px solid var(--border-subtle);
   text-align: left;
-  cursor: pointer;
   transition: background var(--dur-fast) var(--ease-out);
+}
+.tools-artifact-row__select {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-15);
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+.tools-artifact-row__run {
+  align-self: flex-end;
+  padding: 3px 9px;
+  color: var(--text-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.tools-artifact-row__run:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 .tools-artifact-row:hover {
   background: var(--bg-hover);
@@ -432,6 +456,11 @@ body {
 .tools-runner {
   display: flex;
   flex-direction: column;
+  gap: var(--space-2);
+}
+.tools-runner__form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: var(--space-2);
 }
 .tools-runner__target {

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -12743,12 +12743,23 @@
     const call = async (name, args) => parseMcpPayload(
       await mcp.callTool(name, args)
     );
+    const panelCall = async (name, args) => {
+      if (typeof mcp.callPanelTool !== "function") {
+        throw new Error("Trusted panel Tool Library channel is unavailable");
+      }
+      return parseMcpPayload(await mcp.callPanelTool(name, args));
+    };
     return {
       index: (args = {}) => call("ae_toolIndex", args),
       search: (args = {}) => call("ae_toolSearch", args),
       inspect: (artifactId, options = {}) => call("ae_toolInspect", {
         artifact_id: artifactId,
         ...options
+      }),
+      developerIndex: (args = {}) => panelCall("ae_toolIndex", args),
+      developerSearch: (args = {}) => panelCall("ae_toolSearch", args),
+      developerInspect: (artifactId) => panelCall("ae_toolInspect", {
+        artifact_id: artifactId
       }),
       create: (input) => call("ae_toolCreate", input),
       edit: (input) => call("ae_toolEdit", input),
@@ -12770,14 +12781,21 @@
       exportPackage: (artifactIds, outPath) => call("ae_toolExport", {
         artifact_ids: artifactIds,
         out_path: outPath
-      })
+      }),
+      newOperationId: () => {
+        if (typeof mcp.newOperationId !== "function") {
+          throw new Error("Secure operation id generation is unavailable");
+        }
+        return mcp.newOperationId();
+      }
     };
   }
   async function startToolPlan(api, {
     artifactId,
     operation,
     args = {},
-    target = {}
+    target = {},
+    operationId = api.newOperationId()
   }) {
     const plan = await api.use({
       artifact_id: artifactId,
@@ -12791,11 +12809,22 @@
       plan_hash: plan.planHash,
       grant_scope: "once"
     });
-    return api.use({
+    const startRequest = {
       action: "start",
       plan_hash: plan.planHash,
-      grant_id: grant.grantId
-    });
+      grant_id: grant.grantId,
+      operation_id: operationId
+    };
+    try {
+      return await api.use(startRequest);
+    } catch (firstError) {
+      try {
+        return await api.use(startRequest);
+      } catch (secondError) {
+        secondError.startRetryCause = firstError;
+        throw secondError;
+      }
+    }
   }
   async function waitForToolExecution(api, execution, {
     pollIntervalMs = 250,
@@ -13115,6 +13144,7 @@
     const [developerMode, setDeveloperMode] = import_react40.default.useState(false);
     const loadSequence = import_react40.default.useRef(0);
     const inspectSequence = import_react40.default.useRef(0);
+    const rowRunLock = import_react40.default.useRef(false);
     const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
     const artifact = state.inspected && state.inspected.artifact || null;
     const load = import_react40.default.useCallback(async () => {
@@ -13126,11 +13156,10 @@
         const needsSearch = Boolean(
           state.query || state.category || state.risk || state.kinds && state.kinds.length
         );
-        const payload = needsSearch ? await api.search({ ...searchArgsFromState(state), developer_mode: developerMode }) : await api.index({
+        const payload = needsSearch ? await (developerMode ? api.developerSearch : api.search)(searchArgsFromState(state)) : await (developerMode ? api.developerIndex : api.index)({
           statuses: state.statuses,
           source_types: state.sourceType ? [state.sourceType] : void 0,
           include_candidates: state.statuses.includes("candidate"),
-          developer_mode: developerMode,
           limit: 100
         });
         if (sequence === loadSequence.current) dispatch({ type: "load-success", payload });
@@ -13153,7 +13182,7 @@
       dispatch({ type: "select", id });
       setRunResult(null);
       try {
-        const payload = await api.inspect(id, { developer_mode: developerMode });
+        const payload = await (developerMode ? api.developerInspect(id) : api.inspect(id));
         if (sequence === inspectSequence.current) {
           dispatch({ type: "inspect-success", payload });
           const defaults = initialToolArgs(payload.artifact && payload.artifact.argsSchema);
@@ -13333,16 +13362,21 @@
       await executeArtifact(artifact, args, normalizedTarget);
     };
     const inspectForRun = async (row) => {
-      if (busy || !row) return;
-      const payload = await inspect(row.id);
-      const inspectedArtifact = payload && payload.artifact;
-      const capability = toolExecutionCapabilities(inspectedArtifact);
-      if (!capability.directRun || capability.requiresTarget) return;
-      const defaults = initialToolArgs(inspectedArtifact.argsSchema);
+      if (busy || rowRunLock.current || !row) return;
+      rowRunLock.current = true;
       try {
-        const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
-        await executeArtifact(inspectedArtifact, args);
-      } catch {
+        const payload = await inspect(row.id);
+        const inspectedArtifact = payload && payload.artifact;
+        const capability = toolExecutionCapabilities(inspectedArtifact);
+        if (!capability.directRun || capability.requiresTarget) return;
+        const defaults = initialToolArgs(inspectedArtifact.argsSchema);
+        try {
+          const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
+          await executeArtifact(inspectedArtifact, args);
+        } catch {
+        }
+      } finally {
+        rowRunLock.current = false;
       }
     };
     const cancelExecution = async () => {
@@ -13387,10 +13421,9 @@
         await api.commitImport(state.importPreview.importId, state.conflictResolutions);
         dispatch({ type: "import-finished" });
         dispatch({ type: "set-filter", key: "statuses", value: ["candidate", "saved", "pinned"] });
-        const payload = await api.index({
+        const payload = await (developerMode ? api.developerIndex : api.index)({
           statuses: ["candidate", "saved", "pinned"],
           include_candidates: true,
-          developer_mode: developerMode,
           limit: 100
         });
         dispatch({ type: "load-success", payload });
@@ -17334,6 +17367,20 @@
   var INITIALIZE_TIMEOUT_MS = 12e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
   var PANEL_VERSION = "0.9.2";
+  function defaultRandomBytes(size) {
+    const cryptoImpl = globalThis.crypto;
+    if (!cryptoImpl || typeof cryptoImpl.getRandomValues !== "function") {
+      throw new Error("Secure random generation is unavailable");
+    }
+    const value = new Uint8Array(size);
+    cryptoImpl.getRandomValues(value);
+    return value;
+  }
+  function secureHex(randomBytes, size) {
+    const value = randomBytes(size);
+    if (!value || value.length !== size) throw new Error("Secure random generation failed");
+    return Array.from(value, (byte) => Number(byte).toString(16).padStart(2, "0")).join("");
+  }
   function findProjectRoot({ extRoot, repoRoot, fsImpl, platform }) {
     const adapter = platform || createPlatformAdapter();
     if (repoRoot && fsImpl.existsSync(adapter.paths.join([repoRoot, "pyproject.toml"]))) return adapter.paths.resolve([repoRoot]);
@@ -17501,7 +17548,8 @@
     getExpertGuidance = () => true,
     packageVersion = PANEL_VERSION,
     retryDelays = [1e3, 2e3, 4e3],
-    initializeTimeoutMs = INITIALIZE_TIMEOUT_MS
+    initializeTimeoutMs = INITIALIZE_TIMEOUT_MS,
+    randomBytes = defaultRandomBytes
   } = {}) {
     let proc = null;
     let rpc = null;
@@ -17514,6 +17562,7 @@
     let lastError = null;
     let stopped = false;
     let restartTimer = null;
+    const panelCapability = secureHex(randomBytes, 32);
     function currentState() {
       return { status, retryCount, error: lastError, tools };
     }
@@ -17561,6 +17610,7 @@
         const commandSpec = await resolveCommand({ extRoot, repoRoot, platform: adapter || void 0 });
         const additions = {
           AE_MCP_BACKEND: "ae-mcp",
+          AE_MCP_PANEL_CAPABILITY: panelCapability,
           ...expertGuidanceEnv(getExpertGuidance())
         };
         const spawnEnv = adapter ? adapter.completeSpawnEnv(env || {}, additions) : Object.assign({}, env || {}, additions);
@@ -17660,6 +17710,12 @@
       await start();
       return rpc.request("tools/call", { name, arguments: args });
     }
+    async function callPanelTool(name, args = {}) {
+      return callTool(name, { ...args, _ae_panel_capability: panelCapability });
+    }
+    function newOperationId() {
+      return secureHex(randomBytes, 16);
+    }
     function stop() {
       stopped = true;
       clearTimeout(restartTimer);
@@ -17677,7 +17733,16 @@
       serverInfo = null;
       startPromise = null;
     }
-    return { start, listTools, callTool, stop, state: currentState, getServerInstructions: () => serverInstructions };
+    return {
+      start,
+      listTools,
+      callTool,
+      callPanelTool,
+      newOperationId,
+      stop,
+      state: currentState,
+      getServerInstructions: () => serverInstructions
+    };
   }
 
   // src/cep/approvalTierFile.js
@@ -27737,7 +27802,7 @@ data: ${JSON.stringify(payload)}
       revision: valueRef.revision
     };
   }
-  function defaultRandomBytes(size) {
+  function defaultRandomBytes2(size) {
     if (globalThis.crypto && typeof globalThis.crypto.getRandomValues === "function") {
       const bytes = new Uint8Array(size);
       globalThis.crypto.getRandomValues(bytes);
@@ -27771,7 +27836,7 @@ data: ${JSON.stringify(payload)}
   function createProviderSecretService({
     getHost,
     createReference = createProviderSecretReference,
-    randomBytes = defaultRandomBytes
+    randomBytes = defaultRandomBytes2
   } = {}) {
     if (typeof getHost !== "function") throw new TypeError("getHost must be a function");
     if (typeof createReference !== "function") throw new TypeError("createReference must be a function");
@@ -34541,7 +34606,8 @@ ${baseUrl}`),
       resolveCommand: getMcpSpec,
       env: approvalTierFile.env(),
       onElicitation: elicitationCoordinator.handle,
-      getExpertGuidance: () => loadExpertGuidance(window.localStorage)
+      getExpertGuidance: () => loadExpertGuidance(window.localStorage),
+      randomBytes: (size) => cepRequire4("crypto").randomBytes(size)
     }), [approvalTierFile, elicitationCoordinator, extRoot, getMcpSpec, platform]);
     const toolsApi = import_react45.default.useMemo(() => createToolsApi(mcp), [mcp]);
     import_react45.default.useEffect(() => () => mcp.stop(), [mcp]);

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // ../../../../plugin/panel/node_modules/react/cjs/react.production.min.js
+  // node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "../../../../plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
+    "node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react/index.js
+  // node_modules/react/index.js
   var require_react = __commonJS({
-    "../../../../plugin/panel/node_modules/react/index.js"(exports, module) {
+    "node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
+  // node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "../../../../plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/scheduler/index.js
+  // node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "../../../../plugin/panel/node_modules/scheduler/index.js"(exports, module) {
+    "node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
+  // node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "../../../../plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react-dom/index.js
+  // node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "../../../../plugin/panel/node_modules/react-dom/index.js"(exports, module) {
+    "node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react-dom/client.js
+  // node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "../../../../plugin/panel/node_modules/react-dom/client.js"(exports) {
+    "node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "../../../../plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // ../../../../plugin/panel/node_modules/react/jsx-runtime.js
+  // node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "../../../../plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
+    "node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7318,19 +7318,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -7343,7 +7343,7 @@
     strokeLinejoin: "round"
   };
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -7375,7 +7375,7 @@
     }
   );
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -7389,13 +7389,13 @@
     return Component;
   };
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
+  // node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -7407,7 +7407,7 @@
     ]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
+  // node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -7420,7 +7420,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
+  // node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -7445,58 +7445,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
+  // node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
+  // node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
+  // node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
+  // node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
+  // node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -7516,7 +7516,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
+  // node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -7528,7 +7528,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
+  // node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -7537,7 +7537,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
+  // node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -7549,28 +7549,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
+  // node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
+  // node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
+  // node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -7579,7 +7579,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
+  // node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -7589,23 +7589,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
+  // node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
+  // node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
+  // node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
+  // node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -7613,25 +7613,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
+  // node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
+  // node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
+  // node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -7643,7 +7643,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
+  // node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -7655,7 +7655,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -7668,7 +7668,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
+  // node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -7679,7 +7679,7 @@
     ]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -7694,12 +7694,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
+  // node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -7708,7 +7708,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -7717,7 +7717,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -7730,13 +7730,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
+  // node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -7747,13 +7747,13 @@
     ]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
+  // node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
+  // node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",
@@ -17331,6 +17331,7 @@
 
   // src/cep/mcpClient.js
   var DEFAULT_TIMEOUT_MS2 = 3e4;
+  var INITIALIZE_TIMEOUT_MS = 12e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
   var PANEL_VERSION = "0.9.2";
   function findProjectRoot({ extRoot, repoRoot, fsImpl, platform }) {
@@ -17465,12 +17466,13 @@
     }
     const handleChunk = createNdjsonReader(handleMessage);
     if (onLine) onLine(handleChunk);
-    function request(method, params) {
+    function request(method, params, timeoutOverrideMs) {
       const id = nextId2++;
       const message = { jsonrpc: "2.0", id, method };
       if (params !== void 0) message.params = params;
+      const limit = Number.isFinite(timeoutOverrideMs) && timeoutOverrideMs > 0 ? timeoutOverrideMs : timeoutMs;
       const promise = new Promise((resolve, reject) => {
-        const timer = setTimeout(() => rejectPending(id, new Error(method + " timed out after " + timeoutMs + "ms")), timeoutMs);
+        const timer = setTimeout(() => rejectPending(id, new Error(method + " timed out after " + limit + "ms")), limit);
         pending.set(id, { resolve, reject, timer });
       });
       writeMessage(message);
@@ -17498,7 +17500,8 @@
     repoRoot,
     getExpertGuidance = () => true,
     packageVersion = PANEL_VERSION,
-    retryDelays = [1e3, 2e3, 4e3]
+    retryDelays = [1e3, 2e3, 4e3],
+    initializeTimeoutMs = INITIALIZE_TIMEOUT_MS
   } = {}) {
     let proc = null;
     let rpc = null;
@@ -17572,20 +17575,25 @@
         } else {
           proc = spawnImpl(commandSpec.command, commandSpec.args || [], { ...options, shell: false });
         }
+        const spawnedProc = proc;
         rpc = _createRpc(
-          (line) => proc.stdin.write(line),
-          (handler) => proc.stdout.on("data", handler),
+          (line) => spawnedProc.stdin.write(line),
+          (handler) => spawnedProc.stdout.on("data", handler),
           { onRequest: handleServerRequest }
         );
-        proc.on("exit", (code, signal) => handleExit(code, signal));
-        proc.on("error", (err) => handleCrash(err));
+        proc.on("exit", (code, signal) => {
+          if (proc === spawnedProc) handleExit(code, signal);
+        });
+        proc.on("error", (err) => {
+          if (proc === spawnedProc) handleCrash(err);
+        });
         if (proc.stderr && proc.stderr.on) proc.stderr.on("data", () => {
         });
         const initResult = await rpc.request("initialize", {
           protocolVersion: MCP_PROTOCOL_VERSION,
           clientInfo: { name: "panel-chat", version: packageVersion },
           capabilities: { elicitation: {} }
-        });
+        }, initializeTimeoutMs);
         serverInstructions = initResult && initResult.instructions || "";
         serverInfo = initResult && initResult.serverInfo && typeof initResult.serverInfo === "object" ? { ...initResult.serverInfo } : null;
         rpc.notify("notifications/initialized");
@@ -17600,6 +17608,17 @@
       try {
         return await startPromise;
       } catch (e) {
+        const failedRpc = rpc;
+        const failedProc = proc;
+        rpc = null;
+        proc = null;
+        if (failedRpc) failedRpc.close(e instanceof Error ? e : new Error("MCP initialization failed"));
+        if (failedProc && failedProc.kill) {
+          try {
+            failedProc.kill();
+          } catch (killError) {
+          }
+        }
         status = "error";
         lastError = e;
         throw e;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // node_modules/react/cjs/react.production.min.js
+  // ../../../../plugin/panel/node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "node_modules/react/cjs/react.production.min.js"(exports) {
+    "../../../../plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // node_modules/react/index.js
+  // ../../../../plugin/panel/node_modules/react/index.js
   var require_react = __commonJS({
-    "node_modules/react/index.js"(exports, module) {
+    "../../../../plugin/panel/node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // node_modules/scheduler/cjs/scheduler.production.min.js
+  // ../../../../plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "../../../../plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // node_modules/scheduler/index.js
+  // ../../../../plugin/panel/node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "node_modules/scheduler/index.js"(exports, module) {
+    "../../../../plugin/panel/node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // node_modules/react-dom/cjs/react-dom.production.min.js
+  // ../../../../plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "../../../../plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // node_modules/react-dom/index.js
+  // ../../../../plugin/panel/node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "node_modules/react-dom/index.js"(exports, module) {
+    "../../../../plugin/panel/node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // node_modules/react-dom/client.js
+  // ../../../../plugin/panel/node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "node_modules/react-dom/client.js"(exports) {
+    "../../../../plugin/panel/node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // ../../../../plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "../../../../plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // node_modules/react/jsx-runtime.js
+  // ../../../../plugin/panel/node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "node_modules/react/jsx-runtime.js"(exports, module) {
+    "../../../../plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7318,19 +7318,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -7343,7 +7343,7 @@
     strokeLinejoin: "round"
   };
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -7375,7 +7375,7 @@
     }
   );
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -7389,13 +7389,13 @@
     return Component;
   };
 
-  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/book-open.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -7407,7 +7407,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/box.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -7420,7 +7420,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/brain.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -7445,58 +7445,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/check.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/copy.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/download.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/external-link.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -7516,7 +7516,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -7528,7 +7528,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/file-text.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -7537,7 +7537,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/github.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -7549,28 +7549,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/globe.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/history.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/info.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -7579,7 +7579,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -7589,23 +7589,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/message-square.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/pause.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/play.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plug.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -7613,25 +7613,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plus.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/search.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/send.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -7643,7 +7643,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/settings.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -7655,7 +7655,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -7668,7 +7668,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -7679,7 +7679,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -7694,12 +7694,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/square.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -7708,7 +7708,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -7717,7 +7717,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -7730,13 +7730,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/wrench.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -7747,13 +7747,13 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/x.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/zap.js
+  // ../../../../plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",
@@ -12187,7 +12187,8 @@
       revision: value.revision,
       updatedAt: value.updatedAt,
       lastUsedAt: (_a = value.lastUsedAt) != null ? _a : null,
-      sourceType: value.sourceType || value.source && value.source.type || ""
+      sourceType: value.sourceType || value.source && value.source.type || "",
+      executionCapabilities: value.executionCapabilities || null
     };
   }
   function messageOf(error) {
@@ -12204,11 +12205,14 @@
       case "load-success": {
         const payload = event.payload || event;
         const summaries = (payload.artifacts || payload.summaries || []).map(toSummary);
+        const selectedVisible = summaries.some((row) => row.id === state.selectedId);
         return {
           ...state,
           phase: "ready",
           summaries: sortSummaries(summaries),
           total: Number.isFinite(payload.total) ? payload.total : summaries.length,
+          selectedId: selectedVisible ? state.selectedId : null,
+          inspected: selectedVisible ? state.inspected : null,
           error: "",
           refreshRequired: false
         };
@@ -12320,19 +12324,22 @@
   }
   function canEditArtifact(artifact) {
     return Boolean(
-      artifact && sourceType(artifact) !== "bundled" && !["archived", "deprecated"].includes(artifact.status)
+      artifact && artifact.kind !== "system-command" && sourceType(artifact) !== "bundled" && !["archived", "deprecated"].includes(artifact.status)
     );
   }
-  function canExecuteArtifact(artifact) {
-    return Boolean(artifact && ["saved", "pinned"].includes(artifact.status));
-  }
   function toolExecutionCapabilities(artifact) {
-    const enabled = canExecuteArtifact(artifact);
-    const kind = artifact && artifact.kind;
+    const contract = artifact && artifact.executionCapabilities;
+    const operations = Array.isArray(contract && contract.operations) ? contract.operations : [];
+    const direct = contract && contract.directRun && typeof contract.directRun === "object" ? contract.directRun : {};
     return {
-      render: enabled && ["expression", "prompt-skill"].includes(kind),
-      execute: enabled && ["jsx", "diagnostic", "recipe"].includes(kind),
-      apply: enabled && kind === "expression"
+      render: operations.includes("render"),
+      execute: operations.includes("execute"),
+      apply: operations.includes("apply"),
+      directRun: Boolean(direct.available),
+      operation: direct.operation || null,
+      requiresTarget: Boolean(direct.requiresTarget),
+      disabledReason: direct.disabledReason || null,
+      runtime: contract && contract.runtime || null
     };
   }
   function canPromoteArtifact(artifact) {
@@ -12569,8 +12576,8 @@
   var import_react39 = __toESM(require_react(), 1);
   var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
   var L2 = {
-    zh: { never: "\u672A\u4F7F\u7528", verified: "\u5DF2\u9A8C\u8BC1" },
-    en: { never: "Never used", verified: "Verified" }
+    zh: { never: "\u672A\u4F7F\u7528", verified: "\u5DF2\u9A8C\u8BC1", run: "\u8FD0\u884C" },
+    en: { never: "Never used", verified: "Verified", run: "Run" }
   };
   function riskStatus(risk) {
     if (risk === "external" || risk === "destructive") return "error";
@@ -12585,30 +12592,58 @@
       return t.never;
     }
   }
-  function ToolArtifactRow({ artifact, selected = false, onSelect, lang = "zh" }) {
+  function ToolArtifactRow({
+    artifact,
+    selected = false,
+    onSelect,
+    onRun,
+    runDisabled = false,
+    lang = "zh"
+  }) {
     const t = L2[lang] || L2.zh;
+    const directRun = Boolean(
+      artifact && artifact.executionCapabilities && artifact.executionCapabilities.directRun && artifact.executionCapabilities.directRun.available
+    );
     return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
-      "button",
+      "div",
       {
-        type: "button",
         className: `tools-artifact-row ds-focusable${selected ? " is-selected" : ""}`,
-        "aria-current": selected || void 0,
-        onClick: () => onSelect && onSelect(artifact.id),
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__top", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { className: "tools-artifact-row__name", children: artifact.name }),
-            artifact.verified ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: "ok", icon: "check", children: t.verified }) : null
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__badges", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.kind }),
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.category }),
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: riskStatus(artifact.declaredRisk), children: artifact.declaredRisk }),
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: artifact.status === "candidate" ? "warn" : artifact.status === "pinned" ? "accent" : "neutral", children: artifact.status })
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__meta", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: artifact.sourceType }),
-            /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: lastUsed(artifact.lastUsedAt, t) })
-          ] })
+          /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
+            "button",
+            {
+              type: "button",
+              className: "tools-artifact-row__select",
+              "aria-current": selected || void 0,
+              onClick: () => onSelect && onSelect(artifact.id),
+              children: [
+                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__top", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { className: "tools-artifact-row__name", children: artifact.name }),
+                  artifact.verified ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: "ok", icon: "check", children: t.verified }) : null
+                ] }),
+                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__badges", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.kind }),
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.category }),
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: riskStatus(artifact.declaredRisk), children: artifact.declaredRisk }),
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: artifact.status === "candidate" ? "warn" : artifact.status === "pinned" ? "accent" : "neutral", children: artifact.status })
+                ] }),
+                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__meta", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: artifact.sourceType }),
+                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: lastUsed(artifact.lastUsedAt, t) })
+                ] })
+              ]
+            }
+          ),
+          directRun ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
+            "button",
+            {
+              type: "button",
+              className: "tools-artifact-row__run",
+              onClick: () => onRun && onRun(artifact),
+              disabled: runDisabled,
+              children: t.run
+            }
+          ) : null
         ]
       }
     );
@@ -12616,6 +12651,7 @@
 
   // src/cep/toolFileDialogs.js
   var TOOL_PACKAGE_SUFFIX = ".aemcptools";
+  var SYSTEM_COMMAND_SUFFIXES = [".ps1", ".psm1", ".bat", ".cmd", ".sh", ".command"];
   function selectedValue(result) {
     if (!result || Number(result.err || 0) !== 0) return null;
     const data = result.data;
@@ -12643,13 +12679,14 @@
       false,
       title,
       initialPath,
-      ["aemcptools"]
+      ["aemcptools", "ps1", "psm1", "bat", "cmd", "sh", "command"]
     );
     const selected = selectedValue(result);
     if (!selected) return null;
     const path = normalizePath2(normalizeFileUrl(selected));
-    if (!path.toLowerCase().endsWith(TOOL_PACKAGE_SUFFIX)) {
-      throw new Error("Select a .aemcptools package");
+    const lower = path.toLowerCase();
+    if (!lower.endsWith(TOOL_PACKAGE_SUFFIX) && !SYSTEM_COMMAND_SUFFIXES.some((suffix) => lower.endsWith(suffix))) {
+      throw new Error("Select a .aemcptools package or a quarantined system-command file");
     }
     return path;
   }
@@ -12709,7 +12746,10 @@
     return {
       index: (args = {}) => call("ae_toolIndex", args),
       search: (args = {}) => call("ae_toolSearch", args),
-      inspect: (artifactId) => call("ae_toolInspect", { artifact_id: artifactId }),
+      inspect: (artifactId, options = {}) => call("ae_toolInspect", {
+        artifact_id: artifactId,
+        ...options
+      }),
       create: (input) => call("ae_toolCreate", input),
       edit: (input) => call("ae_toolEdit", input),
       delete: (input) => call("ae_toolDelete", input),
@@ -12733,7 +12773,7 @@
       })
     };
   }
-  async function executeToolPlan(api, {
+  async function startToolPlan(api, {
     artifactId,
     operation,
     args = {},
@@ -12752,10 +12792,97 @@
       grant_scope: "once"
     });
     return api.use({
-      action: "execute",
+      action: "start",
       plan_hash: plan.planHash,
       grant_id: grant.grantId
     });
+  }
+  async function waitForToolExecution(api, execution, {
+    pollIntervalMs = 250,
+    onProgress = () => {
+    },
+    wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+  } = {}) {
+    let current = execution;
+    onProgress(current);
+    while (!current.terminal) {
+      await wait(pollIntervalMs);
+      current = await api.use({ action: "status", execution_id: current.executionId });
+      onProgress(current);
+    }
+    return current;
+  }
+
+  // src/lib/toolRunForm.js
+  function schemaParts(schema) {
+    const value = schema && typeof schema === "object" && !Array.isArray(schema) ? schema : {};
+    const canonical = value.type === "object" || value.properties || value.required;
+    return {
+      properties: canonical ? value.properties || {} : value,
+      required: new Set(canonical && Array.isArray(value.required) ? value.required : [])
+    };
+  }
+  function initialToolArgs(schema) {
+    const { properties } = schemaParts(schema);
+    return Object.entries(properties).reduce((result, [name, rule]) => {
+      if (rule && Object.hasOwn(rule, "default")) result[name] = rule.default;
+      else if (rule && rule.type === "boolean") result[name] = false;
+      else result[name] = "";
+      return result;
+    }, {});
+  }
+  function toolArgFields(schema) {
+    const { properties, required } = schemaParts(schema);
+    return Object.entries(properties).map(([name, rawRule]) => {
+      const rule = rawRule && typeof rawRule === "object" ? rawRule : {};
+      return {
+        name,
+        type: rule.type || "string",
+        required: required.has(name),
+        enum: Array.isArray(rule.enum) ? rule.enum : null,
+        minimum: rule.minimum,
+        maximum: rule.maximum,
+        supported: ["string", "number", "integer", "boolean"].includes(rule.type || "string") || Array.isArray(rule.enum)
+      };
+    });
+  }
+  function buildToolArgs(schema, values) {
+    const fields = toolArgFields(schema);
+    const result = {};
+    for (const field of fields) {
+      const value = values && values[field.name];
+      if ((value === "" || value === void 0) && !field.required) continue;
+      if ((value === "" || value === void 0) && field.required) {
+        throw new TypeError(`Missing required argument: ${field.name}`);
+      }
+      if (field.type === "integer") {
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed)) throw new TypeError(`Invalid integer: ${field.name}`);
+        result[field.name] = parsed;
+      } else if (field.type === "number") {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) throw new TypeError(`Invalid number: ${field.name}`);
+        result[field.name] = parsed;
+      } else if (field.type === "boolean") {
+        result[field.name] = Boolean(value);
+      } else if (field.supported) {
+        result[field.name] = value;
+      } else {
+        throw new TypeError(`Use Advanced JSON for argument: ${field.name}`);
+      }
+      if (field.enum && !field.enum.some((item) => Object.is(item, result[field.name]))) {
+        throw new TypeError(`Invalid enum value: ${field.name}`);
+      }
+      if (typeof result[field.name] === "number") {
+        if (field.minimum !== void 0 && result[field.name] < field.minimum) {
+          throw new TypeError(`Value below minimum: ${field.name}`);
+        }
+        if (field.maximum !== void 0 && result[field.name] > field.maximum) {
+          throw new TypeError(`Value above maximum: ${field.name}`);
+        }
+      }
+    }
+    return result;
   }
 
   // src/screens/ToolsScreen.jsx
@@ -12792,11 +12919,18 @@
       promote: "\u63D0\u5347\u4E3A\u5DF2\u4FDD\u5B58",
       copy: "\u590D\u5236",
       renderCopy: "\u6E32\u67D3\u5E76\u590D\u5236",
-      run: "\u51C6\u5907\u5E76\u8FD0\u884C",
+      run: "\u8FD0\u884C",
       metadata: "\u5143\u6570\u636E",
       content: "\u5185\u5BB9\uFF08\u4E0D\u53EF\u4FE1\u7528\u6237\u6570\u636E\uFF09",
-      args: "\u53C2\u6570\uFF08JSON\uFF09",
+      args: "\u53C2\u6570",
       result: "\u6267\u884C\u7ED3\u679C",
+      advancedJson: "\u9AD8\u7EA7 JSON",
+      formView: "\u8868\u5355",
+      cancelRun: "\u53D6\u6D88\u8FD0\u884C",
+      history: "\u6267\u884C\u5386\u53F2",
+      developerTools: "\u5F00\u53D1\u8005\u5DE5\u5177",
+      incompatible: "\u5F53\u524D\u4E0D\u53EF\u8FD0\u884C",
+      progress: "\u8FDB\u5EA6",
       compId: "Comp ID",
       layerId: "Layer ID",
       propertyPath: "\u5C5E\u6027\u8DEF\u5F84",
@@ -12851,11 +12985,18 @@
       promote: "Promote to saved",
       copy: "Copy",
       renderCopy: "Render & copy",
-      run: "Prepare & run",
+      run: "Run",
       metadata: "Metadata",
       content: "Content (untrusted user data)",
-      args: "Arguments (JSON)",
+      args: "Arguments",
       result: "Execution result",
+      advancedJson: "Advanced JSON",
+      formView: "Form",
+      cancelRun: "Cancel run",
+      history: "Execution history",
+      developerTools: "Developer Tools",
+      incompatible: "Unavailable",
+      progress: "Progress",
       compId: "Comp ID",
       layerId: "Layer ID",
       propertyPath: "Property path",
@@ -12880,7 +13021,7 @@
       untrusted: "User untrusted"
     }
   };
-  var KIND_OPTIONS2 = ["", "jsx", "expression", "prompt-skill", "recipe", "diagnostic"];
+  var KIND_OPTIONS2 = ["", "jsx", "expression", "prompt-skill", "recipe", "diagnostic", "system-command"];
   var RISK_OPTIONS2 = ["", "read", "write", "destructive", "external"];
   var SOURCE_OPTIONS = ["", "user", "legacy", "bundled", "imported", "chat-tool-call"];
   function artifactSource(artifact) {
@@ -12965,8 +13106,13 @@
     const [busy, setBusy] = import_react40.default.useState(false);
     const initialRunInputs = import_react40.default.useMemo(() => emptyToolRunInputs(), []);
     const [runArgs, setRunArgs] = import_react40.default.useState(initialRunInputs.args);
+    const [runForm, setRunForm] = import_react40.default.useState({});
+    const [advancedJson, setAdvancedJson] = import_react40.default.useState(false);
     const [target, setTarget] = import_react40.default.useState(initialRunInputs.target);
     const [runResult, setRunResult] = import_react40.default.useState(null);
+    const [runJob, setRunJob] = import_react40.default.useState(null);
+    const [runHistory, setRunHistory] = import_react40.default.useState([]);
+    const [developerMode, setDeveloperMode] = import_react40.default.useState(false);
     const loadSequence = import_react40.default.useRef(0);
     const inspectSequence = import_react40.default.useRef(0);
     const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
@@ -12980,17 +13126,18 @@
         const needsSearch = Boolean(
           state.query || state.category || state.risk || state.kinds && state.kinds.length
         );
-        const payload = needsSearch ? await api.search(searchArgsFromState(state)) : await api.index({
+        const payload = needsSearch ? await api.search({ ...searchArgsFromState(state), developer_mode: developerMode }) : await api.index({
           statuses: state.statuses,
           source_types: state.sourceType ? [state.sourceType] : void 0,
           include_candidates: state.statuses.includes("candidate"),
+          developer_mode: developerMode,
           limit: 100
         });
         if (sequence === loadSequence.current) dispatch({ type: "load-success", payload });
       } catch (error) {
         if (sequence === loadSequence.current) dispatch({ type: "load-error", error });
       }
-    }, [api, state.query, state.kinds, state.category, state.risk, state.statuses, state.sourceType]);
+    }, [api, state.query, state.kinds, state.category, state.risk, state.statuses, state.sourceType, developerMode]);
     import_react40.default.useEffect(() => {
       const timer = setTimeout(load, 120);
       return () => clearTimeout(timer);
@@ -13000,12 +13147,30 @@
       inspectSequence.current = sequence;
       const freshInputs = emptyToolRunInputs();
       setRunArgs(freshInputs.args);
+      setRunForm({});
+      setAdvancedJson(false);
       setTarget(freshInputs.target);
       dispatch({ type: "select", id });
       setRunResult(null);
       try {
-        const payload = await api.inspect(id);
-        if (sequence === inspectSequence.current) dispatch({ type: "inspect-success", payload });
+        const payload = await api.inspect(id, { developer_mode: developerMode });
+        if (sequence === inspectSequence.current) {
+          dispatch({ type: "inspect-success", payload });
+          const defaults = initialToolArgs(payload.artifact && payload.artifact.argsSchema);
+          setRunForm(defaults);
+          let initialJson = {};
+          try {
+            initialJson = buildToolArgs(payload.artifact && payload.artifact.argsSchema, defaults);
+          } catch {
+            initialJson = Object.fromEntries(
+              Object.entries(defaults).filter(([, value]) => value !== "")
+            );
+          }
+          setRunArgs(JSON.stringify(initialJson, null, 2));
+          const history = await api.use({ action: "history", artifact_id: id, limit: 20 });
+          setRunHistory(history.executions || []);
+        }
+        return payload;
       } catch (error) {
         if (sequence === inspectSequence.current) dispatch({ type: "load-error", error });
       }
@@ -13120,18 +13285,44 @@
         setBusy(false);
       }
     };
+    const executeArtifact = async (artifactToRun, args, normalizedTarget = {}) => {
+      const capability = toolExecutionCapabilities(artifactToRun);
+      const operation = capability.operation;
+      if (!capability.directRun || !operation) return;
+      setBusy(true);
+      setRunResult(null);
+      setRunJob(null);
+      try {
+        const started = await startToolPlan(api, {
+          artifactId: artifactToRun.id,
+          operation,
+          args,
+          target: normalizedTarget
+        });
+        const completed = await waitForToolExecution(api, started, {
+          onProgress: setRunJob
+        });
+        await refreshAndInspect(artifactToRun.id);
+        setRunJob(completed);
+        setRunResult(completed);
+      } catch (error) {
+        dispatch({ type: "load-error", error });
+      } finally {
+        setBusy(false);
+      }
+    };
     const execute = async () => {
       if (!artifact) return;
       let args;
       try {
-        args = asObject(runArgs);
-      } catch {
+        args = advancedJson ? asObject(runArgs) : buildToolArgs(artifact.argsSchema, runForm);
+      } catch (error) {
         dispatch({ type: "load-error", error: new Error(t.invalidArgs) });
         return;
       }
-      const operation = artifact.kind === "expression" ? "apply" : "execute";
+      const capability = toolExecutionCapabilities(artifact);
       let normalizedTarget = {};
-      if (operation === "apply") {
+      if (capability.operation === "apply") {
         try {
           normalizedTarget = normalizeExpressionTarget(target);
         } catch {
@@ -13139,20 +13330,28 @@
           return;
         }
       }
-      setBusy(true);
+      await executeArtifact(artifact, args, normalizedTarget);
+    };
+    const inspectForRun = async (row) => {
+      if (busy || !row) return;
+      const payload = await inspect(row.id);
+      const inspectedArtifact = payload && payload.artifact;
+      const capability = toolExecutionCapabilities(inspectedArtifact);
+      if (!capability.directRun || capability.requiresTarget) return;
+      const defaults = initialToolArgs(inspectedArtifact.argsSchema);
       try {
-        const result = await executeToolPlan(api, {
-          artifactId: artifact.id,
-          operation,
-          args,
-          target: normalizedTarget
-        });
-        setRunResult(result);
-        await refreshAndInspect(artifact.id);
+        const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
+        await executeArtifact(inspectedArtifact, args);
+      } catch {
+      }
+    };
+    const cancelExecution = async () => {
+      if (!runJob || runJob.terminal) return;
+      try {
+        const next = await api.use({ action: "cancel", execution_id: runJob.executionId });
+        setRunJob(next);
       } catch (error) {
         dispatch({ type: "load-error", error });
-      } finally {
-        setBusy(false);
       }
     };
     const previewImport = async () => {
@@ -13191,6 +13390,7 @@
         const payload = await api.index({
           statuses: ["candidate", "saved", "pinned"],
           include_candidates: true,
+          developer_mode: developerMode,
           limit: 100
         });
         dispatch({ type: "load-success", payload });
@@ -13222,19 +13422,21 @@
     const source = artifactSource(artifact);
     const editable = canEditArtifact(artifact);
     const execution = toolExecutionCapabilities(artifact);
-    const executable = execution.render || execution.execute || execution.apply;
+    const executable = execution.render || execution.directRun;
+    const argFields = toolArgFields(artifact && artifact.argsSchema);
     return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-screen", children: [
       /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("header", { className: "tools-header", children: [
         /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-header__title", children: t.library }),
         /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-header__actions", children: [
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "primary", icon: "plus", onClick: () => dispatch({ type: "edit-start", editor: { mode: "create", artifact: null } }), children: t.new }),
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "download", onClick: previewImport, disabled: busy, children: t.import }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "external-link", onClick: exportPackage, disabled: busy || !state.summaries.length, children: t.export })
+          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "external-link", onClick: exportPackage, disabled: busy || !state.summaries.length, children: t.export }),
+          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: developerMode ? "danger" : "ghost", onClick: () => setDeveloperMode((value) => !value), disabled: busy, children: t.developerTools })
         ] })
       ] }),
       /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-filters", children: [
         /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: state.query, onChange: (value) => dispatch({ type: "set-query", value }), placeholder: t.search }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.kinds[0] || "", onChange: (value) => dispatch({ type: "set-filter", key: "kinds", value: value ? [value] : [] }), options: KIND_OPTIONS2.map((value) => ({ value, label: value || t.allKinds })) }),
+        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.kinds[0] || "", onChange: (value) => dispatch({ type: "set-filter", key: "kinds", value: value ? [value] : [] }), options: KIND_OPTIONS2.filter((value) => developerMode || value !== "system-command").map((value) => ({ value, label: value || t.allKinds })) }),
         /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: state.category, onChange: (value) => dispatch({ type: "set-filter", key: "category", value }), placeholder: t.category }),
         /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.risk, onChange: (value) => dispatch({ type: "set-filter", key: "risk", value }), options: RISK_OPTIONS2.map((value) => ({ value, label: value || t.allRisk })) }),
         /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: statusValue, onChange: (value) => dispatch({ type: "set-filter", key: "statuses", value: value.split(",").filter(Boolean) }), options: [
@@ -13260,6 +13462,8 @@
             artifact: row,
             selected: row.id === state.selectedId,
             onSelect: inspect,
+            onRun: inspectForRun,
+            runDisabled: busy,
             lang
           },
           row.id
@@ -13297,6 +13501,8 @@
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.status }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Source" }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: source }),
+              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Runtime" }),
+              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: execution.runtime || "\u2014" }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Hash" }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.contentHash })
             ] })
@@ -13307,7 +13513,36 @@
           ] }),
           executable ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section tools-runner", children: [
             /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.args }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Textarea, { mono: true, value: runArgs, onChange: setRunArgs, rows: 4 }),
+            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-runner__actions", children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setAdvancedJson((value) => !value), disabled: busy, children: advancedJson ? t.formView : t.advancedJson }) }),
+            advancedJson ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Textarea, { mono: true, value: runArgs, onChange: setRunArgs, rows: 4 }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-runner__form", children: argFields.length ? argFields.map((field) => {
+              var _a;
+              return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: `${field.name}${field.required ? " *" : ""}`, children: field.type === "boolean" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+                Select,
+                {
+                  value: String(Boolean(runForm[field.name])),
+                  onChange: (value) => setRunForm((current) => ({ ...current, [field.name]: value === "true" })),
+                  options: [{ value: "false", label: "false" }, { value: "true", label: "true" }]
+                }
+              ) : field.enum ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+                Select,
+                {
+                  value: runForm[field.name] === "" ? "" : JSON.stringify(runForm[field.name]),
+                  onChange: (value) => setRunForm((current) => ({ ...current, [field.name]: JSON.parse(value) })),
+                  options: [
+                    ...!field.required ? [{ value: "", label: "\u2014" }] : [],
+                    ...field.enum.map((value) => ({ value: JSON.stringify(value), label: String(value) }))
+                  ]
+                }
+              ) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+                Input,
+                {
+                  value: (_a = runForm[field.name]) != null ? _a : "",
+                  type: ["number", "integer"].includes(field.type) ? "number" : "text",
+                  disabled: !field.supported,
+                  onChange: (value) => setRunForm((current) => ({ ...current, [field.name]: value }))
+                }
+              ) }, field.name);
+            }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: "{}" }) }),
             artifact.kind === "expression" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-runner__target", children: [
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: t.compId, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: target.compId, onChange: (value) => setTarget((current) => ({ ...current, compId: value })) }) }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: t.layerId, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: target.layerId, onChange: (value) => setTarget((current) => ({ ...current, layerId: value })) }) }),
@@ -13315,12 +13550,27 @@
             ] }) : null,
             /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-runner__actions", children: [
               execution.render ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "secondary", onClick: renderAndCopy, disabled: busy, children: t.renderCopy }) : null,
-              execution.execute || execution.apply ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy, children: t.run }) : null
+              execution.directRun ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy, children: t.run }) : null,
+              runJob && !runJob.terminal ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "danger", onClick: cancelExecution, children: t.cancelRun }) : null
             ] }),
+            runJob ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { children: [
+              t.progress,
+              ": ",
+              runJob.progress,
+              "% \xB7 ",
+              runJob.status
+            ] }) : null,
             runResult ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.result }),
               /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { className: "tools-content", children: JSON.stringify(runResult, null, 2) })
+            ] }) : null,
+            runHistory.length ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.history }),
+              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { className: "tools-content", children: JSON.stringify(runHistory, null, 2) })
             ] }) : null
+          ] }) : execution.disabledReason ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.incompatible }),
+            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("p", { children: execution.disabledReason.message })
           ] }) : null
         ] }) })
       ] }),

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -12828,6 +12828,7 @@
   }
   async function waitForToolExecution(api, execution, {
     pollIntervalMs = 250,
+    statusRetryLimit = 2,
     onProgress = () => {
     },
     wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -12836,7 +12837,22 @@
     onProgress(current);
     while (!current.terminal) {
       await wait(pollIntervalMs);
-      current = await api.use({ action: "status", execution_id: current.executionId });
+      let lastError;
+      for (let attempt = 0; attempt <= statusRetryLimit; attempt += 1) {
+        try {
+          current = await api.use({ action: "status", execution_id: current.executionId });
+          lastError = null;
+          break;
+        } catch (error) {
+          lastError = error;
+          if (attempt < statusRetryLimit) await wait(pollIntervalMs);
+        }
+      }
+      if (lastError) {
+        lastError.execution = current;
+        lastError.recoveryAction = "resume-status";
+        throw lastError;
+      }
       onProgress(current);
     }
     return current;
@@ -12956,6 +12972,7 @@
       advancedJson: "\u9AD8\u7EA7 JSON",
       formView: "\u8868\u5355",
       cancelRun: "\u53D6\u6D88\u8FD0\u884C",
+      resumeRun: "\u6062\u590D\u72B6\u6001",
       history: "\u6267\u884C\u5386\u53F2",
       developerTools: "\u5F00\u53D1\u8005\u5DE5\u5177",
       incompatible: "\u5F53\u524D\u4E0D\u53EF\u8FD0\u884C",
@@ -13022,6 +13039,7 @@
       advancedJson: "Advanced JSON",
       formView: "Form",
       cancelRun: "Cancel run",
+      resumeRun: "Resume status",
       history: "Execution history",
       developerTools: "Developer Tools",
       incompatible: "Unavailable",
@@ -13147,6 +13165,7 @@
     const rowRunLock = import_react40.default.useRef(false);
     const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
     const artifact = state.inspected && state.inspected.artifact || null;
+    const runPending = Boolean(runJob && !runJob.terminal);
     const load = import_react40.default.useCallback(async () => {
       if (!api) return;
       const sequence = loadSequence.current + 1;
@@ -13315,6 +13334,7 @@
       }
     };
     const executeArtifact = async (artifactToRun, args, normalizedTarget = {}) => {
+      if (runPending) return;
       const capability = toolExecutionCapabilities(artifactToRun);
       const operation = capability.operation;
       if (!capability.directRun || !operation) return;
@@ -13335,13 +13355,14 @@
         setRunJob(completed);
         setRunResult(completed);
       } catch (error) {
+        if (error && error.execution) setRunJob(error.execution);
         dispatch({ type: "load-error", error });
       } finally {
         setBusy(false);
       }
     };
     const execute = async () => {
-      if (!artifact) return;
+      if (!artifact || runPending) return;
       let args;
       try {
         args = advancedJson ? asObject(runArgs) : buildToolArgs(artifact.argsSchema, runForm);
@@ -13362,7 +13383,7 @@
       await executeArtifact(artifact, args, normalizedTarget);
     };
     const inspectForRun = async (row) => {
-      if (busy || rowRunLock.current || !row) return;
+      if (busy || runPending || rowRunLock.current || !row) return;
       rowRunLock.current = true;
       try {
         const payload = await inspect(row.id);
@@ -13386,6 +13407,23 @@
         setRunJob(next);
       } catch (error) {
         dispatch({ type: "load-error", error });
+      }
+    };
+    const resumeExecution = async () => {
+      if (!runJob || runJob.terminal) return;
+      setBusy(true);
+      try {
+        const completed = await waitForToolExecution(api, runJob, {
+          onProgress: setRunJob
+        });
+        await refreshAndInspect(completed.artifactId);
+        setRunJob(completed);
+        setRunResult(completed);
+      } catch (error) {
+        if (error && error.execution) setRunJob(error.execution);
+        dispatch({ type: "load-error", error });
+      } finally {
+        setBusy(false);
       }
     };
     const previewImport = async () => {
@@ -13464,6 +13502,8 @@
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "primary", icon: "plus", onClick: () => dispatch({ type: "edit-start", editor: { mode: "create", artifact: null } }), children: t.new }),
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "download", onClick: previewImport, disabled: busy, children: t.import }),
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "external-link", onClick: exportPackage, disabled: busy || !state.summaries.length, children: t.export }),
+          runPending ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: resumeExecution, disabled: busy, children: t.resumeRun }) : null,
+          runPending ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "danger", onClick: cancelExecution, disabled: busy, children: t.cancelRun }) : null,
           /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: developerMode ? "danger" : "ghost", onClick: () => setDeveloperMode((value) => !value), disabled: busy, children: t.developerTools })
         ] })
       ] }),
@@ -13496,7 +13536,7 @@
             selected: row.id === state.selectedId,
             onSelect: inspect,
             onRun: inspectForRun,
-            runDisabled: busy,
+            runDisabled: busy || runPending,
             lang
           },
           row.id
@@ -13583,8 +13623,7 @@
             ] }) : null,
             /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-runner__actions", children: [
               execution.render ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "secondary", onClick: renderAndCopy, disabled: busy, children: t.renderCopy }) : null,
-              execution.directRun ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy, children: t.run }) : null,
-              runJob && !runJob.terminal ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "danger", onClick: cancelExecution, children: t.cancelRun }) : null
+              execution.directRun ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy || runPending, children: t.run }) : null
             ] }),
             runJob ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { children: [
               t.progress,

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -576,6 +576,7 @@ function Shell({ cs }) {
     env: approvalTierFile.env(),
     onElicitation: elicitationCoordinator.handle,
     getExpertGuidance: () => loadExpertGuidance(window.localStorage),
+    randomBytes: (size) => cepRequire('crypto').randomBytes(size),
   }), [approvalTierFile, elicitationCoordinator, extRoot, getMcpSpec, platform]);
   const toolsApi = React.useMemo(() => createToolsApi(mcp), [mcp]);
   React.useEffect(() => () => mcp.stop(), [mcp]);

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -7,6 +7,22 @@ const INITIALIZE_TIMEOUT_MS = 120000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const PANEL_VERSION = '0.9.2';
 
+function defaultRandomBytes(size) {
+  const cryptoImpl = globalThis.crypto;
+  if (!cryptoImpl || typeof cryptoImpl.getRandomValues !== 'function') {
+    throw new Error('Secure random generation is unavailable');
+  }
+  const value = new Uint8Array(size);
+  cryptoImpl.getRandomValues(value);
+  return value;
+}
+
+function secureHex(randomBytes, size) {
+  const value = randomBytes(size);
+  if (!value || value.length !== size) throw new Error('Secure random generation failed');
+  return Array.from(value, (byte) => Number(byte).toString(16).padStart(2, '0')).join('');
+}
+
 export function findProjectRoot({ extRoot, repoRoot, fsImpl, platform }) {
   const adapter = platform || createPlatformAdapter();
   if (repoRoot && fsImpl.existsSync(adapter.paths.join([repoRoot, 'pyproject.toml']))) return adapter.paths.resolve([repoRoot]);
@@ -193,6 +209,7 @@ export function createMcpClient({
   packageVersion = PANEL_VERSION,
   retryDelays = [1000, 2000, 4000],
   initializeTimeoutMs = INITIALIZE_TIMEOUT_MS,
+  randomBytes = defaultRandomBytes,
 } = {}) {
   let proc = null;
   let rpc = null;
@@ -205,6 +222,7 @@ export function createMcpClient({
   let lastError = null;
   let stopped = false;
   let restartTimer = null;
+  const panelCapability = secureHex(randomBytes, 32);
 
   function currentState() {
     return { status, retryCount, error: lastError, tools };
@@ -258,6 +276,7 @@ export function createMcpClient({
       const commandSpec = await resolveCommand({ extRoot, repoRoot, platform: adapter || undefined });
       const additions = {
         AE_MCP_BACKEND: 'ae-mcp',
+        AE_MCP_PANEL_CAPABILITY: panelCapability,
         ...expertGuidanceEnv(getExpertGuidance()),
       };
       const spawnEnv = adapter ? adapter.completeSpawnEnv(env || {}, additions) : Object.assign({}, env || {}, additions);
@@ -363,6 +382,14 @@ export function createMcpClient({
     return rpc.request('tools/call', { name, arguments: args });
   }
 
+  async function callPanelTool(name, args = {}) {
+    return callTool(name, { ...args, _ae_panel_capability: panelCapability });
+  }
+
+  function newOperationId() {
+    return secureHex(randomBytes, 16);
+  }
+
   function stop() {
     stopped = true;
     clearTimeout(restartTimer);
@@ -378,5 +405,14 @@ export function createMcpClient({
     startPromise = null;
   }
 
-  return { start, listTools, callTool, stop, state: currentState, getServerInstructions: () => serverInstructions };
+  return {
+    start,
+    listTools,
+    callTool,
+    callPanelTool,
+    newOperationId,
+    stop,
+    state: currentState,
+    getServerInstructions: () => serverInstructions,
+  };
 }

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -3,6 +3,7 @@ import { expertGuidanceEnv } from './externalClients.js';
 import { createPlatformAdapter } from './platform/index.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
+const INITIALIZE_TIMEOUT_MS = 120000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const PANEL_VERSION = '0.9.2';
 
@@ -150,12 +151,15 @@ export function _createRpc(stdinWrite, onLine, options = {}) {
 
   if (onLine) onLine(handleChunk);
 
-  function request(method, params) {
+  function request(method, params, timeoutOverrideMs) {
     const id = nextId++;
     const message = { jsonrpc: '2.0', id, method };
     if (params !== undefined) message.params = params;
+    const limit = Number.isFinite(timeoutOverrideMs) && timeoutOverrideMs > 0
+      ? timeoutOverrideMs
+      : timeoutMs;
     const promise = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => rejectPending(id, new Error(method + ' timed out after ' + timeoutMs + 'ms')), timeoutMs);
+      const timer = setTimeout(() => rejectPending(id, new Error(method + ' timed out after ' + limit + 'ms')), limit);
       pending.set(id, { resolve, reject, timer });
     });
     writeMessage(message);
@@ -188,6 +192,7 @@ export function createMcpClient({
   getExpertGuidance = () => true,
   packageVersion = PANEL_VERSION,
   retryDelays = [1000, 2000, 4000],
+  initializeTimeoutMs = INITIALIZE_TIMEOUT_MS,
 } = {}) {
   let proc = null;
   let rpc = null;
@@ -267,20 +272,25 @@ export function createMcpClient({
       } else {
         proc = spawnImpl(commandSpec.command, commandSpec.args || [], { ...options, shell: false });
       }
+      const spawnedProc = proc;
       rpc = _createRpc(
-        (line) => proc.stdin.write(line),
-        (handler) => proc.stdout.on('data', handler),
+        (line) => spawnedProc.stdin.write(line),
+        (handler) => spawnedProc.stdout.on('data', handler),
         { onRequest: handleServerRequest },
       );
-      proc.on('exit', (code, signal) => handleExit(code, signal));
-      proc.on('error', (err) => handleCrash(err));
+      proc.on('exit', (code, signal) => {
+        if (proc === spawnedProc) handleExit(code, signal);
+      });
+      proc.on('error', (err) => {
+        if (proc === spawnedProc) handleCrash(err);
+      });
       if (proc.stderr && proc.stderr.on) proc.stderr.on('data', () => {});
 
       const initResult = await rpc.request('initialize', {
         protocolVersion: MCP_PROTOCOL_VERSION,
         clientInfo: { name: 'panel-chat', version: packageVersion },
         capabilities: { elicitation: {} },
-      });
+      }, initializeTimeoutMs);
       serverInstructions = (initResult && initResult.instructions) || '';
       serverInfo = initResult && initResult.serverInfo && typeof initResult.serverInfo === 'object'
         ? { ...initResult.serverInfo }
@@ -298,6 +308,14 @@ export function createMcpClient({
     try {
       return await startPromise;
     } catch (e) {
+      const failedRpc = rpc;
+      const failedProc = proc;
+      rpc = null;
+      proc = null;
+      if (failedRpc) failedRpc.close(e instanceof Error ? e : new Error('MCP initialization failed'));
+      if (failedProc && failedProc.kill) {
+        try { failedProc.kill(); } catch (killError) { /* best effort */ }
+      }
       status = 'error';
       lastError = e;
       throw e;

--- a/plugin/panel/src/cep/toolFileDialogs.js
+++ b/plugin/panel/src/cep/toolFileDialogs.js
@@ -1,4 +1,5 @@
 const TOOL_PACKAGE_SUFFIX = '.aemcptools';
+const SYSTEM_COMMAND_SUFFIXES = ['.ps1', '.psm1', '.bat', '.cmd', '.sh', '.command'];
 
 function selectedValue(result) {
   if (!result || Number(result.err || 0) !== 0) return null;
@@ -29,13 +30,15 @@ export function chooseToolPackage(cepFs, {
     false,
     title,
     initialPath,
-    ['aemcptools'],
+    ['aemcptools', 'ps1', 'psm1', 'bat', 'cmd', 'sh', 'command'],
   );
   const selected = selectedValue(result);
   if (!selected) return null;
   const path = normalizePath(normalizeFileUrl(selected));
-  if (!path.toLowerCase().endsWith(TOOL_PACKAGE_SUFFIX)) {
-    throw new Error('Select a .aemcptools package');
+  const lower = path.toLowerCase();
+  if (!lower.endsWith(TOOL_PACKAGE_SUFFIX)
+      && !SYSTEM_COMMAND_SUFFIXES.some((suffix) => lower.endsWith(suffix))) {
+    throw new Error('Select a .aemcptools package or a quarantined system-command file');
   }
   return path;
 }

--- a/plugin/panel/src/cep/toolsApi.js
+++ b/plugin/panel/src/cep/toolsApi.js
@@ -39,7 +39,10 @@ export function createToolsApi(mcp) {
   return {
     index: (args = {}) => call('ae_toolIndex', args),
     search: (args = {}) => call('ae_toolSearch', args),
-    inspect: (artifactId) => call('ae_toolInspect', { artifact_id: artifactId }),
+    inspect: (artifactId, options = {}) => call('ae_toolInspect', {
+      artifact_id: artifactId,
+      ...options,
+    }),
     create: (input) => call('ae_toolCreate', input),
     edit: (input) => call('ae_toolEdit', input),
     delete: (input) => call('ae_toolDelete', input),
@@ -83,4 +86,44 @@ export async function executeToolPlan(api, {
     plan_hash: plan.planHash,
     grant_id: grant.grantId,
   });
+}
+
+export async function startToolPlan(api, {
+  artifactId,
+  operation,
+  args = {},
+  target = {},
+}) {
+  const plan = await api.use({
+    artifact_id: artifactId,
+    action: 'prepare',
+    operation,
+    args,
+    target,
+  });
+  const grant = await api.use({
+    action: 'grant',
+    plan_hash: plan.planHash,
+    grant_scope: 'once',
+  });
+  return api.use({
+    action: 'start',
+    plan_hash: plan.planHash,
+    grant_id: grant.grantId,
+  });
+}
+
+export async function waitForToolExecution(api, execution, {
+  pollIntervalMs = 250,
+  onProgress = () => {},
+  wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+} = {}) {
+  let current = execution;
+  onProgress(current);
+  while (!current.terminal) {
+    await wait(pollIntervalMs);
+    current = await api.use({ action: 'status', execution_id: current.executionId });
+    onProgress(current);
+  }
+  return current;
 }

--- a/plugin/panel/src/cep/toolsApi.js
+++ b/plugin/panel/src/cep/toolsApi.js
@@ -36,12 +36,23 @@ export function createToolsApi(mcp) {
   const call = async (name, args) => parseMcpPayload(
     await mcp.callTool(name, args),
   );
+  const panelCall = async (name, args) => {
+    if (typeof mcp.callPanelTool !== 'function') {
+      throw new Error('Trusted panel Tool Library channel is unavailable');
+    }
+    return parseMcpPayload(await mcp.callPanelTool(name, args));
+  };
   return {
     index: (args = {}) => call('ae_toolIndex', args),
     search: (args = {}) => call('ae_toolSearch', args),
     inspect: (artifactId, options = {}) => call('ae_toolInspect', {
       artifact_id: artifactId,
       ...options,
+    }),
+    developerIndex: (args = {}) => panelCall('ae_toolIndex', args),
+    developerSearch: (args = {}) => panelCall('ae_toolSearch', args),
+    developerInspect: (artifactId) => panelCall('ae_toolInspect', {
+      artifact_id: artifactId,
     }),
     create: (input) => call('ae_toolCreate', input),
     edit: (input) => call('ae_toolEdit', input),
@@ -60,6 +71,12 @@ export function createToolsApi(mcp) {
     exportPackage: (artifactIds, outPath) => call('ae_toolExport', {
       artifact_ids: artifactIds, out_path: outPath,
     }),
+    newOperationId: () => {
+      if (typeof mcp.newOperationId !== 'function') {
+        throw new Error('Secure operation id generation is unavailable');
+      }
+      return mcp.newOperationId();
+    },
   };
 }
 
@@ -93,6 +110,7 @@ export async function startToolPlan(api, {
   operation,
   args = {},
   target = {},
+  operationId = api.newOperationId(),
 }) {
   const plan = await api.use({
     artifact_id: artifactId,
@@ -106,11 +124,24 @@ export async function startToolPlan(api, {
     plan_hash: plan.planHash,
     grant_scope: 'once',
   });
-  return api.use({
+  const startRequest = {
     action: 'start',
     plan_hash: plan.planHash,
     grant_id: grant.grantId,
-  });
+    operation_id: operationId,
+  };
+  try {
+    return await api.use(startRequest);
+  } catch (firstError) {
+    // The start response can be lost after the server has accepted the job.
+    // One bounded retry with the same operation id is idempotent server-side.
+    try {
+      return await api.use(startRequest);
+    } catch (secondError) {
+      secondError.startRetryCause = firstError;
+      throw secondError;
+    }
+  }
 }
 
 export async function waitForToolExecution(api, execution, {

--- a/plugin/panel/src/cep/toolsApi.js
+++ b/plugin/panel/src/cep/toolsApi.js
@@ -85,6 +85,7 @@ export async function executeToolPlan(api, {
   operation,
   args = {},
   target = {},
+  operationId = api.newOperationId(),
 }) {
   const plan = await api.use({
     artifact_id: artifactId,
@@ -102,6 +103,7 @@ export async function executeToolPlan(api, {
     action: 'execute',
     plan_hash: plan.planHash,
     grant_id: grant.grantId,
+    operation_id: operationId,
   });
 }
 
@@ -146,6 +148,7 @@ export async function startToolPlan(api, {
 
 export async function waitForToolExecution(api, execution, {
   pollIntervalMs = 250,
+  statusRetryLimit = 2,
   onProgress = () => {},
   wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
 } = {}) {
@@ -153,7 +156,22 @@ export async function waitForToolExecution(api, execution, {
   onProgress(current);
   while (!current.terminal) {
     await wait(pollIntervalMs);
-    current = await api.use({ action: 'status', execution_id: current.executionId });
+    let lastError;
+    for (let attempt = 0; attempt <= statusRetryLimit; attempt += 1) {
+      try {
+        current = await api.use({ action: 'status', execution_id: current.executionId });
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        if (attempt < statusRetryLimit) await wait(pollIntervalMs);
+      }
+    }
+    if (lastError) {
+      lastError.execution = current;
+      lastError.recoveryAction = 'resume-status';
+      throw lastError;
+    }
     onProgress(current);
   }
   return current;

--- a/plugin/panel/src/components/tools/ToolArtifactRow.jsx
+++ b/plugin/panel/src/components/tools/ToolArtifactRow.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Badge } from '../core/Badge';
 
 const L = {
-  zh: { never: '未使用', verified: '已验证' },
-  en: { never: 'Never used', verified: 'Verified' },
+  zh: { never: '未使用', verified: '已验证', run: '运行' },
+  en: { never: 'Never used', verified: 'Verified', run: 'Run' },
 };
 
 function riskStatus(risk) {
@@ -17,29 +17,50 @@ function lastUsed(value, t) {
   try { return new Date(value).toLocaleString(); } catch { return t.never; }
 }
 
-export function ToolArtifactRow({ artifact, selected = false, onSelect, lang = 'zh' }) {
+export function ToolArtifactRow({
+  artifact, selected = false, onSelect, onRun, runDisabled = false, lang = 'zh',
+}) {
   const t = L[lang] || L.zh;
+  const directRun = Boolean(
+    artifact && artifact.executionCapabilities
+    && artifact.executionCapabilities.directRun
+    && artifact.executionCapabilities.directRun.available,
+  );
   return (
-    <button
-      type="button"
+    <div
       className={`tools-artifact-row ds-focusable${selected ? ' is-selected' : ''}`}
-      aria-current={selected || undefined}
-      onClick={() => onSelect && onSelect(artifact.id)}
     >
-      <span className="tools-artifact-row__top">
-        <span className="tools-artifact-row__name">{artifact.name}</span>
-        {artifact.verified ? <Badge status="ok" icon="check">{t.verified}</Badge> : null}
-      </span>
-      <span className="tools-artifact-row__badges">
-        <Badge>{artifact.kind}</Badge>
-        <Badge>{artifact.category}</Badge>
-        <Badge status={riskStatus(artifact.declaredRisk)}>{artifact.declaredRisk}</Badge>
-        <Badge status={artifact.status === 'candidate' ? 'warn' : artifact.status === 'pinned' ? 'accent' : 'neutral'}>{artifact.status}</Badge>
-      </span>
-      <span className="tools-artifact-row__meta">
-        <span>{artifact.sourceType}</span>
-        <span>{lastUsed(artifact.lastUsedAt, t)}</span>
-      </span>
-    </button>
+      <button
+        type="button"
+        className="tools-artifact-row__select"
+        aria-current={selected || undefined}
+        onClick={() => onSelect && onSelect(artifact.id)}
+      >
+        <span className="tools-artifact-row__top">
+          <span className="tools-artifact-row__name">{artifact.name}</span>
+          {artifact.verified ? <Badge status="ok" icon="check">{t.verified}</Badge> : null}
+        </span>
+        <span className="tools-artifact-row__badges">
+          <Badge>{artifact.kind}</Badge>
+          <Badge>{artifact.category}</Badge>
+          <Badge status={riskStatus(artifact.declaredRisk)}>{artifact.declaredRisk}</Badge>
+          <Badge status={artifact.status === 'candidate' ? 'warn' : artifact.status === 'pinned' ? 'accent' : 'neutral'}>{artifact.status}</Badge>
+        </span>
+        <span className="tools-artifact-row__meta">
+          <span>{artifact.sourceType}</span>
+          <span>{lastUsed(artifact.lastUsedAt, t)}</span>
+        </span>
+      </button>
+      {directRun ? (
+        <button
+          type="button"
+          className="tools-artifact-row__run"
+          onClick={() => onRun && onRun(artifact)}
+          disabled={runDisabled}
+        >
+          {t.run}
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/plugin/panel/src/lib/toolRunForm.js
+++ b/plugin/panel/src/lib/toolRunForm.js
@@ -1,0 +1,75 @@
+function schemaParts(schema) {
+  const value = schema && typeof schema === 'object' && !Array.isArray(schema) ? schema : {};
+  const canonical = value.type === 'object' || value.properties || value.required;
+  return {
+    properties: canonical ? value.properties || {} : value,
+    required: new Set(canonical && Array.isArray(value.required) ? value.required : []),
+  };
+}
+
+export function initialToolArgs(schema) {
+  const { properties } = schemaParts(schema);
+  return Object.entries(properties).reduce((result, [name, rule]) => {
+    if (rule && Object.hasOwn(rule, 'default')) result[name] = rule.default;
+    else if (rule && rule.type === 'boolean') result[name] = false;
+    else result[name] = '';
+    return result;
+  }, {});
+}
+
+export function toolArgFields(schema) {
+  const { properties, required } = schemaParts(schema);
+  return Object.entries(properties).map(([name, rawRule]) => {
+    const rule = rawRule && typeof rawRule === 'object' ? rawRule : {};
+    return {
+      name,
+      type: rule.type || 'string',
+      required: required.has(name),
+      enum: Array.isArray(rule.enum) ? rule.enum : null,
+      minimum: rule.minimum,
+      maximum: rule.maximum,
+      supported: ['string', 'number', 'integer', 'boolean'].includes(rule.type || 'string')
+        || Array.isArray(rule.enum),
+    };
+  });
+}
+
+export function buildToolArgs(schema, values) {
+  const fields = toolArgFields(schema);
+  const result = {};
+  for (const field of fields) {
+    const value = values && values[field.name];
+    if ((value === '' || value === undefined) && !field.required) continue;
+    if ((value === '' || value === undefined) && field.required) {
+      throw new TypeError(`Missing required argument: ${field.name}`);
+    }
+    if (field.type === 'integer') {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed)) throw new TypeError(`Invalid integer: ${field.name}`);
+      result[field.name] = parsed;
+    } else if (field.type === 'number') {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) throw new TypeError(`Invalid number: ${field.name}`);
+      result[field.name] = parsed;
+    } else if (field.type === 'boolean') {
+      result[field.name] = Boolean(value);
+    } else if (field.supported) {
+      result[field.name] = value;
+    } else {
+      throw new TypeError(`Use Advanced JSON for argument: ${field.name}`);
+    }
+    if (field.enum && !field.enum.some((item) => Object.is(item, result[field.name]))) {
+      throw new TypeError(`Invalid enum value: ${field.name}`);
+    }
+    if (typeof result[field.name] === 'number') {
+      if (field.minimum !== undefined && result[field.name] < field.minimum) {
+        throw new TypeError(`Value below minimum: ${field.name}`);
+      }
+      if (field.maximum !== undefined && result[field.name] > field.maximum) {
+        throw new TypeError(`Value above maximum: ${field.name}`);
+      }
+    }
+  }
+  return result;
+}
+

--- a/plugin/panel/src/lib/toolRunForm.js
+++ b/plugin/panel/src/lib/toolRunForm.js
@@ -72,4 +72,3 @@ export function buildToolArgs(schema, values) {
   }
   return result;
 }
-

--- a/plugin/panel/src/lib/toolsState.js
+++ b/plugin/panel/src/lib/toolsState.js
@@ -62,6 +62,7 @@ function toSummary(value) {
     updatedAt: value.updatedAt,
     lastUsedAt: value.lastUsedAt ?? null,
     sourceType: value.sourceType || value.source && value.source.type || '',
+    executionCapabilities: value.executionCapabilities || null,
   };
 }
 
@@ -81,11 +82,14 @@ export function reduceToolsState(state = INITIAL_TOOLS_STATE, event = {}) {
     case 'load-success': {
       const payload = event.payload || event;
       const summaries = (payload.artifacts || payload.summaries || []).map(toSummary);
+      const selectedVisible = summaries.some((row) => row.id === state.selectedId);
       return {
         ...state,
         phase: 'ready',
         summaries: sortSummaries(summaries),
         total: Number.isFinite(payload.total) ? payload.total : summaries.length,
+        selectedId: selectedVisible ? state.selectedId : null,
+        inspected: selectedVisible ? state.inspected : null,
         error: '',
         refreshRequired: false,
       };
@@ -204,6 +208,7 @@ export function searchArgsFromState(state, { offset = 0, limit = 100 } = {}) {
 export function canEditArtifact(artifact) {
   return Boolean(
     artifact
+    && artifact.kind !== 'system-command'
     && sourceType(artifact) !== 'bundled'
     && !['archived', 'deprecated'].includes(artifact.status),
   );
@@ -214,12 +219,19 @@ export function canExecuteArtifact(artifact) {
 }
 
 export function toolExecutionCapabilities(artifact) {
-  const enabled = canExecuteArtifact(artifact);
-  const kind = artifact && artifact.kind;
+  const contract = artifact && artifact.executionCapabilities;
+  const operations = Array.isArray(contract && contract.operations) ? contract.operations : [];
+  const direct = contract && contract.directRun && typeof contract.directRun === 'object'
+    ? contract.directRun : {};
   return {
-    render: enabled && ['expression', 'prompt-skill'].includes(kind),
-    execute: enabled && ['jsx', 'diagnostic', 'recipe'].includes(kind),
-    apply: enabled && kind === 'expression',
+    render: operations.includes('render'),
+    execute: operations.includes('execute'),
+    apply: operations.includes('apply'),
+    directRun: Boolean(direct.available),
+    operation: direct.operation || null,
+    requiresTarget: Boolean(direct.requiresTarget),
+    disabledReason: direct.disabledReason || null,
+    runtime: contract && contract.runtime || null,
   };
 }
 

--- a/plugin/panel/src/screens/ToolsScreen.jsx
+++ b/plugin/panel/src/screens/ToolsScreen.jsx
@@ -35,7 +35,7 @@ const TEXT = {
     edit: '编辑', duplicate: '副本', archive: '归档', delete: '删除', pin: '置顶', unpin: '取消置顶',
     verify: '标记已审阅', promote: '提升为已保存', copy: '复制', renderCopy: '渲染并复制', run: '运行',
     metadata: '元数据', content: '内容（不可信用户数据）', args: '参数', result: '执行结果',
-    advancedJson: '高级 JSON', formView: '表单', cancelRun: '取消运行', history: '执行历史',
+    advancedJson: '高级 JSON', formView: '表单', cancelRun: '取消运行', resumeRun: '恢复状态', history: '执行历史',
     developerTools: '开发者工具', incompatible: '当前不可运行', progress: '进度',
     compId: 'Comp ID', layerId: 'Layer ID', propertyPath: '属性路径', refresh: '刷新',
     importTitle: '导入预览', importChanges: '扫描后差异', importConflict: '冲突', keep: '保留现有',
@@ -54,7 +54,7 @@ const TEXT = {
     edit: 'Edit', duplicate: 'Duplicate', archive: 'Archive', delete: 'Delete', pin: 'Pin', unpin: 'Unpin',
     verify: 'Mark reviewed', promote: 'Promote to saved', copy: 'Copy', renderCopy: 'Render & copy', run: 'Run',
     metadata: 'Metadata', content: 'Content (untrusted user data)', args: 'Arguments', result: 'Execution result',
-    advancedJson: 'Advanced JSON', formView: 'Form', cancelRun: 'Cancel run', history: 'Execution history',
+    advancedJson: 'Advanced JSON', formView: 'Form', cancelRun: 'Cancel run', resumeRun: 'Resume status', history: 'Execution history',
     developerTools: 'Developer Tools', incompatible: 'Unavailable', progress: 'Progress',
     compId: 'Comp ID', layerId: 'Layer ID', propertyPath: 'Property path', refresh: 'Refresh',
     importTitle: 'Import preview', importChanges: 'Post-scan changes', importConflict: 'Conflict', keep: 'Keep existing',
@@ -168,6 +168,7 @@ export function ToolsScreen({
   const rowRunLock = React.useRef(false);
   const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
   const artifact = state.inspected && state.inspected.artifact || null;
+  const runPending = Boolean(runJob && !runJob.terminal);
 
   const load = React.useCallback(async () => {
     if (!api) return;
@@ -361,6 +362,7 @@ export function ToolsScreen({
   };
 
   const executeArtifact = async (artifactToRun, args, normalizedTarget = {}) => {
+    if (runPending) return;
     const capability = toolExecutionCapabilities(artifactToRun);
     const operation = capability.operation;
     if (!capability.directRun || !operation) return;
@@ -381,6 +383,7 @@ export function ToolsScreen({
       setRunJob(completed);
       setRunResult(completed);
     } catch (error) {
+      if (error && error.execution) setRunJob(error.execution);
       dispatch({ type: 'load-error', error });
     } finally {
       setBusy(false);
@@ -388,7 +391,7 @@ export function ToolsScreen({
   };
 
   const execute = async () => {
-    if (!artifact) return;
+    if (!artifact || runPending) return;
     let args;
     try {
       args = advancedJson
@@ -412,7 +415,7 @@ export function ToolsScreen({
   };
 
   const inspectForRun = async (row) => {
-    if (busy || rowRunLock.current || !row) return;
+    if (busy || runPending || rowRunLock.current || !row) return;
     rowRunLock.current = true;
     try {
       const payload = await inspect(row.id);
@@ -439,6 +442,24 @@ export function ToolsScreen({
       setRunJob(next);
     } catch (error) {
       dispatch({ type: 'load-error', error });
+    }
+  };
+
+  const resumeExecution = async () => {
+    if (!runJob || runJob.terminal) return;
+    setBusy(true);
+    try {
+      const completed = await waitForToolExecution(api, runJob, {
+        onProgress: setRunJob,
+      });
+      await refreshAndInspect(completed.artifactId);
+      setRunJob(completed);
+      setRunResult(completed);
+    } catch (error) {
+      if (error && error.execution) setRunJob(error.execution);
+      dispatch({ type: 'load-error', error });
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -523,6 +544,8 @@ export function ToolsScreen({
           <Button size="sm" variant="primary" icon="plus" onClick={() => dispatch({ type: 'edit-start', editor: { mode: 'create', artifact: null } })}>{t.new}</Button>
           <Button size="sm" variant="secondary" icon="download" onClick={previewImport} disabled={busy}>{t.import}</Button>
           <Button size="sm" variant="secondary" icon="external-link" onClick={exportPackage} disabled={busy || !state.summaries.length}>{t.export}</Button>
+          {runPending ? <Button size="sm" variant="secondary" onClick={resumeExecution} disabled={busy}>{t.resumeRun}</Button> : null}
+          {runPending ? <Button size="sm" variant="danger" onClick={cancelExecution} disabled={busy}>{t.cancelRun}</Button> : null}
           <Button size="sm" variant={developerMode ? 'danger' : 'ghost'} onClick={() => setDeveloperMode((value) => !value)} disabled={busy}>{t.developerTools}</Button>
         </div>
       </header>
@@ -561,7 +584,7 @@ export function ToolsScreen({
               selected={row.id === state.selectedId}
               onSelect={inspect}
               onRun={inspectForRun}
-              runDisabled={busy}
+              runDisabled={busy || runPending}
               lang={lang}
             />
           )) : (
@@ -665,8 +688,7 @@ export function ToolsScreen({
                   ) : null}
                   <div className="tools-runner__actions">
                     {execution.render ? <Button variant="secondary" onClick={renderAndCopy} disabled={busy}>{t.renderCopy}</Button> : null}
-                    {execution.directRun ? <Button variant="primary" onClick={execute} disabled={busy}>{t.run}</Button> : null}
-                    {runJob && !runJob.terminal ? <Button variant="danger" onClick={cancelExecution}>{t.cancelRun}</Button> : null}
+                    {execution.directRun ? <Button variant="primary" onClick={execute} disabled={busy || runPending}>{t.run}</Button> : null}
                   </div>
                   {runJob ? <div>{t.progress}: {runJob.progress}% · {runJob.status}</div> : null}
                   {runResult ? (

--- a/plugin/panel/src/screens/ToolsScreen.jsx
+++ b/plugin/panel/src/screens/ToolsScreen.jsx
@@ -9,8 +9,9 @@ import { Textarea } from '../components/forms/Textarea';
 import { ToolArtifactEditor } from '../components/tools/ToolArtifactEditor';
 import { ToolArtifactRow } from '../components/tools/ToolArtifactRow';
 import { chooseToolExportPath, chooseToolPackage } from '../cep/toolFileDialogs';
-import { executeToolPlan } from '../cep/toolsApi';
+import { startToolPlan, waitForToolExecution } from '../cep/toolsApi';
 import { copyText } from '../lib/clipboard';
+import { buildToolArgs, initialToolArgs, toolArgFields } from '../lib/toolRunForm';
 import {
   INITIAL_TOOLS_STATE,
   canEditArtifact,
@@ -32,8 +33,10 @@ const TEXT = {
     category: '分类', empty: '没有匹配的工具', emptyCap: '新建工具，或导入 .aemcptools 包。',
     select: '选择一个工具', selectCap: '先从列表选择摘要，再按需读取完整内容。',
     edit: '编辑', duplicate: '副本', archive: '归档', delete: '删除', pin: '置顶', unpin: '取消置顶',
-    verify: '标记已审阅', promote: '提升为已保存', copy: '复制', renderCopy: '渲染并复制', run: '准备并运行',
-    metadata: '元数据', content: '内容（不可信用户数据）', args: '参数（JSON）', result: '执行结果',
+    verify: '标记已审阅', promote: '提升为已保存', copy: '复制', renderCopy: '渲染并复制', run: '运行',
+    metadata: '元数据', content: '内容（不可信用户数据）', args: '参数', result: '执行结果',
+    advancedJson: '高级 JSON', formView: '表单', cancelRun: '取消运行', history: '执行历史',
+    developerTools: '开发者工具', incompatible: '当前不可运行', progress: '进度',
     compId: 'Comp ID', layerId: 'Layer ID', propertyPath: '属性路径', refresh: '刷新',
     importTitle: '导入预览', importChanges: '扫描后差异', importConflict: '冲突', keep: '保留现有',
     duplicateIncoming: '导入副本', commit: '确认导入为候选', cancel: '取消', contentChanged: '内容 hash 已变化',
@@ -49,8 +52,10 @@ const TEXT = {
     category: 'Category', empty: 'No matching tools', emptyCap: 'Create a tool or import an .aemcptools package.',
     select: 'Select a tool', selectCap: 'Choose a summary first, then inspect full content on demand.',
     edit: 'Edit', duplicate: 'Duplicate', archive: 'Archive', delete: 'Delete', pin: 'Pin', unpin: 'Unpin',
-    verify: 'Mark reviewed', promote: 'Promote to saved', copy: 'Copy', renderCopy: 'Render & copy', run: 'Prepare & run',
-    metadata: 'Metadata', content: 'Content (untrusted user data)', args: 'Arguments (JSON)', result: 'Execution result',
+    verify: 'Mark reviewed', promote: 'Promote to saved', copy: 'Copy', renderCopy: 'Render & copy', run: 'Run',
+    metadata: 'Metadata', content: 'Content (untrusted user data)', args: 'Arguments', result: 'Execution result',
+    advancedJson: 'Advanced JSON', formView: 'Form', cancelRun: 'Cancel run', history: 'Execution history',
+    developerTools: 'Developer Tools', incompatible: 'Unavailable', progress: 'Progress',
     compId: 'Comp ID', layerId: 'Layer ID', propertyPath: 'Property path', refresh: 'Refresh',
     importTitle: 'Import preview', importChanges: 'Post-scan changes', importConflict: 'Conflict', keep: 'Keep existing',
     duplicateIncoming: 'Import duplicate', commit: 'Import as candidates', cancel: 'Cancel', contentChanged: 'Content hash changed',
@@ -61,7 +66,7 @@ const TEXT = {
   },
 };
 
-const KIND_OPTIONS = ['', 'jsx', 'expression', 'prompt-skill', 'recipe', 'diagnostic'];
+const KIND_OPTIONS = ['', 'jsx', 'expression', 'prompt-skill', 'recipe', 'diagnostic', 'system-command'];
 const RISK_OPTIONS = ['', 'read', 'write', 'destructive', 'external'];
 const SOURCE_OPTIONS = ['', 'user', 'legacy', 'bundled', 'imported', 'chat-tool-call'];
 
@@ -151,8 +156,13 @@ export function ToolsScreen({
   const [busy, setBusy] = React.useState(false);
   const initialRunInputs = React.useMemo(() => emptyToolRunInputs(), []);
   const [runArgs, setRunArgs] = React.useState(initialRunInputs.args);
+  const [runForm, setRunForm] = React.useState({});
+  const [advancedJson, setAdvancedJson] = React.useState(false);
   const [target, setTarget] = React.useState(initialRunInputs.target);
   const [runResult, setRunResult] = React.useState(null);
+  const [runJob, setRunJob] = React.useState(null);
+  const [runHistory, setRunHistory] = React.useState([]);
+  const [developerMode, setDeveloperMode] = React.useState(false);
   const loadSequence = React.useRef(0);
   const inspectSequence = React.useRef(0);
   const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
@@ -168,18 +178,19 @@ export function ToolsScreen({
         state.query || state.category || state.risk || (state.kinds && state.kinds.length),
       );
       const payload = needsSearch
-        ? await api.search(searchArgsFromState(state))
+        ? await api.search({ ...searchArgsFromState(state), developer_mode: developerMode })
         : await api.index({
           statuses: state.statuses,
           source_types: state.sourceType ? [state.sourceType] : undefined,
           include_candidates: state.statuses.includes('candidate'),
+          developer_mode: developerMode,
           limit: 100,
         });
       if (sequence === loadSequence.current) dispatch({ type: 'load-success', payload });
     } catch (error) {
       if (sequence === loadSequence.current) dispatch({ type: 'load-error', error });
     }
-  }, [api, state.query, state.kinds, state.category, state.risk, state.statuses, state.sourceType]);
+  }, [api, state.query, state.kinds, state.category, state.risk, state.statuses, state.sourceType, developerMode]);
 
   React.useEffect(() => {
     const timer = setTimeout(load, 120);
@@ -191,12 +202,30 @@ export function ToolsScreen({
     inspectSequence.current = sequence;
     const freshInputs = emptyToolRunInputs();
     setRunArgs(freshInputs.args);
+    setRunForm({});
+    setAdvancedJson(false);
     setTarget(freshInputs.target);
     dispatch({ type: 'select', id });
     setRunResult(null);
     try {
-      const payload = await api.inspect(id);
-      if (sequence === inspectSequence.current) dispatch({ type: 'inspect-success', payload });
+      const payload = await api.inspect(id, { developer_mode: developerMode });
+      if (sequence === inspectSequence.current) {
+        dispatch({ type: 'inspect-success', payload });
+        const defaults = initialToolArgs(payload.artifact && payload.artifact.argsSchema);
+        setRunForm(defaults);
+        let initialJson = {};
+        try {
+          initialJson = buildToolArgs(payload.artifact && payload.artifact.argsSchema, defaults);
+        } catch {
+          initialJson = Object.fromEntries(
+            Object.entries(defaults).filter(([, value]) => value !== ''),
+          );
+        }
+        setRunArgs(JSON.stringify(initialJson, null, 2));
+        const history = await api.use({ action: 'history', artifact_id: id, limit: 20 });
+        setRunHistory(history.executions || []);
+      }
+      return payload;
     } catch (error) {
       if (sequence === inspectSequence.current) dispatch({ type: 'load-error', error });
     }
@@ -331,16 +360,47 @@ export function ToolsScreen({
     }
   };
 
+  const executeArtifact = async (artifactToRun, args, normalizedTarget = {}) => {
+    const capability = toolExecutionCapabilities(artifactToRun);
+    const operation = capability.operation;
+    if (!capability.directRun || !operation) return;
+    setBusy(true);
+    setRunResult(null);
+    setRunJob(null);
+    try {
+      const started = await startToolPlan(api, {
+        artifactId: artifactToRun.id,
+        operation,
+        args,
+        target: normalizedTarget,
+      });
+      const completed = await waitForToolExecution(api, started, {
+        onProgress: setRunJob,
+      });
+      await refreshAndInspect(artifactToRun.id);
+      setRunJob(completed);
+      setRunResult(completed);
+    } catch (error) {
+      dispatch({ type: 'load-error', error });
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const execute = async () => {
     if (!artifact) return;
     let args;
-    try { args = asObject(runArgs); } catch {
+    try {
+      args = advancedJson
+        ? asObject(runArgs)
+        : buildToolArgs(artifact.argsSchema, runForm);
+    } catch (error) {
       dispatch({ type: 'load-error', error: new Error(t.invalidArgs) });
       return;
     }
-    const operation = artifact.kind === 'expression' ? 'apply' : 'execute';
+    const capability = toolExecutionCapabilities(artifact);
     let normalizedTarget = {};
-    if (operation === 'apply') {
+    if (capability.operation === 'apply') {
       try {
         normalizedTarget = normalizeExpressionTarget(target);
       } catch {
@@ -348,20 +408,32 @@ export function ToolsScreen({
         return;
       }
     }
-    setBusy(true);
+    await executeArtifact(artifact, args, normalizedTarget);
+  };
+
+  const inspectForRun = async (row) => {
+    if (busy || !row) return;
+    const payload = await inspect(row.id);
+    const inspectedArtifact = payload && payload.artifact;
+    const capability = toolExecutionCapabilities(inspectedArtifact);
+    if (!capability.directRun || capability.requiresTarget) return;
+    const defaults = initialToolArgs(inspectedArtifact.argsSchema);
     try {
-      const result = await executeToolPlan(api, {
-        artifactId: artifact.id,
-        operation,
-        args,
-        target: normalizedTarget,
-      });
-      setRunResult(result);
-      await refreshAndInspect(artifact.id);
+      const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
+      await executeArtifact(inspectedArtifact, args);
+    } catch {
+      // Required values without defaults belong in the detail form. Selecting
+      // the row above has already opened that deterministic input surface.
+    }
+  };
+
+  const cancelExecution = async () => {
+    if (!runJob || runJob.terminal) return;
+    try {
+      const next = await api.use({ action: 'cancel', execution_id: runJob.executionId });
+      setRunJob(next);
     } catch (error) {
       dispatch({ type: 'load-error', error });
-    } finally {
-      setBusy(false);
     }
   };
 
@@ -401,7 +473,8 @@ export function ToolsScreen({
       dispatch({ type: 'import-finished' });
       dispatch({ type: 'set-filter', key: 'statuses', value: ['candidate', 'saved', 'pinned'] });
       const payload = await api.index({
-        statuses: ['candidate', 'saved', 'pinned'], include_candidates: true, limit: 100,
+        statuses: ['candidate', 'saved', 'pinned'], include_candidates: true,
+        developer_mode: developerMode, limit: 100,
       });
       dispatch({ type: 'load-success', payload });
     } catch (error) {
@@ -434,7 +507,8 @@ export function ToolsScreen({
   const source = artifactSource(artifact);
   const editable = canEditArtifact(artifact);
   const execution = toolExecutionCapabilities(artifact);
-  const executable = execution.render || execution.execute || execution.apply;
+  const executable = execution.render || execution.directRun;
+  const argFields = toolArgFields(artifact && artifact.argsSchema);
 
   return (
     <div className="tools-screen">
@@ -444,12 +518,13 @@ export function ToolsScreen({
           <Button size="sm" variant="primary" icon="plus" onClick={() => dispatch({ type: 'edit-start', editor: { mode: 'create', artifact: null } })}>{t.new}</Button>
           <Button size="sm" variant="secondary" icon="download" onClick={previewImport} disabled={busy}>{t.import}</Button>
           <Button size="sm" variant="secondary" icon="external-link" onClick={exportPackage} disabled={busy || !state.summaries.length}>{t.export}</Button>
+          <Button size="sm" variant={developerMode ? 'danger' : 'ghost'} onClick={() => setDeveloperMode((value) => !value)} disabled={busy}>{t.developerTools}</Button>
         </div>
       </header>
 
       <div className="tools-filters">
         <Input value={state.query} onChange={(value) => dispatch({ type: 'set-query', value })} placeholder={t.search} />
-        <Select value={state.kinds[0] || ''} onChange={(value) => dispatch({ type: 'set-filter', key: 'kinds', value: value ? [value] : [] })} options={KIND_OPTIONS.map((value) => ({ value, label: value || t.allKinds }))} />
+        <Select value={state.kinds[0] || ''} onChange={(value) => dispatch({ type: 'set-filter', key: 'kinds', value: value ? [value] : [] })} options={KIND_OPTIONS.filter((value) => developerMode || value !== 'system-command').map((value) => ({ value, label: value || t.allKinds }))} />
         <Input value={state.category} onChange={(value) => dispatch({ type: 'set-filter', key: 'category', value })} placeholder={t.category} />
         <Select value={state.risk} onChange={(value) => dispatch({ type: 'set-filter', key: 'risk', value })} options={RISK_OPTIONS.map((value) => ({ value, label: value || t.allRisk }))} />
         <Select value={statusValue} onChange={(value) => dispatch({ type: 'set-filter', key: 'statuses', value: value.split(',').filter(Boolean) })} options={[
@@ -480,6 +555,8 @@ export function ToolsScreen({
               artifact={row}
               selected={row.id === state.selectedId}
               onSelect={inspect}
+              onRun={inspectForRun}
+              runDisabled={busy}
               lang={lang}
             />
           )) : (
@@ -525,6 +602,7 @@ export function ToolsScreen({
                   <dt>Risk</dt><dd>{artifact.declaredRisk}</dd>
                   <dt>Status</dt><dd>{artifact.status}</dd>
                   <dt>Source</dt><dd>{source}</dd>
+                  <dt>Runtime</dt><dd>{execution.runtime || '—'}</dd>
                   <dt>Hash</dt><dd>{artifact.contentHash}</dd>
                 </dl>
               </section>
@@ -535,7 +613,44 @@ export function ToolsScreen({
               {executable ? (
                 <section className="tools-detail__section tools-runner">
                   <h3>{t.args}</h3>
-                  <Textarea mono value={runArgs} onChange={setRunArgs} rows={4} />
+                  <div className="tools-runner__actions">
+                    <Button size="sm" variant="ghost" onClick={() => setAdvancedJson((value) => !value)} disabled={busy}>
+                      {advancedJson ? t.formView : t.advancedJson}
+                    </Button>
+                  </div>
+                  {advancedJson ? (
+                    <Textarea mono value={runArgs} onChange={setRunArgs} rows={4} />
+                  ) : (
+                    <div className="tools-runner__form">
+                      {argFields.length ? argFields.map((field) => (
+                        <Field key={field.name} label={`${field.name}${field.required ? ' *' : ''}`}>
+                          {field.type === 'boolean' ? (
+                            <Select
+                              value={String(Boolean(runForm[field.name]))}
+                              onChange={(value) => setRunForm((current) => ({ ...current, [field.name]: value === 'true' }))}
+                              options={[{ value: 'false', label: 'false' }, { value: 'true', label: 'true' }]}
+                            />
+                          ) : field.enum ? (
+                            <Select
+                              value={runForm[field.name] === '' ? '' : JSON.stringify(runForm[field.name])}
+                              onChange={(value) => setRunForm((current) => ({ ...current, [field.name]: JSON.parse(value) }))}
+                              options={[
+                                ...(!field.required ? [{ value: '', label: '—' }] : []),
+                                ...field.enum.map((value) => ({ value: JSON.stringify(value), label: String(value) })),
+                              ]}
+                            />
+                          ) : (
+                            <Input
+                              value={runForm[field.name] ?? ''}
+                              type={['number', 'integer'].includes(field.type) ? 'number' : 'text'}
+                              disabled={!field.supported}
+                              onChange={(value) => setRunForm((current) => ({ ...current, [field.name]: value }))}
+                            />
+                          )}
+                        </Field>
+                      )) : <span>{'{}'}</span>}
+                    </div>
+                  )}
                   {artifact.kind === 'expression' ? (
                     <div className="tools-runner__target">
                       <Field label={t.compId}><Input value={target.compId} onChange={(value) => setTarget((current) => ({ ...current, compId: value }))} /></Field>
@@ -545,14 +660,27 @@ export function ToolsScreen({
                   ) : null}
                   <div className="tools-runner__actions">
                     {execution.render ? <Button variant="secondary" onClick={renderAndCopy} disabled={busy}>{t.renderCopy}</Button> : null}
-                    {execution.execute || execution.apply ? <Button variant="primary" onClick={execute} disabled={busy}>{t.run}</Button> : null}
+                    {execution.directRun ? <Button variant="primary" onClick={execute} disabled={busy}>{t.run}</Button> : null}
+                    {runJob && !runJob.terminal ? <Button variant="danger" onClick={cancelExecution}>{t.cancelRun}</Button> : null}
                   </div>
+                  {runJob ? <div>{t.progress}: {runJob.progress}% · {runJob.status}</div> : null}
                   {runResult ? (
                     <React.Fragment>
                       <h3>{t.result}</h3>
                       <pre className="tools-content">{JSON.stringify(runResult, null, 2)}</pre>
                     </React.Fragment>
                   ) : null}
+                  {runHistory.length ? (
+                    <React.Fragment>
+                      <h3>{t.history}</h3>
+                      <pre className="tools-content">{JSON.stringify(runHistory, null, 2)}</pre>
+                    </React.Fragment>
+                  ) : null}
+                </section>
+              ) : execution.disabledReason ? (
+                <section className="tools-detail__section">
+                  <h3>{t.incompatible}</h3>
+                  <p>{execution.disabledReason.message}</p>
                 </section>
               ) : null}
             </React.Fragment>

--- a/plugin/panel/src/screens/ToolsScreen.jsx
+++ b/plugin/panel/src/screens/ToolsScreen.jsx
@@ -165,6 +165,7 @@ export function ToolsScreen({
   const [developerMode, setDeveloperMode] = React.useState(false);
   const loadSequence = React.useRef(0);
   const inspectSequence = React.useRef(0);
+  const rowRunLock = React.useRef(false);
   const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
   const artifact = state.inspected && state.inspected.artifact || null;
 
@@ -178,12 +179,11 @@ export function ToolsScreen({
         state.query || state.category || state.risk || (state.kinds && state.kinds.length),
       );
       const payload = needsSearch
-        ? await api.search({ ...searchArgsFromState(state), developer_mode: developerMode })
-        : await api.index({
+        ? await (developerMode ? api.developerSearch : api.search)(searchArgsFromState(state))
+        : await (developerMode ? api.developerIndex : api.index)({
           statuses: state.statuses,
           source_types: state.sourceType ? [state.sourceType] : undefined,
           include_candidates: state.statuses.includes('candidate'),
-          developer_mode: developerMode,
           limit: 100,
         });
       if (sequence === loadSequence.current) dispatch({ type: 'load-success', payload });
@@ -208,7 +208,7 @@ export function ToolsScreen({
     dispatch({ type: 'select', id });
     setRunResult(null);
     try {
-      const payload = await api.inspect(id, { developer_mode: developerMode });
+      const payload = await (developerMode ? api.developerInspect(id) : api.inspect(id));
       if (sequence === inspectSequence.current) {
         dispatch({ type: 'inspect-success', payload });
         const defaults = initialToolArgs(payload.artifact && payload.artifact.argsSchema);
@@ -412,18 +412,23 @@ export function ToolsScreen({
   };
 
   const inspectForRun = async (row) => {
-    if (busy || !row) return;
-    const payload = await inspect(row.id);
-    const inspectedArtifact = payload && payload.artifact;
-    const capability = toolExecutionCapabilities(inspectedArtifact);
-    if (!capability.directRun || capability.requiresTarget) return;
-    const defaults = initialToolArgs(inspectedArtifact.argsSchema);
+    if (busy || rowRunLock.current || !row) return;
+    rowRunLock.current = true;
     try {
-      const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
-      await executeArtifact(inspectedArtifact, args);
-    } catch {
-      // Required values without defaults belong in the detail form. Selecting
-      // the row above has already opened that deterministic input surface.
+      const payload = await inspect(row.id);
+      const inspectedArtifact = payload && payload.artifact;
+      const capability = toolExecutionCapabilities(inspectedArtifact);
+      if (!capability.directRun || capability.requiresTarget) return;
+      const defaults = initialToolArgs(inspectedArtifact.argsSchema);
+      try {
+        const args = buildToolArgs(inspectedArtifact.argsSchema, defaults);
+        await executeArtifact(inspectedArtifact, args);
+      } catch {
+        // Required values without defaults belong in the detail form. Selecting
+        // the row above has already opened that deterministic input surface.
+      }
+    } finally {
+      rowRunLock.current = false;
     }
   };
 
@@ -472,9 +477,9 @@ export function ToolsScreen({
       await api.commitImport(state.importPreview.importId, state.conflictResolutions);
       dispatch({ type: 'import-finished' });
       dispatch({ type: 'set-filter', key: 'statuses', value: ['candidate', 'saved', 'pinned'] });
-      const payload = await api.index({
+      const payload = await (developerMode ? api.developerIndex : api.index)({
         statuses: ['candidate', 'saved', 'pinned'], include_candidates: true,
-        developer_mode: developerMode, limit: 100,
+        limit: 100,
       });
       dispatch({ type: 'load-success', payload });
     } catch (error) {

--- a/plugin/panel/src/styles/index.css
+++ b/plugin/panel/src/styles/index.css
@@ -109,9 +109,32 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
   border: 0;
   border-bottom: 1px solid var(--border-subtle);
   text-align: left;
-  cursor: pointer;
   transition: background var(--dur-fast) var(--ease-out);
 }
+
+.tools-artifact-row__select {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-15);
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tools-artifact-row__run {
+  align-self: flex-end;
+  padding: 3px 9px;
+  color: var(--text-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.tools-artifact-row__run:disabled { opacity: 0.45; cursor: default; }
 
 .tools-artifact-row:hover { background: var(--bg-hover); }
 .tools-artifact-row.is-selected { background: var(--bg-selected); }
@@ -192,6 +215,11 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
 }
 
 .tools-runner { display: flex; flex-direction: column; gap: var(--space-2); }
+.tools-runner__form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-2);
+}
 .tools-runner__target {
   display: grid;
   grid-template-columns: minmax(80px, 1fr) minmax(80px, 1fr) minmax(140px, 2fr);

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -45,6 +45,17 @@ test('_createRpc rejects timed out requests', async () => {
   await assert.rejects(io.rpc.request('slow', {}), /timed out/);
 });
 
+test('_createRpc supports a longer timeout for cold-start initialization', async () => {
+  const io = makeRpc(5);
+
+  const pending = io.rpc.request('initialize', {}, 50);
+  const id = JSON.parse(io.writes[0]).id;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  io.pushChunk(JSON.stringify({ jsonrpc: '2.0', id, result: { ok: true } }) + '\n');
+
+  assert.deepEqual(await pending, { ok: true });
+});
+
 test('_createRpc rejects JSON-RPC error responses', async () => {
   const io = makeRpc();
 
@@ -112,18 +123,34 @@ test('resolveMcpCommand reports a repair hint when no executable can be found', 
 
 function makeFakeProc() {
   const stdoutHandlers = [];
+  let killed = false;
   return {
     stdin: { write() {} },
     stdout: { on(event, handler) { if (event === 'data') stdoutHandlers.push(handler); } },
     stderr: { on() {} },
     on() {},
-    kill() {},
+    kill() { killed = true; },
+    get killed() { return killed; },
     pushStdout(message) {
       const line = typeof message === 'string' ? message : JSON.stringify(message) + '\n';
       for (const handler of stdoutHandlers) handler(line);
     },
   };
 }
+
+test('createMcpClient terminates a child that cannot initialize in time', async () => {
+  const proc = makeFakeProc();
+  const client = createMcpClient({
+    spawnImpl: () => proc,
+    resolveCommand: async () => ({ command: 'ae-mcp', args: [], source: 'explicit' }),
+    initializeTimeoutMs: 5,
+    retryDelays: [],
+  });
+
+  await assert.rejects(client.start(), /initialize timed out after 5ms/);
+  assert.equal(proc.killed, true);
+  assert.equal(client.state().status, 'error');
+});
 
 // Spawn fake that auto-answers initialize (with a configurable result) and
 // tools/list so createMcpClient.start() resolves to ready.

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -169,6 +169,12 @@ function spawnReplying(initResult) {
         proc.pushStdout({ jsonrpc: '2.0', id: msg.id, result: initResult });
       } else if (msg.method === 'tools/list') {
         proc.pushStdout({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } });
+      } else if (msg.method === 'tools/call') {
+        proc.pushStdout({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: { content: [{ type: 'text', text: '{"ok":true}' }] },
+        });
       }
     };
     return proc;
@@ -214,6 +220,23 @@ test('createMcpClient passes the Tool Library tier file into the direct MCP proc
     getProc().spawnOptions.env.AE_MCP_TOOL_APPROVAL_TIER_FILE,
     '/tmp/panel.tier',
   );
+  client.stop();
+});
+
+test('createMcpClient keeps Developer Tools behind a per-process panel capability', async () => {
+  const { spawnImpl, getProc } = spawnReplying({});
+  const client = createMcpClient({
+    spawnImpl,
+    randomBytes: (size) => new Uint8Array(size).fill(0xab),
+    resolveCommand: async () => ({ command: 'ae-mcp', args: [], source: 'explicit' }),
+  });
+
+  await client.start();
+  assert.equal(getProc().spawnOptions.env.AE_MCP_PANEL_CAPABILITY, 'ab'.repeat(32));
+  await client.callPanelTool('ae_toolIndex', { kinds: ['system-command'] });
+  const call = getProc().clientWrites.find((message) => message.method === 'tools/call');
+  assert.equal(call.params.arguments._ae_panel_capability, 'ab'.repeat(32));
+  assert.equal(client.newOperationId(), 'ab'.repeat(16));
   client.stop();
 });
 

--- a/plugin/panel/test/toolFileDialogs.test.js
+++ b/plugin/panel/test/toolFileDialogs.test.js
@@ -16,7 +16,9 @@ test('chooseToolPackage passes the exact CEP open-dialog contract', () => {
   assert.equal(chooseToolPackage(cepFs, {
     title: 'Import tools', initialPath: 'C:\\Tools', normalizePath: (value) => value.replaceAll('\\', '/'),
   }), 'C:/Tools/in.aemcptools');
-  assert.deepEqual(calls, [[false, false, 'Import tools', 'C:\\Tools', ['aemcptools']]]);
+  assert.deepEqual(calls, [[false, false, 'Import tools', 'C:\\Tools', [
+    'aemcptools', 'ps1', 'psm1', 'bat', 'cmd', 'sh', 'command',
+  ]]]);
 });
 
 test('chooseToolPackage returns null on cancel and rejects wrong extensions', () => {
@@ -26,6 +28,9 @@ test('chooseToolPackage returns null on cancel and rejects wrong extensions', ()
   assert.throws(() => chooseToolPackage({
     showOpenDialog: () => ({ err: 0, data: ['/tmp/tools.zip'] }),
   }), /\.aemcptools/i);
+  assert.equal(chooseToolPackage({
+    showOpenDialog: () => ({ err: 0, data: ['/tmp/developer.ps1'] }),
+  }), '/tmp/developer.ps1');
 });
 
 test('chooseToolExportPath normalizes cancellation and appends the extension', () => {

--- a/plugin/panel/test/toolRunForm.test.js
+++ b/plugin/panel/test/toolRunForm.test.js
@@ -36,4 +36,3 @@ test('schema form coerces bounded values and rejects missing or invalid input', 
   assert.throws(() => buildToolArgs(schema, { count: '7', mode: 'safe' }), /maximum/);
   assert.throws(() => buildToolArgs(schema, { count: '2', mode: 'unsafe' }), /enum/);
 });
-

--- a/plugin/panel/test/toolRunForm.test.js
+++ b/plugin/panel/test/toolRunForm.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildToolArgs, initialToolArgs, toolArgFields } from '../src/lib/toolRunForm.js';
+
+const schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', default: 'Layer' },
+    count: { type: 'integer', minimum: 1, maximum: 5 },
+    enabled: { type: 'boolean', default: true },
+    mode: { type: 'string', enum: ['safe', 'fast'] },
+  },
+  required: ['count', 'mode'],
+  additionalProperties: false,
+};
+
+test('schema form derives deterministic fields and defaults', () => {
+  assert.deepEqual(initialToolArgs(schema), {
+    name: 'Layer', count: '', enabled: true, mode: '',
+  });
+  assert.deepEqual(toolArgFields(schema).map(({ name, type, required, supported }) => ({
+    name, type, required, supported,
+  })), [
+    { name: 'name', type: 'string', required: false, supported: true },
+    { name: 'count', type: 'integer', required: true, supported: true },
+    { name: 'enabled', type: 'boolean', required: false, supported: true },
+    { name: 'mode', type: 'string', required: true, supported: true },
+  ]);
+});
+
+test('schema form coerces bounded values and rejects missing or invalid input', () => {
+  assert.deepEqual(buildToolArgs(schema, {
+    name: 'Layer', count: '2', enabled: false, mode: 'safe',
+  }), { name: 'Layer', count: 2, enabled: false, mode: 'safe' });
+  assert.throws(() => buildToolArgs(schema, { count: '', mode: 'safe' }), /count/);
+  assert.throws(() => buildToolArgs(schema, { count: '7', mode: 'safe' }), /maximum/);
+  assert.throws(() => buildToolArgs(schema, { count: '2', mode: 'unsafe' }), /enum/);
+});
+

--- a/plugin/panel/test/toolsApi.test.js
+++ b/plugin/panel/test/toolsApi.test.js
@@ -4,6 +4,8 @@ import {
   createToolsApi,
   executeToolPlan,
   parseMcpPayload,
+  startToolPlan,
+  waitForToolExecution,
 } from '../src/cep/toolsApi.js';
 
 test('Tools API uses exact progressive and mutation tool names', async () => {
@@ -58,6 +60,47 @@ test('Tools API uses exact progressive and mutation tool names', async () => {
   assert.deepEqual(calls[13].args, {
     artifact_ids: ['user:1'], out_path: '/tmp/out.aemcptools',
   });
+});
+
+test('startToolPlan uses once approval and returns one server job', async () => {
+  const calls = [];
+  const api = {
+    async use(input) {
+      calls.push(input);
+      if (input.action === 'prepare') return { planHash: 'plan-1' };
+      if (input.action === 'grant') return { grantId: 'grant-1' };
+      return { executionId: 'execution-1', status: 'queued', terminal: false };
+    },
+  };
+  const started = await startToolPlan(api, {
+    artifactId: 'user:1', operation: 'execute', args: { amount: 2 }, target: {},
+  });
+  assert.equal(started.executionId, 'execution-1');
+  assert.deepEqual(calls.map((value) => value.action), ['prepare', 'grant', 'start']);
+  assert.equal(calls[1].grant_scope, 'once');
+});
+
+test('waitForToolExecution reports late terminal completion without a second start', async () => {
+  const calls = [];
+  const states = [
+    { executionId: 'execution-1', status: 'running', progress: 25, terminal: false },
+    { executionId: 'execution-1', status: 'succeeded', progress: 100, terminal: true },
+  ];
+  const progress = [];
+  const result = await waitForToolExecution({
+    async use(input) {
+      calls.push(input);
+      return states.shift();
+    },
+  }, { executionId: 'execution-1', status: 'queued', progress: 0, terminal: false }, {
+    wait: async () => {}, onProgress: (value) => progress.push(value.status),
+  });
+  assert.equal(result.status, 'succeeded');
+  assert.deepEqual(progress, ['queued', 'running', 'succeeded']);
+  assert.deepEqual(calls, [
+    { action: 'status', execution_id: 'execution-1' },
+    { action: 'status', execution_id: 'execution-1' },
+  ]);
 });
 
 test('parseMcpPayload joins text blocks and preserves structured errors', () => {

--- a/plugin/panel/test/toolsApi.test.js
+++ b/plugin/panel/test/toolsApi.test.js
@@ -74,10 +74,57 @@ test('startToolPlan uses once approval and returns one server job', async () => 
   };
   const started = await startToolPlan(api, {
     artifactId: 'user:1', operation: 'execute', args: { amount: 2 }, target: {},
+    operationId: 'operation-panel-0001',
   });
   assert.equal(started.executionId, 'execution-1');
   assert.deepEqual(calls.map((value) => value.action), ['prepare', 'grant', 'start']);
   assert.equal(calls[1].grant_scope, 'once');
+  assert.equal(calls[2].operation_id, 'operation-panel-0001');
+});
+
+test('startToolPlan retries one lost start response with the same operation id', async () => {
+  const starts = [];
+  const api = {
+    async use(input) {
+      if (input.action === 'prepare') return { planHash: 'plan-1' };
+      if (input.action === 'grant') return { grantId: 'grant-1' };
+      starts.push(input);
+      if (starts.length === 1) throw new Error('response lost');
+      return { executionId: 'execution-1', operationId: input.operation_id };
+    },
+  };
+  const result = await startToolPlan(api, {
+    artifactId: 'user:1',
+    operation: 'execute',
+    operationId: 'operation-retry-0001',
+  });
+  assert.equal(result.executionId, 'execution-1');
+  assert.equal(starts.length, 2);
+  assert.equal(starts[0].operation_id, starts[1].operation_id);
+  assert.equal(starts[1].operation_id, 'operation-retry-0001');
+});
+
+test('developer discovery uses only the trusted panel channel', async () => {
+  const publicCalls = [];
+  const panelCalls = [];
+  const api = createToolsApi({
+    async callTool(name, args) {
+      publicCalls.push({ name, args });
+      return { content: [{ type: 'text', text: '{"ok":true}' }] };
+    },
+    async callPanelTool(name, args) {
+      panelCalls.push({ name, args });
+      return { content: [{ type: 'text', text: '{"ok":true}' }] };
+    },
+    newOperationId: () => 'operation-api-0001',
+  });
+  await api.developerIndex({ kinds: ['system-command'] });
+  await api.developerSearch({ query: 'script' });
+  await api.developerInspect('user:command');
+  assert.equal(publicCalls.length, 0);
+  assert.deepEqual(panelCalls.map((value) => value.name), [
+    'ae_toolIndex', 'ae_toolSearch', 'ae_toolInspect',
+  ]);
 });
 
 test('waitForToolExecution reports late terminal completion without a second start', async () => {

--- a/plugin/panel/test/toolsApi.test.js
+++ b/plugin/panel/test/toolsApi.test.js
@@ -150,6 +150,44 @@ test('waitForToolExecution reports late terminal completion without a second sta
   ]);
 });
 
+test('waitForToolExecution retries status with the same execution id', async () => {
+  const calls = [];
+  let attempts = 0;
+  const result = await waitForToolExecution({
+    async use(input) {
+      calls.push(input);
+      attempts += 1;
+      if (attempts < 3) throw new Error('status response lost');
+      return { executionId: 'execution-1', status: 'succeeded', terminal: true };
+    },
+  }, { executionId: 'execution-1', status: 'running', terminal: false }, {
+    wait: async () => {},
+  });
+  assert.equal(result.status, 'succeeded');
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every((input) => input.execution_id === 'execution-1'));
+});
+
+test('waitForToolExecution preserves a nonterminal job for explicit status resume', async () => {
+  const current = {
+    executionId: 'execution-1', operationId: 'operation-1', status: 'running', terminal: false,
+  };
+  const calls = [];
+  await assert.rejects(
+    waitForToolExecution({
+      async use(input) {
+        calls.push(input);
+        throw new Error('status unavailable');
+      },
+    }, current, { wait: async () => {}, statusRetryLimit: 1 }),
+    (error) => error.execution === current && error.recoveryAction === 'resume-status',
+  );
+  assert.deepEqual(calls, [
+    { action: 'status', execution_id: 'execution-1' },
+    { action: 'status', execution_id: 'execution-1' },
+  ]);
+});
+
 test('parseMcpPayload joins text blocks and preserves structured errors', () => {
   assert.deepEqual(parseMcpPayload({
     isError: false,
@@ -185,6 +223,7 @@ test('executeToolPlan binds prepare, once grant, and execute in order', async ()
     operation: 'apply',
     args: { amount: 2 },
     target: { compId: '7', layerId: 1, path: 'Transform/Opacity' },
+    operationId: 'operation-execute-0001',
   }), { ok: true });
   assert.deepEqual(calls, [
     {
@@ -195,6 +234,9 @@ test('executeToolPlan binds prepare, once grant, and execute in order', async ()
       target: { compId: '7', layerId: 1, path: 'Transform/Opacity' },
     },
     { action: 'grant', plan_hash: 'plan-1', grant_scope: 'once' },
-    { action: 'execute', plan_hash: 'plan-1', grant_id: 'grant-1' },
+    {
+      action: 'execute', plan_hash: 'plan-1', grant_id: 'grant-1',
+      operation_id: 'operation-execute-0001',
+    },
   ]);
 });

--- a/plugin/panel/test/toolsState.test.js
+++ b/plugin/panel/test/toolsState.test.js
@@ -119,25 +119,36 @@ test('artifact capabilities enforce source and status boundaries', () => {
 });
 
 test('execution capabilities enforce kind operations and executable statuses', () => {
-  assert.deepEqual(toolExecutionCapabilities(summary({ kind: 'prompt-skill' })), {
-    render: true, execute: false, apply: false,
+  const unavailable = {
+    render: false, execute: false, apply: false, directRun: false,
+    operation: null, requiresTarget: false, disabledReason: null, runtime: null,
+  };
+  assert.deepEqual(toolExecutionCapabilities(summary({ kind: 'jsx' })), unavailable);
+
+  const disabledReason = { code: 'tool_platform_incompatible', message: 'Wrong platform' };
+  assert.deepEqual(toolExecutionCapabilities(summary({
+    kind: 'recipe',
+    executionCapabilities: {
+      runtime: 'native-aegp',
+      operations: ['render', 'execute'],
+      directRun: {
+        available: true, operation: 'execute', requiresTarget: false, disabledReason: null,
+      },
+    },
+  })), {
+    render: true, execute: true, apply: false, directRun: true,
+    operation: 'execute', requiresTarget: false, disabledReason: null, runtime: 'native-aegp',
   });
-  assert.deepEqual(toolExecutionCapabilities(summary({ kind: 'expression' })), {
-    render: true, execute: false, apply: true,
+  assert.deepEqual(toolExecutionCapabilities(summary({
+    kind: 'jsx',
+    executionCapabilities: {
+      runtime: 'jsx', operations: ['render', 'execute'],
+      directRun: { available: false, operation: 'execute', disabledReason },
+    },
+  })), {
+    render: true, execute: true, apply: false, directRun: false,
+    operation: 'execute', requiresTarget: false, disabledReason, runtime: 'jsx',
   });
-  for (const kind of ['jsx', 'diagnostic', 'recipe']) {
-    assert.deepEqual(toolExecutionCapabilities(summary({ kind })), {
-      render: false, execute: true, apply: false,
-    });
-  }
-  for (const status of ['candidate', 'archived', 'deprecated']) {
-    assert.deepEqual(toolExecutionCapabilities(summary({ kind: 'prompt-skill', status })), {
-      render: false, execute: false, apply: false,
-    });
-    assert.deepEqual(toolExecutionCapabilities(summary({ kind: 'jsx', status })), {
-      render: false, execute: false, apply: false,
-    });
-  }
 });
 
 test('stale revision errors retain the editor draft and request refresh', () => {


### PR DESCRIPTION
Closes #62.

## Outcome

Tool Library can now run supported tools directly from the CEP panel without an Agent. The same Core execution service, approval gates, compatibility checks, operation identity, structured status, cancellation, audit, and history are used by both panel and agent callers.

System-level scripts (`.ps1/.psm1/.bat/.cmd/.sh/.command`) are imported only as developer-only `system-command` artifacts. They remain hidden from ordinary MCP discovery and inspect, cannot be selected through the public schema, and have no execution path.

## What changed

- Server-declared execution capabilities and hash-bound `start/status/cancel/history` jobs.
- Row/detail Run controls, schema-derived inputs/defaults, once-only approval, progress, Resume/Cancel, result, and history UI.
- Stable `operation_id` recovery: a retry with the same operation ID does not redispatch an uncertain native write.
- Structured preservation of `outcomeUnknown`, side-effect, recovery, execution ID, and audit metadata.
- Cold-Core startup retry and panel status polling with bounded recovery.
- Per-process secret-bound developer channel; public MCP has no model-settable developer mode.
- Persisted `system-command` allowlist and import/reopen regression coverage.

## Automated validation

Exact head: `5de068b9989c8a8d9a0493d75244711f477a8b9b`.

- Python/workspace: `860 passed, 4 skipped, 25 deselected`.
- Panel: `960 passed, 2 skipped, 0 failed`.
- Targeted Core: `126 passed`; reviewer rerun: Core `149 passed`, panel `26 passed`.
- Panel production build and tracked dist verification passed.
- Full-branch `git diff --check` passed.
- GitHub CI run 29562583451: all Linux packaging/native-contract, Windows JS/panel/host, and Windows Python jobs passed.
- Independent diff review of exact `5de068b`: PASS, no unresolved in-scope P0/P1.

## Exact-candidate hardware gate

Host identity:

- Formal app only: `/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app`.
- Bundle ID `com.adobe.AfterEffects.application`; Beta not running.
- After Effects `26.3.0`, build `87`.
- Native SDK provenance `25.6.61`.
- Core, CEP, native receipt/runtime, and validation checkout all bound to exact `5de068b`.

Native artifact:

- Bundle tree: `33025f6f18a6c4bf59159b8e91cd4dd07adb777561645f4e05c5c6673e9f48b7`.
- Executable: `83517e46d760fcffbca500a45a2db3b1d51ff5e7f4a01694114942e753182266`.
- PiPL: `4c439de251ad7d3d8f49bb54967e420152063d06909db29612c7eac60722c665`.
- Ad-hoc signature verified; AE mapped only the canonical MediaCore `ae-mcp/AeMcpNative.plugin`.

Public MCP cold-start read:

```json
{
  "tool": "ae_projectSummary",
  "request": {},
  "response": {
    "ok": true,
    "projectOpen": true,
    "itemCount": 0,
    "engine": "native-aegp",
    "capabilityId": "ae.project.summary",
    "capabilityVersion": 1,
    "sourceCommit": "5de068b9989c8a8d9a0493d75244711f477a8b9b",
    "verifiedPostcondition": true
  }
}
```

The panel row Run control then invoked the saved native recipe without an Agent. Native request `mcp-143ae05cab464c1fa80be8dcb52581a0` returned `itemCount=0`; Tool Library audit `startedAt=1784272248583`, `finishedAt=1784272248793` recorded `backend=native-aegp`, `engine=native-aegp`, `outcome=success`.

## Exact-candidate write, Undo, and recovery evidence

Disposable fixture only; initial state was `itemCount=0`.

- Panel row Run on `issue62-jsx-create-comp` required explicit product approval and received a once grant.
- Audit `startedAt=1784272740772`, `finishedAt=1784272740969`: `backend=ae-mcp`, `engine=maintained-jsx`, `outcome=success`.
- Public native reads at the same exact source commit verified: write `0 -> 1`; real AE Undo `1 -> 0`; real AE Redo `0 -> 1`; final Undo `1 -> 0`.
- Every read reported `engine=native-aegp`, exact source commit, and `verifiedPostcondition=true`.
- Final restored state was saved. No ambiguous or possibly-side-effecting failure occurred.

## Exact-candidate system-command quarantine

A disposable `issue62-quarantined.ps1` was imported through public MCP at exact `5de068b`.

```json
{
  "kind": "system-command",
  "risk": "external",
  "ordinaryHidden": true,
  "ordinaryInspect": {"ok": false, "error": "tool_not_found"},
  "prepareDenied": {"ok": false, "error": "tool_status_blocked"},
  "publicSchema": {
    "developerMode": false,
    "systemCommandKind": false,
    "operationId": true,
    "useActions": ["render", "prepare", "grant", "execute", "start", "status", "cancel", "history"]
  },
  "cleanup": {"ok": true}
}
```

The developer view separately showed the quarantined metadata and the explicit message that system-command assets cannot execute. The disposable artifact was deleted through public MCP after verification.

## Recovery/restart gate

After full formal-AE quit/restart, a new native host instance loaded exact `5de068b`, pairing fingerprint `0358-6976` was matched inside AE, and public `ae_projectSummary {}` again returned `itemCount=0` with native provenance and verified postcondition. Tool Library cold-started, loaded saved tools, and direct native Run succeeded.

## Remaining risk / follow-ups

- Durable execution status/history across a Core restart is intentionally P1 #136.
- Generic shell/PowerShell execution is intentionally absent; system commands stay quarantined.
- Signing/notarization, Windows native implementation, Provider work, folder hierarchy, and future AEGP/JSX routing remain outside #62.
- Reference-table documentation drift is tracked separately as P2 and does not affect runtime behavior.