### PR TITLE
docs: streamline capability-package delivery

### DIFF
--- a/.github/ISSUE_TEMPLATE/capability-package.md
+++ b/.github/ISSUE_TEMPLATE/capability-package.md
@@ -16,7 +16,7 @@ Follow `docs/CAPABILITY_PACKAGE_WORKFLOW.md`. This Issue is the single source of
 - User-visible outcome:
 - Normal target: 6-10 tools (allowed range 5-15)
 
-## Child Issues
+## Child Issues (optional)
 
 - [ ] #
 
@@ -43,7 +43,7 @@ Follow `docs/CAPABILITY_PACKAGE_WORKFLOW.md`. This Issue is the single source of
 
 ## Public capability and acceptance matrix
 
-| Child Issue | Public MCP tool and schema | Capability ID / shared primitive | R/W | Postcondition | Undo | Important interaction | Status |
+| Optional child Issue | Public MCP tool and schema | Capability ID / shared primitive | R/W | Postcondition | Undo | Important interaction | Status |
 |---|---|---|---|---|---|---|---|
 | # |  |  |  |  |  |  | planned |
 
@@ -71,10 +71,10 @@ public MCP tool
 - T0 commands:
 - T1 commands:
 - T2 commands:
-- T3 full regression / required CI:
+- T3 full regression / required CI for each frozen candidate SHA:
 - T4 narrow hardware smoke, if required:
 - T5 candidate harness:
-- T6 clean-main harness:
+- T6 clean-main harness (every included public tool; accepted optional child Issues; every write Undo):
 
 ## Hardware preflight
 
@@ -92,4 +92,4 @@ public MCP tool
 - [ ] Every write has executed and verified Undo.
 - [ ] Review/CI pass and candidate identity is exact.
 - [ ] Clean-main rebuild/reinstall and package smoke pass.
-- [ ] Per-Issue disposition and remaining risks are recorded.
+- [ ] Per-tool acceptance, optional per-Issue disposition, and remaining risks are recorded.

--- a/.github/ISSUE_TEMPLATE/capability-package.md
+++ b/.github/ISSUE_TEMPLATE/capability-package.md
@@ -1,0 +1,95 @@
+---
+name: Native capability package
+about: Plan related native public MCP tools with one review and real-AE closure loop
+title: "[Native Capability Package] "
+labels: ""
+assignees: ""
+---
+
+Follow `docs/CAPABILITY_PACKAGE_WORKFLOW.md`. This Issue is the single source of truth for package scope and the acceptance matrix.
+
+## Package identity
+
+- Parent Epic:
+- Priority: P0 / P1 / P2 / P3
+- Owner worktree/branch:
+- User-visible outcome:
+- Normal target: 6-10 tools (allowed range 5-15)
+
+## Child Issues
+
+- [ ] #
+
+## Scope freeze
+
+### Shared implementation
+
+- AEGP suites / native primitive:
+- Locator / lifecycle:
+- Dispatcher path:
+- Disposable fixture:
+- Undo / recovery model:
+- User scenario:
+
+### Explicit exclusions
+
+-
+
+### Native novelty
+
+- [ ] No new real-AE primitive; T4 is not required.
+- [ ] New suite/lifecycle/main-thread mechanism; one narrow T4 smoke is required.
+- T4 hypothesis and observable result:
+
+## Public capability and acceptance matrix
+
+| Child Issue | Public MCP tool and schema | Capability ID / shared primitive | R/W | Postcondition | Undo | Important interaction | Status |
+|---|---|---|---|---|---|---|---|
+| # |  |  |  |  |  |  | planned |
+
+## Executable acceptance path
+
+```text
+public MCP tool
+  -> Core handler/backend
+  -> native RPC
+  -> AEGP main-thread dispatcher
+  -> After Effects state
+  -> typed result
+  -> audit evidence
+```
+
+- Public request(s):
+- Read-state evidence:
+- Write before/after evidence:
+- Undo execution and verification:
+- Recovery / uncertain-failure check:
+- Restart/reconnect check:
+
+## Test plan
+
+- T0 commands:
+- T1 commands:
+- T2 commands:
+- T3 full regression / required CI:
+- T4 narrow hardware smoke, if required:
+- T5 candidate harness:
+- T6 clean-main harness:
+
+## Hardware preflight
+
+- [ ] Formal AE path/version/build selected; Beta excluded.
+- [ ] Target machine unlocked/awake; OS permissions and GUI control prepared.
+- [ ] Canonical CEP/native paths and scan roots checked.
+- [ ] Disposable fixture and evidence root prepared.
+- [ ] Pairing and known modal-dialog recovery prepared.
+- [ ] Exact SHA, clean state, artifact hashes, and installed receipts will be captured.
+
+## Exit conditions
+
+- [ ] All included tools pass the public-MCP candidate session.
+- [ ] Typed result, AE state, provenance, audit, and postcondition agree.
+- [ ] Every write has executed and verified Undo.
+- [ ] Review/CI pass and candidate identity is exact.
+- [ ] Clean-main rebuild/reinstall and package smoke pass.
+- [ ] Per-Issue disposition and remaining risks are recorded.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+Follow `docs/CAPABILITY_PACKAGE_WORKFLOW.md`. The linked Issue is the source of truth for a capability package's scope and acceptance matrix; do not copy it here.
+
+Complete **Common** for every PR. For an AE-dependent capability package, also complete **Native package evidence**. For any other PR, delete that section or write one `N/A` line with the reason and observable acceptance check; do not fill field-by-field `N/A` values.
+
+## Common
+
+- Change type: native capability package / isolated fix / docs / infrastructure
+- Issue or package Issue:
+- User-visible outcome:
+- Scope and explicit non-goals:
+
+Commands and results:
+
+```text
+
+```
+
+Review findings and disposition (blocker / follow-up / out of scope):
+
+## Native package evidence (conditional)
+
+- Deviation from the frozen Issue: none / describe and link the decision
+- Frozen candidate SHA:
+- T3 and required CI status on that SHA:
+- All relevant Core / CEP / native / protocol identities match: yes / no
+- Redacted T5 real-AE evidence link or summary:
+- Post-freeze SHA replacement and reason: none / describe
+
+After merge, record T6, child-Issue closure, and efficiency counters once in the package completion comment using `docs/templates/capability-package-completion.md`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,6 @@ Review findings and disposition (blocker / follow-up / out of scope):
 - T3 and required CI status on that SHA:
 - All relevant Core / CEP / native / protocol identities match: yes / no
 - Redacted T5 real-AE evidence link or summary:
-- Post-freeze SHA replacement and reason: none / describe
+- Post-freeze SHA replacement and reason: none / describe; if replaced, record required CI for the replacement SHA
 
