### PR TITLE
fix(tool-library): persist terminal execution recovery

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -244,6 +244,8 @@ Edit 的 `changes` 只允许 `name`, `description`, `kind`, `category`, `tags`, 
 
 grant 只能消费一次。execute 前会重新读取制品、args schema 与 recipe/handler 依赖，任一变化都会使旧 plan/grant 失效。
 
+完成后的 Tool Library execution job 会以最多 500 条的脱敏终态记录保存在 Tool Library 根目录的 `execution-history.json`。`status`/`history` 因此可在 Core 重启后恢复 `succeeded`、`failed`、`cancelled` 或 `outcome-unknown`；相同 `operation_id` 与相同 plan 返回原 execution，不会再次派发 backend，若 plan 不同则返回 `tool_operation_conflict`。该记录只用于执行恢复，与 artifact 的 `lastUsedAt` 和追加式 `audit.jsonl` 各自独立；它不保存 grant、批准秘密、panel capability token 或未脱敏参数。只有已经终止的 job 进入该文件，不能把尚未产生终态的进程中任务描述成已持久恢复。
+
 四档最低策略：read 始终可读；readonly 拒绝其他风险；manual 对 write/destructive/external 询问；auto/none 自动放行普通 write，但 destructive/external 仍逐次询问。只有 write plan 可获得 session 放行；destructive/external 只能 once。write 的 session key 绑定 artifact/content/operation/normalized target，不按工具名缓存。
 
 Import flow：
@@ -567,6 +569,8 @@ The exact `ae.toolUse` action shapes are:
 | `execute` | `action`, `plan_hash`, `grant_id` | none | the kind/operation-specific render, backend, or handler result with `ok: true`; recipes return `results[]` |
 
 A grant is consumed once. Immediately before execution the artifact, args schema, and recipe/handler dependencies are re-read, so any change invalidates the old plan/grant.
+
+Completed Tool Library execution jobs are retained as at most 500 redacted terminal records in `execution-history.json` under the Tool Library root. `status` and `history` can therefore recover `succeeded`, `failed`, `cancelled`, or `outcome-unknown` after a Core restart. Reusing the same `operation_id` with the same plan returns the original execution without backend redispatch; a different plan returns `tool_operation_conflict`. This recovery record is separate from artifact `lastUsedAt` metadata and the append-only `audit.jsonl`. It stores no grants, approval secrets, panel capability tokens, or unredacted arguments. Only terminal jobs enter this file; an in-process job that has not reached a terminal state must not be described as durably recovered.
 
 Minimum four-tier policy: reads are allowed; readonly denies other risks; manual asks for write/destructive/external; auto and none allow ordinary writes, while destructive/external always ask. Only write plans can receive session approval; destructive/external plans are once-only. A write session key binds artifact/content/operation/normalized target and is never cached by tool name.
 

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -32,6 +32,7 @@ from ae_mcp.tool_artifact import (
     validate_args_schema,
 )
 from ae_mcp.tool_audit import AuditRecord, ToolAuditLog, redact_audit_value
+from ae_mcp.tool_execution_history import ExecutionJobStore, ExecutionJobStoreError
 from ae_mcp.tool_secrets import RegexSecretScanner, SecretScanner
 
 
@@ -709,6 +710,27 @@ class _ExecutionJob:
     error: Mapping[str, JsonValue] | None = None
     audit: Mapping[str, JsonValue] | None = None
 
+    @classmethod
+    def from_record(cls, value: Mapping[str, JsonValue]) -> "_ExecutionJob":
+        return cls(
+            execution_id=cast(str, value["executionId"]),
+            operation_id=cast(str, value["operationId"]),
+            artifact_id=cast(str, value["artifactId"]),
+            content_hash=cast(str, value["contentHash"]),
+            artifact_revision=cast(int, value["artifactRevision"]),
+            plan_hash=cast(str, value["planHash"]),
+            operation=cast(ArtifactOperation, value["operation"]),
+            initiator=cast(str, value["initiator"]),
+            status=cast(str, value["status"]),
+            created_at=cast(int, value["createdAt"]),
+            started_at=cast(int | None, value.get("startedAt")),
+            finished_at=cast(int | None, value.get("finishedAt")),
+            cancel_requested=cast(bool, value.get("cancelRequested", False)),
+            result=cast(Mapping[str, JsonValue] | None, value.get("result")),
+            error=cast(Mapping[str, JsonValue] | None, value.get("error")),
+            audit=cast(Mapping[str, JsonValue] | None, value.get("audit")),
+        )
+
     def public_dict(self) -> dict[str, JsonValue]:
         terminal = self.status in {"succeeded", "failed", "cancelled", "outcome-unknown"}
         progress = 100 if terminal else 25 if self.status == "running" else 0
