### PR TITLE
Reserve Tool Library operations across Core processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ The Tools tab stores native artifacts under `~/.ae-mcp/tools` and indexes existi
 
 Discovery is progressive: call `ae_toolIndex`, then `ae_toolSearch`, then `ae_toolInspect`. Non-executing rendering uses `ae_toolUse(action="render")`; execute/apply operations use the content-bound prepare → grant → execute sequence. The plan binds the artifact and dependency hashes, normalized arguments, operation, target, risk, and expiry; grants are short-lived and one-time. Read-only denies writes, manual asks for writes, auto allows ordinary writes, and destructive/external plans always require a fresh decision even in bypass mode. Session approval is available only for write-risk plans and is bound to artifact content, operation, and normalized target rather than the tool name.
 
+Give each side-effecting start/execute request a stable `operation_id` and reuse it only for retries of the same `planHash`. Concurrent Core clients sharing the Tool Library return the same queued/running/terminal execution for that pair, so only the reservation owner dispatches the backend; reusing the operation ID with another plan returns `tool_operation_conflict`. If an owner exits after dispatch, recovery becomes `outcome-unknown` with `inspect-state`; check AE state and audit evidence before using a new operation ID.
+
 ## Usage Notes
 
 AI is not a finished-motion-design replacement. ae-mcp works best when you keep creative direction, taste, and final compositing judgment in human hands, while delegating repetitive operations, procedural animation, expression work, project cleanup, and refactoring of reusable AE structures.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -161,6 +161,8 @@ v0.9.2 最终 Panel 生成的最小配置形态如下：
 
 发现顺序是 `ae_toolIndex` → `ae_toolSearch` → `ae_toolInspect`。只渲染、不执行时使用 `ae_toolUse(action="render")`；execute/apply 操作使用 prepare → grant → execute 三阶段协议。计划绑定制品及依赖哈希、规范化参数、operation、target、risk 与过期时间；grant 短时有效且只能消费一次。session 放行只适用于 write 风险，并绑定 content hash、operation 和规范化 target，不能按工具名缓存。
 
+每次有副作用的 start/execute 请求都应使用稳定的 `operation_id`，且只能在重试同一 `planHash` 时复用。共享同一 Tool Library 的多个 Core 会为这组标识返回同一个 queued/running/terminal execution，只有预约持有者会分发 backend；同一 operation ID 配另一个计划会返回 `tool_operation_conflict`。若持有者在分发后退出，恢复结果会是 `outcome-unknown` 与 `inspect-state`；使用新 operation ID 前必须先核对 AE 状态和审计证据。
+
 ## 使用建议
 
 AI 目前还不能稳定替代动效师、合成师或设计师的最终判断。更可靠的使用方式是分工协作：

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -173,6 +173,8 @@ ae_toolIndex
 
 Index/Search 只含摘要；Inspect 才读取完整、按 user-untrusted 处理的 content。只渲染、不执行时，在 Inspect 后调用 `ae_toolUse(action="render")`，不需要 grant。candidate、archived、deprecated 不能执行；history candidate 用 `ae_toolPromoteFromHistory` 保存，imported candidate 用 `ae_toolEdit` 将 status 改为 saved，操作前都应检查内容。Prepare 后不要改制品、参数 schema、target 或 recipe/handler 依赖；任何变化都会让旧 `planHash`/grant 失效。grant 只能消费一次，destructive/external 不提供 session 放行。
 
+start/execute 必须携带稳定的 `operation_id`；相同 operation ID 只用于同一 `planHash` 的网络重试或跨 Core 恢复。共享 Tool Library 的 Core 会原子预约该标识，未持有预约的进程返回已有 execution 而不会再次执行；不同计划会明确冲突。`outcome-unknown` 不能自动重试，应先用 status/history、AE 状态和审计记录核对副作用。
+
 ## 7. 常见故障定位
 
 如果工具可见但调用失败，按这个顺序排：