-After merge, record T6, child-Issue closure, and efficiency counters once in the package completion comment using `docs/templates/capability-package-completion.md`.
+After merge, record per-tool T6, any optional child-Issue closure, and efficiency counters once in the package completion comment using `docs/templates/capability-package-completion.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-  # Stacked native P0 PRs target their dependency branch until real-host
-  # validation is complete, so CI must run for every pull-request base.
+  # Test every PR base so an explicitly reviewed dependency branch remains testable;
+  # this does not authorize per-tool or dependent stacked PRs.
   pull_request: {}
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ These rules apply to human developers and coding agents working in this reposito
 
 - Do not implement issues by issue number or creation order. Maintain P0/P1/P2/P3 priorities based on dependency and user value.
 - Work on one dependent P0 capability package at a time. A capability package normally groups about 5-15 tightly related tools that share an AEGP SDK suite, dispatcher, fixture, Undo model, or user scenario. Small infrastructure changes and isolated fixes may remain single-Issue packages when they do not belong to a tool family.
-- Prefer 6-10 tools for a normal capability package. Before implementation, freeze a short package brief containing the child Issues, public MCP schemas, capability/interaction matrix, native novelty, disposable fixture, Undo model, executable acceptance path, and explicit non-goals. Do not split the frozen package into one branch or PR per simple tool.
+- Prefer 6-10 tools for a normal capability package. Before implementation, freeze a short package brief containing any optional child Issues, public MCP schemas, capability/interaction matrix, native novelty, disposable fixture, Undo model, executable acceptance path, and explicit non-goals. Do not split the frozen package into one branch or PR per simple tool.
 - A capability package may retain multiple child Issues and acceptance checklists, but it uses one branch/worktree, one PR, one concentrated review, one exact-candidate hardware acceptance run, and one clean-`main` hardware revalidation. Close each child Issue only when its own acceptance result passed in the package evidence.
 - The package closure loop is: design the public MCP schemas and interaction matrix -> implement with incremental unit/contract/compile tests -> independent diff review -> CI -> exact-build package hardware validation -> merge -> rebuild/reinstall from `main` -> package hardware revalidation -> close accepted child Issues and update their parent epic.
 - Parallel work is allowed only when it is genuinely independent and cannot cause mixed builds, shared-fixture conflicts, or premature assumptions about an unmerged interface.
@@ -47,12 +47,12 @@ public MCP tool
 - Any package whose acceptance depends on AE loading, lifecycle, GUI state, main-thread behavior, CEP/native communication, or project mutation still requires this package-level real-machine validation before merge.
 - Automated tests and CI never substitute for hardware validation.
 - Build, install, and test the exact candidate commit. Core, CEP host, native plugin, protocol metadata, and test evidence must report the same full commit SHA. Abort validation on any mismatch.
-- After merge, repeat the relevant public MCP smoke test from a clean `main` build. Do not rely on the pre-merge installation.
+- After merge, repeat the public MCP package smoke from a clean `main` build. It must touch every included public tool, cover each accepted optional child Issue, and verify real Undo for every included write. Do not rely on the pre-merge installation.
 - Use a dedicated disposable AE project. Never use the user's production project for write testing.
 - Prepare GUI access, permissions, pairing, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
 - After concentrated review has no unresolved blocker and all source, generated bundles, documentation, license metadata, fixtures, and evidence schemas are committed, designate that exact SHA as the candidate freeze. Run T3 and required CI on the frozen SHA; except for the single narrow smoke allowed for a genuinely new native primitive, do not begin exact-candidate hardware acceptance until they pass. This is the candidate freeze.
-- After candidate freeze, change the SHA only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate.
-- The normal target is at most two candidate builds, one full CI run for the frozen candidate, one candidate hardware session, and one clean-`main` hardware session. Exceeding the target must be explained in the completion evidence; it is not a reason to weaken a gate.
+- After candidate freeze, change the SHA only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate. The replacement is a new frozen candidate and must pass required CI before any T5 acceptance evidence is collected.
+- The normal target is one candidate and one full CI run. At most one replacement candidate is allowed for a reproduced blocker; that replacement gets its own required CI run, while already-passing unaffected local tiers need not be repeated. The normal hardware target remains one successful candidate session and one clean-`main` session. Exceeding these targets must be explained in the completion evidence; it is not a reason to weaken a gate.
 
 ## 5. Keep review feedback from expanding P0
 
@@ -74,10 +74,10 @@ Use the lowest test tier that can falsify the current change, then escalate at p
 - **T0, every edit:** formatting, syntax, lint, or a single focused unit test; target seconds.
 - **T1, each tool or adapter:** schema, codec, suite adapter, structured-error, and postcondition contract tests; target 1-5 minutes.
 - **T2, package integration:** affected native compile tests, Core/CEP integration, shared fixture, interaction corpus, and generated-file checks; target 10-30 minutes.
-- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once after concentrated review.
+- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once for each exact candidate SHA after concentrated or focused replacement review.
 - **T4, optional native-novelty smoke:** one narrow real-AE check only when the package introduces an unverified suite, object lifecycle, or main-thread mechanism.
 - **T5, candidate acceptance:** one exact-SHA public-MCP package run on real AE.
-- **T6, clean-main acceptance:** one rebuild/reinstall and package smoke from the merge commit.
+- **T6, clean-main acceptance:** one rebuild/reinstall and package smoke from the merge commit that touches every included public tool, covers each accepted optional child Issue, and verifies real Undo for every included write.
 
 Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should drive the smallest reproducing lower-tier test first; return to the higher tier only after the fix set is complete.
 
@@ -91,7 +91,7 @@ Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should dr
 
 ## 7. Preserve build and workspace identity
 
-- Use one worktree and one branch for each capability package. Record the child Issues and acceptance matrix owned by that worktree, and know which package owns every build, install, test artifact, and running process.
+- Use one worktree and one branch for each capability package. Record any optional child Issues and the acceptance matrix owned by that worktree, and know which package owns every build, install, test artifact, and running process.
 - Before building or deploying, record `git rev-parse HEAD`, dirty state, artifact hashes, installed paths, and runtime-reported source commit.
 - Never mix Core, CEP, native plugin, or protocol files from different commits. A convenient partial redeploy is not valid evidence.
 - Keep backup, staging, rollback, and evidence directories outside Adobe's plugin scan roots.
@@ -132,7 +132,7 @@ Treat this Skip -> Continue sequence as established project knowledge. Do not re
 
 A capability-package completion report must include:
 
-- package PR, parent Epic and child Issue links, per-Issue acceptance disposition, exact tested commit, and merge commit;
+- package PR, parent Epic, any optional child Issue links and dispositions, per-tool acceptance disposition, exact tested commit, and merge commit;
 - the public MCP request and structured response;
 - AE state evidence before and after the operation;
 - native/AEGP provenance and matching source commit;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ These rules apply to human developers and coding agents working in this reposito
 ## 1. Measure outcomes, not activity
 
 - The primary P0 measure is a working capability through the public MCP surface. Lines changed, tests added, commits, PRs, protocol completeness, and CI status are supporting evidence, not delivery.
-- Prefer the smallest real vertical slice over a sequence of horizontal infrastructure layers.
+- Prefer the smallest real vertical slice to prove a new primitive over a sequence of horizontal infrastructure layers. Once the primitive is proven, batch related tools into the capability package in section 2 instead of creating one-tool delivery units.
 - A build, mock, isolated RPC test, internal function call, or ping-only result does not prove an AE capability works.
 - Do not describe a capability as complete until its observable AE result has been verified on the target machine.
 
@@ -13,9 +13,13 @@ These rules apply to human developers and coding agents working in this reposito
 
 - Do not implement issues by issue number or creation order. Maintain P0/P1/P2/P3 priorities based on dependency and user value.
 - Work on one dependent P0 capability package at a time. A capability package normally groups about 5-15 tightly related tools that share an AEGP SDK suite, dispatcher, fixture, Undo model, or user scenario. Small infrastructure changes and isolated fixes may remain single-Issue packages when they do not belong to a tool family.
+- Prefer 6-10 tools for a normal capability package. Before implementation, freeze a short package brief containing the child Issues, public MCP schemas, capability/interaction matrix, native novelty, disposable fixture, Undo model, executable acceptance path, and explicit non-goals. Do not split the frozen package into one branch or PR per simple tool.
 - A capability package may retain multiple child Issues and acceptance checklists, but it uses one branch/worktree, one PR, one concentrated review, one exact-candidate hardware acceptance run, and one clean-`main` hardware revalidation. Close each child Issue only when its own acceptance result passed in the package evidence.
 - The package closure loop is: design the public MCP schemas and interaction matrix -> implement with incremental unit/contract/compile tests -> independent diff review -> CI -> exact-build package hardware validation -> merge -> rebuild/reinstall from `main` -> package hardware revalidation -> close accepted child Issues and update their parent epic.
 - Parallel work is allowed only when it is genuinely independent and cannot cause mixed builds, shared-fixture conflicts, or premature assumptions about an unmerged interface.
+- The WIP limit is one dependent native capability package. That package may use at most three coordinated implementation tracks (native, Core/bridge/public MCP, and tests/fixture), but they share one schema freeze, one branch/worktree, and one acceptance matrix. Do not begin the next dependent package before the current package passes clean-`main` revalidation.
+- Treat schedule targets as scope alarms, not permission to weaken evidence: package framing should normally take 2-4 hours, implementation 1-2.5 working days, concentrated review and CI 0.5-1 day, and the prepared hardware session 60-90 minutes excluding deterministic build time. When a target is exceeded, cut unrelated scope or repair the environment instead of accumulating more infrastructure inside the package.
+- Workflow infrastructure must remove a measured repeated cost from the active acceptance path and is timeboxed to one working day unless the user explicitly promotes it. Otherwise record it as a follow-up and continue the capability package.
 
 ## 3. Define the public vertical-slice acceptance test first
 
@@ -46,6 +50,9 @@ public MCP tool
 - After merge, repeat the relevant public MCP smoke test from a clean `main` build. Do not rely on the pre-merge installation.
 - Use a dedicated disposable AE project. Never use the user's production project for write testing.
 - Prepare GUI access, permissions, pairing, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
+- After concentrated review has no unresolved blocker and all source, generated bundles, documentation, license metadata, fixtures, and evidence schemas are committed, designate that exact SHA as the candidate freeze. Run T3 and required CI on the frozen SHA; except for the single narrow smoke allowed for a genuinely new native primitive, do not begin exact-candidate hardware acceptance until they pass. This is the candidate freeze.
+- After candidate freeze, change the SHA only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate.
+- The normal target is at most two candidate builds, one full CI run for the frozen candidate, one candidate hardware session, and one clean-`main` hardware session. Exceeding the target must be explained in the completion evidence; it is not a reason to weaken a gate.
 
 ## 5. Keep review feedback from expanding P0
 
@@ -58,6 +65,21 @@ Classify every newly discovered risk or reviewer comment before implementing it:
 - Do not silently promote concurrency hardening, power-loss behavior, installer edge cases, signing, notarization, cross-platform expansion, or generalized framework work into P0.
 - Timebox investigations of non-reproduced edge cases. Once the current acceptance path is safe and reliable, defer the rest.
 - A reviewer finding is evidence to evaluate, not an automatic change request or priority override.
+- Use no more than two concentrated review rounds by default. A further round is justified only when the previous round found a reproduced blocker or the fix changed the public acceptance boundary. Limit investigation of a non-reproduced edge case to 60-90 minutes before classifying it as follow-up or out of scope.
+
+### 5.1 Escalate tests by risk and lifecycle
+
+Use the lowest test tier that can falsify the current change, then escalate at package milestones:
+
+- **T0, every edit:** formatting, syntax, lint, or a single focused unit test; target seconds.
+- **T1, each tool or adapter:** schema, codec, suite adapter, structured-error, and postcondition contract tests; target 1-5 minutes.
+- **T2, package integration:** affected native compile tests, Core/CEP integration, shared fixture, interaction corpus, and generated-file checks; target 10-30 minutes.
+- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once after concentrated review.
+- **T4, optional native-novelty smoke:** one narrow real-AE check only when the package introduces an unverified suite, object lifecycle, or main-thread mechanism.
+- **T5, candidate acceptance:** one exact-SHA public-MCP package run on real AE.
+- **T6, clean-main acceptance:** one rebuild/reinstall and package smoke from the merge commit.
+
+Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should drive the smallest reproducing lower-tier test first; return to the higher tier only after the fix set is complete.
 
 ## 6. Treat writes and uncertain failures explicitly
 
@@ -75,10 +97,12 @@ Classify every newly discovered risk or reviewer comment before implementing it:
 - Keep backup, staging, rollback, and evidence directories outside Adobe's plugin scan roots.
 - Keep disposable projects, generated scripts, logs, and smoke outputs out of tracked source paths unless they are intentional fixtures.
 - Do not use a stale or dirty root checkout as an implicit source for another issue's build.
+- Keep the active build and evidence worktree on fully local, non-evictable storage. Cloud/on-demand placeholders, including macOS `dataless` files, are not valid candidate inputs; hydrate the complete scoped inputs or create a local checkout before freezing the candidate.
 
 ## 8. Minimize human interruption during hardware work
 
 - Consolidate all known permissions and GUI prerequisites into one preflight.
+- Run package hardware acceptance as one continuous prepared session. Keep pairing, fixture creation, all tool calls, write verification, Undo/Redo, restart/reconnect, and evidence collection in the same orchestrated window; do not spread a short-lived pairing flow across conversational round trips.
 - Once the user has authorized routine AE/macOS GUI control, perform normal focus, open/save/close, pairing, restart, disposable-project, and test Undo/Redo operations without repeatedly asking them to click.
 - Pause only for a genuinely required system confirmation, credential/license decision, destructive action outside the disposable fixture, or a product choice that changes the result.
 - When blocked, report the single concrete blocker and the evidence already gathered; do not offload ordinary debugging steps to the user.
@@ -116,6 +140,7 @@ A capability-package completion report must include:
 - Undo and recovery evidence for writes;
 - CI/review status and the clean-`main` hardware revalidation;
 - remaining risks and their follow-up issue classification.
+- package-efficiency counters: included tools, review rounds, candidate builds, full CI runs, candidate/main hardware runs, first-hardware-pass result, environment/pairing interruptions, and elapsed time from scope freeze to clean-`main` acceptance.
 
 Do not claim completion using only "tests passed", "CI is green", "the plugin compiled", or "the PR merged".
 

--- a/docs/CAPABILITY_PACKAGE_WORKFLOW.md
+++ b/docs/CAPABILITY_PACKAGE_WORKFLOW.md
@@ -21,7 +21,7 @@ The package owns one branch/worktree, one PR, one acceptance matrix, one concent
 
 Use `.github/ISSUE_TEMPLATE/capability-package.md` to freeze:
 
-- parent Epic, child Issues, priority, and user-visible outcome;
+- parent Epic, optional child Issues, priority, and user-visible outcome;
 - public MCP names and schemas;
 - shared native primitives and which ones are new on real AE;
 - read/write, side-effect, idempotency, postcondition, and Undo contracts;
@@ -36,16 +36,16 @@ Implementation may refine an ambiguous field, but a material scope expansion req
 
 | Phase | Normal target | Work | Exit condition |
 |---|---:|---|---|
-| Frame | 2-4 hours | Freeze schemas, matrix, fixture, native novelty, acceptance harness skeleton, exclusions | Matrix is reviewable and every child Issue has an observable result |
+| Frame | 2-4 hours | Freeze schemas, matrix, fixture, native novelty, acceptance harness skeleton, exclusions | Matrix is reviewable and every included public tool has an observable result |
 | Native novelty smoke | 0-1 focused run | Only for an unverified suite, lifecycle, or main-thread mechanism | Primitive works in real AE or the package is redesigned |
 | Implement | 1-2.5 working days | Up to three coordinated tracks: native; Core/bridge/public MCP; tests/fixture | All matrix rows pass T0-T2 and generated artifacts are current |
 | Review, freeze, and CI | 0.5-1 day | Concentrated review and blocker fixes, freeze the exact SHA, then run T3 and required CI | No unresolved in-scope blocker; the frozen SHA passes T3 and CI |
-| Candidate hardware | 60-90 minutes plus deterministic build time | One continuous exact-SHA package session on real AE | Every included child Issue has evidence; writes have verified Undo |
-| Merge and main | 0.5-1.5 hours plus build time | Merge, rebuild/reinstall from clean `main`, rerun package smoke | Merge SHA passes and accepted child Issues can close |
+| Candidate hardware | 60-90 minutes plus deterministic build time | One continuous exact-SHA package session on real AE | Every included public tool has evidence; writes have verified Undo |
+| Merge and main | 0.5-1.5 hours plus build time | Merge, rebuild/reinstall from clean `main`, rerun package smoke | Merge SHA passes; any accepted child Issues can close |
 
 These are scope alarms, not promises and not permission to drop evidence. When a phase exceeds its target, first remove unrelated work, repair the environment, or split a genuinely oversized package.
 
-Keep edit-level work local to the package worktree and run T0-T2 there. Publish the package branch for concentrated review/CI after the integration checkpoint instead of pushing every small edit and triggering a full remote matrix repeatedly.
+Keep edit-level work local to the package worktree and run T0-T2 there. Complete the concentrated review, resolve blockers, and freeze the exact candidate before the first branch publication and required CI run. Do not push every small edit and trigger a full remote matrix repeatedly. If a genuinely required human review can only occur on GitHub, publish a Draft explicitly as pre-candidate review input; any CI run on that unfrozen SHA is not candidate evidence and the completion report must explain the extra run.
 
 ## 4. Test escalation
 
@@ -87,9 +87,9 @@ Freeze the exact candidate SHA after:
 - concentrated review has no unresolved blocker;
 - the worktree is clean and all components can report the same full SHA.
 
-Run the relevant T3 full regression and required CI on that frozen SHA. T5 hardware starts only after they pass. If T3 or CI finds a blocker, unfreeze the candidate, collect and batch the complete fix set, run focused lower-tier tests and review, then freeze one replacement candidate. After freeze, a new SHA is otherwise allowed only for a reproduced acceptance blocker or an evidence-invalidating defect. Do not deploy once per small fix.
+Run the relevant T3 full regression and required CI on that frozen SHA. T5 hardware starts only after they pass. If T3 or CI finds a blocker, unfreeze the candidate, collect and batch the complete fix set, run focused lower-tier tests and review, then freeze one replacement candidate. The replacement SHA must pass required CI before T5; already-passing unaffected local tiers need not be repeated. After freeze, a new SHA is otherwise allowed only for a reproduced acceptance blocker or an evidence-invalidating defect. Do not deploy once per small fix.
 
-Normal budget: at most two candidate builds, one frozen-candidate full CI run, one candidate hardware session, and one clean-main hardware session. Record the reason for any excess.
+Normal budget: one candidate build and one full CI run. A reproduced blocker may justify one replacement build and its required CI run. The hardware budget remains one successful candidate session and one clean-main session. Record the reason for any excess.
 
 ## 7. Continuous hardware session
 
@@ -125,15 +125,15 @@ After candidate acceptance:
 
 1. Merge the single package PR.
 2. Build and install every relevant component from a clean merge commit.
-3. Run T6 with the same harness; the reduced smoke still touches every child Issue, and every write still verifies Undo.
+3. Run T6 with the same harness; the reduced smoke still touches every included public tool, covers every accepted optional child Issue, and verifies real Undo for every included write.
 4. Fill `docs/templates/capability-package-completion.md`.
-5. Close only the child Issues that passed, then update the parent Epic.
+5. Close only optional child Issues that passed, then update the parent Epic.
 
 ## 9. Efficiency counters
 
 Record these counters in the completion report:
 
-- included tools and accepted child Issues;
+- included tools and accepted optional child Issues;
 - elapsed time from scope freeze to clean-main acceptance;
 - review rounds and finding dispositions;
 - candidate builds and candidate SHA changes;

--- a/docs/CAPABILITY_PACKAGE_WORKFLOW.md
+++ b/docs/CAPABILITY_PACKAGE_WORKFLOW.md
@@ -1,0 +1,154 @@
+# Capability Package Delivery Workflow
+
+This playbook turns the repository rules in `AGENTS.md` into a low-overhead delivery loop for After Effects native capabilities. It optimizes repeated work without weakening real-AE acceptance.
+
+## 1. Delivery unit
+
+The default delivery unit is one capability package containing 6-10 related public MCP tools (5-15 is the allowed range). Tools belong in the same package when they share at least two of these:
+
+- AEGP SDK suite or native object lifecycle;
+- locator and stale-object behavior;
+- main-thread dispatcher path;
+- disposable AE fixture;
+- Undo or recovery model;
+- user scenario and tool interactions.
+
+An isolated bug or infrastructure fix may remain a single-Issue package. Do not create one PR per simple tool merely because each tool has a child Issue.
+
+The package owns one branch/worktree, one PR, one acceptance matrix, one concentrated review, one frozen candidate, one candidate hardware session, and one clean-`main` revalidation. T4-T6 apply to AE-dependent packages; a non-AE isolated fix uses the applicable lower tiers and records its observable acceptance check instead of manufacturing hardware evidence.
+
+## 2. Scope freeze before implementation
+
+Use `.github/ISSUE_TEMPLATE/capability-package.md` to freeze:
+
+- parent Epic, child Issues, priority, and user-visible outcome;
+- public MCP names and schemas;
+- shared native primitives and which ones are new on real AE;
+- read/write, side-effect, idempotency, postcondition, and Undo contracts;
+- disposable fixture and important inter-tool interactions;
+- executable public-MCP acceptance path;
+- explicit exclusions and follow-up boundaries;
+- relevant T0-T3 commands and the hardware preflight.
+
+Implementation may refine an ambiguous field, but a material scope expansion requires an explicit package decision. Reviewer suggestions do not silently change the freeze.
+
+## 3. Package lifecycle
+
+| Phase | Normal target | Work | Exit condition |
+|---|---:|---|---|
+| Frame | 2-4 hours | Freeze schemas, matrix, fixture, native novelty, acceptance harness skeleton, exclusions | Matrix is reviewable and every child Issue has an observable result |
+| Native novelty smoke | 0-1 focused run | Only for an unverified suite, lifecycle, or main-thread mechanism | Primitive works in real AE or the package is redesigned |
+| Implement | 1-2.5 working days | Up to three coordinated tracks: native; Core/bridge/public MCP; tests/fixture | All matrix rows pass T0-T2 and generated artifacts are current |
+| Review, freeze, and CI | 0.5-1 day | Concentrated review and blocker fixes, freeze the exact SHA, then run T3 and required CI | No unresolved in-scope blocker; the frozen SHA passes T3 and CI |
+| Candidate hardware | 60-90 minutes plus deterministic build time | One continuous exact-SHA package session on real AE | Every included child Issue has evidence; writes have verified Undo |
+| Merge and main | 0.5-1.5 hours plus build time | Merge, rebuild/reinstall from clean `main`, rerun package smoke | Merge SHA passes and accepted child Issues can close |
+
+These are scope alarms, not promises and not permission to drop evidence. When a phase exceeds its target, first remove unrelated work, repair the environment, or split a genuinely oversized package.
+
+Keep edit-level work local to the package worktree and run T0-T2 there. Publish the package branch for concentrated review/CI after the integration checkpoint instead of pushing every small edit and triggering a full remote matrix repeatedly.
+
+## 4. Test escalation
+
+Use the lowest tier that can disprove the current edit. Escalate only at the listed milestone.
+
+| Tier | When | Typical coverage | Expected frequency |
+|---|---|---|---|
+| T0 | Every edit | syntax, formatting, lint, one focused unit | Many times |
+| T1 | Each tool/adapter | schema, codec, suite adapter, error and postcondition contract | Per matrix row |
+| T2 | Package integration | affected native compile, Core/CEP bridge, fixture and interaction corpus, generated-file checks | At integration checkpoints |
+| T3 | Frozen candidate | relevant full repository regression and required CI | Once after review |
+| T4 | New primitive only | narrow real-AE smoke for the unverified mechanism | Zero or one per package |
+| T5 | Candidate | full exact-SHA public-MCP package acceptance | Once normally |
+| T6 | Clean main | rebuild/reinstall plus package smoke from merge SHA | Once |
+
+After a T3-T6 failure, first add or run the smallest reproducing T0-T2 test. Batch the complete fix set before returning to the expensive tier.
+
+## 5. Review disposition and timebox
+
+Every finding receives one of three dispositions:
+
+| Class | Required evidence | Action in active package |
+|---|---|---|
+| Current blocker | Reproduced on the package acceptance path, or demonstrably breaks correctness, recovery, audit, Undo, or safe use | Fix before candidate freeze |
+| Follow-up | Credible improvement that does not block the frozen outcome | Record a P1/P2 Issue and keep it out of the PR |
+| Out of scope | Hypothetical, duplicated, unsupported, or contrary to the product decision | Document why; do not implement |
+
+Use no more than two concentrated review rounds by default. Investigation of a non-reproduced edge case is limited to 60-90 minutes. Additional review is warranted only when a blocker fix changes the public acceptance boundary.
+
+Concurrency hardening, power-loss behavior, extreme installer recovery, signing/notarization, Windows expansion, generalized frameworks, Provider routing, Tool Library work, and AEGP/JSX resolution do not become P0 without acceptance-path evidence or an explicit user priority change.
+
+## 6. Candidate freeze
+
+Freeze the exact candidate SHA after:
+
+- all product source and generated bundles are committed;
+- schemas, fixtures, docs, license/policy metadata, and evidence format are final;
+- T0-T2 pass for the exact source and generated files under review;
+- concentrated review has no unresolved blocker;
+- the worktree is clean and all components can report the same full SHA.
+
+Run the relevant T3 full regression and required CI on that frozen SHA. T5 hardware starts only after they pass. If T3 or CI finds a blocker, unfreeze the candidate, collect and batch the complete fix set, run focused lower-tier tests and review, then freeze one replacement candidate. After freeze, a new SHA is otherwise allowed only for a reproduced acceptance blocker or an evidence-invalidating defect. Do not deploy once per small fix.
+
+Normal budget: at most two candidate builds, one frozen-candidate full CI run, one candidate hardware session, and one clean-main hardware session. Record the reason for any excess.
+
+## 7. Continuous hardware session
+
+Prepare before launching AE:
+
+- formal AE absolute path, version, and build;
+- target machine unlocked/awake, required OS permissions, and normal GUI control;
+- Beta and unrelated AE processes closed;
+- canonical CEP/native paths and scan-root audit;
+- exact source SHA, clean state, artifact hashes, and installed receipts;
+- disposable project/fixture, evidence root, logs, pairing flow, and known optional dialogs.
+
+Run the package in one continuous window:
+
+1. Launch formal AE and verify host identity and canonical plug-in mapping.
+2. Pair immediately without conversational round trips.
+3. Create the disposable fixture once.
+4. Run every read tool and record the real AE state.
+5. For every write: record before state, invoke once, record response/audit/after state, execute Undo, and verify the Undo state.
+6. Exercise the important inter-tool combinations from the matrix.
+7. Quit and relaunch AE once; verify a new host/session and repeat the package smoke.
+8. Emit one machine-readable evidence bundle and a redacted completion summary.
+
+If a write returns `POSSIBLY_SIDE_EFFECTING_FAILURE`, stop retries and reconcile AE state plus audit first.
+
+Commit the package acceptance driver with the package and use the same driver for candidate and clean-`main` runs. The driver must call the public MCP surface, support the package's real dynamic locators and generation changes, create a fresh intent key for each new write while reusing that key for reconciliation, and bind its evidence to separately verified Core/CEP/native/protocol identities. A hashed test plan is explicit authorization for the disposable fixture only; it does not prove the production approval/elicitation path unless the package explicitly exercises that path. Temporary `/private/tmp` clients are not acceptance assets.
+
+Do not introduce a generalized plan language speculatively. Promote repeated driver code into a shared runner only after at least two capability packages demonstrate the same stable need; a shared runner must not infer exact component identity from native self-report or model an invented response/Undo contract.
+
+## 8. Merge and completion
+
+After candidate acceptance:
+
+1. Merge the single package PR.
+2. Build and install every relevant component from a clean merge commit.
+3. Run T6 with the same harness; the reduced smoke still touches every child Issue, and every write still verifies Undo.
+4. Fill `docs/templates/capability-package-completion.md`.
+5. Close only the child Issues that passed, then update the parent Epic.
+
+## 9. Efficiency counters
+
+Record these counters in the completion report:
+
+- included tools and accepted child Issues;
+- elapsed time from scope freeze to clean-main acceptance;
+- review rounds and finding dispositions;
+- candidate builds and candidate SHA changes;
+- full CI runs;
+- T4, T5, and T6 hardware runs;
+- first candidate hardware pass/fail;
+- environment, pairing, and permission interruptions;
+- follow-up work created outside the active package.
+
+Useful targets are 6-10 tools per package, no more than two review rounds, no more than two candidate builds, and exactly one T5 plus one T6 run under normal conditions. These counters diagnose process waste; they are not substitutes for functional evidence.
+
+## 10. WIP and exceptions
+
+- Keep one dependent native capability package in flight.
+- The package may have up to three coordinated implementation tracks, but only one schema freeze and acceptance matrix.
+- One truly independent auxiliary package may proceed only if it cannot mix builds, fixtures, interfaces, or hardware state.
+- Do not start the next dependent package until clean-main acceptance finishes.
+- A one-day workflow improvement is allowed only when it removes a measured repeated cost on the active path. Larger infrastructure work needs explicit user promotion.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -8,23 +8,25 @@
 
 ```text
 MCP 客户端或面板内嵌 AI