@@ -838,6 +860,7 @@ class ToolExecutionEngine:
         audit_log: ToolAuditLog | None = None,
         prepared_plans: PreparedPlanStore | None = None,
         grants: GrantStore | None = None,
+        job_store: ExecutionJobStore | None = None,
         now: Callable[[], int] | None = None,
     ) -> None:
         self.store = store
@@ -847,10 +870,16 @@ class ToolExecutionEngine:
         self._now = now or _now_ms
         self.prepared_plans = prepared_plans or PreparedPlanStore(now=self._now)
         self.grants = grants or GrantStore(now=self._now)
+        self.job_store = job_store
         self._jobs: dict[str, _ExecutionJob] = {}
         self._job_operations: dict[str, str] = {}
         self._job_tasks: dict[str, asyncio.Task[None]] = {}
         self._job_lock = threading.RLock()
+        if self.job_store is not None:
+            for record in self.job_store.load():
+                job = _ExecutionJob.from_record(record)
+                self._jobs[job.execution_id] = job
+                self._job_operations[job.operation_id] = job.execution_id
         self._unsubscribe: Callable[[], None] | None = None
         subscribe = getattr(store, "subscribe", None)
         if callable(subscribe):
@@ -1186,6 +1215,24 @@ class ToolExecutionEngine:
             # write failure must never invite a duplicate side-effecting retry.
             return
 