@@ -379,6 +381,8 @@ ae_toolIndex
 ```
 
 Index/Search contain summaries only; Inspect is the first call that reads full content, which remains user-untrusted. For rendering without execution, call `ae_toolUse(action="render")` after Inspect; no grant is required. Candidate, archived, and deprecated artifacts cannot execute. Save history candidates with `ae_toolPromoteFromHistory`; save imported candidates by changing status to saved with `ae_toolEdit`, inspecting content before either operation. After Prepare, do not change content, argument schema, target, or recipe/handler dependencies: any change invalidates the old `planHash` and grant. Grants are one-time, and destructive/external plans never offer session approval.
+
+Start/execute requests must carry a stable `operation_id`; reuse an operation ID only for network retries or cross-Core recovery of the same `planHash`. Cores sharing a Tool Library atomically reserve the identifier, and a non-owner returns the existing execution without dispatching again; a different plan fails with an explicit conflict. Never auto-retry `outcome-unknown`: reconcile status/history, AE state, and audit evidence first.
 
 ## 7. Common Failure Isolation
 

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -1001,8 +1001,10 @@ class AeToolUseArgs(_StrictModel):
         min_length=16,
         max_length=128,
         description=(
-            "Stable caller-generated id for execute/start. Reuse it when a response "
-            "is lost; changing it authorizes a distinct execution."
+            "Stable caller-generated id for execute/start. Reuse it only for the "
+            "same planHash after a lost response or across Core clients; the server "
+            "returns the existing execution. A different planHash conflicts, while "
+            "changing operation_id authorizes a distinct execution."
         ),
     )
     limit: Optional[int] = Field(None, ge=1, le=100)

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -32,7 +32,11 @@ from ae_mcp.tool_artifact import (
     validate_args_schema,
 )
 from ae_mcp.tool_audit import AuditRecord, ToolAuditLog, redact_audit_value
-from ae_mcp.tool_execution_history import ExecutionJobStore, ExecutionJobStoreError
+from ae_mcp.tool_execution_history import (
+    ExecutionJobStore,
+    ExecutionJobStoreError,
+    ExecutionOperationConflict,
+)
 from ae_mcp.tool_secrets import RegexSecretScanner, SecretScanner
 
 
@@ -709,6 +713,7 @@ class _ExecutionJob:
     result: Mapping[str, JsonValue] | None = None
     error: Mapping[str, JsonValue] | None = None
     audit: Mapping[str, JsonValue] | None = None
+    owner_token: str | None = None
 
     @classmethod
     def from_record(cls, value: Mapping[str, JsonValue]) -> "_ExecutionJob":
@@ -876,7 +881,7 @@ class ToolExecutionEngine:
         self._job_tasks: dict[str, asyncio.Task[None]] = {}
         self._job_lock = threading.RLock()
         if self.job_store is not None:
-            for record in self.job_store.load():
+            for record in self.job_store.snapshot():
                 job = _ExecutionJob.from_record(record)
                 self._jobs[job.execution_id] = job
                 self._job_operations[job.operation_id] = job.execution_id
@@ -889,6 +894,53 @@ class ToolExecutionEngine:
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None
+
+    @staticmethod
+    def _job_store_failure(
+        exc: ExecutionJobStoreError, message: str
+    ) -> ToolExecutionError:
+        if isinstance(exc, ExecutionOperationConflict):
+            return ToolExecutionError("tool_operation_conflict", str(exc))
+        return ToolExecutionError(
+            exc.code,
+            message,
+            error_details={
+                "sideEffect": "not-started",
+                "recovery": {
+                    "action": "retry-later",
+                    "hint": "Repair the Tool Library execution store before retrying.",
+                },
+            },
+        )
+
+    def _remember_shared_record(
+        self, record: Mapping[str, JsonValue]
+    ) -> _ExecutionJob:
+        incoming = _ExecutionJob.from_record(record)
+        with self._job_lock:
+            current = self._jobs.get(incoming.execution_id)
+            # The reservation owner can have more recent in-memory knowledge
+            # than the durable queued/running row. In particular, AE may have
+            # finished while terminal persistence failed. Preserve the local
+            # outcome-unknown record so a refresh cannot invite a blind retry.
+            if current is not None and current.owner_token is not None:
+                return current
+            self._jobs[incoming.execution_id] = incoming
+            self._job_operations[incoming.operation_id] = incoming.execution_id
+            return incoming
+
+    def _lookup_shared_operation(self, operation_id: str) -> _ExecutionJob | None:
+        if self.job_store is None:
+            return None
+        try:
+            record = self.job_store.lookup_operation(operation_id)
+        except ExecutionJobStoreError as exc:
+            raise self._job_store_failure(
+                exc, "Execution reservation state could not be read."
+            ) from exc
+        if record is None:
+            return None
+        return self._remember_shared_record(record)
 
     @staticmethod
     def describe(artifact: ToolArtifact) -> dict[str, JsonValue]:
@@ -1219,16 +1271,29 @@ class ToolExecutionEngine:
         if self.job_store is None:
             return
         try:
-            self.job_store.upsert(job.public_dict())
+            if job.owner_token is None:
+                self.job_store.upsert(job.public_dict())
+            else:
+                self.job_store.complete(
+                    job.public_dict(), owner_token=job.owner_token
+                )
+                job.owner_token = None
         except ExecutionJobStoreError as exc:
+            dispatched = job.started_at is not None
             raise ToolExecutionError(
                 exc.code,
                 "Execution recovery state could not be persisted.",
                 error_details={
-                    "sideEffect": "not-started",
+                    "sideEffect": (
+                        "may-have-occurred" if dispatched else "not-started"
+                    ),
                     "recovery": {
-                        "action": "retry-later",
-                        "hint": "Repair the Tool Library store before retrying.",
+                        "action": "inspect-state" if dispatched else "retry-later",
+                        "hint": (
+                            "Inspect AE state and audit evidence before retrying."
+                            if dispatched
+                            else "Repair the Tool Library store before retrying."
+                        ),
                     },
                 },
             ) from exc
@@ -1255,7 +1320,20 @@ class ToolExecutionEngine:
                         "tool_operation_conflict",
                         "Operation id is already bound to a different execution plan.",
                     )
-                return existing.public_dict()
+                if not (
+                    self.job_store is not None
+                    and existing.owner_token is None
+                    and existing.status in {"queued", "running"}
+                ):
+                    return existing.public_dict()
+        shared = self._lookup_shared_operation(operation_id)
+        if shared is not None:
+            if shared.plan_hash != plan_hash:
+                raise ToolExecutionError(
+                    "tool_operation_conflict",
+                    "Operation id is already bound to a different execution plan.",
+                )
+            return shared.public_dict()
         plan = self.prepared_plans.get(plan_hash)
         self.grants.peek(grant_id, plan)
         artifact, _analysis = self._assert_current(plan)
@@ -1282,6 +1360,22 @@ class ToolExecutionEngine:
                 status="queued",
                 created_at=self._now(),
             )
+            if self.job_store is not None:
+                try:
+                    claim = self.job_store.claim(job.public_dict())
+                except ExecutionJobStoreError as exc:
+                    raise self._job_store_failure(
+                        exc, "Execution operation could not be reserved before dispatch."
+                    ) from exc
+                if not claim.owned:
+                    existing = self._remember_shared_record(claim.record)
+                    if existing.plan_hash != plan_hash:
+                        raise ToolExecutionError(
+                            "tool_operation_conflict",
+                            "Operation id is already bound to a different execution plan.",
+                        )
+                    return existing.public_dict()
+                job.owner_token = claim.owner_token
             self._jobs[execution_id] = job
             self._job_operations[operation_id] = execution_id
             task = asyncio.create_task(
@@ -1376,6 +1470,38 @@ class ToolExecutionEngine:
                         },
                     }
             return
+        if self.job_store is not None and job.owner_token is not None:
+            try:
+                self.job_store.mark_running(
+                    job.execution_id,
+                    owner_token=job.owner_token,
+                    started_at=cast(int, job.started_at),
+                )
+            except ExecutionJobStoreError:
+                with self._job_lock:
+                    job.status = "failed"
+                    job.finished_at = self._now()
+                    job.error = {
+                        "code": "tool_execution_history_failed",
+                        "message": "Execution reservation could not be confirmed before dispatch.",
+                        "sideEffect": "not-started",
+                        "recovery": {
+                            "action": "retry-later",
+                            "hint": "Repair the Tool Library execution store before retrying.",
+                        },
+                    }
+                    self._job_tasks.pop(job.execution_id, None)
+                try:
+                    self._persist_job(job)
+                except ToolExecutionError:
+                    pass
+                return
+        heartbeat: asyncio.Task[None] | None = None
+        if self.job_store is not None and job.owner_token is not None:
+            heartbeat = asyncio.create_task(
+                self._renew_job_reservation(job),
+                name=f"ae-mcp-tool-lease-{job.execution_id}",
+            )
         try:
             result = await self.execute(job.plan_hash, grant_id, ctx=ctx)
         except ToolExecutionError as exc:
@@ -1413,6 +1539,8 @@ class ToolExecutionEngine:
                 job.finished_at = self._now()
                 job.audit = self._latest_audit(job.plan_hash, job.artifact_id)
         finally:
+            if heartbeat is not None:
+                heartbeat.cancel()
             with self._job_lock:
                 self._job_tasks.pop(job.execution_id, None)
         try:
@@ -1431,8 +1559,42 @@ class ToolExecutionEngine:
                 }
                 job.status = "outcome-unknown"
                 job.finished_at = self._now()
+        if heartbeat is not None:
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
+
+    async def _renew_job_reservation(self, job: _ExecutionJob) -> None:
+        store = self.job_store
+        owner_token = job.owner_token
+        if store is None or owner_token is None:
+            return
+        interval = max(0.05, min(5.0, store.reservation_lease_ms / 3_000))
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                store.renew(job.execution_id, owner_token=owner_token)
+            except ExecutionJobStoreError:
+                # The write may already be running. Stopping or retrying it here
+                # would be unsafe. Terminal persistence will either reconcile the
+                # reservation or return outcome-unknown with inspect-state.
+                return
 
     def job_status(self, execution_id: str) -> Mapping[str, JsonValue]:
+        with self._job_lock:
+            job = self._jobs.get(execution_id)
+            if job is not None and job.owner_token is not None:
+                return job.public_dict()
+        if self.job_store is not None:
+            try:
+                record = self.job_store.lookup_execution(execution_id)
+            except ExecutionJobStoreError as exc:
+                raise self._job_store_failure(
+                    exc, "Execution status could not be refreshed."
+                ) from exc
+            if record is not None:
+                return self._remember_shared_record(record).public_dict()
         with self._job_lock:
             job = self._jobs.get(execution_id)
             if job is None:
@@ -1444,7 +1606,13 @@ class ToolExecutionEngine:
             job = self._jobs.get(execution_id)
             if job is None:
                 raise ToolExecutionError("tool_execution_not_found", "Execution was not found.")
-            if job.status == "queued":
+            if (
+                self.job_store is not None
+                and job.owner_token is None
+                and job.status in {"queued", "running"}
+            ):
+                disposition = "owned-by-another-core"
+            elif job.status == "queued":
                 job.cancel_requested = True
                 disposition = "cancelled-before-dispatch"
             elif job.status == "running":
@@ -1461,6 +1629,15 @@ class ToolExecutionEngine:
     ) -> Mapping[str, JsonValue]:
         if not 1 <= limit <= 100:
             raise ToolExecutionError("tool_invalid_input", "History limit is invalid.")
+        if self.job_store is not None:
+            try:
+                shared = self.job_store.snapshot()
+            except ExecutionJobStoreError as exc:
+                raise self._job_store_failure(
+                    exc, "Execution history could not be refreshed."
+                ) from exc
+            for record in shared:
+                self._remember_shared_record(record)
         with self._job_lock:
             rows = [job for job in self._jobs.values() if job.artifact_id == artifact_id]
             rows.sort(key=lambda job: (job.created_at, job.execution_id), reverse=True)

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -1402,11 +1402,19 @@ class ToolExecutionEngine:
             initiator=initiator,
         )
         execution_id = cast(str, started["executionId"])
-        with self._job_lock:
-            task = self._job_tasks.get(execution_id)
-        if task is not None:
-            await asyncio.shield(task)
-        status = self.job_status(execution_id)
+        while True:
+            with self._job_lock:
+                task = self._job_tasks.get(execution_id)
+            if task is not None:
+                await asyncio.shield(task)
+            status = self.job_status(execution_id)
+            if cast(bool, status["terminal"]):
+                break
+            # A synchronous execute routed to a different Core must retain its
+            # synchronous contract. The shared owner has the only local task,
+            # so refresh the durable reservation until it reaches a terminal
+            # result instead of reporting a still-running execution as failed.
+            await asyncio.sleep(0.05)
         if status["status"] == "succeeded":
             result = status.get("result")
             if isinstance(result, Mapping):

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -714,6 +714,7 @@ class _ExecutionJob:
     error: Mapping[str, JsonValue] | None = None
     audit: Mapping[str, JsonValue] | None = None
     owner_token: str | None = None
+    local_owner: bool = False
 
     @classmethod
     def from_record(cls, value: Mapping[str, JsonValue]) -> "_ExecutionJob":
@@ -923,7 +924,7 @@ class ToolExecutionEngine:
             # than the durable queued/running row. In particular, AE may have
             # finished while terminal persistence failed. Preserve the local
             # outcome-unknown record so a refresh cannot invite a blind retry.
-            if current is not None and current.owner_token is not None:
+            if current is not None and current.local_owner:
                 return current
             self._jobs[incoming.execution_id] = incoming
             self._job_operations[incoming.operation_id] = incoming.execution_id
@@ -1359,6 +1360,7 @@ class ToolExecutionEngine:
                 initiator=initiator or "unknown",
                 status="queued",
                 created_at=self._now(),
+                local_owner=True,
             )
             if self.job_store is not None:
                 try:
@@ -1585,14 +1587,16 @@ class ToolExecutionEngine:
                 store.renew(job.execution_id, owner_token=owner_token)
             except ExecutionJobStoreError:
                 # The write may already be running. Stopping or retrying it here
-                # would be unsafe. Terminal persistence will either reconcile the
-                # reservation or return outcome-unknown with inspect-state.
-                return
+                # would be unsafe. Keep retrying while the local task is alive so
+                # one transient store failure does not abandon an otherwise-live
+                # lease. If ownership was actually lost, terminal persistence will
+                # reconcile it as outcome-unknown with inspect-state guidance.
+                continue
 
     def job_status(self, execution_id: str) -> Mapping[str, JsonValue]:
         with self._job_lock:
             job = self._jobs.get(execution_id)
-            if job is not None and job.owner_token is not None:
+            if job is not None and job.local_owner:
                 return job.public_dict()
         if self.job_store is not None:
             try:

--- a/packages/core/ae_mcp/tool_execution_history.py
+++ b/packages/core/ae_mcp/tool_execution_history.py
@@ -567,7 +567,17 @@ class ExecutionJobStore:
                     raise ExecutionJobStoreError("Execution reservation was not found.")
                 reservations.remove(owned)
                 executions.append(normalized)
-                executions = self._prune(executions)
+                # The operation that just crossed from a reservation to durable
+                # history must survive this write even when newer records have
+                # already filled the retention window. Otherwise another Core
+                # can immediately reclaim the same operation id and dispatch a
+                # duplicate side effect.
+                executions = self._prune(
+                    executions,
+                    protected_operation_ids=frozenset(
+                        {cast(str, normalized["operationId"])}
+                    ),
+                )
                 self._write_state_unlocked(executions, reservations)
                 return _public(normalized)
         except (OSError, ToolStoreError) as exc:

--- a/packages/core/ae_mcp/tool_execution_history.py
+++ b/packages/core/ae_mcp/tool_execution_history.py
@@ -282,16 +282,32 @@ class ExecutionJobStore:
         return executions, reservations, cast(int, schema)
 
     def _prune(
-        self, records: list[dict[str, JsonValue]]
+        self,
+        records: list[dict[str, JsonValue]],
+        *,
+        protected_operation_ids: frozenset[str] = frozenset(),
     ) -> list[dict[str, JsonValue]]:
-        records.sort(
+        protected = [
+            row
+            for row in records
+            if cast(str, row["operationId"]) in protected_operation_ids
+        ]
+        unprotected = [
+            row
+            for row in records
+            if cast(str, row["operationId"]) not in protected_operation_ids
+        ]
+        unprotected.sort(
             key=lambda row: (
                 cast(int, row["createdAt"]),
                 cast(str, row["executionId"]),
             ),
             reverse=True,
         )
-        kept = records[: self.max_records]
+        kept = [
+            *protected,
+            *unprotected[: max(0, self.max_records - len(protected))],
+        ]
         kept.sort(
             key=lambda row: (
                 cast(int, row["createdAt"]),
@@ -321,6 +337,7 @@ class ExecutionJobStore:
     ) -> tuple[list[dict[str, JsonValue]], list[dict[str, JsonValue]], bool]:
         now = self._now()
         retained: list[dict[str, JsonValue]] = []
+        recovered_operation_ids: set[str] = set()
         changed = False
         for reservation in reservations:
             owner = cast(Mapping[str, JsonValue], reservation["owner"])
@@ -371,8 +388,16 @@ class ExecutionJobStore:
                 }
             )
             executions.append(_normalize(terminal))
+            recovered_operation_ids.add(cast(str, reservation["operationId"]))
             changed = True
-        return self._prune(executions), retained, changed
+        return (
+            self._prune(
+                executions,
+                protected_operation_ids=frozenset(recovered_operation_ids),
+            ),
+            retained,
+            changed,
+        )
 
     @staticmethod
     def _same_identity(

--- a/packages/core/ae_mcp/tool_execution_history.py
+++ b/packages/core/ae_mcp/tool_execution_history.py
@@ -1,10 +1,15 @@
-"""Crash-safe, redacted recovery records for Tool Library executions."""
+"""Crash-safe, cross-process recovery records for Tool Library executions."""
 
 from __future__ import annotations
 
 import json
+import os
 import re
-from collections.abc import Mapping
+import secrets
+import socket
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -13,18 +18,32 @@ from ae_mcp.tool_audit import redact_audit_value
 from ae_mcp.tool_store import StoreLock, ToolStoreError, atomic_write_json
 
 
-EXECUTION_HISTORY_SCHEMA_VERSION = 1
+EXECUTION_HISTORY_SCHEMA_VERSION = 2
 EXECUTION_HISTORY_MAX_RECORDS = 500
+EXECUTION_RESERVATION_LEASE_MS = 30_000
 
+_LEGACY_SCHEMA_VERSION = 1
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 _TERMINAL_STATUSES = frozenset(
     {"succeeded", "failed", "cancelled", "outcome-unknown"}
 )
+_RESERVATION_STATUSES = frozenset({"queued", "running"})
 _OPERATIONS = frozenset({"render", "execute", "apply"})
 
 
 class ExecutionJobStoreError(RuntimeError):
     code = "tool_execution_history_failed"
+
+
+class ExecutionOperationConflict(ExecutionJobStoreError):
+    code = "tool_operation_conflict"
+
+
+@dataclass(frozen=True)
+class ExecutionClaim:
+    owned: bool
+    record: Mapping[str, JsonValue]
+    owner_token: str | None
 
 
 def _bounded_string(value: Any, *, minimum: int = 1, maximum: int = 256) -> str:
@@ -65,7 +84,7 @@ def _optional_mapping(value: Any) -> Mapping[str, JsonValue] | None:
     return cast(Mapping[str, JsonValue], redacted)
 
 
-def _normalize(record: Mapping[str, Any]) -> dict[str, JsonValue]:
+def _identity(record: Mapping[str, Any]) -> dict[str, JsonValue]:
     execution_id = _bounded_string(record.get("executionId"), maximum=128)
     operation_id = _bounded_string(
         record.get("operationId"), minimum=16, maximum=128
@@ -81,28 +100,8 @@ def _normalize(record: Mapping[str, Any]) -> dict[str, JsonValue]:
     operation = _bounded_string(record.get("operation"), maximum=16)
     if operation not in _OPERATIONS:
         raise ExecutionJobStoreError("Execution history operation is invalid.")
-    # client_identity.set_client() exposes labels up to 120 characters. Keep
-    # the durable envelope aligned so a valid public client cannot execute a
-    # write and only then fail recovery persistence.
     initiator = _bounded_string(record.get("initiator"), maximum=120)
-    status = _bounded_string(record.get("status"), maximum=32)
-    if status not in _TERMINAL_STATUSES:
-        raise ExecutionJobStoreError("Execution history status is invalid.")
-    cancel_requested = record.get("cancelRequested", False)
-    if not isinstance(cancel_requested, bool):
-        raise ExecutionJobStoreError("Execution history cancellation state is invalid.")
-    finished_at = _timestamp(record.get("finishedAt"))
-
-    result = _optional_mapping(record.get("result"))
-    error = _optional_mapping(record.get("error"))
-    if status == "succeeded" and (result is None or error is not None):
-        raise ExecutionJobStoreError("Execution history success payload is invalid.")
-    if status in {"failed", "outcome-unknown"} and error is None:
-        raise ExecutionJobStoreError("Execution history error payload is invalid.")
-    if status == "cancelled" and result is not None:
-        raise ExecutionJobStoreError("Execution history cancellation payload is invalid.")
-
-    normalized: dict[str, JsonValue] = {
+    return {
         "executionId": execution_id,
         "operationId": operation_id,
         "artifactId": artifact_id,
@@ -111,26 +110,117 @@ def _normalize(record: Mapping[str, Any]) -> dict[str, JsonValue]:
         "planHash": plan_hash,
         "operation": operation,
         "initiator": initiator,
-        "status": status,
         "createdAt": cast(int, _timestamp(record.get("createdAt"))),
-        "startedAt": _timestamp(record.get("startedAt"), optional=True),
-        "finishedAt": cast(int, finished_at),
-        "cancelRequested": cancel_requested,
-        "result": cast(JsonValue, result),
-        "error": cast(JsonValue, error),
-        "audit": cast(JsonValue, _optional_mapping(record.get("audit"))),
     }
+
+
+def _normalize(record: Mapping[str, Any]) -> dict[str, JsonValue]:
+    normalized = _identity(record)
+    status = _bounded_string(record.get("status"), maximum=32)
+    if status not in _TERMINAL_STATUSES:
+        raise ExecutionJobStoreError("Execution history status is invalid.")
+    cancel_requested = record.get("cancelRequested", False)
+    if not isinstance(cancel_requested, bool):
+        raise ExecutionJobStoreError("Execution history cancellation state is invalid.")
+    result = _optional_mapping(record.get("result"))
+    error = _optional_mapping(record.get("error"))
+    if status == "succeeded" and (result is None or error is not None):
+        raise ExecutionJobStoreError("Execution history success payload is invalid.")
+    if status in {"failed", "outcome-unknown"} and error is None:
+        raise ExecutionJobStoreError("Execution history error payload is invalid.")
+    if status == "cancelled" and result is not None:
+        raise ExecutionJobStoreError("Execution history cancellation payload is invalid.")
+    normalized.update(
+        {
+            "status": status,
+            "startedAt": _timestamp(record.get("startedAt"), optional=True),
+            "finishedAt": cast(int, _timestamp(record.get("finishedAt"))),
+            "cancelRequested": cancel_requested,
+            "result": cast(JsonValue, result),
+            "error": cast(JsonValue, error),
+            "audit": cast(JsonValue, _optional_mapping(record.get("audit"))),
+        }
+    )
     return normalized
 
 
+def _normalize_reservation(record: Mapping[str, Any]) -> dict[str, JsonValue]:
+    normalized = _identity(record)
+    status = _bounded_string(record.get("status"), maximum=32)
+    if status not in _RESERVATION_STATUSES:
+        raise ExecutionJobStoreError("Execution reservation status is invalid.")
+    started_at = _timestamp(record.get("startedAt"), optional=True)
+    if status == "queued" and started_at is not None:
+        raise ExecutionJobStoreError("Queued execution reservation has a start time.")
+    if status == "running" and started_at is None:
+        raise ExecutionJobStoreError("Running execution reservation lacks a start time.")
+    owner = record.get("owner")
+    if not isinstance(owner, Mapping):
+        raise ExecutionJobStoreError("Execution reservation owner is invalid.")
+    token = _bounded_string(owner.get("token"), minimum=16, maximum=128)
+    host = _bounded_string(owner.get("host"), maximum=255)
+    pid = owner.get("pid")
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        raise ExecutionJobStoreError("Execution reservation owner pid is invalid.")
+    normalized.update(
+        {
+            "status": status,
+            "startedAt": started_at,
+            "owner": {
+                "token": token,
+                "host": host,
+                "pid": pid,
+                "leaseExpiresAt": cast(
+                    int, _timestamp(owner.get("leaseExpiresAt"))
+                ),
+            },
+        }
+    )
+    return normalized
+
+
+def _public(record: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    status = cast(str, record["status"])
+    terminal = status in _TERMINAL_STATUSES
+    return {
+        "ok": True,
+        **{
+            key: record[key]
+            for key in (
+                "executionId",
+                "operationId",
+                "artifactId",
+                "contentHash",
+                "artifactRevision",
+                "planHash",
+                "operation",
+                "initiator",
+                "status",
+                "createdAt",
+                "startedAt",
+            )
+        },
+        "progress": 100 if terminal else 25 if status == "running" else 0,
+        "terminal": terminal,
+        "cancelRequested": cast(bool, record.get("cancelRequested", False)),
+        "outcomeUnknown": status == "outcome-unknown",
+        "finishedAt": record.get("finishedAt"),
+        "result": record.get("result"),
+        "error": record.get("error"),
+        "audit": record.get("audit"),
+    }
+
+
 class ExecutionJobStore:
-    """Persist bounded execution recovery without persisting grants or arguments."""
+    """Persist terminal jobs and atomically reserve operation IDs before dispatch."""
 
     def __init__(
         self,
         root: Path,
         *,
         max_records: int = EXECUTION_HISTORY_MAX_RECORDS,
+        reservation_lease_ms: int = EXECUTION_RESERVATION_LEASE_MS,
+        now: Callable[[], int] | None = None,
     ) -> None:
         if (
             isinstance(max_records, bool)
@@ -138,42 +228,62 @@ class ExecutionJobStore:
             or max_records < 1
         ):
             raise ValueError("execution history max_records must be positive")
+        if (
+            isinstance(reservation_lease_ms, bool)
+            or not isinstance(reservation_lease_ms, int)
+            or reservation_lease_ms < 1
+        ):
+            raise ValueError("execution reservation lease must be positive")
         self.root = Path(root).expanduser().absolute()
         self.path = self.root / "execution-history.json"
         self.max_records = max_records
+        self.reservation_lease_ms = reservation_lease_ms
+        self._now = now or (lambda: int(time.time() * 1000))
+        self._host = socket.gethostname()
+        self._pid = os.getpid()
 
-    def _read_unlocked(self) -> list[dict[str, JsonValue]]:
+    def _read_state_unlocked(
+        self,
+    ) -> tuple[list[dict[str, JsonValue]], list[dict[str, JsonValue]], int]:
         if not self.path.exists():
-            return []
+            return [], [], EXECUTION_HISTORY_SCHEMA_VERSION
         if self.path.is_symlink() or not self.path.is_file():
             raise ExecutionJobStoreError("Execution history path is invalid.")
         try:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
             raise ExecutionJobStoreError("Execution history cannot be read.") from exc
-        if (
-            not isinstance(raw, Mapping)
-            or raw.get("schemaVersion") != EXECUTION_HISTORY_SCHEMA_VERSION
-            or not isinstance(raw.get("executions"), list)
-        ):
+        if not isinstance(raw, Mapping):
             raise ExecutionJobStoreError("Execution history schema is invalid.")
-        records = [
+        schema = raw.get("schemaVersion")
+        if schema not in {_LEGACY_SCHEMA_VERSION, EXECUTION_HISTORY_SCHEMA_VERSION}:
+            raise ExecutionJobStoreError("Execution history schema is invalid.")
+        raw_executions = raw.get("executions")
+        raw_reservations = [] if schema == _LEGACY_SCHEMA_VERSION else raw.get("reservations")
+        if not isinstance(raw_executions, list) or not isinstance(raw_reservations, list):
+            raise ExecutionJobStoreError("Execution history schema is invalid.")
+        executions = [
             _normalize(cast(Mapping[str, Any], item))
-            for item in cast(list[Any], raw["executions"])
+            for item in raw_executions
             if isinstance(item, Mapping)
         ]
-        if len(records) != len(raw["executions"]):
+        reservations = [
+            _normalize_reservation(cast(Mapping[str, Any], item))
+            for item in raw_reservations
+            if isinstance(item, Mapping)
+        ]
+        if len(executions) != len(raw_executions) or len(reservations) != len(raw_reservations):
             raise ExecutionJobStoreError("Execution history record is invalid.")
-        execution_ids = [cast(str, row["executionId"]) for row in records]
-        operation_ids = [cast(str, row["operationId"]) for row in records]
-        if (
-            len(set(execution_ids)) != len(records)
-            or len(set(operation_ids)) != len(records)
-        ):
+        combined = [*executions, *reservations]
+        execution_ids = [cast(str, row["executionId"]) for row in combined]
+        operation_ids = [cast(str, row["operationId"]) for row in combined]
+        if len(set(execution_ids)) != len(combined) or len(set(operation_ids)) != len(combined):
             raise ExecutionJobStoreError("Execution history identities are duplicated.")
-        return records
+        return executions, reservations, cast(int, schema)
 
-    def _prune(self, records: list[dict[str, JsonValue]]) -> list[dict[str, JsonValue]]:
+    def _prune(
+        self, records: list[dict[str, JsonValue]]
+    ) -> list[dict[str, JsonValue]]:
         records.sort(
             key=lambda row: (
                 cast(int, row["createdAt"]),
@@ -190,21 +300,54 @@ class ExecutionJobStore:
         )
         return kept
 
-    def _write_unlocked(self, records: list[dict[str, JsonValue]]) -> None:
+    def _write_state_unlocked(
+        self,
+        executions: list[dict[str, JsonValue]],
+        reservations: list[dict[str, JsonValue]],
+    ) -> None:
         atomic_write_json(
             self.path,
             {
                 "schemaVersion": EXECUTION_HISTORY_SCHEMA_VERSION,
-                "executions": cast(JsonValue, records),
+                "executions": cast(JsonValue, executions),
+                "reservations": cast(JsonValue, reservations),
             },
         )
 
-    def upsert(self, record: Mapping[str, Any]) -> None:
-        normalized = _normalize(record)
-        try:
-            with StoreLock(self.root):
-                records = self._read_unlocked()
-                immutable = (
+    def _recover_orphans(
+        self,
+        executions: list[dict[str, JsonValue]],
+        reservations: list[dict[str, JsonValue]],
+    ) -> tuple[list[dict[str, JsonValue]], list[dict[str, JsonValue]], bool]:
+        now = self._now()
+        retained: list[dict[str, JsonValue]] = []
+        changed = False
+        for reservation in reservations:
+            owner = cast(Mapping[str, JsonValue], reservation["owner"])
+            if now < cast(int, owner["leaseExpiresAt"]):
+                retained.append(reservation)
+                continue
+            running = reservation["status"] == "running"
+            error: dict[str, JsonValue] = {
+                "code": "tool_execution_owner_exited",
+                "message": (
+                    "Execution owner exited after dispatch; inspect AE state before retrying."
+                    if running
+                    else "Execution owner exited before dispatch."
+                ),
+                "sideEffect": "may-have-occurred" if running else "not-started",
+                "recovery": {
+                    "action": "inspect-state" if running else "retry-with-new-operation-id",
+                    "hint": (
+                        "Inspect AE state and audit evidence before any retry."
+                        if running
+                        else "Use a new operation id only after confirming the prior owner never dispatched."
+                    ),
+                },
+            }
+            terminal = {
+                key: reservation[key]
+                for key in (
                     "executionId",
                     "operationId",
                     "artifactId",
@@ -212,52 +355,289 @@ class ExecutionJobStore:
                     "artifactRevision",
                     "planHash",
                     "operation",
+                    "initiator",
                     "createdAt",
+                    "startedAt",
                 )
-                for current in records:
-                    same_execution = (
-                        current["executionId"] == normalized["executionId"]
+            }
+            terminal.update(
+                {
+                    "status": "outcome-unknown" if running else "failed",
+                    "finishedAt": now,
+                    "cancelRequested": False,
+                    "result": None,
+                    "error": error,
+                    "audit": None,
+                }
+            )
+            executions.append(_normalize(terminal))
+            changed = True
+        return self._prune(executions), retained, changed
+
+    @staticmethod
+    def _same_identity(
+        current: Mapping[str, JsonValue], incoming: Mapping[str, JsonValue]
+    ) -> bool:
+        return all(
+            current[key] == incoming[key]
+            for key in (
+                "executionId",
+                "operationId",
+                "artifactId",
+                "contentHash",
+                "artifactRevision",
+                "planHash",
+                "operation",
+                "createdAt",
+            )
+        )
+
+    def claim(self, record: Mapping[str, Any]) -> ExecutionClaim:
+        identity = _identity(record)
+        queued = {
+            **identity,
+            "status": "queued",
+            "startedAt": None,
+            "owner": {
+                "token": secrets.token_urlsafe(24),
+                "host": self._host,
+                "pid": self._pid,
+                "leaseExpiresAt": self._now() + self.reservation_lease_ms,
+            },
+        }
+        normalized = _normalize_reservation(queued)
+        try:
+            with StoreLock(self.root):
+                executions, reservations, schema = self._read_state_unlocked()
+                executions, reservations, recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                for current in [*executions, *reservations]:
+                    if current["operationId"] != normalized["operationId"]:
+                        continue
+                    if current["planHash"] != normalized["planHash"]:
+                        raise ExecutionOperationConflict(
+                            "Operation id is already bound to a different execution plan."
+                        )
+                    if recovered or schema != EXECUTION_HISTORY_SCHEMA_VERSION:
+                        self._write_state_unlocked(executions, reservations)
+                    return ExecutionClaim(False, _public(current), None)
+                if len(reservations) >= self.max_records:
+                    raise ExecutionJobStoreError(
+                        "Execution reservation capacity is exhausted."
                     )
-                    same_operation = (
-                        current["operationId"] == normalized["operationId"]
+                reservations.append(normalized)
+                self._write_state_unlocked(executions, reservations)
+                owner = cast(Mapping[str, JsonValue], normalized["owner"])
+                return ExecutionClaim(
+                    True, _public(normalized), cast(str, owner["token"])
+                )
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError(
+                "Execution operation could not be reserved."
+            ) from exc
+
+    def mark_running(
+        self, execution_id: str, *, owner_token: str, started_at: int
+    ) -> Mapping[str, JsonValue]:
+        _bounded_string(execution_id, maximum=128)
+        _bounded_string(owner_token, minimum=16, maximum=128)
+        started = cast(int, _timestamp(started_at))
+        try:
+            with StoreLock(self.root):
+                executions, reservations, _schema = self._read_state_unlocked()
+                executions, reservations, recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                for reservation in reservations:
+                    if reservation["executionId"] != execution_id:
+                        continue
+                    owner = cast(dict[str, JsonValue], reservation["owner"])
+                    if owner["token"] != owner_token:
+                        raise ExecutionJobStoreError(
+                            "Execution reservation is owned by another Core process."
+                        )
+                    reservation["status"] = "running"
+                    reservation["startedAt"] = started
+                    owner["leaseExpiresAt"] = self._now() + self.reservation_lease_ms
+                    self._write_state_unlocked(executions, reservations)
+                    return _public(reservation)
+                if recovered:
+                    self._write_state_unlocked(executions, reservations)
+                raise ExecutionJobStoreError("Execution reservation was not found.")
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError(
+                "Execution reservation could not enter running state."
+            ) from exc
+
+    def renew(self, execution_id: str, *, owner_token: str) -> None:
+        _bounded_string(execution_id, maximum=128)
+        _bounded_string(owner_token, minimum=16, maximum=128)
+        try:
+            with StoreLock(self.root):
+                executions, reservations, _schema = self._read_state_unlocked()
+                executions, reservations, recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                for reservation in reservations:
+                    if reservation["executionId"] != execution_id:
+                        continue
+                    owner = cast(dict[str, JsonValue], reservation["owner"])
+                    if owner["token"] != owner_token:
+                        raise ExecutionJobStoreError(
+                            "Execution reservation is owned by another Core process."
+                        )
+                    owner["leaseExpiresAt"] = (
+                        self._now() + self.reservation_lease_ms
                     )
+                    self._write_state_unlocked(executions, reservations)
+                    return
+                if recovered:
+                    self._write_state_unlocked(executions, reservations)
+                raise ExecutionJobStoreError("Execution reservation was not found.")
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError(
+                "Execution reservation lease could not be renewed."
+            ) from exc
+
+    def complete(
+        self, record: Mapping[str, Any], *, owner_token: str
+    ) -> Mapping[str, JsonValue]:
+        normalized = _normalize(record)
+        _bounded_string(owner_token, minimum=16, maximum=128)
+        try:
+            with StoreLock(self.root):
+                executions, reservations, _schema = self._read_state_unlocked()
+                executions, reservations, recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                for current in executions:
+                    if current["operationId"] != normalized["operationId"]:
+                        continue
+                    if not self._same_identity(current, normalized):
+                        raise ExecutionOperationConflict(
+                            "Execution completion conflicts with durable history."
+                        )
+                    if current != normalized:
+                        raise ExecutionJobStoreError(
+                            "Execution outcome was already recovered and cannot be overwritten."
+                        )
+                    if recovered:
+                        self._write_state_unlocked(executions, reservations)
+                    return _public(current)
+                owned = None
+                for reservation in reservations:
+                    if reservation["operationId"] != normalized["operationId"]:
+                        continue
+                    owner = cast(Mapping[str, JsonValue], reservation["owner"])
+                    if owner["token"] != owner_token or not self._same_identity(
+                        reservation, normalized
+                    ):
+                        raise ExecutionOperationConflict(
+                            "Execution completion conflicts with its reservation."
+                        )
+                    owned = reservation
+                    break
+                if owned is None:
+                    raise ExecutionJobStoreError("Execution reservation was not found.")
+                reservations.remove(owned)
+                executions.append(normalized)
+                executions = self._prune(executions)
+                self._write_state_unlocked(executions, reservations)
+                return _public(normalized)
+        except (OSError, ToolStoreError) as exc:
+            raise ExecutionJobStoreError(
+                "Execution completion could not be persisted."
+            ) from exc
+
+    def upsert(self, record: Mapping[str, Any]) -> None:
+        normalized = _normalize(record)
+        try:
+            with StoreLock(self.root):
+                executions, reservations, _schema = self._read_state_unlocked()
+                executions, reservations, _recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                for current in [*executions, *reservations]:
+                    same_execution = current["executionId"] == normalized["executionId"]
+                    same_operation = current["operationId"] == normalized["operationId"]
                     if not same_execution and not same_operation:
                         continue
-                    if not same_execution or not same_operation or any(
-                        current[key] != normalized[key] for key in immutable
+                    if not same_execution or not same_operation or not self._same_identity(
+                        current, normalized
                     ):
                         raise ExecutionJobStoreError(
-                            "Execution history identity conflicts with an existing "
-                            "record."
+                            "Execution history identity conflicts with an existing record."
                         )
-                records = [
+                    if current in reservations:
+                        raise ExecutionJobStoreError(
+                            "Execution reservation requires its owner to complete it."
+                        )
+                executions = [
                     row
-                    for row in records
+                    for row in executions
                     if row["executionId"] != normalized["executionId"]
                     and row["operationId"] != normalized["operationId"]
                 ]
-                records.append(normalized)
-                self._write_unlocked(self._prune(records))
+                executions.append(normalized)
+                self._write_state_unlocked(self._prune(executions), reservations)
         except (OSError, ToolStoreError) as exc:
             raise ExecutionJobStoreError(
                 "Execution history cannot be persisted."
             ) from exc
 
-    def load(self) -> list[dict[str, JsonValue]]:
+    def _snapshot(self) -> list[dict[str, JsonValue]]:
         try:
             with StoreLock(self.root):
-                records = self._read_unlocked()
-                pruned = self._prune(records)
-                if len(pruned) != len(records):
-                    self._write_unlocked(pruned)
-                return [dict(row) for row in pruned]
+                executions, reservations, schema = self._read_state_unlocked()
+                original_count = len(executions)
+                executions, reservations, recovered = self._recover_orphans(
+                    executions, reservations
+                )
+                if (
+                    recovered
+                    or len(executions) != original_count
+                    or schema != EXECUTION_HISTORY_SCHEMA_VERSION
+                ):
+                    self._write_state_unlocked(executions, reservations)
+                rows = [_public(row) for row in [*executions, *reservations]]
+                rows.sort(
+                    key=lambda row: (
+                        cast(int, row["createdAt"]),
+                        cast(str, row["executionId"]),
+                    )
+                )
+                return rows
         except (OSError, ToolStoreError) as exc:
             raise ExecutionJobStoreError("Execution history cannot be loaded.") from exc
+
+    def load(self) -> list[dict[str, JsonValue]]:
+        return [row for row in self._snapshot() if cast(bool, row["terminal"])]
+
+    def snapshot(self) -> list[dict[str, JsonValue]]:
+        return self._snapshot()
+
+    def lookup_operation(self, operation_id: str) -> Mapping[str, JsonValue] | None:
+        _bounded_string(operation_id, minimum=16, maximum=128)
+        for record in self._snapshot():
+            if record["operationId"] == operation_id:
+                return record
+        return None
+
+    def lookup_execution(self, execution_id: str) -> Mapping[str, JsonValue] | None:
+        _bounded_string(execution_id, maximum=128)
+        for record in self._snapshot():
+            if record["executionId"] == execution_id:
+                return record
+        return None
 
 
 __all__ = [
     "EXECUTION_HISTORY_MAX_RECORDS",
     "EXECUTION_HISTORY_SCHEMA_VERSION",
+    "EXECUTION_RESERVATION_LEASE_MS",
+    "ExecutionClaim",
     "ExecutionJobStore",
     "ExecutionJobStoreError",
+    "ExecutionOperationConflict",
 ]

--- a/packages/core/ae_mcp/tool_execution_history.py
+++ b/packages/core/ae_mcp/tool_execution_history.py
@@ -299,6 +299,7 @@ class ExecutionJobStore:
         ]
         unprotected.sort(
             key=lambda row: (
+                cast(int, row["finishedAt"]),
                 cast(int, row["createdAt"]),
                 cast(str, row["executionId"]),
             ),

--- a/packages/core/ae_mcp/tool_secrets.py
+++ b/packages/core/ae_mcp/tool_secrets.py
@@ -177,10 +177,19 @@ _JSON_SCHEMA_TYPES = frozenset(
     {"array", "boolean", "integer", "null", "number", "object", "string"}
 )
 
+# Operational request de-duplication identifiers are not credentials. Keep
+# scanning their values for concrete secret formats (JWTs, sk-* tokens, private
+# keys, and so on), but do not reject a Tool Library recipe merely because the
+# public native write contract names this field ``idempotency_key``.
+_NON_CREDENTIAL_KEY_NAMES = frozenset({"idempotencykey"})
+
 
 def _sensitive_name(value: str) -> bool:
     raw = value.strip()
     if not raw:
+        return False
+    compact = re.sub(r"[^a-z0-9]+", "", raw.lower())
+    if compact in _NON_CREDENTIAL_KEY_NAMES:
         return False
     separated = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", raw)
     separated = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", separated)
@@ -191,7 +200,6 @@ def _sensitive_name(value: str) -> bool:
     )
     if any(segment in _SENSITIVE_KEY_SEGMENTS for segment in segments):
         return True
-    compact = re.sub(r"[^a-z0-9]+", "", raw.lower())
     if any(fragment in compact for fragment in _STRONG_SENSITIVE_FRAGMENTS):
         return True
     if not compact.endswith("key"):

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1406,6 +1406,73 @@ async def test_public_tool_use_returns_shared_execution_without_second_dispatch(
     assert len(first_backend.calls) + len(second_backend.calls) == 1
 
 
+@pytest.mark.asyncio
+async def test_public_synchronous_execute_waits_for_shared_terminal_result(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    artifact = _artifact()
+    first_backend = _BlockingBackend()
+    second_backend = _BlockingBackend()
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 37_000,
+    )
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 37_000,
+    )
+    first_plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    second_plan = second.prepare(artifact.id, operation="execute", args={}, target={})
+    first_grant = first.grants.issue_once(first_plan)
+    second_grant = second.grants.issue_once(second_plan)
+    services = iter(
+        [SimpleNamespace(execution=first), SimpleNamespace(execution=second)]
+    )
+    monkeypatch.setattr(tool_handlers, "default_tool_service", lambda: next(services))
+
+    first_call = asyncio.create_task(
+        tool_handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="execute",
+                plan_hash=first_plan.plan_hash,
+                grant_id=first_grant.grant_id,
+                operation_id="operation-public-sync-cross-core",
+            ),
+            None,
+        )
+    )
+    second_call = asyncio.create_task(
+        tool_handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="execute",
+                plan_hash=second_plan.plan_hash,
+                grant_id=second_grant.grant_id,
+                operation_id="operation-public-sync-cross-core",
+            ),
+            None,
+        )
+    )
+    while len(first_backend.calls) + len(second_backend.calls) == 0:
+        await asyncio.sleep(0)
+    assert not first_call.done()
+    assert not second_call.done()
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+
+    if first_backend.calls:
+        first_backend.release.set()
+    else:
+        second_backend.release.set()
+    first_result, second_result = await asyncio.gather(first_call, second_call)
+    assert first_result == {"ok": True}
+    assert second_result == {"ok": True}
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+
+
 def test_operation_claim_is_atomic_across_spawned_processes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1493,6 +1560,71 @@ def test_orphaned_shared_reservation_recovers_without_blind_redispatch(
     assert duplicate.record["status"] == "outcome-unknown"
     persisted = (tmp_path / "execution-history.json").read_text(encoding="utf-8")
     assert "ownerToken" not in persisted
+
+
+def test_orphan_recovery_tombstone_survives_full_history_pruning(
+    tmp_path: Path,
+) -> None:
+    clock = [100]
+    store = ExecutionJobStore(
+        tmp_path,
+        max_records=2,
+        now=lambda: clock[0],
+        reservation_lease_ms=100,
+    )
+    queued = {
+        "executionId": "execution-old-orphan",
+        "operationId": "operation-old-orphan",
+        "artifactId": "user:one",
+        "contentHash": "a" * 64,
+        "artifactRevision": 1,
+        "planHash": "b" * 64,
+        "operation": "execute",
+        "initiator": "first-core",
+        "status": "queued",
+        "createdAt": 100,
+    }
+    claim = store.claim(queued)
+    assert claim.owner_token is not None
+    store.mark_running(
+        "execution-old-orphan",
+        owner_token=claim.owner_token,
+        started_at=101,
+    )
+    for index in range(2):
+        store.upsert(
+            {
+                "executionId": f"execution-newer-{index}",
+                "operationId": f"operation-newer-{index}",
+                "artifactId": "user:one",
+                "contentHash": "a" * 64,
+                "artifactRevision": 1,
+                "planHash": chr(ord("c") + index) * 64,
+                "operation": "execute",
+                "initiator": "other-core",
+                "status": "succeeded",
+                "createdAt": 200 + index,
+                "startedAt": 200 + index,
+                "finishedAt": 200 + index,
+                "cancelRequested": False,
+                "result": {"ok": True},
+                "error": None,
+                "audit": None,
+            }
+        )
+
+    clock[0] = 201
+    recovered = store.lookup_operation("operation-old-orphan")
+    assert recovered is not None
+    assert recovered["status"] == "outcome-unknown"
+    assert len(store.snapshot()) == 2
+
+    retry = dict(queued)
+    retry["executionId"] = "execution-old-orphan-retry"
+    duplicate = store.claim(retry)
+    assert duplicate.owned is False
+    assert duplicate.record["executionId"] == "execution-old-orphan"
+    assert duplicate.record["status"] == "outcome-unknown"
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1764,6 +1764,94 @@ async def test_running_job_renews_its_shared_reservation_lease(
 
 
 @pytest.mark.asyncio
+async def test_running_job_retries_a_transient_renewal_failure(
+    tmp_path: Path,
+) -> None:
+    class TransientRenewStore(ExecutionJobStore):
+        def __init__(self, root: Path) -> None:
+            super().__init__(root, reservation_lease_ms=300)
+            self.renew_attempts = 0
+            self.renewed = asyncio.Event()
+
+        def renew(self, execution_id, *, owner_token):
+            self.renew_attempts += 1
+            if self.renew_attempts == 1:
+                raise ExecutionJobStoreError("transient renewal failure")
+            super().renew(execution_id, owner_token=owner_token)
+            self.renewed.set()
+
+    artifact = _artifact()
+    backend = _BlockingBackend()
+    store = TransientRenewStore(tmp_path)
+    engine = ToolExecutionEngine(
+        _Store(artifact),
+        backend,
+        job_store=store,
+    )
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-renew-after-transient-failure",
+        ctx=None,
+        initiator="first-core",
+    )
+    await backend.started.wait()
+    await asyncio.wait_for(store.renewed.wait(), timeout=1.0)
+
+    assert store.renew_attempts >= 2
+    reservation = store.lookup_execution(started["executionId"])
+    assert reservation is not None
+    assert reservation["status"] == "running"
+
+    backend.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert engine.job_status(started["executionId"])["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_owner_keeps_complete_unredacted_terminal_result_in_memory(
+    tmp_path: Path,
+) -> None:
+    long_value = "x" * 700
+    long_list = list(range(70))
+
+    class LargeResultBackend(_Backend):
+        async def exec(self, code, **kwargs):
+            self.calls.append({"code": code, **kwargs})
+            return json.dumps({"ok": True, "value": long_value, "items": long_list})
+
+    artifact = _artifact()
+    engine = ToolExecutionEngine(
+        _Store(artifact),
+        LargeResultBackend(),
+        job_store=ExecutionJobStore(tmp_path),
+    )
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    result = await engine.execute_tracked(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-local-full-terminal-result",
+        ctx=None,
+        initiator="first-core",
+    )
+
+    assert result["value"] == long_value
+    assert result["items"] == long_list
+    [durable] = engine.job_store.snapshot()
+    assert durable["result"]["value"].endswith("…")
+    assert durable["result"]["items"] != long_list
+    assert durable["result"]["items"][-1].startswith("[TRUNCATED ")
+    status = engine.job_status(durable["executionId"])
+    assert status["result"] == result
+    engine.job_history(artifact.id)
+    assert engine.job_status(durable["executionId"])["result"] == result
+
+
+@pytest.mark.asyncio
 async def test_terminal_persistence_failure_keeps_local_outcome_unknown(
     tmp_path: Path,
 ) -> None:

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1686,6 +1686,29 @@ def test_just_completed_reservation_survives_full_history_pruning(
     assert stored["status"] == "succeeded"
     assert len(store.snapshot()) == 2
 
+    # A later history write must not immediately evict the long-running
+    # operation merely because it was created before the retention window.
+    store.upsert(
+        {
+            "executionId": "execution-newer-complete-2",
+            "operationId": "operation-newer-complete-2",
+            "artifactId": "user:one",
+            "contentHash": "a" * 64,
+            "artifactRevision": 1,
+            "planHash": "e" * 64,
+            "operation": "execute",
+            "initiator": "other-core",
+            "status": "succeeded",
+            "createdAt": 202,
+            "startedAt": 202,
+            "finishedAt": 202,
+            "cancelRequested": False,
+            "result": {"ok": True},
+            "error": None,
+            "audit": None,
+        }
+    )
+
     duplicate = store.claim(
         {
             **queued,

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1406,7 +1406,15 @@ async def test_public_tool_use_returns_shared_execution_without_second_dispatch(
     assert len(first_backend.calls) + len(second_backend.calls) == 1
 
 
-def test_operation_claim_is_atomic_across_spawned_processes(tmp_path: Path) -> None:
+def test_operation_claim_is_atomic_across_spawned_processes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pytest console launcher does not necessarily put the checkout root on
+    # a spawned interpreter's sys.path (notably on Windows). The pickled target
+    # is imported as packages.core.tests.test_tool_execution, so make that
+    # import path explicit for the child without changing the product runtime.
+    repo_root = str(Path(__file__).resolve().parents[3])
+    monkeypatch.syspath_prepend(repo_root)
     context = multiprocessing.get_context("spawn")
     start = context.Event()
     results = context.Queue()

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
+import multiprocessing
 import re
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from mcp.types import ToolAnnotations
 
+from ae_mcp import schemas as S
 from ae_mcp import tool_execution as execution_module
 from ae_mcp.backends.native import NativeBackendError
 from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.handlers import tools as tool_handlers
 from ae_mcp.tool_artifact import (
     ToolArtifact,
     ToolSource,
@@ -33,8 +38,38 @@ from ae_mcp.tool_execution import (
     normalize_args,
     normalize_target,
 )
-from ae_mcp.tool_execution_history import ExecutionJobStore
+from ae_mcp.tool_execution_history import ExecutionJobStore, ExecutionJobStoreError
 from ae_mcp.tool_store import StoreMutation
+
+
+def _claim_operation_in_spawned_process(
+    root: str,
+    start: Any,
+    results: Any,
+    execution_id: str,
+) -> None:
+    store = ExecutionJobStore(Path(root), reservation_lease_ms=60_000)
+    start.wait(10)
+    claim = store.claim(
+        {
+            "executionId": execution_id,
+            "operationId": "operation-spawned-process-claim",
+            "artifactId": "user:one",
+            "contentHash": "a" * 64,
+            "artifactRevision": 1,
+            "planHash": "b" * 64,
+            "operation": "execute",
+            "initiator": execution_id,
+            "status": "queued",
+            "createdAt": 1,
+        }
+    )
+    results.put(
+        {
+            "owned": claim.owned,
+            "executionId": claim.record["executionId"],
+        }
+    )
 
 
 def _source() -> ToolSource:
@@ -1223,6 +1258,314 @@ async def test_outcome_unknown_survives_restart_with_recovery_and_no_redispatch(
     assert second_backend.calls == []
 
 
+@pytest.mark.asyncio
+async def test_shared_job_store_claims_operation_before_cross_process_dispatch(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    first_backend = _BlockingBackend()
+    second_backend = _BlockingBackend()
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 30_000,
+    )
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 30_000,
+    )
+    first_plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    second_plan = second.prepare(artifact.id, operation="execute", args={}, target={})
+    assert first_plan.plan_hash == second_plan.plan_hash
+    first_grant = first.grants.issue_once(first_plan)
+    second_grant = second.grants.issue_once(second_plan)
+
+    first_started, second_started = await asyncio.gather(
+        first.start_job(
+            first_plan.plan_hash,
+            first_grant.grant_id,
+            operation_id="operation-cross-process-claim",
+            ctx=None,
+            initiator="first-core",
+        ),
+        second.start_job(
+            second_plan.plan_hash,
+            second_grant.grant_id,
+            operation_id="operation-cross-process-claim",
+            ctx=None,
+            initiator="second-core",
+        ),
+    )
+    assert first_started["executionId"] == second_started["executionId"]
+    await asyncio.sleep(0)
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+
+    if first_backend.calls:
+        first_backend.release.set()
+    else:
+        second_backend.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    execution_id = first_started["executionId"]
+    assert first.job_status(execution_id)["status"] == "succeeded"
+    assert second.job_status(execution_id)["status"] == "succeeded"
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+    assert len(first.job_history(artifact.id)["executions"]) == 1
+    assert len(second.job_history(artifact.id)["executions"]) == 1
+
+    with pytest.raises(ToolExecutionError) as conflict:
+        await second.start_job(
+            "f" * 64,
+            second_grant.grant_id,
+            operation_id="operation-cross-process-claim",
+            ctx=None,
+            initiator="second-core",
+        )
+    assert conflict.value.code == "tool_operation_conflict"
+
+
+@pytest.mark.asyncio
+async def test_public_tool_use_returns_shared_execution_without_second_dispatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    artifact = _artifact()
+    first_backend = _BlockingBackend()
+    second_backend = _BlockingBackend()
+    first = ToolExecutionEngine(
+        _Store(artifact),
+        first_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 35_000,
+    )
+    second = ToolExecutionEngine(
+        _Store(artifact),
+        second_backend,
+        job_store=ExecutionJobStore(tmp_path),
+        now=lambda: 35_000,
+    )
+    first_plan = first.prepare(artifact.id, operation="execute", args={}, target={})
+    second_plan = second.prepare(artifact.id, operation="execute", args={}, target={})
+    first_grant = first.grants.issue_once(first_plan)
+    second_grant = second.grants.issue_once(second_plan)
+    services = iter(
+        [SimpleNamespace(execution=first), SimpleNamespace(execution=second)]
+    )
+    monkeypatch.setattr(tool_handlers, "default_tool_service", lambda: next(services))
+    first_started, second_started = await asyncio.gather(
+        tool_handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="start",
+                plan_hash=first_plan.plan_hash,
+                grant_id=first_grant.grant_id,
+                operation_id="operation-public-cross-core",
+            ),
+            None,
+        ),
+        tool_handlers._run_tool_use(
+            S.AeToolUseArgs(
+                action="start",
+                plan_hash=second_plan.plan_hash,
+                grant_id=second_grant.grant_id,
+                operation_id="operation-public-cross-core",
+            ),
+            None,
+        ),
+    )
+    assert first_started["executionId"] == second_started["executionId"]
+    await asyncio.sleep(0)
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+
+    monkeypatch.setattr(
+        tool_handlers,
+        "default_tool_service",
+        lambda: SimpleNamespace(execution=second),
+    )
+    conflict = await tool_handlers._run_tool_use(
+        S.AeToolUseArgs(
+            action="start",
+            plan_hash="f" * 64,
+            grant_id=second_grant.grant_id,
+            operation_id="operation-public-cross-core",
+        ),
+        None,
+    )
+    assert conflict["ok"] is False
+    assert conflict["error"] == "tool_operation_conflict"
+
+    if first_backend.calls:
+        first_backend.release.set()
+    else:
+        second_backend.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(first_backend.calls) + len(second_backend.calls) == 1
+
+
+def test_operation_claim_is_atomic_across_spawned_processes(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_claim_operation_in_spawned_process,
+            args=(str(tmp_path), start, results, f"spawned-execution-{index}"),
+        )
+        for index in range(2)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(15)
+        assert process.exitcode == 0
+
+    claims = [results.get(timeout=5) for _ in processes]
+    assert sum(1 for claim in claims if claim["owned"]) == 1
+    assert len({claim["executionId"] for claim in claims}) == 1
+    [reservation] = ExecutionJobStore(tmp_path).snapshot()
+    assert reservation["executionId"] == claims[0]["executionId"]
+    assert reservation["status"] == "queued"
+    assert reservation["terminal"] is False
+
+
+def test_orphaned_shared_reservation_recovers_without_blind_redispatch(
+    tmp_path: Path,
+) -> None:
+    clock = [40_000]
+    store = ExecutionJobStore(
+        tmp_path,
+        now=lambda: clock[0],
+        reservation_lease_ms=1_000,
+    )
+    queued = {
+        "executionId": "execution-orphan-running",
+        "operationId": "operation-orphan-running",
+        "artifactId": "user:one",
+        "contentHash": "a" * 64,
+        "artifactRevision": 1,
+        "planHash": "b" * 64,
+        "operation": "execute",
+        "initiator": "first-core",
+        "status": "queued",
+        "createdAt": clock[0],
+        "startedAt": None,
+        "finishedAt": None,
+        "cancelRequested": False,
+        "result": None,
+        "error": None,
+        "audit": None,
+    }
+    claim = store.claim(queued)
+    assert claim.owned is True
+    assert claim.owner_token is not None
+    store.mark_running(
+        "execution-orphan-running",
+        owner_token=claim.owner_token,
+        started_at=40_100,
+    )
+
+    clock[0] = 41_001
+    recovered = store.lookup_operation("operation-orphan-running")
+    assert recovered is not None
+    assert recovered["status"] == "outcome-unknown"
+    assert recovered["outcomeUnknown"] is True
+    assert recovered["error"]["sideEffect"] == "may-have-occurred"
+    assert recovered["error"]["recovery"]["action"] == "inspect-state"
+
+    retry = dict(queued)
+    retry["executionId"] = "execution-orphan-retry"
+    duplicate = store.claim(retry)
+    assert duplicate.owned is False
+    assert duplicate.record["executionId"] == "execution-orphan-running"
+    assert duplicate.record["status"] == "outcome-unknown"
+    persisted = (tmp_path / "execution-history.json").read_text(encoding="utf-8")
+    assert "ownerToken" not in persisted
+
+
+@pytest.mark.asyncio
+async def test_running_job_renews_its_shared_reservation_lease(
+    tmp_path: Path,
+) -> None:
+    clock = [60_000]
+    artifact = _artifact()
+    backend = _BlockingBackend()
+    store = ExecutionJobStore(
+        tmp_path,
+        now=lambda: clock[0],
+        reservation_lease_ms=60,
+    )
+    engine = ToolExecutionEngine(
+        _Store(artifact),
+        backend,
+        job_store=store,
+        now=lambda: clock[0],
+    )
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-renew-running-lease",
+        ctx=None,
+        initiator="first-core",
+    )
+    await backend.started.wait()
+
+    clock[0] = 60_050
+    await asyncio.sleep(0.08)
+    clock[0] = 60_070
+    reservation = store.lookup_execution(started["executionId"])
+    assert reservation is not None
+    assert reservation["status"] == "running"
+
+    backend.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert engine.job_status(started["executionId"])["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_terminal_persistence_failure_keeps_local_outcome_unknown(
+    tmp_path: Path,
+) -> None:
+    class FailingCompletionStore(ExecutionJobStore):
+        def complete(self, record, *, owner_token):
+            raise ExecutionJobStoreError("fixture completion failure")
+
+    artifact = _artifact()
+    backend = _Backend()
+    engine = ToolExecutionEngine(
+        _Store(artifact),
+        backend,
+        job_store=FailingCompletionStore(tmp_path),
+        now=lambda: 50_000,
+    )
+    plan = engine.prepare(artifact.id, operation="execute", args={}, target={})
+    grant = engine.grants.issue_once(plan)
+    started = await engine.start_job(
+        plan.plan_hash,
+        grant.grant_id,
+        operation_id="operation-persistence-failure",
+        ctx=None,
+        initiator="first-core",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    status = engine.job_status(started["executionId"])
+    assert status["status"] == "outcome-unknown"
+    assert status["error"]["sideEffect"] == "may-have-occurred"
+    assert status["error"]["recovery"]["action"] == "inspect-state"
+    assert len(backend.calls) == 1
+    [durable] = ExecutionJobStore(tmp_path).snapshot()
+    assert durable["status"] == "running"
+
+
 def test_execution_job_store_bounds_retention_and_redacts_secrets(
     tmp_path: Path,
 ) -> None:
@@ -1295,3 +1638,41 @@ def test_execution_job_store_accepts_full_public_client_identity(
     )
 
     assert store.load()[0]["initiator"] == initiator
+
+
+def test_execution_job_store_migrates_legacy_terminal_history(tmp_path: Path) -> None:
+    legacy = {
+        "schemaVersion": 1,
+        "executions": [
+            {
+                "executionId": "execution-legacy-terminal",
+                "operationId": "operation-legacy-terminal",
+                "artifactId": "user:one",
+                "contentHash": "a" * 64,
+                "artifactRevision": 1,
+                "planHash": "b" * 64,
+                "operation": "execute",
+                "initiator": "panel-direct",
+                "status": "succeeded",
+                "createdAt": 100,
+                "startedAt": 101,
+                "finishedAt": 102,
+                "cancelRequested": False,
+                "result": {"ok": True},
+                "error": None,
+                "audit": None,
+            }
+        ],
+    }
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "execution-history.json").write_text(
+        json.dumps(legacy), encoding="utf-8"
+    )
+
+    [recovered] = ExecutionJobStore(tmp_path).load()
+    assert recovered["executionId"] == "execution-legacy-terminal"
+    upgraded = json.loads(
+        (tmp_path / "execution-history.json").read_text(encoding="utf-8")
+    )
+    assert upgraded["schemaVersion"] == 2
+    assert upgraded["reservations"] == []

--- a/packages/core/tests/test_tool_execution.py
+++ b/packages/core/tests/test_tool_execution.py
@@ -1627,6 +1627,77 @@ def test_orphan_recovery_tombstone_survives_full_history_pruning(
     assert duplicate.record["status"] == "outcome-unknown"
 
 
+def test_just_completed_reservation_survives_full_history_pruning(
+    tmp_path: Path,
+) -> None:
+    store = ExecutionJobStore(tmp_path, max_records=2)
+    queued = {
+        "executionId": "execution-old-completing",
+        "operationId": "operation-old-completing",
+        "artifactId": "user:one",
+        "contentHash": "a" * 64,
+        "artifactRevision": 1,
+        "planHash": "b" * 64,
+        "operation": "execute",
+        "initiator": "first-core",
+        "status": "queued",
+        "createdAt": 100,
+    }
+    claim = store.claim(queued)
+    assert claim.owner_token is not None
+    store.mark_running(
+        "execution-old-completing",
+        owner_token=claim.owner_token,
+        started_at=101,
+    )
+    for index in range(2):
+        store.upsert(
+            {
+                "executionId": f"execution-newer-complete-{index}",
+                "operationId": f"operation-newer-complete-{index}",
+                "artifactId": "user:one",
+                "contentHash": "a" * 64,
+                "artifactRevision": 1,
+                "planHash": chr(ord("c") + index) * 64,
+                "operation": "execute",
+                "initiator": "other-core",
+                "status": "succeeded",
+                "createdAt": 200 + index,
+                "startedAt": 200 + index,
+                "finishedAt": 200 + index,
+                "cancelRequested": False,
+                "result": {"ok": True},
+                "error": None,
+                "audit": None,
+            }
+        )
+
+    completed = {
+        **queued,
+        "status": "succeeded",
+        "startedAt": 101,
+        "finishedAt": 300,
+        "cancelRequested": False,
+        "result": {"ok": True},
+        "error": None,
+        "audit": None,
+    }
+    stored = store.complete(completed, owner_token=claim.owner_token)
+    assert stored["status"] == "succeeded"
+    assert len(store.snapshot()) == 2
+
+    duplicate = store.claim(
+        {
+            **queued,
+            "executionId": "execution-old-completing-retry",
+            "createdAt": 400,
+        }
+    )
+    assert duplicate.owned is False
+    assert duplicate.record["executionId"] == "execution-old-completing"
+    assert duplicate.record["status"] == "succeeded"
+
+
 @pytest.mark.asyncio
 async def test_running_job_renews_its_shared_reservation_lease(
     tmp_path: Path,

--- a/packages/core/tests/test_tool_secrets.py
+++ b/packages/core/tests/test_tool_secrets.py
@@ -111,6 +111,25 @@ def test_scan_json_allows_schema_objects_and_empty_sensitive_defaults():
     ) == ()
 
 
+@pytest.mark.parametrize("key", ["idempotency_key", "idempotencyKey"])
+def test_scan_json_allows_native_write_idempotency_fields(key):
+    assert RegexSecretScanner().scan_json(
+        "native-recipe.json",
+        {
+            "ref": "ae.createComposition",
+            "args": {key: "issue139-native-write-intent-0001"},
+        },
+    ) == ()
+
+
+def test_scan_json_still_detects_concrete_secret_in_idempotency_field():
+    findings = RegexSecretScanner().scan_json(
+        "native-recipe.json",
+        {"args": {"idempotency_key": "sk-this-is-still-a-provider-secret"}},
+    )
+    assert any(finding.kind == "sk-key" for finding in findings)
+
+
 @pytest.mark.parametrize(
     "value",
     [


### PR DESCRIPTION
Closes #139.

## What changed

- atomically reserve each Tool Library `operation_id` + `planHash` in the shared store before backend dispatch;
- return the same queued/running/terminal execution to another Core and reject a different plan with `tool_operation_conflict`;
- renew live reservations, retry transient renewal failures, and recover expired queued/running owners without blind redispatch;
- preserve the owning Core's complete terminal response in memory while keeping restart history bounded and redacted;
- preserve terminal restart recovery, migrate execution history v1 -> v2, and retain recently completed/orphan-recovered operation tombstones during pruning;
- keep owner tokens private and terminal-persistence failures explicitly side-effecting;
- allow native recipe idempotency fields while still detecting concrete secrets;
- document the public stable-operation contract in both READMEs and the workflow guide.

## Exact candidate gates

Candidate: `c327112a61950a9ed824456f2ece41e81e50579a`

- full Python suite: **882 passed, 4 skipped, 25 deselected**;
- focused Tool Library execution suite: **64 passed**;
- `git diff --check`: clean;
- GitHub CI run [29582092729](https://github.com/JUNKDOGE-JOE/after-effects-mcp/actions/runs/29582092729): success;
- independent exact-head Codex diff review: no unresolved in-scope P0/P1;
- two P2 follow-ups (bounded non-owner synchronous result and uninformed cross-Core cancel refresh) are recorded in #142 and do not weaken the verified single-dispatch path.

## Formal-AE public-MCP hardware acceptance

Host gate:

- formal `/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app`;
- bundle `com.adobe.AfterEffects.application`;
- host 26.3.0 build 87; Beta excluded;
- Core, CEP, native load event, typed provenance, and evidence all reported exact candidate `c327112…`;
- AE mapped only the canonical `AeMcpNative.plugin`.

Public `ae_toolUse(action="start")` concurrent path:

- two independent MCP/Core processes used one stable operation ID and one plan;
- both observed execution `1ab97cd4a5f840b4b3d75ef3edc6825e`;
- exactly one native `ae.composition.create`, one Tool Library history row, and one matching audit row;
- a different plan with the same operation ID returned `tool_operation_conflict` without another AE mutation;
- public project summary changed `itemCount 0 -> 1`, native result reported `replayed=false` and `undoAvailable=true`;
- real AE Undo followed by public `ae_projectSummary` verified `itemCount=0`.

Public `ae_toolUse(action="execute")` concurrent path:

- both Core clients returned the same terminal typed result for execution `e2d82e8471dd44a196205d53628ac7fa`;
- exactly one native write, one history row, and one audit row;
- public project summary changed `0 -> 1`;
- real AE Undo followed by public summary verified `itemCount=0`.

Restart gate:

- the zero-item fixture was saved, formal AE was quit and relaunched by absolute path;
- the new native load event again reported `c327112…`, host 26.3.0 build 87, and a new host instance;
- after fresh fingerprint-matched pairing, public `ae_projectSummary` returned `itemCount=0` with `native-aegp` provenance.

Evidence files retained outside source/plugin scan roots:

- `public-mcp-start-candidate.json`
- `public-mcp-execute-candidate.json`
- `public-mcp-post-start-undo-candidate.json`
- `public-mcp-post-execute-undo-candidate.json`
- `public-mcp-restart-candidate.json`

## Clean-main delivery gate (passed)

Merge commit: `f24cc3f4137059734f4f32fb9b762d40855628fc`

- root `main` fast-forwarded cleanly and matched `origin/main`;
- clean-main full Python suite: **882 passed, 4 skipped, 25 deselected**;
- native plugin, CEP host, and Core were rebuilt/reinstalled from exact merge commit `f24cc3f…`;
- native artifact hashes: bundle tree `110d17a060a480ece534b93ee304ccad29bec2b899908032cc9b5ad4cfa720dd`, executable `50066f3b70145db58aeabff9bd39a2ee025ffb01a3cc400b66d34ec4492c50a3`;
- formal AE gate: bundle `com.adobe.AfterEffects.application`, host 26.3.0 build 87, Beta absent, only canonical `AeMcpNative.plugin` mapped;
- concurrent public `ae_toolUse(action="start")`: both Core clients converged on execution `9b7d58aa2dea48b7b36538d601a48b33`, exactly one native write/history/audit row, conflict plan rejected, project `0 -> 1`, real AE Undo verified `itemCount=0`;
- concurrent public `ae_toolUse(action="execute")`: both Core clients converged on execution `2845692ddfc94447b3cbf293aab090d7`, exactly one native write/history/audit row, project `0 -> 1`, real AE Undo verified `itemCount=0`;
- after save/quit/cold-start by the formal app's absolute path and fingerprint-matched pairing, public `ae_projectSummary` returned `itemCount=0`, `native-aegp` provenance, and exact source commit `f24cc3f…`;
- clean-main evidence retained under the exact-SHA evidence directory as `public-mcp-start-main.json`, `public-mcp-execute-main.json`, both post-Undo reads, and `public-mcp-restart-main.json`; disposable AEP fixtures were archived alongside evidence outside source/plugin scan roots.

The two non-blocking P2 contract improvements remain tracked in #142. No unresolved in-scope P0/P1 remains.