### PR TITLE
Redact composition names from native diagnostics

### DIFF
--- a/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
+++ b/native/ae-plugin/include/aemcp_native/rpc_codec.hpp
@@ -163,6 +163,8 @@ struct ParsedRequest {
     std::string_view idempotency_key);
 [[nodiscard]] std::string digest_composition_create_postcondition(
     const CompositionCreated& value);
+[[nodiscard]] std::string composition_create_persistent_diagnostic_fields(
+    const CompositionCreated& value);
 [[nodiscard]] std::string digest_composition_layer_create_arguments(
     const ObjectLocator& composition_locator,
     std::string_view kind,

--- a/native/ae-plugin/src/aegp/plugin_entry.cpp
+++ b/native/ae-plugin/src/aegp/plugin_entry.cpp
@@ -4852,19 +4852,9 @@ void log_completion(
              << completion.composition_time_change_result
                     .composition_locator.generation;
     } else if (completion.capability_id == kCompositionCreateCapability) {
-      output << ",\"result\":{\"changed\":true,\"name\":\""
-             << json_escape(completion.composition_create_result.name)
-             << "\",\"projectItemCountBefore\":"
-             << completion.composition_create_result.project_item_count_before
-             << ",\"projectItemCountAfter\":"
-             << completion.composition_create_result.project_item_count_after
-             << ",\"layerCount\":"
-             << completion.composition_create_result.layer_count
-             << ",\"width\":" << completion.composition_create_result.width
-             << ",\"height\":" << completion.composition_create_result.height
-             << ",\"projectGeneration\":"
-             << completion.composition_create_result
-                    .composition_locator.generation;
+      output << ",\"result\":{"
+             << aemcp::native::rpc::composition_create_persistent_diagnostic_fields(
+                    completion.composition_create_result);
     } else if (completion.capability_id == kCompositionLayerCreateCapability) {
       output << ",\"result\":{\"changed\":true,\"kind\":\""
              << json_escape(completion.composition_layer_create_result.kind)

--- a/native/ae-plugin/src/core/rpc_codec.cpp
+++ b/native/ae-plugin/src/core/rpc_codec.cpp
@@ -2387,6 +2387,22 @@ std::string digest_composition_create_postcondition(
       + canonical_composition_create_value(value) + "}");
 }
 
+std::string composition_create_persistent_diagnostic_fields(
+    const CompositionCreated& value) {
+  // Deliberately keep the user-provided composition name out of the persistent
+  // native JSONL diagnostics. The immediate, already-validated RPC response
+  // remains unchanged and still returns the name.
+  return "\"changed\":true,\"nameRedacted\":true,\"projectItemCountBefore\":"
+      + std::to_string(value.project_item_count_before)
+      + ",\"projectItemCountAfter\":"
+      + std::to_string(value.project_item_count_after)
+      + ",\"layerCount\":" + std::to_string(value.layer_count)
+      + ",\"width\":" + std::to_string(value.width)
+      + ",\"height\":" + std::to_string(value.height)
+      + ",\"projectGeneration\":"
+      + std::to_string(value.composition_locator.generation);
+}
+
 std::string digest_composition_layer_create_arguments(
     const ObjectLocator& composition_locator,
     std::string_view kind,

--- a/native/ae-plugin/tests/rpc_codec_test.cpp
+++ b/native/ae-plugin/tests/rpc_codec_test.cpp
@@ -64,6 +64,7 @@ using aemcp::native::rpc::digest_composition_selected_layers_postcondition;
 using aemcp::native::rpc::digest_composition_time_postcondition;
 using aemcp::native::rpc::digest_composition_time_set_postcondition;
 using aemcp::native::rpc::digest_composition_create_postcondition;
+using aemcp::native::rpc::composition_create_persistent_diagnostic_fields;
 using aemcp::native::rpc::digest_composition_layer_create_postcondition;
 using aemcp::native::rpc::digest_layer_effect_apply_postcondition;
 using aemcp::native::rpc::digest_layer_properties_postcondition;
@@ -980,6 +981,32 @@ void project_graph_invokes_and_results_are_closed_and_deterministic() {
           && composition_create_body.find("\"projectItemCountAfter\":2")
               != std::string::npos,
       "composition create success omitted typed mutation evidence");
+  auto private_composition_created = composition_created;
+  private_composition_created.name = "PRIVATE_CUSTOMER_COMPOSITION_123";
+  const std::string persistent_diagnostic = "{"
+      + composition_create_persistent_diagnostic_fields(private_composition_created)
+      + ",\"postconditionDigest\":\"fixture-digest\"}";
+  require(persistent_diagnostic.find(private_composition_created.name)
+              == std::string::npos
+          && persistent_diagnostic.find("\"name\":") == std::string::npos
+          && persistent_diagnostic.find("\"nameRedacted\":true")
+              != std::string::npos
+          && persistent_diagnostic.find("\"projectItemCountBefore\":1")
+              != std::string::npos
+          && persistent_diagnostic.find("\"projectItemCountAfter\":2")
+              != std::string::npos
+          && persistent_diagnostic.find("\"layerCount\":0")
+              != std::string::npos
+          && persistent_diagnostic.find("\"width\":1920")
+              != std::string::npos
+          && persistent_diagnostic.find("\"height\":1080")
+              != std::string::npos
+          && persistent_diagnostic.find("\"projectGeneration\":9")
+              != std::string::npos
+          && persistent_diagnostic.find(
+                 "\"postconditionDigest\":\"fixture-digest\"")
+              != std::string::npos,
+      "persistent composition-create diagnostics exposed the name or lost bounded evidence");
   composition_create_success.replayed = true;
   require(body(encode_composition_create_success(composition_create_success)).find(
               "\"replayed\":true") != std::string::npos,

--- a/scripts/package/test/native-aegp-build-contract.test.mjs
+++ b/scripts/package/test/native-aegp-build-contract.test.mjs
@@ -126,6 +126,23 @@ test('native pairing command is enabled by the AE update-menu hook', () => {
   );
 });
 
+test('native composition-create diagnostics use the redacted serializer', () => {
+  const completionStart = PLUGIN_ENTRY.indexOf('void log_completion(');
+  const completionEnd = PLUGIN_ENTRY.indexOf('bool PluginState::start_ipc', completionStart);
+  assert.notEqual(completionStart, -1);
+  assert.notEqual(completionEnd, -1);
+
+  const completionLogger = PLUGIN_ENTRY.slice(completionStart, completionEnd);
+  assert.match(
+    completionLogger,
+    /composition_create_persistent_diagnostic_fields\(\s*completion\.composition_create_result\s*\)/u,
+  );
+  assert.doesNotMatch(
+    completionLogger,
+    /composition_create_result\.name/u,
+  );
+});
+
 test('native README examples use safe shell variables and the complete build inputs', async () => {
   for (const readmePath of ['README.md', 'README.zh-CN.md']) {
     const readme = await fs.promises.readFile(readmePath, 'utf8');


### PR DESCRIPTION
Closes #123.

## What changed

- persistent native `invoke.terminal` diagnostics for `ae.composition.create` now record `nameRedacted=true` instead of the user-provided composition name;
- bounded operational evidence remains available: before/after project item counts, layer count, dimensions, project generation, request digest, timestamps, and postcondition digest;
- the immediate typed public MCP/RPC result is intentionally unchanged and still returns the created name for caller verification;
- portable tests bind the AEGP logger to the redacted serializer and prove the sensitive name is absent while operational evidence remains.

## Candidate and automated gates

Exact candidate: `f6c19ae2c59c2151c36600a1681873b9d92ae4f9`

- full Python: **882 passed, 4 skipped, 25 deselected**;
- protocol: **38 passed**;
- packaging: **379 passed, 6 skipped**;
- focused native build contract: **9 passed**;
- portable RPC codec, native connection, and dispatcher: PASS;
- independent exact-head diff review: no findings;
- required Actions run **29584505731**: success.

## Candidate hardware gate — passed

Formal After Effects 26.3.0 build 87, bundle `com.adobe.AfterEffects.application`; exact Core/CEP/native candidate SHA and canonical plug-in mapping.

- public `ae_projectSummary`: item count 0;
- public `ae_createComposition`: request `mcp-c8be4e7d82d841388bb9b0e52d7da1cb`, immediate typed result retained the requested name, item count 0 → 1, native AEGP provenance, committed audit, verified postcondition, Undo available;
- persistent native row omitted the raw name and `result.name`, while retaining `nameRedacted=true`, counts, dimensions, generation, and matching postcondition digest;
- real AE Undo + public read restored item count 0;
- formal AE restart + reopened fixture + public read remained item count 0 at the exact candidate SHA.

## Clean-main hardware gate — passed

Merge commit: `db725058cfc03810df0cc2bcbca8c10af33c4ece`

Rebuilt native from clean synchronized `main`, installed matching CEP and native artifacts, and reran the full gate on formal AE 26.3.0 build 87.

- build receipt: bundle tree `b677dbba03391a763376f56fc3c6d075e5905ae668dadb48164e6428735aac9e`, executable `598c45b47f43e9b8feb4213acbcf9b52e1cc8a5554bc62d9a217199251e66b7c`;
- public write request `mcp-2f6f0ab168074ca6ac92c077a7ea2779`: typed name present, item count 0 → 1, verified native AEGP postcondition and audit;
- matching native diagnostic: raw name absent, `result.name` absent, `nameRedacted=true`, bounded mutation fields retained;
- real AE Undo + public read request `mcp-78f34d5996eb43f9ba2321763184d9cb`: item count 0;
- formal AE restart, exact merge load, canonical mapping, reopened fixture, public read request `mcp-4b5ee7ec7cd84e8b84ad3e0ef6d90ef9`: item count 0.

Candidate and clean-main evidence, build receipts, and disposable fixtures are archived outside the repository under the corresponding exact-SHA evidence directories. Beta evidence was not used.