-  -> packages/core (ae_mcp, Python stdio MCP server, 49 ae_ tools)
+  -> packages/core (ae_mcp, Python stdio MCP server, public typed tools)
   -> backend (packages/bridge, httpx)
   -> CEP panel Node host (plugin/host, Express, 127.0.0.1:11488)
-  -> CSInterface.evalScript
-  -> ExtendScript (plugin/jsx/runtime.jsx + jsx_templates/*.jsx)
-  -> After Effects project state
+     -> native broker -> local RPC -> AEGP plug-in -> AE main thread/state
+     -> maintained JSX -> CSInterface.evalScript -> ExtendScript -> AE state
 ```
 
 ```mermaid
 flowchart LR
-    A["AI client / embedded chat"] --> B["ae_mcp stdio server<br/>49 ae_ tools"]
+    A["AI client / embedded chat"] --> B["ae_mcp stdio server<br/>public typed tools"]
     B --> C["ae-mcp bridge<br/>httpx backend"]
     C --> D["127.0.0.1:11488"]
     D --> E["CEP panel host<br/>Express"]
-    E --> F["CSInterface.evalScript"]
-    F --> G["ExtendScript runtime + templates"]
-    G --> H["After Effects"]
+    E --> F["/native/* -> native broker + local RPC"]
+    F --> G["AEGP plug-in<br/>AE main thread"]
+    E --> H["/exec -> CSInterface.evalScript"]
+    H --> I["maintained JSX"]
+    G --> J["After Effects state"]
+    I --> J
 ```
 
 每一层各自负责：
@@ -32,8 +34,9 @@ flowchart LR
 - 面板内嵌 AI 或外部 MCP 客户端：发起工具调用，例如 `ae_previewFrame`、`ae_createRig`、`ae_exec`。
 - `ae-mcp` / `ae_mcp`：暴露 MCP tool surface，做 schema 校验、工具 annotations、审批 gate 和 handler 路由。
 - `ae-mcp-bridge`：把 handler 的 AE 调用转成对本机面板的 HTTP 请求。
-- CEP panel host：常驻在 AE 内，接收 HTTP 请求并把 JSX 投给 ExtendScript。
-- ExtendScript：在 AE 里真正读取项目、改图层、写表达式、创建 rig、保存 checkpoint。
+- CEP panel host：常驻在 AE 内，按固定端点执行请求：`/native/*` 进入原生 broker，`/exec` 进入 JSX。实现绑定由 Core/public handler 显式定义；当前不存在运行时 AEGP/JSX resolver，也不会在原生失败后自动 fallback。
+- AEGP plug-in：通过本地 native RPC 在 AE 主线程读取或修改真实 AE 状态，并返回原生 provenance、审计和可验证后置条件。
+- ExtendScript：承担仍由 maintained JSX 实现的能力；它不是原生 AEGP 执行证据，也不会自动替代失败的原生调用。
 - `ae-mcp-snapshot-mss`：提供跨平台截图 backend。
 
 v0.9.2 的普通用户路径只使用同一个 candidate SHA 生成的离线平台资产：
@@ -214,23 +217,25 @@ This document describes the two v0.9.2 (unreleased candidate) usage paths: built
 
 ```text
 MCP client or panel-embedded AI
-  -> packages/core (ae_mcp, Python stdio MCP server, 49 ae_ tools)
+  -> packages/core (ae_mcp, Python stdio MCP server, public typed tools)
   -> backend (packages/bridge, httpx)
   -> CEP panel Node host (plugin/host, Express, 127.0.0.1:11488)
-  -> CSInterface.evalScript
-  -> ExtendScript (plugin/jsx/runtime.jsx + jsx_templates/*.jsx)
-  -> After Effects project state
+     -> native broker -> local RPC -> AEGP plug-in -> AE main thread/state
+     -> maintained JSX -> CSInterface.evalScript -> ExtendScript -> AE state
 ```
 
 ```mermaid
 flowchart LR
-    A["AI client / embedded chat"] --> B["ae_mcp stdio server<br/>49 ae_ tools"]
+    A["AI client / embedded chat"] --> B["ae_mcp stdio server<br/>public typed tools"]
     B --> C["ae-mcp bridge<br/>httpx backend"]
     C --> D["127.0.0.1:11488"]
     D --> E["CEP panel host<br/>Express"]
-    E --> F["CSInterface.evalScript"]
-    F --> G["ExtendScript runtime + templates"]
-    G --> H["After Effects"]
+    E --> F["/native/* -> native broker + local RPC"]
+    F --> G["AEGP plug-in<br/>AE main thread"]
+    E --> H["/exec -> CSInterface.evalScript"]
+    H --> I["maintained JSX"]
+    G --> J["After Effects state"]
+    I --> J
 ```
 
 Each layer is responsible for:
@@ -238,8 +243,9 @@ Each layer is responsible for:
 - Embedded AI or external MCP client: issues tool calls such as `ae_previewFrame`, `ae_createRig`, or `ae_exec`.
 - `ae-mcp` / `ae_mcp`: exposes MCP tools, schemas, tool annotations, approval gates, and handler routing.
 - `ae-mcp-bridge`: turns handler-side AE requests into HTTP calls to the local panel.
-- CEP panel host: stays resident inside AE, receives HTTP requests, and forwards JSX into ExtendScript.
-- ExtendScript: performs project reads, layer edits, expression writes, rig creation, and checkpoints.
+- CEP panel host: stays resident inside AE and follows fixed endpoints: `/native/*` enters the native broker and `/exec` enters JSX. Core/public handlers bind implementations explicitly; there is no runtime AEGP/JSX resolver or automatic fallback after a native failure.
+- AEGP plug-in: uses local native RPC and the AE main thread to read or mutate real AE state, returning native provenance, audit, and verifiable postconditions.
+- ExtendScript: implements capabilities that remain maintained JSX; it is not native AEGP evidence and is not an automatic fallback for a failed native call.
 - `ae-mcp-snapshot-mss`: provides the cross-platform screenshot backend.
 
 The normal-user v0.9.2 path uses only offline platform assets built from the same candidate SHA:

--- a/docs/templates/capability-package-completion.md
+++ b/docs/templates/capability-package-completion.md
@@ -6,11 +6,11 @@ Publish only redacted summaries. Omit credentials, tokens, pairing fingerprints,
 
 - Package PR:
 - Parent Epic:
-- Child Issues:
+- Child Issues (optional):
 - Exact candidate SHA:
 - Merge / clean-main SHA:
 
-## Per-Issue disposition
+## Per-Issue disposition (when child Issues are used)
 
 | Child Issue | Public tool(s) | Acceptance result | Evidence reference | Disposition |
 |---|---|---|---|---|
@@ -55,13 +55,13 @@ Provide one row per included public tool. Summarize request/response shapes here
 - Blockers fixed:
 - Follow-ups created:
 - Out-of-scope findings:
-- Required CI status:
+- Required CI status for each frozen candidate SHA:
 
 ## Candidate and clean-main hardware
 
 - Candidate T5 result and evidence:
 - Clean-main rebuild/reinstall identity:
-- Clean-main T6 result and evidence:
+- Clean-main T6 result and evidence (every included public tool; accepted optional child Issues; every write Undo):
 - Canonical plug-in mapping:
 
 ## Remaining risks
@@ -72,7 +72,7 @@ Provide one row per included public tool. Summarize request/response shapes here
 
 ## Efficiency counters
 
-- Included tools / accepted child Issues:
+- Included tools / accepted optional child Issues:
 - Scope-freeze to clean-main elapsed time:
 - Review rounds:
 - Candidate builds:

--- a/docs/templates/capability-package-completion.md
+++ b/docs/templates/capability-package-completion.md
@@ -1,0 +1,82 @@
+# Capability Package Completion
+
+Publish only redacted summaries. Omit credentials, tokens, pairing fingerprints, user project names, private paths, and other sensitive values; retain full machine evidence locally.
+
+## Identity
+
+- Package PR:
+- Parent Epic:
+- Child Issues:
+- Exact candidate SHA:
+- Merge / clean-main SHA:
+
+## Per-Issue disposition
+
+| Child Issue | Public tool(s) | Acceptance result | Evidence reference | Disposition |
+|---|---|---|---|---|
+| # |  | pass / fail / deferred |  | close / keep open |
+
+## Public MCP evidence
+
+- Full redacted package evidence bundle/reference:
+
+Provide one row per included public tool. Summarize request/response shapes here; keep full structured envelopes in the linked package evidence.
+
+| Public tool | Request shape / scenario | Typed outcome | AE state verified | Evidence reference |
+|---|---|---|---|---|
+|  |  |  |  |  |
+
+## Real After Effects state
+
+- Formal AE path/version/build:
+- Disposable fixture:
+- Before state:
+- After state:
+- Restart/reconnect state:
+
+## Native provenance and audit
+
+- Core / CEP / native / protocol source commit:
+- Native capability and engine:
+- Host/session identity:
+- Audit request/operation ID:
+- Request digest:
+- Postcondition digest and verification:
+
+## Writes, Undo, and recovery
+
+| Tool / operation | Before | After | Undo available | Undo executed | Undo state verified | Uncertain-failure reconciliation |
+|---|---|---|---|---|---|---|
+|  |  |  |  |  |  |  |
+
+## Review and CI
+
+- Independent review rounds:
+- Blockers fixed:
+- Follow-ups created:
+- Out-of-scope findings:
+- Required CI status:
+
+## Candidate and clean-main hardware
+
+- Candidate T5 result and evidence:
+- Clean-main rebuild/reinstall identity:
+- Clean-main T6 result and evidence:
+- Canonical plug-in mapping:
+
+## Remaining risks
+
+| Risk | Classification | Follow-up Issue | Why it does not block this package |
+|---|---|---|---|
+|  | P1 / P2 / P3 / out | # |  |
+
+## Efficiency counters
+
+- Included tools / accepted child Issues:
+- Scope-freeze to clean-main elapsed time:
+- Review rounds:
+- Candidate builds:
+- Full CI runs:
+- T4 / T5 / T6 runs:
+- First candidate hardware pass:
+- Environment / pairing / permission interruptions:

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = 'cf384c1e4c800fc9b784cbcb01edc1534ef24a720c87218c8c7741e433b49da6';
+export const GOVERNANCE_SHA256 = '766e9e84cbffd31c1a0df98ae0fc1817da57533ed2530ac862da866286a2d2c0';
 
 const REQUIRED_RULES = [
   '# Repository Development and Delivery Rules',
@@ -26,6 +26,12 @@ const REQUIRED_RULES = [
   'Automated tests and CI never substitute for hardware validation.',
   'After merge, repeat the relevant public MCP smoke test from a clean `main` build.',
   'Never blindly repeat a possibly completed write.',
+  'This is the candidate freeze.',
+  '**T0, every edit:**',
+  '**T6, clean-main acceptance:**',
+  'no more than two concentrated review rounds by default',
+  'fully local, non-evictable storage',
+  'The WIP limit is one dependent native capability package.',
 ];
 
 export const FINAL_WORKTREES = [

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -9,7 +9,13 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = '766e9e84cbffd31c1a0df98ae0fc1817da57533ed2530ac862da866286a2d2c0';
+export const GOVERNANCE_SHA256 = '06c98ef7c5423b6bdde3a32849da88ae7ccb04136a0aca9784d1f1fd2d0fb949';
+export const SUPPORTING_WORKFLOW_PATHS = [
+  '.github/ISSUE_TEMPLATE/capability-package.md',
+  '.github/pull_request_template.md',
+  'docs/CAPABILITY_PACKAGE_WORKFLOW.md',
+  'docs/templates/capability-package-completion.md',
+];
 
 const REQUIRED_RULES = [
   '# Repository Development and Delivery Rules',
@@ -24,7 +30,7 @@ const REQUIRED_RULES = [
   '## 10. Stop conditions before starting the next dependent capability package',
   'Do not implement issues by issue number or creation order.',
   'Automated tests and CI never substitute for hardware validation.',
-  'After merge, repeat the relevant public MCP smoke test from a clean `main` build.',
+  'After merge, repeat the public MCP package smoke from a clean `main` build.',
   'Never blindly repeat a possibly completed write.',
   'This is the candidate freeze.',
   '**T0, every edit:**',
@@ -83,6 +89,9 @@ export function validateGovernance({ agentsText, inventoryText, trackedPaths }) 
   }
   if (!trackedPaths.has(GOVERNANCE_PATH)) errors.push(`${GOVERNANCE_PATH} must be tracked by git`);
   if (!trackedPaths.has(INVENTORY_PATH)) errors.push(`${INVENTORY_PATH} must be tracked by git`);
+  for (const workflowPath of SUPPORTING_WORKFLOW_PATHS) {
+    if (!trackedPaths.has(workflowPath)) errors.push(`${workflowPath} must be tracked by git`);
+  }
   if (!inventoryText.includes('Initial registered worktrees: **26**')) {
     errors.push(`${INVENTORY_PATH} must record the 26-worktree baseline`);
   }

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -6,6 +6,7 @@ import {
   FINAL_WORKTREES,
   INVENTORY_PATH,
   REQUIRED_ARCHIVE_REFS,
+  SUPPORTING_WORKFLOW_PATHS,
   extractFinalRetainedWorktrees,
   normalizeWorktreePath,
   missingFinalWorktrees,
@@ -20,7 +21,7 @@ test('tracked repository rules and worktree baseline pass the governance contrac
   const errors = validateGovernance({
     agentsText,
     inventoryText,
-    trackedPaths: new Set([GOVERNANCE_PATH, INVENTORY_PATH]),
+    trackedPaths: new Set([GOVERNANCE_PATH, INVENTORY_PATH, ...SUPPORTING_WORKFLOW_PATHS]),
   });
   assert.deepEqual(errors, []);
 });
@@ -35,7 +36,7 @@ test('missing delivery rules and untracked governance files fail closed', () => 
 test('semantic rule reversal and final retained-set removal fail closed', () => {
   const agentsText = fs.readFileSync(GOVERNANCE_PATH, 'utf8');
   const inventoryText = fs.readFileSync(INVENTORY_PATH, 'utf8');
-  const trackedPaths = new Set([GOVERNANCE_PATH, INVENTORY_PATH]);
+  const trackedPaths = new Set([GOVERNANCE_PATH, INVENTORY_PATH, ...SUPPORTING_WORKFLOW_PATHS]);
   const weakened = agentsText.replace(
     'Automated tests and CI never substitute for hardware validation.',
     'Automated tests and CI fully substitute for hardware validation.',
@@ -52,6 +53,15 @@ test('semantic rule reversal and final retained-set removal fail closed', () => 
   assert.ok(validateGovernance({ agentsText, inventoryText: withoutFinalSet, trackedPaths })
     .some((error) => error.includes('final retained worktree set')));
   assert.equal(extractFinalRetainedWorktrees(withoutFinalSet).size, 0);
+});
+
+test('supporting capability-package workflow files must remain tracked', () => {
+  const agentsText = fs.readFileSync(GOVERNANCE_PATH, 'utf8');
+  const inventoryText = fs.readFileSync(INVENTORY_PATH, 'utf8');
+  const trackedPaths = new Set([GOVERNANCE_PATH, INVENTORY_PATH, ...SUPPORTING_WORKFLOW_PATHS]);
+  trackedPaths.delete(SUPPORTING_WORKFLOW_PATHS[0]);
+  assert.ok(validateGovernance({ agentsText, inventoryText, trackedPaths })
+    .some((error) => error.includes(SUPPORTING_WORKFLOW_PATHS[0])));
 });
 
 test('live registry validation rejects a missing required retained worktree', () => {


### PR DESCRIPTION
## Outcome

Makes the faster capability-package workflow enforceable before implementation of #150:

- one 5–15-tool package branch/worktree/PR instead of one PR per small tool;
- public MCP acceptance first, exact-SHA package hardware gate, then one clean-`main` revalidation;
- maximum three parallel tracks with explicit ownership;
- reviewer findings classified as current blocker, follow-up, or out of scope;
- keep edit-level work local through concentrated review and candidate freeze, then publish once for required CI;
- T6 must cover every included public tool and every write Undo even when the package has no child Issues;
- one replacement candidate only for a reproduced blocker, with its own required CI;
- no repeated deploy/review loop per simple tool and no generalized framework without repeated evidence;
- issue/PR/completion templates and CI governance checks aligned with the same rules and required to remain tracked.

## Scope

Documentation, repository governance, templates, and the existing CI governance command only. No product runtime, Core, CEP, native AEGP, installer, Provider, or Tool Library behavior changes.

## Verification

- `node scripts/check-repository-governance.mjs`: passed.
- governance contract suite: 8/8 passed.
- `git diff --check`: passed.
- independent review identified two workflow contradictions (premature CI publication and vacuous child-Issue-only T6); both are fixed in the current head.

## Follow-up

#150 is the first capability package using this workflow. It remains a separate branch and PR.