+    def _persist_job(self, job: _ExecutionJob) -> None:
+        if self.job_store is None:
+            return
+        try:
+            self.job_store.upsert(job.public_dict())
+        except ExecutionJobStoreError as exc:
+            raise ToolExecutionError(
+                exc.code,
+                "Execution recovery state could not be persisted.",
+                error_details={
+                    "sideEffect": "not-started",
+                    "recovery": {
+                        "action": "retry-later",
+                        "hint": "Repair the Tool Library store before retrying.",
+                    },
+                },
+            ) from exc
+
     async def start_job(
         self,
         plan_hash: str,
@@ -1298,6 +1345,7 @@ class ToolExecutionEngine:
 
     async def _run_job(self, job: _ExecutionJob, *, grant_id: str, ctx: Any) -> None:
         await asyncio.sleep(0)
+        cancelled_before_dispatch = False
         with self._job_lock:
             if job.cancel_requested:
                 try:
@@ -1308,9 +1356,26 @@ class ToolExecutionEngine:
                 job.status = "cancelled"
                 job.finished_at = self._now()
                 self._job_tasks.pop(job.execution_id, None)
-                return
-            job.status = "running"
-            job.started_at = self._now()
+                cancelled_before_dispatch = True
+            else:
+                job.status = "running"
+                job.started_at = self._now()
+        if cancelled_before_dispatch:
+            try:
+                self._persist_job(job)
+            except ToolExecutionError:
+                with self._job_lock:
+                    job.status = "failed"
+                    job.error = {
+                        "code": "tool_execution_history_failed",
+                        "message": "Cancellation recovery state could not be persisted.",
+                        "sideEffect": "not-started",
+                        "recovery": {
+                            "action": "retry-later",
+                            "hint": "Repair the Tool Library store before retrying.",
+                        },
+                    }
+            return
         try:
             result = await self.execute(job.plan_hash, grant_id, ctx=ctx)
         except ToolExecutionError as exc:
@@ -1350,6 +1415,22 @@ class ToolExecutionEngine:
         finally:
             with self._job_lock:
                 self._job_tasks.pop(job.execution_id, None)
+        try:
+            self._persist_job(job)
+        except ToolExecutionError:
+            with self._job_lock:
+                job.result = None
+                job.error = {
+                    "code": "tool_execution_history_failed",
+                    "message": "Execution finished but durable recovery could not be confirmed.",
+                    "sideEffect": "may-have-occurred",
+                    "recovery": {
+                        "action": "inspect-state",
+                        "hint": "Inspect AE state and audit evidence before retrying.",
+                    },
+                }
+                job.status = "outcome-unknown"
+                job.finished_at = self._now()
 
     def job_status(self, execution_id: str) -> Mapping[str, JsonValue]:
         with self._job_lock:

--- a/packages/core/ae_mcp/tool_execution_history.py
+++ b/packages/core/ae_mcp/tool_execution_history.py
@@ -1,0 +1,263 @@
+"""Crash-safe, redacted recovery records for Tool Library executions."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from ae_mcp.tool_artifact import JsonValue
+from ae_mcp.tool_audit import redact_audit_value
+from ae_mcp.tool_store import StoreLock, ToolStoreError, atomic_write_json
+
+
+EXECUTION_HISTORY_SCHEMA_VERSION = 1
+EXECUTION_HISTORY_MAX_RECORDS = 500
+
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+_TERMINAL_STATUSES = frozenset(
+    {"succeeded", "failed", "cancelled", "outcome-unknown"}
+)
+_OPERATIONS = frozenset({"render", "execute", "apply"})
+
+
+class ExecutionJobStoreError(RuntimeError):
+    code = "tool_execution_history_failed"
+
+
+def _bounded_string(value: Any, *, minimum: int = 1, maximum: int = 256) -> str:
+    if not isinstance(value, str) or not minimum <= len(value) <= maximum:
+        raise ExecutionJobStoreError("Execution history contains an invalid string.")
+    return value
+
+
+def _timestamp(value: Any, *, optional: bool = False) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ExecutionJobStoreError("Execution history contains an invalid timestamp.")
+    return value
+
+
+def _optional_mapping(value: Any) -> Mapping[str, JsonValue] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ExecutionJobStoreError("Execution history payload must be an object.")
+
+    def strip_ephemeral(item: JsonValue) -> JsonValue:
+        if isinstance(item, dict):
+            return {
+                key: strip_ephemeral(child)
+                for key, child in item.items()
+                if re.sub(r"[^a-z0-9]", "", key.casefold())
+                not in {"grant", "grantid", "grantscope"}
+            }
+        if isinstance(item, list):
+            return [strip_ephemeral(child) for child in item]
+        return item
+
+    redacted = redact_audit_value(strip_ephemeral(cast(JsonValue, dict(value))))
+    if not isinstance(redacted, dict):
+        raise ExecutionJobStoreError("Execution history payload is invalid.")
+    return cast(Mapping[str, JsonValue], redacted)
+
+
+def _normalize(record: Mapping[str, Any]) -> dict[str, JsonValue]:
+    execution_id = _bounded_string(record.get("executionId"), maximum=128)
+    operation_id = _bounded_string(
+        record.get("operationId"), minimum=16, maximum=128
+    )
+    artifact_id = _bounded_string(record.get("artifactId"), maximum=256)
+    content_hash = _bounded_string(record.get("contentHash"), minimum=64, maximum=64)
+    plan_hash = _bounded_string(record.get("planHash"), minimum=64, maximum=64)
+    if not _HEX_64.fullmatch(content_hash) or not _HEX_64.fullmatch(plan_hash):
+        raise ExecutionJobStoreError("Execution history hashes are invalid.")
+    revision = record.get("artifactRevision")
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ExecutionJobStoreError("Execution history revision is invalid.")
+    operation = _bounded_string(record.get("operation"), maximum=16)
+    if operation not in _OPERATIONS:
+        raise ExecutionJobStoreError("Execution history operation is invalid.")
+    # client_identity.set_client() exposes labels up to 120 characters. Keep
+    # the durable envelope aligned so a valid public client cannot execute a
+    # write and only then fail recovery persistence.
+    initiator = _bounded_string(record.get("initiator"), maximum=120)
+    status = _bounded_string(record.get("status"), maximum=32)
+    if status not in _TERMINAL_STATUSES:
+        raise ExecutionJobStoreError("Execution history status is invalid.")
+    cancel_requested = record.get("cancelRequested", False)
+    if not isinstance(cancel_requested, bool):
+        raise ExecutionJobStoreError("Execution history cancellation state is invalid.")
+    finished_at = _timestamp(record.get("finishedAt"))
+
+    result = _optional_mapping(record.get("result"))
+    error = _optional_mapping(record.get("error"))
+    if status == "succeeded" and (result is None or error is not None):
+        raise ExecutionJobStoreError("Execution history success payload is invalid.")
+    if status in {"failed", "outcome-unknown"} and error is None:
+        raise ExecutionJobStoreError("Execution history error payload is invalid.")
+    if status == "cancelled" and result is not None:
+        raise ExecutionJobStoreError("Execution history cancellation payload is invalid.")
+
+    normalized: dict[str, JsonValue] = {
+        "executionId": execution_id,
+        "operationId": operation_id,
+        "artifactId": artifact_id,
+        "contentHash": content_hash,
+        "artifactRevision": revision,
+        "planHash": plan_hash,
+        "operation": operation,
+        "initiator": initiator,
+        "status": status,
+        "createdAt": cast(int, _timestamp(record.get("createdAt"))),
+        "startedAt": _timestamp(record.get("startedAt"), optional=True),
+        "finishedAt": cast(int, finished_at),
+        "cancelRequested": cancel_requested,
+        "result": cast(JsonValue, result),
+        "error": cast(JsonValue, error),
+        "audit": cast(JsonValue, _optional_mapping(record.get("audit"))),
+    }
+    return normalized
+
+
+class ExecutionJobStore:
+    """Persist bounded execution recovery without persisting grants or arguments."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        max_records: int = EXECUTION_HISTORY_MAX_RECORDS,
+    ) -> None:
+        if (
+            isinstance(max_records, bool)
+            or not isinstance(max_records, int)
+            or max_records < 1
+        ):
+            raise ValueError("execution history max_records must be positive")
+        self.root = Path(root).expanduser().absolute()
+        self.path = self.root / "execution-history.json"
+        self.max_records = max_records
+
+    def _read_unlocked(self) -> list[dict[str, JsonValue]]:
+        if not self.path.exists():
+            return []
+        if self.path.is_symlink() or not self.path.is_file():
+            raise ExecutionJobStoreError("Execution history path is invalid.")
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ExecutionJobStoreError("Execution history cannot be read.") from exc
+        if (
+            not isinstance(raw, Mapping)
+            or raw.get("schemaVersion") != EXECUTION_HISTORY_SCHEMA_VERSION
+            or not isinstance(raw.get("executions"), list)
+        ):
+            raise ExecutionJobStoreError("Execution history schema is invalid.")
+        records = [
+            _normalize(cast(Mapping[str, Any], item))
+            for item in cast(list[Any], raw["executions"])
+            if isinstance(item, Mapping)
+        ]
+        if len(records) != len(raw["executions"]):
+            raise ExecutionJobStoreError("Execution history record is invalid.")
+        execution_ids = [cast(str, row["executionId"]) for row in records]
+        operation_ids = [cast(str, row["operationId"]) for row in records]
+        if (
+            len(set(execution_ids)) != len(records)
+            or len(set(operation_ids)) != len(records)
+        ):
+            raise ExecutionJobStoreError("Execution history identities are duplicated.")
+        return records
+
+    def _prune(self, records: list[dict[str, JsonValue]]) -> list[dict[str, JsonValue]]:
+        records.sort(
+            key=lambda row: (
+                cast(int, row["createdAt"]),
+                cast(str, row["executionId"]),
+            ),
+            reverse=True,
+        )
+        kept = records[: self.max_records]
+        kept.sort(
+            key=lambda row: (
+                cast(int, row["createdAt"]),
+                cast(str, row["executionId"]),
+            )
+        )
+        return kept
+
+    def _write_unlocked(self, records: list[dict[str, JsonValue]]) -> None:
+        atomic_write_json(
+            self.path,
+            {
+                "schemaVersion": EXECUTION_HISTORY_SCHEMA_VERSION,
+                "executions": cast(JsonValue, records),
+            },
+        )
+
+    def upsert(self, record: Mapping[str, Any]) -> None:
+        normalized = _normalize(record)
+        try:
+            with StoreLock(self.root):
+                records = self._read_unlocked()
+                immutable = (
+                    "executionId",
+                    "operationId",
+                    "artifactId",
+                    "contentHash",
+                    "artifactRevision",
+                    "planHash",
+                    "operation",
+                    "createdAt",
+                )
+                for current in records:
+                    same_execution = (
+                        current["executionId"] == normalized["executionId"]
+                    )
+                    same_operation = (
+                        current["operationId"] == normalized["operationId"]
+                    )
+                    if not same_execution and not same_operation:
+                        continue
+                    if not same_execution or not same_operation or any(
+                        current[key] != normalized[key] for key in immutable
+                    ):
+                        raise ExecutionJobStoreError(
+                            "Execution history identity conflicts with an existing "
+                            "record."
+                        )
+                records = [
+                    row
+                    for row in records
+                    if row["executionId"] != normalized["executionId"]
+                    and row["operationId"] != normalized["operationId"]
+                ]
+                records.append(normalized)
+                self._write_unlocked(self._prune(records))
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError(
+                "Execution history cannot be persisted."
+            ) from exc
+
+    def load(self) -> list[dict[str, JsonValue]]:
+        try:
+            with StoreLock(self.root):
+                records = self._read_unlocked()
+                pruned = self._prune(records)
+                if len(pruned) != len(records):
+                    self._write_unlocked(pruned)
+                return [dict(row) for row in pruned]
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError("Execution history cannot be loaded.") from exc
+
+
+__all__ = [
+    "EXECUTION_HISTORY_MAX_RECORDS",
+    "EXECUTION_HISTORY_SCHEMA_VERSION",
+    "ExecutionJobStore",
+    "ExecutionJobStoreError",
+]

