### PR TITLE
Publish positive duration for native composition creation

### DIFF
--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -242,6 +242,12 @@ class AeCompositionTimeInput(_StrictModel):
     scale: int = Field(..., ge=1, le=4_294_967_295)
 
 
+class AePositiveCompositionTimeInput(AeCompositionTimeInput):
+    """Exact positive A_Time value/scale pair for composition durations."""
+
+    value: int = Field(..., ge=1, le=2_147_483_647)
+
+
 class AeSetCompositionTimeArgs(_StrictModel):
     """ae.setCompositionTime — set exact composition time through native AEGP.
 
@@ -311,8 +317,8 @@ class AeCreateCompositionArgs(_StrictModel):
     )
     width: int = Field(1920, ge=1, le=30_000)
     height: int = Field(1080, ge=1, le=30_000)
-    duration: AeCompositionTimeInput = Field(
-        default_factory=lambda: AeCompositionTimeInput(value=5, scale=1),
+    duration: AePositiveCompositionTimeInput = Field(
+        default_factory=lambda: AePositiveCompositionTimeInput(value=5, scale=1),
         description="Exact positive duration; defaults to five seconds.",
     )
     frame_rate: AePositiveRatioInput = Field(
@@ -338,8 +344,6 @@ class AeCreateCompositionArgs(_StrictModel):
     def _valid_native_values(self) -> "AeCreateCompositionArgs":
         if any(0xD800 <= ord(character) <= 0xDFFF for character in self.name):
             raise ValueError("name must contain only Unicode scalar values")
-        if self.duration.value <= 0:
-            raise ValueError("duration must be positive")
         return self
 
 

--- a/packages/core/tests/test_composition_create_native.py
+++ b/packages/core/tests/test_composition_create_native.py
@@ -266,28 +266,82 @@ async def test_tampered_postcondition_is_uncertain_and_never_retried():
 
 @pytest.mark.asyncio
 async def test_public_mcp_schema_is_registered_and_rejects_before_dispatch(monkeypatch):
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    from ae_mcp import schemas, server as server_module
+
     load_all()
     schema_cls, _ = HANDLERS["ae.createComposition"]
+    dispatches: list[Any] = []
 
-    async def _must_not_dispatch(_validated, _ctx):
-        pytest.fail("invalid public MCP arguments reached the native handler")
+    async def _run(validated, _ctx):
+        dispatches.append(validated)
+        return {"ok": True, "value": {"accepted": True}}
 
-    monkeypatch.setitem(HANDLERS, "ae.createComposition", (schema_cls, _must_not_dispatch))
-    result = await build_server()._ae_call_tool(
-        "ae_createComposition",
-        {
-            "name": "SYNTHETIC_COMP",
-            "duration": {"value": 0, "scale": 1},
-            "idempotency_key": "synthetic-comp-create-0004",
-        },
+    async def _allow(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setitem(HANDLERS, "ae.createComposition", (schema_cls, _run))
+    monkeypatch.setattr(
+        server_module,
+        "_filtered_tool_names",
+        lambda: {"ae.createComposition"},
     )
+    monkeypatch.setattr(
+        server_module.approval_gate,
+        "enforce",
+        _allow,
+    )
+    server = build_server()
 
-    assert result.isError is True
-    payload = json.loads(result.content[0].text)
-    assert payload["error"]["code"] == "INVALID_ARGUMENT"
-    assert payload["error"]["sideEffect"] == "not-started"
-    assert payload["error"]["recovery"]["action"] == "change-arguments"
-    assert payload["error"]["details"] == {
-        "field": "arguments",
-        "capabilityId": "ae.composition.create",
-    }
+    async with create_connected_server_and_client_session(server) as client:
+        listed = await client.list_tools()
+        assert [tool.name for tool in listed.tools] == ["ae_createComposition"]
+        public_schema = listed.tools[0].inputSchema
+        duration_ref = public_schema["properties"]["duration"]["$ref"]
+        duration_schema = public_schema["$defs"][duration_ref.rsplit("/", 1)[1]]
+        assert duration_schema["properties"]["value"] == {
+            "maximum": 2_147_483_647,
+            "minimum": 1,
+            "title": "Value",
+            "type": "integer",
+        }
+
+        for bad_value in (0, -1):
+            result = await client.call_tool(
+                "ae_createComposition",
+                {
+                    "name": "SYNTHETIC_COMP",
+                    "duration": {"value": bad_value, "scale": 1},
+                    "idempotency_key": "synthetic-comp-create-0004",
+                },
+            )
+
+            assert result.isError is True
+            payload = json.loads(result.content[0].text)
+            assert payload["error"]["code"] == "INVALID_ARGUMENT"
+            assert payload["error"]["sideEffect"] == "not-started"
+            assert payload["error"]["recovery"]["action"] == "change-arguments"
+            assert payload["error"]["details"] == {
+                "field": "arguments.duration.value",
+                "capabilityId": "ae.composition.create",
+            }
+        assert dispatches == []
+
+        accepted = await client.call_tool(
+            "ae_createComposition",
+            {
+                "name": "SYNTHETIC_COMP",
+                "duration": {"value": 5, "scale": 2},
+                "idempotency_key": "synthetic-comp-create-0004",
+            },
+        )
+        assert accepted.isError is False
+        assert len(dispatches) == 1
+        assert dispatches[0].duration.value == 5
+        assert dispatches[0].duration.scale == 2
+
+    set_time_schema = schemas.AeSetCompositionTimeArgs.model_json_schema()
+    target_ref = set_time_schema["properties"]["target_time"]["$ref"]
+    target_schema = set_time_schema["$defs"][target_ref.rsplit("/", 1)[1]]
+    assert target_schema["properties"]["value"]["minimum"] == -2_147_483_648


### PR DESCRIPTION
Closes #122.

## What changed

- added a composition-create-specific positive `A_Time` input model so public `ae_createComposition` publishes `duration.value.minimum = 1`;
- removed the redundant model-level duration check so the advertised schema and runtime validation agree at the exact field;
- preserved signed `AeCompositionTimeInput` ranges for timeline and unrelated duration inputs.

## Exact candidate and gates

Candidate: `27571e69a0b1ae7a87382485b80428884bfa6216`

Through a real in-memory public MCP client:
- `tools/list` exposed the positive duration minimum;
- 0 and -1 returned structured `INVALID_ARGUMENT`, `sideEffect=not-started`, `recovery.action=change-arguments`, field `arguments.duration.value`, with zero dispatches;
- exact duration `5/2` reached the handler once;
- `ae_setCompositionTime.target_time.value` retained signed int32 minimum.

Candidate gates:
- focused public/schema tests: **67 passed**;
- full Python: **882 passed, 4 skipped, 25 deselected**;
- native protocol: **38 passed**;
- independent exact-head review: no findings;
- required CI run **29586552593**: success.

## Hardware classification

No AE hardware gate was required because the change is entirely public Core schema/pre-dispatch validation and does not alter the native execution path.

## Clean-main gate — passed

Merge commit: `9494a2e33b430c3394f9545c6fa6c384f96e826a`

After fast-forwarding a clean synchronized `main`, the same public MCP schema/rejection/positive-duration test and full schema suite passed: **67 passed**. Root remained clean and synchronized.