### PR TITLE
docs: define .aep fixture lifecycle policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,31 @@ Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should dr
 - Do not use a stale or dirty root checkout as an implicit source for another issue's build.
 - Keep the active build and evidence worktree on fully local, non-evictable storage. Cloud/on-demand placeholders, including macOS `dataless` files, are not valid candidate inputs; hydrate the complete scoped inputs or create a local checkout before freezing the candidate.
 
+### 7.1 Classify `.aep` lifecycle by purpose
+
+Classify every agent-created After Effects project before creating it. Lifecycle follows the project's purpose, not its Issue, PR, branch, candidate SHA, or evidence directory. The default is `ephemeral-validation`.
+
+- **`ephemeral-validation`:** single candidate, read/write, Undo, recovery, or acceptance work. After structured evidence is extracted, move it to a short-lived recoverable archive outside Adobe scan roots.
+- **`reusable-fixture`:** deterministic input shared by multiple capability packages. Keep exactly one canonical copy plus its rebuild recipe; do not duplicate it per Issue or candidate.
+- **`persistent-workspace`:** a project the user explicitly chose for continued editing, or a project in a user-selected workspace. Never move, archive, overwrite, or delete it automatically.
+- **`evidence-snapshot`:** allowed only when an unresolved defect cannot be reproduced from structured logs and a deterministic recipe. Keep one minimal, redacted snapshot bound to the exact source SHA.
+
+Before creating, retaining, moving, or archiving an `.aep`, determine and record:
+
+1. whether the user created it or selected its directory;
+2. whether public MCP or a checked-in recipe can rebuild it deterministically;
+3. whether an unresolved defect genuinely requires the complete project;
+4. whether an open acceptance checklist explicitly references it; and
+5. whether the user explicitly requested persistent retention.
+
+- If long-term value cannot be demonstrated, do not retain the project permanently under an Issue or candidate directory; use a dated recovery archive with a cleanup condition.
+- One T5/T6 hardware session may have only one active fixture. Retry by resetting or deterministically rebuilding that fixture; do not accumulate projects through repeated Save As operations.
+- Issue and evidence directories should normally store the fixture ID, lifecycle, owner, rebuild recipe, exact SHA, content digest, public MCP request/response, before/after state, audit, Undo, and result—not a complete `.aep`.
+- When a candidate is superseded, archive its ephemeral project by default. An old SHA is traceability metadata, not a reason for permanent retention.
+- Permanent retention requires a recorded reason, owner, references, exact SHA, and cleanup condition. A canonical reusable fixture also requires a uniqueness check before another copy is created.
+- Use centralized `canonical`, `active`, `recovery`, and `evidence` roots outside Adobe scan directories. Do not create a new file-management framework merely to enforce this lifecycle.
+- Completion evidence must report `.aep` counts: created, canonical retained, evidence snapshots retained, archived, unclassified, and logical/physical space moved or released.
+
 ## 8. Minimize human interruption during hardware work
 
 - Consolidate all known permissions and GUI prerequisites into one preflight.

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = '06c98ef7c5423b6bdde3a32849da88ae7ccb04136a0aca9784d1f1fd2d0fb949';
+export const GOVERNANCE_SHA256 = 'be81ef88bcf8778ae99a74dbe5e0cd78f5ab15fa9ad2721fcf55f6da63583eb9';
 export const SUPPORTING_WORKFLOW_PATHS = [
   '.github/ISSUE_TEMPLATE/capability-package.md',
   '.github/pull_request_template.md',

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = '0c82c647c42903154074c920a30298ebfae9238443a56b0b2541303f9c333d8e';
+export const GOVERNANCE_SHA256 = '20dbc057da24f10c8b7ad96f24555d288fde6e8129f5edf59aedd5ff0b911861';
 export const SUPPORTING_WORKFLOW_PATHS = [
   '.github/ISSUE_TEMPLATE/capability-package.md',
   '.github/pull_request_template.md',

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = 'be81ef88bcf8778ae99a74dbe5e0cd78f5ab15fa9ad2721fcf55f6da63583eb9';
+export const GOVERNANCE_SHA256 = '0c82c647c42903154074c920a30298ebfae9238443a56b0b2541303f9c333d8e';
 export const SUPPORTING_WORKFLOW_PATHS = [
   '.github/ISSUE_TEMPLATE/capability-package.md',
   '.github/pull_request_template.md',


### PR DESCRIPTION
## Outcome

Adds a narrow repository rule for the lifecycle of agent-created After Effects `.aep` projects.

## Why

The #150 cleanup showed that organizing disposable projects by Issue or candidate SHA encourages duplicate fixtures and long-lived validation artifacts. Issue identity is traceability metadata, not proof that a project has durable value.

## Policy

- classify projects before creation as `ephemeral-validation`, `reusable-fixture`, `persistent-workspace`, or `evidence-snapshot`
- default agent-created projects to `ephemeral-validation`
- allow only one active fixture per T5/T6 session
- retry by reset/rebuild, not repeated Save As
- prefer rebuild recipes and structured MCP/state/audit/Undo/provenance evidence over complete project copies
- require reason, owner, references, exact SHA, and cleanup condition for permanent retention
- report created/retained/archived/unclassified project counts and logical/physical space disposition

This does not create a new file-management framework and does not change product code or acceptance gates.

## Validation

- exact base: `b50303b9a36d15c489ff300f649833012960b34a`
- exact head: `1c9a695ddf91c1b8802ad7354b5583147eee72d6`
- two-file governance change: `AGENTS.md` plus its deliberately locked UTF-8 SHA-256
- exact `AGENTS.md` SHA-256: `20dbc057da24f10c8b7ad96f24555d288fde6e8129f5edf59aedd5ff0b911861`
- focused repository-governance tests: 8/8 pass
- GitHub Actions CI #229: Windows Python, Windows JS/contracts, and Linux packaging/release all pass
- the first two CI attempts failed only because the governance content lock was not yet bound to the exact GitHub UTF-8 blob; no product code or acceptance boundary changed

## Cleanup evidence

The completed #150 project was classified `ephemeral-validation` after T6:

- one agent-created fixture and one AE autosave moved to a recoverable archive
- canonical reusable fixtures retained: 0
- evidence snapshots retained: 0
- unclassified package projects: 0
- logical `.aep` bytes archived: 127,688 B
- physical bytes released: approximately 0 B because the move was recoverable on the same APFS volume

Canonical installed components and the structured clean-main T6 evidence were not moved.