--- a/packages/core/ae_mcp/tool_service.py
+++ b/packages/core/ae_mcp/tool_service.py
@@ -23,6 +23,7 @@ from ae_mcp.tool_artifact import (
 )
 from ae_mcp.tool_audit import ToolAuditLog
 from ae_mcp.tool_execution import ToolExecutionEngine
+from ae_mcp.tool_execution_history import ExecutionJobStore
 from ae_mcp.tool_legacy import LegacyMetadataStore, LegacySkillAdapter
 from ae_mcp.tool_migrations import ToolDataMigrator
 from ae_mcp.tool_secrets import RegexSecretScanner
@@ -414,6 +415,7 @@ def default_tool_service() -> ToolLibraryService:
             discovery.select_backend,
             scanner=scanner,
             audit_log=ToolAuditLog(root),
+            job_store=ExecutionJobStore(root),
         )
         packages = ToolPackageManager(store, scanner)
         _default_service = ToolLibraryService(

--- a/packages/core/tests/test_handlers_tools.py
+++ b/packages/core/tests/test_handlers_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import replace
 from pathlib import Path
@@ -19,6 +20,7 @@ from ae_mcp.tool_archive import (
 )
 from ae_mcp.tool_artifact import (
     ToolArtifact,
+    ToolArtifactDraft,
     ToolSource,
     ToolSummary,
     ToolVerification,
@@ -484,6 +486,119 @@ async def test_tool_use_dispatches_staged_protocol_exactly(service, action):
     else:
         assert result["ok"] is True
     assert service.execution.calls[0][0] == action
+
+
+@pytest.mark.asyncio
+async def test_public_status_history_and_start_recover_after_default_service_restart(
+    monkeypatch, tmp_path
+):
+    from ae_mcp import tool_service as service_module
+
+    class Backend:
+        name = "restart-fixture"
+
+        def __init__(self):
+            self.calls = []
+
+        async def exec(self, code, **kwargs):
+            self.calls.append((code, kwargs))
+            return '{"ok":true}'
+
+    reset_default_tool_service_for_tests()
+    monkeypatch.setenv("AE_MCP_TOOL_DIR", str(tmp_path / "tools"))
+    monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path / "skills"))
+    backend = Backend()
+    monkeypatch.setattr(service_module.discovery, "select_backend", lambda: backend)
+
+    draft = ToolArtifactDraft(
+        name="restart fixture",
+        description="",
+        kind="jsx",
+        category="verification",
+        tags=(),
+        compatibility={},
+        declared_risk="read",
+        source=ToolSource("user", "manual", None, None, {}),
+        status="saved",
+        content="return true;",
+        args_schema={},
+    )
+    try:
+        first = default_tool_service()
+        artifact = first.store.create(draft)
+        plan = first.execution.prepare(
+            artifact.id, operation="execute", args={}, target={}
+        )
+        grant = first.execution.grants.issue_once(plan)
+        started = await first.execution.start_job(
+            plan.plan_hash,
+            grant.grant_id,
+            operation_id="operation-public-restart",
+            ctx=None,
+            initiator="panel-direct",
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert (
+            first.execution.job_status(started["executionId"])["status"]
+            == "succeeded"
+        )
+        reset_default_tool_service_for_tests()
+
+        recovered_status = await handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="status", execution_id=started["executionId"]
+            ),
+            None,
+        )
+        recovered_history = await handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="history", artifact_id=artifact.id, limit=10
+            ),
+            None,
+        )
+        duplicate_start = await handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="start",
+                plan_hash=plan.plan_hash,
+                grant_id=grant.grant_id,
+                operation_id="operation-public-restart",
+            ),
+            None,
+        )
+
+        assert recovered_status["executionId"] == started["executionId"]
+        assert recovered_status["status"] == "succeeded"
+        assert (
+            recovered_history["executions"][0]["executionId"]
+            == started["executionId"]
+        )
+        assert duplicate_start["executionId"] == started["executionId"]
+        assert len(backend.calls) == 1
+    finally:
+        reset_default_tool_service_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_execution_history_fails_closed_through_public_index(
+    monkeypatch, tmp_path
+):
+    reset_default_tool_service_for_tests()
+    tool_root = tmp_path / "tools"
+    tool_root.mkdir()
+    (tool_root / "execution-history.json").write_text("{broken", encoding="utf-8")
+    monkeypatch.setenv("AE_MCP_TOOL_DIR", str(tool_root))
+    monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path / "skills"))
+
+    try:
+        result = await handlers._run_tool_index(S.AeToolIndexArgs(), None)
+        assert result == {
+            "ok": False,
+            "error": "tool_execution_history_failed",
+            "message": "Execution history cannot be read.",
+        }
+    finally:
+        reset_default_tool_service_for_tests()
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -33,6 +33,7 @@ from ae_mcp.tool_execution import (
     normalize_args,
     normalize_target,
 )
