### PR TITLE
fix(native-protocol): align keyframe precondition recovery and frame-limit docs

### DIFF
--- a/native/ae-plugin/protocol/README.md
+++ b/native/ae-plugin/protocol/README.md
@@ -27,7 +27,7 @@ provenance, or compatibility with any AE/SDK/OS combination. Compatibility stays
 
 Each message is UTF-8 JSON preceded by one unsigned, four-byte, big-endian
 length. The length covers only the JSON bytes. Version 1 rejects zero-length,
-invalid UTF-8, trailing bytes inside a frame, and frames over 65,536 bytes.
+invalid UTF-8, trailing bytes inside a frame, and frames over 131,072 bytes.
 Transport implementations may apply a lower authenticated-session limit.
 
 Parsers also reject duplicate object keys, unsafe integers, more than 16 JSON
@@ -133,7 +133,7 @@ session after bounded tombstones expire or are evicted.
 
 - omitted request deadline: 5,000 ms from broker send time;
 - maximum accepted deadline: 30,000 ms;
-- maximum frame size: 65,536 bytes;
+- maximum frame size: 131,072 bytes;
 - omitted capability detail: `summary`;
 - omitted capability page size: 50, maximum 100;
 - public project-item and composition-layer page size: 25 by default, maximum

--- a/native/ae-plugin/protocol/protocol.test.mjs
+++ b/native/ae-plugin/protocol/protocol.test.mjs
@@ -179,6 +179,7 @@ function strictTerminalValidator(request, response, timing) {
 }
 
 test('schema locks strict framing, bounded defaults, rate limits, and native provenance', () => {
+  const protocolReadme = fs.readFileSync(path.join(here, 'README.md'), 'utf8');
   assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
   assert.deepEqual(schema['x-framing'], {
     lengthPrefixBytes: 4,
@@ -191,6 +192,8 @@ test('schema locks strict framing, bounded defaults, rate limits, and native pro
     stringLengthUnit: 'unicode-scalar-values',
     duplicateObjectKeys: 'reject',
   });
+  assert.equal([...protocolReadme.matchAll(/131,072 bytes/gu)].length, 2);
+  assert.doesNotMatch(protocolReadme, /65,536 bytes/u);
   assert.equal(schema['x-lifecycle'].defaultDeadlineMs, 5000);
   assert.equal(schema['x-lifecycle'].maximumDeadlineMs, 30000);
   assert.equal(schema['x-lifecycle'].pagination, 'capability-owned-offset-limit-v1');
@@ -970,6 +973,29 @@ test('every error code has one safe retry/side-effect/recovery tuple', () => {
   cancelled.recovery.retryAfterMs = 250;
   assert.equal(schemaAccepts(schema.$defs.rpcError, cancelled), false);
   assert.equal(validateErrorPolicy(cancelled, schema), false);
+});
+
+test('property-locator preconditions use bounded capability-specific recovery', () => {
+  for (const capabilityId of [
+    'ae.layer.property.set',
+    'ae.layer.property.keyframes.list',
+  ]) {
+    const error = errorVector('PRECONDITION_FAILED');
+    error.details = {
+      capabilityId,
+      field: 'params.arguments.propertyLocator',
+    };
+    error.recovery.action = 'change-arguments';
+    assert.equal(validateErrorPolicy(error, schema), true, capabilityId);
+  }
+
+  const wrongField = errorVector('PRECONDITION_FAILED');
+  wrongField.details = {
+    capabilityId: 'ae.layer.property.keyframes.list',
+    field: 'params.arguments.offset',
+  };
+  wrongField.recovery.action = 'change-arguments';
+  assert.equal(validateErrorPolicy(wrongField, schema), false);
 });
 
 test('request ledger resists poisoning and only replays verified, live, identical reads', () => {

--- a/native/ae-plugin/src/core/native_rpc_connection.cpp
+++ b/native/ae-plugin/src/core/native_rpc_connection.cpp
@@ -125,14 +125,22 @@ rpc::ErrorResponse error_for(
       capability_id = invoke->capability_id;
     }
   }
-  const bool property_precondition = mapped == RpcErrorCode::kPreconditionFailed
+  const bool set_property_precondition = mapped == RpcErrorCode::kPreconditionFailed
       && capability_id == kLayerPropertySetCapability
       && field == "params.arguments.propertyLocator";
+  const bool keyframe_property_precondition =
+      mapped == RpcErrorCode::kPreconditionFailed
+      && capability_id == kLayerPropertyKeyframesListCapability
+      && field == "params.arguments.propertyLocator";
+  const bool property_precondition =
+      set_property_precondition || keyframe_property_precondition;
   response.code = mapped;
   response.message = std::move(message);
-  response.recovery_hint = property_precondition
-      ? "Choose a non-keyframed supported primitive property and retry with fresh locators."
-      : recovery_hint(mapped);
+  response.recovery_hint = keyframe_property_precondition
+      ? "Copy a keyframeable primitive scalar, vector, or color leaf locator from ae_listLayerProperties."
+      : set_property_precondition
+          ? "Choose a non-keyframed supported primitive property and retry with fresh locators."
+          : recovery_hint(mapped);
   if (property_precondition) response.recovery_action = "change-arguments";
   if (mapped == RpcErrorCode::kQueueFull) response.retry_after_ms = 50;
   if (mapped == RpcErrorCode::kWireVersionMismatch) {

--- a/native/ae-plugin/src/core/rpc_codec.cpp
+++ b/native/ae-plugin/src/core/rpc_codec.cpp
@@ -3990,13 +3990,15 @@ std::vector<std::uint8_t> encode_error_response(const ErrorResponse& response) {
   }
   std::string recovery_action = policy.recovery;
   if (response.recovery_action.has_value()) {
+    const bool property_locator_precondition = response.details.has_value()
+        && response.details->capability_id.has_value()
+        && (*response.details->capability_id == kLayerPropertySetCapability
+          || *response.details->capability_id == kLayerPropertyKeyframesListCapability)
+        && response.details->field.has_value()
+        && *response.details->field == "params.arguments.propertyLocator";
     if (response.code != RpcErrorCode::kPreconditionFailed
         || *response.recovery_action != "change-arguments"
-        || !response.details.has_value()
-        || !response.details->capability_id.has_value()
-        || *response.details->capability_id != kLayerPropertySetCapability
-        || !response.details->field.has_value()
-        || *response.details->field != "params.arguments.propertyLocator") {
+        || !property_locator_precondition) {
       invalid_argument("invalid capability-specific recovery action");
     }
     recovery_action = *response.recovery_action;

--- a/native/ae-plugin/tests/native_rpc_connection_test.cpp
+++ b/native/ae-plugin/tests/native_rpc_connection_test.cpp
@@ -354,6 +354,16 @@ class FakeHost final : public HostApi {
   [[nodiscard]] HostLayerPropertyKeyframesResult list_layer_property_keyframes(
       const aemcp::native::LayerPropertyKeyframesQuery& query, TimePoint) override {
     ++layer_property_keyframes_calls;
+    if (query.offset == 1) {
+      return HostLayerPropertyKeyframesResult::failure(
+          "PRECONDITION_FAILED",
+          "property must be a keyframeable primitive scalar, vector, or color leaf stream",
+          "params.arguments.propertyLocator");
+    }
+    if (query.offset == 2) {
+      return HostLayerPropertyKeyframesResult::failure(
+          "PRECONDITION_FAILED", "an After Effects project must be open");
+    }
     aemcp::native::LayerPropertyKeyframesPage page;
     page.property_locator = query.property_locator;
     page.value_type = "one-d";
@@ -827,14 +837,15 @@ std::string layer_properties_invoke_json(std::string_view request_id) {
       + ",\"offset\":0,\"limit\":25}}}";
 }
 
-std::string layer_property_keyframes_invoke_json(std::string_view request_id) {
+std::string layer_property_keyframes_invoke_json(
+    std::string_view request_id, std::size_t offset = 0) {
   return "{\"wireVersion\":1,\"kind\":\"request\",\"sessionId\":\""
       + std::string(kSession) + "\",\"requestId\":\"" + std::string(request_id)
       + "\",\"method\":\"invoke\",\"deadlineUnixMs\":1900000005000,"
         "\"params\":{\"capabilityId\":\"ae.layer.property.keyframes.list\","
         "\"capabilityVersion\":1,\"arguments\":{\"propertyLocator\":"
       + graph_locator_json("stream", "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
-      + ",\"offset\":0,\"limit\":2}}}";
+      + ",\"offset\":" + std::to_string(offset) + ",\"limit\":2}}}";
 }
 
 std::string cancel_json(std::string_view request_id, std::string_view target_request_id) {
@@ -1570,6 +1581,44 @@ void hello_capabilities_invoke_cancel_and_fencing_work() {
           && host.layer_property_keyframes_calls == 1,
       "layer-property keyframes terminal evidence was not verified");
 
+  send_json(sockets[0], layer_property_keyframes_invoke_json(
+      "invoke-layer-property-keyframes-precondition", 1));
+  require_contains(read_body(sockets[0]), "\"event\":\"progress\"",
+      "layer-property keyframes precondition progress");
+  wait_until([&] { return dispatcher.queued() == 1; },
+      "queued layer-property keyframes precondition invoke");
+  const auto keyframes_precondition_batch = dispatcher.drain(host);
+  require(keyframes_precondition_batch.completions.size() == 1
+          && !keyframes_precondition_batch.completions[0].ok,
+      "owner dispatcher did not preserve keyframe property precondition failure");
+  const std::string keyframes_precondition = read_body(sockets[0]);
+  require_contains(keyframes_precondition, "\"code\":\"PRECONDITION_FAILED\"",
+      "layer-property keyframes precondition response");
+  require_contains(keyframes_precondition, "\"action\":\"change-arguments\"",
+      "layer-property keyframes precondition recovery");
+  require_contains(keyframes_precondition,
+      "Copy a keyframeable primitive scalar, vector, or color leaf locator from ae_listLayerProperties.",
+      "layer-property keyframes precondition hint");
+  require_contains(keyframes_precondition,
+      "\"field\":\"params.arguments.propertyLocator\"",
+      "layer-property keyframes precondition field");
+
+  send_json(sockets[0], layer_property_keyframes_invoke_json(
+      "invoke-layer-property-keyframes-no-project", 2));
+  require_contains(read_body(sockets[0]), "\"event\":\"progress\"",
+      "layer-property keyframes no-project progress");
+  wait_until([&] { return dispatcher.queued() == 1; },
+      "queued layer-property keyframes no-project invoke");
+  const auto keyframes_no_project_batch = dispatcher.drain(host);
+  require(keyframes_no_project_batch.completions.size() == 1
+          && !keyframes_no_project_batch.completions[0].ok,
+      "owner dispatcher did not preserve keyframe no-project failure");
+  const std::string keyframes_no_project = read_body(sockets[0]);
+  require_contains(keyframes_no_project, "\"code\":\"PRECONDITION_FAILED\"",
+      "layer-property keyframes no-project response");
+  require_contains(keyframes_no_project, "\"action\":\"open-project\"",
+      "layer-property keyframes no-project recovery");
+
   send_json(sockets[0], layer_property_set_invoke_json("invoke-layer-property-set"));
   require_contains(read_body(sockets[0]), "\"event\":\"progress\"",
       "layer-property set progress");
@@ -1707,7 +1756,7 @@ void hello_capabilities_invoke_cancel_and_fencing_work() {
   require_contains(cancel, "\"terminalResponseExpected\":true", "cancel response");
   const std::string cancelled_terminal = read_body(sockets[0]);
   require_contains(cancelled_terminal, "\"code\":\"CANCELLED\"", "cancel terminal");
-  require(idle_signal.calls() == 22,
+  require(idle_signal.calls() == 24,
       "accepted invokes did not each schedule exactly one idle wake; observed "
           + std::to_string(idle_signal.calls()));
 

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -2093,6 +2093,64 @@ test('CEP client preserves the complete structured native error contract', {
     );
 });
 
+test('CEP client preserves actionable keyframe property precondition recovery', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    const protocol = installProtocol(fixture.server, {
+        invokeError: {
+            code: 'PRECONDITION_FAILED',
+            message: 'property must be a keyframeable primitive leaf stream',
+            retryable: false,
+            sideEffect: 'not-started',
+            recovery: {
+                action: 'change-arguments',
+                hint: 'Copy a keyframeable primitive scalar, vector, or color leaf locator from ae_listLayerProperties.',
+            },
+            details: {
+                capabilityId: 'ae.layer.property.keyframes.list',
+                field: 'params.arguments.propertyLocator',
+            },
+        },
+    });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        requestTimeoutMs: 2000,
+        now: function () { return 1900000000000; },
+    });
+    t.after(function () { return client.close(); });
+    await client.beginPairing();
+    protocol.authorize();
+    await client.waitUntilConnected();
+    await client.capabilities({ detail: 'full', limit: 100 });
+    await assert.rejects(
+        client.invoke({
+            requestId: 'core-keyframe-precondition',
+            capabilityId: 'ae.layer.property.keyframes.list',
+            capabilityVersion: 1,
+            arguments: structuredClone(
+                LAYER_PROPERTY_KEYFRAMES_VECTOR.request.params.arguments,
+            ),
+            deadlineUnixMs: 1900000002000,
+        }),
+        function (error) {
+            assert.equal(error.code, 'PRECONDITION_FAILED');
+            assert.equal(error.retryable, false);
+            assert.equal(error.sideEffect, 'not-started');
+            assert.equal(error.recovery.action, 'change-arguments');
+            assert.equal(error.recovery.hint,
+                'Copy a keyframeable primitive scalar, vector, or color leaf locator from ae_listLayerProperties.');
+            assert.deepEqual(error.details, {
+                capabilityId: 'ae.layer.property.keyframes.list',
+                field: 'params.arguments.propertyLocator',
+            });
+            return true;
+        },
+    );
+});
+
 for (const errorFixture of [
     {
         name: 'keeps an actual native INVALID_REQUEST distinct',


### PR DESCRIPTION
Closes #134

## What changed

- Map `ae.layer.property.keyframes.list@1` property-locator preconditions to the actionable `change-arguments` recovery at the native wire boundary.
- Keep all other `PRECONDITION_FAILED` responses on the existing `open-project` default.
- Allow the exact keyframe-list/property-set exception in the native response encoder.
- Add serialized native RPC, protocol policy, and CEP preservation coverage.
- Correct the protocol documentation from the obsolete 65,536-byte ceiling to 131,072 bytes.

## Root cause

Core already remapped this keyframe precondition and protocol conformance already allowed it, but native `error_for()` emitted the generic recovery and the encoder only admitted the property-set exception. Direct native/CEP consumers therefore disagreed with the public MCP response and capability descriptor.

## Candidate validation

Candidate commit: `3bfe08863c3476f04eb25aa83857a59aab1e8327`

- `native_rpc_connection_test`: PASS, including serialized keyframe property precondition and no-project control
- `rpc_codec_test`: PASS
- protocol contract: 39/39 PASS
- CEP native client: 36/36 PASS
- Python regression: 882 passed, 4 skipped, 25 deselected
- `git diff --check`: PASS
- independent Codex diff review: no findings
- required CI run 29587662658: all three jobs PASS

## Merge and clean-main revalidation

Merge commit: `39a0bd07dd70ceebfbe4c493baed942ffeb7ac59`

From a clean, synchronized `main`:

- protocol contract: 39/39 PASS
- CEP native client: 36/36 PASS
- `rpc_codec_test`: PASS
- `native_rpc_connection_test`: PASS
- root `main` clean and equal to `origin/main`

The serialized failure contract is:

- code: `PRECONDITION_FAILED`
- retryable: `false`
- side effect: `not-started`
- recovery: `change-arguments`
- field: `params.arguments.propertyLocator`
- capability: `ae.layer.property.keyframes.list`
- hint: copy a keyframeable primitive scalar, vector, or color leaf locator from `ae_listLayerProperties`

The no-project control remains `open-project`.

## Hardware-gate classification

No AE hardware gate is required for this PR: it changes only structured failure classification, response encoding validation, tests, and protocol documentation. It does not alter AEGP dispatch, AE state reads/writes, plugin lifecycle, installation, or host behavior.