+from ae_mcp.tool_execution_history import ExecutionJobStore
 from ae_mcp.tool_store import StoreMutation
 
 
@@ -1050,3 +1051,247 @@ async def test_native_uncertain_write_keeps_recovery_and_is_never_blindly_retrie
         )
     assert second.value.public_dict()["executionId"] == public["executionId"]
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_job_survives_restart_and_same_operation_is_not_redispatched(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    first_backend = _Backend()
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        audit_log=ToolAuditLog(tmp_path),
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 10_000,
+    )
+    plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = first.grants.issue_once(plan)
+    started = await first.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-restart-success",
+        ctx=None,
+        initiator="panel-direct",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert first.job_status(started["executionId"])["status"] == "succeeded"
+    assert len(first_backend.calls) == 1
+    first.close()
+
+    second_backend = _Backend()
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        audit_log=ToolAuditLog(tmp_path),
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 10_000,
+    )
+    recovered = second.job_status(started["executionId"])
+    assert recovered["status"] == "succeeded"
+    assert recovered["result"] == {"ok": True}
+    assert recovered["audit"]["outcome"] == "success"
+    assert second.job_history(artifact.id)["executions"][0]["executionId"] == started[
+        "executionId"
+    ]
+
+    second.prepared_plans.put(plan)
+    replacement_grant = second.grants.issue_once(plan)
+    duplicate = await second.start_job(
+        plan.plan_hash,
+        replacement_grant.grant_id,
+        operation_id="operation-restart-success",
+        ctx=None,
+        initiator="panel-direct",
+    )
+    assert duplicate["executionId"] == started["executionId"]
+    assert second_backend.calls == []
+    with pytest.raises(ToolExecutionError) as conflict:
+        await second.start_job(
+            "f" * 64,
+            replacement_grant.grant_id,
+            operation_id="operation-restart-success",
+            ctx=None,
+            initiator="panel-direct",
+        )
+    assert conflict.value.code == "tool_operation_conflict"
+
+
+@pytest.mark.asyncio
+async def test_failed_job_survives_restart_without_backend_replay(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    first_backend = _Backend(RuntimeError("private failure detail"))
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 15_000,
+    )
+    plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = first.grants.issue_once(plan)
+    started = await first.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-restart-failure",
+        ctx=None,
+        initiator="agent",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert first.job_status(started["executionId"])["status"] == "failed"
+    first.close()
+
+    second_backend = _Backend()
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 15_000,
+    )
+    recovered = second.job_status(started["executionId"])
+    assert recovered["status"] == "failed"
+    assert recovered["error"]["code"] == "tool_backend_failed"
+    assert "private failure detail" not in (
+        tmp_path / "execution-history.json"
+    ).read_text(encoding="utf-8")
+
+    second.prepared_plans.put(plan)
+    replacement_grant = second.grants.issue_once(plan)
+    duplicate = await second.start_job(
+        plan.plan_hash,
+        replacement_grant.grant_id,
+        operation_id="operation-restart-failure",
+        ctx=None,
+        initiator="agent",
+    )
+    assert duplicate["executionId"] == started["executionId"]
+    assert second_backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_outcome_unknown_survives_restart_with_recovery_and_no_redispatch(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    first_backend = _Backend(asyncio.TimeoutError())
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 20_000,
+    )
+    plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = first.grants.issue_once(plan)
+    started = await first.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-restart-unknown",
+        ctx=None,
+        initiator="agent",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert first.job_status(started["executionId"])["status"] == "outcome-unknown"
+    first.close()
+
+    second_backend = _Backend()
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 20_000,
+    )
+    recovered = second.job_status(started["executionId"])
+    assert recovered["status"] == "outcome-unknown"
+    assert recovered["error"]["code"] == "tool_backend_timeout"
+    assert recovered["outcomeUnknown"] is True
+
+    second.prepared_plans.put(plan)
+    replacement_grant = second.grants.issue_once(plan)
+    duplicate = await second.start_job(
+        plan.plan_hash,
+        replacement_grant.grant_id,
+        operation_id="operation-restart-unknown",
+        ctx=None,
+        initiator="agent",
+    )
+    assert duplicate["executionId"] == started["executionId"]
+    assert second_backend.calls == []
+
+
+def test_execution_job_store_bounds_retention_and_redacts_secrets(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJobStore(tmp_path, max_records=2)
+    for index in range(3):
+        store.upsert(
+            {
+                "executionId": f"execution-{index:02d}",
+                "operationId": f"operation-retention-{index:02d}",
+                "artifactId": "user:one",
+                "contentHash": "a" * 64,
+                "artifactRevision": 1,
+                "planHash": chr(ord("b") + index) * 64,
+                "operation": "execute",
+                "initiator": "panel-direct",
+                "status": "failed",
+                "createdAt": 100 + index,
+                "startedAt": 100 + index,
+                "finishedAt": 100 + index,
+                "cancelRequested": False,
+                "result": None,
+                "error": {
+                    "code": "fixture",
+                    "message": f"Bearer private-secret-{index}",
+                },
+                "audit": {
+                    "grantId": f"grant-secret-{index}",
+                    "grantScope": "once",
+                    "outcome": "failed",
+                },
+            }
+        )
+
+    recovered = store.load()
+    assert [row["executionId"] for row in recovered] == [
+        "execution-01",
+        "execution-02",
+    ]
+    persisted = (tmp_path / "execution-history.json").read_text(encoding="utf-8")
+    assert "private-secret" not in persisted
+    assert "grant-secret" not in persisted
+    assert "grantId" not in persisted
+    assert "[REDACTED]" in persisted
+
+
+def test_execution_job_store_accepts_full_public_client_identity(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJobStore(tmp_path)
+    initiator = "c" * 120
+    store.upsert(
+        {
+            "executionId": "execution-client-identity",
+            "operationId": "operation-client-identity",
+            "artifactId": "user:one",
+            "contentHash": "a" * 64,
+            "artifactRevision": 1,
+            "planHash": "b" * 64,
+            "operation": "execute",
+            "initiator": initiator,
+            "status": "succeeded",
+            "createdAt": 100,
+            "startedAt": 100,
+            "finishedAt": 101,
+            "cancelRequested": False,
+            "result": {"ok": True},
+            "error": None,
+            "audit": None,
+        }
+    )
+
+    assert store.load()[0]["initiator"] == initiator


### PR DESCRIPTION
Closes #136

Parent: #50  
Priority: P1

## Outcome

Persist the bounded terminal Tool Library execution envelope so public `ae_toolUse` status/history and stable operation-id deduplication survive a Core process restart. Queued/running jobs remain intentionally process-local; the durable file contains terminal records only and strips grant material while preserving structured result/error and audit linkage.

## Changes

- add a schema-versioned, locked, atomic `execution-history.json` store with 0600 permissions and a 500-record default bound;
- restore terminal jobs into the execution engine during Core startup;
- return a restored job for the same operation id before plan/grant lookup, while retaining explicit conflict behavior for another plan hash;
- persist success, failure, cancellation, and outcome-unknown recovery records;
- fail closed on corrupt history and surface an explicit inspect-state recovery when persistence cannot be confirmed after dispatch;
- document durable execution recovery separately from `lastUsedAt` and the append-only audit log.

## Automated validation at exact candidate

Candidate: `20ef808dec6a552baf524c01acf73f19a99ea430`

- full Python workspace: 867 passed, 4 skipped, 25 deselected;
- focused execution/restart coverage: 72 passed;
- native protocol: 38 passed;
- packaging/release contracts: 378 passed, 6 skipped;
- host: 121 passed;
- panel: 960 passed, 2 skipped;
- sidecar: 32 passed;
- worktree governance: passed against the audited 26-worktree baseline;
- panel production build: passed; committed bundle unchanged.

New coverage includes restart recovery for success/failure/outcome-unknown, public handler recovery, operation-id no-replay/conflict, corrupt-store fail-closed behavior, bounded retention, grant/secret redaction, persistence-failure recovery semantics, and the full 120-character public MCP client-identity limit.

## Exact-candidate hardware gate

Target: formal After Effects 26.3.0 build 87, bundle `com.adobe.AfterEffects.application` (Beta excluded).

- native load event reported the full candidate SHA above;
- only the canonical native bundle was mapped by the AE process;
- installed native bundle-tree SHA-256: `88c33c10f59d07577381ce2d79f85a34a28e2fb90d8ecb3dcd4d913b76f8ce4e`;
- installed native executable SHA-256: `a0c16d9907ab2ac5a0795854ef8097e2fccfe4e5caa498d5825d55e282a21180`;
- installed PiPL SHA-256: `4c439de251ad7d3d8f49bb54967e420152063d06909db29612c7eac60722c665`.

Public acceptance on a dedicated disposable AEP:

1. `ae_projectSummary {}` returned `itemCount: 0`, `engine: native-aegp`, verified postcondition, and the exact candidate SHA.
2. Public `ae_toolCreate` created a disposable write-risk JSX artifact in an isolated Tool Library root.
3. Public `ae_toolUse` prepare -> grant -> start used a stable operation id and a 120-character public client identity; terminal status was `succeeded`, result reported one created composition, audit linked `maintained-jsx` / `ae-mcp` / the plan and content hashes.
4. Public native read returned `itemCount: 1`.
5. Core was closed and started again. Public status and history recovered the terminal execution from disk. The expected durable redaction removed grant id/scope from the recovered audit while preserving plan/content/artifact linkage and outcome.
6. Public start with the same operation id returned the existing execution. CEP activity remained at exactly one original JSX dispatch and zero recovery-process JSX dispatches; native read remained `itemCount: 1`. The durable record retained the complete 120-character client identity and no grant fields.
7. A real AE Undo was executed. Public `ae_projectSummary {}` returned `itemCount: 0`, exact candidate SHA, and a verified native postcondition.

An earlier superseded candidate exposed a test-harness comparison problem: pre-restart audit data contains ephemeral grant fields, while the durable restored audit intentionally removes them. Before any further action, AE state, the terminal record, append-only audit, and CEP activity were reconciled; the write was not retried. The exact candidate above was then rebuilt, reinstalled, and rerun from a fresh isolated fixture with the correct normalized comparison.

## Review and CI

- all required CI checks passed on the exact candidate SHA: Windows Python, Windows JS/contracts, and Linux packaging/release contracts;
- independent exact-head review confirmed the sequential restart recovery but identified an active-multi-Core process race. That broader cross-process claim/refresh work is tracked as P1 follow-up #139 because it is outside #136's sequential restart acceptance path;
- an earlier review identified clock-rollback retention ordering as a P2 follow-up, tracked in #140;
- review also identified a public client-identity length mismatch; it was fixed in this candidate, covered by tests, and verified through the public MCP surface with a 120-character identity;
- no unresolved in-scope P0/P1 finding remains for #136.

Private fixture paths, authentication tokens, and grant identifiers are omitted from this PR.

## Remaining gate

- after merge, rebuild/reinstall from clean `main` and repeat the public restart/no-redispatch/Undo smoke test before closing #136.
