### PR TITLE
Dismantle the governance ratchet and scope local-peer auto-authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,18 +42,20 @@ public MCP tool
 
 ## 4. Layer hardware validation by native novelty and capability package
 
+- **Local development trust model:** on the maintainer's single-user development Mac, files just built, copied, or atomically installed by the active agent-owned workflow are trusted by default. Routine development, AE restart, T4, T5, and T6 must not rehash the complete runtime tree or require Core, CEP, native, protocol, runner, and evidence to share one full repository SHA. Use the install receipt, canonical path, component version, file size, and modification time as inexpensive change signals; escalate to content hashing only after an observed inconsistency or for an explicitly requested release/security audit. Hash verification for external downloads such as the Adobe SDK archive remains allowed.
+- The local development MCP path must not require a connection code, fingerprint confirmation, or pairing ceremony. Same-user local IPC and filesystem permissions are sufficient during development. Authentication, pairing, signing, and hostile same-UID process defenses belong to a later release/remote/multi-user security milestone unless a concrete exploit is reproduced on the active path.
 - When a package introduces a new AEGP SDK suite, object-lifecycle rule, main-thread mechanism, or other unverified native primitive, run one narrow intermediate hardware smoke as soon as that primitive is testable. Once the mechanism is proven, do not redeploy for each simple tool built on it.
-- Complete the package with one exact-SHA real-machine run through the public MCP surface that exercises every included tool and their important interactions in the same disposable AE fixture. Batch the structured response, AE state, native provenance, audit, recovery, and write-tool Undo evidence.
+- Complete the package with one prepared real-machine run through the public MCP surface that exercises every included tool and their important interactions in the same disposable AE fixture. Batch the structured response, AE state, native provenance, audit, recovery, and write-tool Undo evidence.
 - Any package whose acceptance depends on AE loading, lifecycle, GUI state, main-thread behavior, CEP/native communication, or project mutation still requires this package-level real-machine validation before merge.
 - Automated tests and CI never substitute for hardware validation.
-- Build, install, and test the exact candidate commit. Core, CEP host, native plugin, protocol metadata, and test evidence must report the same full commit SHA. Abort validation on any mismatch.
+- Record the candidate source revision and installed component receipts for traceability, but do not make full-repository SHA equality a runtime or acceptance gate. Abort only on an observed incompatible protocol/component version, wrong canonical path, failed load, or contradictory AE result.
 - After merge, repeat the public MCP package smoke from a clean `main` build. It must touch every included public tool, cover each accepted optional child Issue, and verify real Undo for every included write. Do not rely on the pre-merge installation.
 - Use a dedicated disposable AE project. Never use the user's production project for write testing.
-- Prepare GUI access, permissions, pairing, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
-- Before T4 or T5, complete a zero-evidence hardware preflight that proves the exact runtime/current pointer, stable launcher, CEP, native plug-in, and protocol metadata are mutually deployable; the formal AE absolute path, GUI, pairing flow, fixture runner, and log directories are usable; and the runner can create or reset, save, reopen from inside AE, and archive its single disposable fixture. A preflight creates no candidate acceptance evidence and does not count as a T4/T5 hardware run.
+- Prepare GUI access, permissions, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
+- Before T4 or T5, complete a zero-evidence hardware preflight that proves the selected runtime/current pointer, stable launcher, CEP, native plug-in, and protocol metadata can communicate; the formal AE absolute path, GUI, fixture runner, and log directories are usable; and the runner can create or reset, save, reopen from inside AE, and archive its single disposable fixture. The preflight uses lightweight receipts/metadata and does not perform a full runtime hash walk or a pairing ceremony. A preflight creates no candidate acceptance evidence and does not count as a T4/T5 hardware run.
 - A failure before the first public MCP tool call is a T0-T2 environment or runner failure, not a failed candidate hardware acceptance. Repair and falsify it at the lowest applicable tier before returning to T4/T5.
-- After concentrated review has no unresolved blocker and all source, generated bundles, documentation, license metadata, fixtures, and evidence schemas are committed, designate that exact SHA as the candidate freeze. Run T3 and required CI on the frozen SHA; except for the single narrow smoke allowed for a genuinely new native primitive, do not begin exact-candidate hardware acceptance until they pass. This is the candidate freeze.
-- After candidate freeze, change the SHA only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate. The replacement is a new frozen candidate and must pass required CI before any T5 acceptance evidence is collected.
+- After concentrated review has no unresolved blocker and all source, generated bundles, documentation, license metadata, fixtures, and evidence schemas are committed, designate that source revision/build as the candidate freeze. Run T3 and required CI once; except for the single narrow smoke allowed for a genuinely new native primitive, do not begin candidate hardware acceptance until they pass.
+- After candidate freeze, create a replacement only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate. The replacement must pass required CI before any T5 acceptance evidence is collected.
 - The normal target is one candidate and one full CI run. At most one replacement candidate is allowed for a reproduced blocker; that replacement gets its own required CI run, while already-passing unaffected local tiers need not be repeated. The normal hardware target remains one successful candidate session and one clean-`main` session. Exceeding these targets must be explained in the completion evidence; it is not a reason to weaken a gate.
 
 ## 5. Keep review feedback from expanding P0
@@ -76,14 +78,25 @@ Use the lowest test tier that can falsify the current change, then escalate at p
 - **T0, every edit:** formatting, syntax, lint, or a single focused unit test; target seconds.
 - **T1, each tool or adapter:** schema, codec, suite adapter, structured-error, and postcondition contract tests; target 1-5 minutes.
 - **T2, package integration:** affected native compile tests, Core/CEP integration, shared fixture, interaction corpus, and generated-file checks; target 10-30 minutes.
-- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once for each exact candidate SHA after concentrated or focused replacement review.
+- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once for each candidate or approved replacement after concentrated or focused replacement review.
 - **T4, optional native-novelty smoke:** one narrow real-AE check only when the package introduces an unverified suite, object lifecycle, or main-thread mechanism.
-- **T5, candidate acceptance:** one exact-SHA public-MCP package run on real AE.
+- **T5, candidate acceptance:** one public-MCP package run on real AE using the recorded candidate build receipts.
 - **T6, clean-main acceptance:** one rebuild/reinstall and package smoke from the merge commit that touches every included public tool, covers each accepted optional child Issue, and verifies real Undo for every included write.
 
 Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should drive the smallest reproducing lower-tier test first; return to the higher tier only after the fix set is complete.
 
-For an immutable installed generation whose identity has already been verified, lower tiers may reuse that verified identity only when the runtime contract proves that the generation and its inputs have not changed. Full payload verification remains mandatory at installation, candidate freeze/acceptance, and clean-`main` acceptance; do not pay the full verification cost repeatedly within one unchanged lower-tier session.
+For an agent-owned installed generation on the single-user development machine, reuse is the default. Check only the canonical pointer, install receipt, component version, size, and modification time on routine starts. Do not perform a full payload hash walk at T4, T5, T6, or AE restart. Escalate to selective/content verification only when those inexpensive signals change, AE reports an incompatible component/protocol, an actual result is contradictory, or a release/security audit explicitly requests it.
+
+### 5.2 Batch independent acceptance defects before repair
+
+During a diagnostic T4, or after a T5/T6 run has already failed, do not stop and modify source after the first ordinary assertion failure. Continue every independent case whose evidence remains trustworthy and whose fixture state is either unchanged or restored, then repair the collected blockers as one fix set.
+
+- The runner must record each case as `PASS`, `FAIL`, `BLOCKED`, or `INDETERMINATE`, together with the failing layer, side-effect status, state-reconciliation result, dependency impact, and evidence identifiers.
+- Continue after a failure only when it is read-only or definitively `not-started`, or when any completed write has been reconciled against AE state and audit evidence and the fixture baseline has been verified as restored.
+- Stop the sweep immediately when a possible write remains unreconciled, the fixture baseline cannot be restored, AE crashes or corrupts the project, an incompatible component/protocol is observed, or subsequent evidence would otherwise be untrustworthy.
+- Mark dependent cases `BLOCKED` and continue unrelated cases; continuing diagnostic collection never converts the failed candidate into accepted evidence.
+- Do not edit source between individual diagnostic cases. After the bounded sweep, group all reproduced current blockers by layer, fix them together, rerun only the affected lower tiers, perform one focused review, and replay the hardware gate once on the permitted replacement candidate.
+- Generate a machine-readable defect ledger from the sweep so the repair batch, replacement review, and completion report consume the same observed failures instead of manually reconstructing them.
 
 ## 6. Treat writes and uncertain failures explicitly
 
@@ -96,9 +109,9 @@ For an immutable installed generation whose identity has already been verified, 
 ## 7. Preserve build and workspace identity
 
 - Use one worktree and one branch for each capability package. Record any optional child Issues and the acceptance matrix owned by that worktree, and know which package owns every build, install, test artifact, and running process.
-- Before starting an expensive build, fail fast on every locked external input and identity prerequisite, including the clean source SHA, Adobe SDK archive/root, Node headers, license approvals, output ownership, and local non-evictable input state. Do not discover a missing build prerequisite after a long runtime or native build has started.
-- Before building or deploying, record `git rev-parse HEAD`, dirty state, artifact hashes, installed paths, and runtime-reported source commit.
-- Never mix Core, CEP, native plugin, or protocol files from different commits. A convenient partial redeploy is not valid evidence.
+- Before starting an expensive build, fail fast on every locked external input and prerequisite, including the Adobe SDK archive/root, Node headers, license approvals, output ownership, and local non-evictable input state. Do not discover a missing build prerequisite after a long runtime or native build has started.
+- Before building or deploying, record the source revision, dirty state, installed paths, component versions, sizes, and modification times. Content hashes are optional diagnostics, not routine acceptance gates.
+- Do not intentionally deploy incompatible Core, CEP, native plug-in, or protocol versions. A source-revision mismatch by itself is not proof of incompatibility and must not block development.
 - Keep backup, staging, rollback, and evidence directories outside Adobe's plugin scan roots.
 - Keep disposable projects, generated scripts, logs, and smoke outputs out of tracked source paths unless they are intentional fixtures.
 - Do not use a stale or dirty root checkout as an implicit source for another issue's build.
@@ -111,7 +124,7 @@ Classify every agent-created After Effects project before creating it. Lifecycle
 - **`ephemeral-validation`:** single candidate, read/write, Undo, recovery, or acceptance work. After structured evidence is extracted, move it to a short-lived recoverable archive outside Adobe scan roots.
 - **`reusable-fixture`:** deterministic input shared by multiple capability packages. Keep exactly one canonical copy plus its rebuild recipe; do not duplicate it per Issue or candidate.
 - **`persistent-workspace`:** a project the user explicitly chose for continued editing, or a project in a user-selected workspace. Never move, archive, overwrite, or delete it automatically.
-- **`evidence-snapshot`:** allowed only when an unresolved defect cannot be reproduced from structured logs and a deterministic recipe. Keep one minimal, redacted snapshot bound to the exact source SHA.
+- **`evidence-snapshot`:** allowed only when an unresolved defect cannot be reproduced from structured logs and a deterministic recipe. Keep one minimal, redacted snapshot with its source revision/build receipt.
 
 Before creating, retaining, moving, or archiving an `.aep`, determine and record:
 
@@ -124,19 +137,19 @@ Before creating, retaining, moving, or archiving an `.aep`, determine and record
 - If long-term value cannot be demonstrated, do not retain the project permanently under an Issue or candidate directory; use a dated recovery archive with a cleanup condition.
 - One T5/T6 hardware session may have only one active fixture. Retry by resetting or deterministically rebuilding that fixture; do not accumulate projects through repeated Save As operations.
 - If an agent-created `ephemeral-validation` fixture fails before the first public tool call, has no AE mutation, and has no unresolved diagnostic value, the runner must move it to recovery and clear the active slot before exit. Once any public call or possible write dispatch occurred, reconcile AE state and audit evidence before resetting, archiving, or retrying.
-- Issue and evidence directories should normally store the fixture ID, lifecycle, owner, rebuild recipe, exact SHA, content digest, public MCP request/response, before/after state, audit, Undo, and result—not a complete `.aep`.
-- When a candidate is superseded, archive its ephemeral project by default. An old SHA is traceability metadata, not a reason for permanent retention.
-- Permanent retention requires a recorded reason, owner, references, exact SHA, and cleanup condition. A canonical reusable fixture also requires a uniqueness check before another copy is created.
+- Issue and evidence directories should normally store the fixture ID, lifecycle, owner, rebuild recipe, source revision/build receipt, public MCP request/response, before/after state, audit, Undo, and result—not a complete `.aep`.
+- When a candidate is superseded, archive its ephemeral project by default. An old build identifier is traceability metadata, not a reason for permanent retention.
+- Permanent retention requires a recorded reason, owner, references, source revision/build receipt, and cleanup condition. A canonical reusable fixture also requires a uniqueness check before another copy is created.
 - Use centralized `canonical`, `active`, `recovery`, and `evidence` roots outside Adobe scan directories. Do not create a new file-management framework merely to enforce this lifecycle.
 - Completion evidence must report `.aep` counts: created, canonical retained, evidence snapshots retained, archived, unclassified, and logical/physical space moved or released.
 
 ## 8. Minimize human interruption during hardware work
 
 - Consolidate all known permissions and GUI prerequisites into one preflight.
-- Run package hardware acceptance as one continuous prepared session. Keep pairing, fixture creation, all tool calls, write verification, Undo/Redo, restart/reconnect, and evidence collection in the same orchestrated window; do not spread a short-lived pairing flow across conversational round trips.
-- Complete each short-lived pairing handshake as one continuous automation action: open the pairing UI, read and verify the current fingerprint, authorize it, and observe the acknowledgement without yielding across model or user turns.
+- Run package hardware acceptance as one continuous prepared session. Keep fixture creation, all tool calls, write verification, Undo/Redo, restart/reconnect, and evidence collection in the same orchestrated window.
+- Do not require or perform a connection-code/fingerprint pairing ceremony on the local single-user development path. If legacy pairing code is still present, bypass it for development until the P0 removal task deletes the mandatory path.
 - Open or reopen acceptance fixtures from the formal AE process using AE's own File/Open or Open Recent flow. Do not use Finder, file double-click, or LaunchServices because they may route the project to Beta or another host.
-- Once the user has authorized routine AE/macOS GUI control, perform normal focus, open/save/close, pairing, restart, disposable-project, and test Undo/Redo operations without repeatedly asking them to click.
+- Once the user has authorized routine AE/macOS GUI control, perform normal focus, open/save/close, restart, disposable-project, and test Undo/Redo operations without repeatedly asking them to click.
 - Pause only for a genuinely required system confirmation, credential/license decision, destructive action outside the disposable fixture, or a product choice that changes the result.
 - When blocked, report the single concrete blocker and the evidence already gathered; do not offload ordinary debugging steps to the user.
 
@@ -165,16 +178,16 @@ Treat this Skip -> Continue sequence as established project knowledge. Do not re
 
 A capability-package completion report must include:
 
-- package PR, parent Epic, any optional child Issue links and dispositions, per-tool acceptance disposition, exact tested commit, and merge commit;
+- package PR, parent Epic, any optional child Issue links and dispositions, per-tool acceptance disposition, tested source revision/build receipt, and merge commit;
 - the public MCP request and structured response;
 - AE state evidence before and after the operation;
-- native/AEGP provenance and matching source commit;
+- native/AEGP provenance and observed component/protocol versions;
 - audit evidence with sensitive values and private paths redacted;
 - Undo and recovery evidence for writes;
 - CI/review status and the clean-`main` hardware revalidation;
 - remaining risks and their follow-up issue classification.
 - package-efficiency counters: included tools, review rounds, candidate builds, full CI runs, candidate/main hardware runs, first-hardware-pass result, environment/pairing interruptions, and elapsed time from scope freeze to clean-`main` acceptance.
-- a machine-generated per-tool summary containing public-call counts, request/result disposition, before/after state, Undo result, exact component SHAs, host instances, audit/postcondition IDs, and fixture lifecycle. PR and Issue updates should consume this generated summary instead of manually transcribing repeated evidence.
+- a machine-generated per-tool summary containing public-call counts, request/result disposition, before/after state, Undo result, component build receipts/versions, host instances, audit/postcondition IDs, and fixture lifecycle. PR and Issue updates should consume this generated summary instead of manually transcribing repeated evidence.
 
 Do not claim completion using only "tests passed", "CI is green", "the plugin compiled", or "the PR merged".
 
@@ -183,7 +196,7 @@ Do not claim completion using only "tests passed", "CI is green", "the plugin co
 Do not proceed to the next dependent capability package when any of the following is true:
 
 - the current public MCP acceptance test has not passed on real AE;
-- the installed components do not share an exact source commit;
+- an installed component or protocol is observed to be incompatible with the active public-MCP path;
 - a write produced an indeterminate result whose AE state and audit outcome are unreconciled;
 - the PR is merged but clean `main` has not been rebuilt, reinstalled, and reverified;
 - the test fixture, logs, or workspace state cannot distinguish the tested build from an older installation;

--- a/README.md
+++ b/README.md
@@ -190,10 +190,16 @@ BUILD_DIR=/private/tmp/ae-mcp-native-73
 node native/ae-plugin/build-macos.mjs \
   --sdk-archive "$AE_SDK_ARCHIVE" \
   --sdk-root "$AE_SDK_ROOT" \
+  --development-trust-local-peer \
   --output "$BUILD_DIR"
 node native/ae-plugin/verify-macos.mjs \
   --bundle "$BUILD_DIR/AeMcpNative.plugin"
 ```
+
+`--development-trust-local-peer` is the explicit local-development opt-in that
+auto-confirms an already admitted same-user AE process-tree peer. Omitting it
+keeps the native pairing decision mandatory, which is the secure compile-time
+default for release builds.
 
 Close every After Effects, AfterFX, and aerender process before installing. The development
 installer verifies the build receipt and installed copy, and installs the loadable bundle at

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,10 +217,14 @@ BUILD_DIR=/private/tmp/ae-mcp-native-73
 node native/ae-plugin/build-macos.mjs \
   --sdk-archive "$AE_SDK_ARCHIVE" \
   --sdk-root "$AE_SDK_ROOT" \
+  --development-trust-local-peer \
   --output "$BUILD_DIR"
 node native/ae-plugin/verify-macos.mjs \
   --bundle "$BUILD_DIR/AeMcpNative.plugin"
 ```
+
+`--development-trust-local-peer` 是本地开发专用的显式选择：仅对已经通过同一用户和 AE
+进程树校验的 peer 自动确认。省略此参数时仍必须完成原生 pairing；这也是 release 构建的安全编译默认值。
 
 安装前必须关闭所有 After Effects、AfterFX 和 aerender 进程。开发安装器会校验构建回执和安装后的副本，
 最终安装位置为

--- a/native/ae-plugin/build-macos.mjs
+++ b/native/ae-plugin/build-macos.mjs
@@ -177,17 +177,31 @@ async function digestFile(filePath) {
 
 function parseCli(argv, environment = process.env) {
   const options = new Map();
-  for (let index = 0; index < argv.length; index += 2) {
+  let developmentTrustLocalPeer = false;
+  for (let index = 0; index < argv.length;) {
     const name = argv[index];
+    if (name === '--development-trust-local-peer') {
+      if (developmentTrustLocalPeer) {
+        throw buildError(
+          'AE_PLUGIN_ARGUMENT_INVALID',
+          '--development-trust-local-peer may be specified only once',
+        );
+      }
+      developmentTrustLocalPeer = true;
+      index += 1;
+      continue;
+    }
     const value = argv[index + 1];
     if (!['--sdk-archive', '--sdk-root', '--output'].includes(name)
         || !value || options.has(name)) {
       throw buildError(
         'AE_PLUGIN_ARGUMENT_INVALID',
-        'expected unique --sdk-archive, --sdk-root, and --output options',
+        'expected unique --sdk-archive, --sdk-root, and --output options, plus an optional '
+          + '--development-trust-local-peer flag',
       );
     }
     options.set(name, value);
+    index += 2;
   }
   const sdkArchive = options.get('--sdk-archive') ?? environment.AE_SDK_ARCHIVE;
   const sdkRoot = options.get('--sdk-root') ?? environment.AE_SDK_ROOT;
@@ -199,7 +213,12 @@ function parseCli(argv, environment = process.env) {
   if (!output || !path.isAbsolute(output)) {
     throw buildError('AE_PLUGIN_ARGUMENT_INVALID', '--output must be an absolute path outside the repository');
   }
-  return { sdkArchive, sdkRoot, output: path.resolve(output) };
+  return {
+    sdkArchive,
+    sdkRoot,
+    output: path.resolve(output),
+    developmentTrustLocalPeer,
+  };
 }
 
 async function resolveSdkRoot(input, expectedRoot) {
@@ -345,7 +364,14 @@ async function buildMacPluginInternal({
   sdkArchive: sdkArchiveInput,
   sdkRoot: sdkRootInput,
   output,
+  developmentTrustLocalPeer = false,
 }) {
+  if (typeof developmentTrustLocalPeer !== 'boolean') {
+    throw buildError(
+      'AE_PLUGIN_ARGUMENT_INVALID',
+      'developmentTrustLocalPeer must be an explicit boolean',
+    );
+  }
   if (process.platform !== 'darwin' || process.arch !== 'arm64') {
     throw buildError('AE_PLUGIN_PLATFORM_UNSUPPORTED', 'macOS arm64 is required for this development build');
   }
@@ -516,6 +542,8 @@ async function buildMacPluginInternal({
       '-isysroot', sysroot,
       `-DAE_MCP_SOURCE_COMMIT="${sourceCommit}"`,
       `-DAE_MCP_PRODUCT_VERSION="${productVersion}"`,
+      ...(developmentTrustLocalPeer === true
+        ? ['-DAE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER=1'] : []),
       '-pthread', '-fPIC', '-fvisibility=hidden', '-fvisibility-inlines-hidden',
       '-Wall', '-Wextra', '-Wpedantic', '-Werror', '-O0',
       ...includes,

--- a/native/ae-plugin/src/platform/macos/mac_ipc_server.cpp
+++ b/native/ae-plugin/src/platform/macos/mac_ipc_server.cpp
@@ -20,6 +20,15 @@
 #include <utility>
 #include <vector>
 
+#ifndef AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER
+#define AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER 0
+#endif
+
+static_assert(
+    AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER == 0
+        || AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER == 1,
+    "AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER must be 0 or 1");
+
 namespace aemcp::native {
 namespace {
 
@@ -199,6 +208,16 @@ void MacIpcServer::handle_connection(int socket_fd) noexcept {
       return;
     }
     observer_.on_ipc_event("pairing", "pending");
+#if AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER
+    // Local development runs inside the already-admitted same-user AE process
+    // tree. Keep the V1 transport shape for compatibility, but authorize the
+    // exact peer binding immediately instead of waiting for a GUI fingerprint.
+    if (!pairing_gate_.confirm(peer->connection_id, begin.fingerprint)) {
+      pairing_gate_.revoke(*peer);
+      observer_.on_ipc_event("pairing", "local-auto-authorization-failed");
+      return;
+    }
+#endif
     const auto pairing_deadline = std::chrono::steady_clock::now() + begin.expires_in;
     bool authorized = false;
     while (!stop_requested_.load() && std::chrono::steady_clock::now() < pairing_deadline) {

--- a/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
+++ b/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
@@ -513,6 +513,7 @@ def make_runtime(tmp_path: Path, mode: str, fake: FakeAe):
     def bind(*, stage: str, previous_instance_id: str | None = None) -> str:
         assert previous_instance_id is None or fake.host != previous_instance_id
         runner.expected_host_instance_id = fake.host
+        runner.expected_native_source_revision = EXPECTED_SHA
         runner.pairing_checkpoint_used = False
         runner.pairing_epoch_start_total = runner.ledger.total
         return fake.host
@@ -564,12 +565,23 @@ def make_identity_config(tmp_path: Path) -> runtime_module.IdentityConfig:
     write_json(
         generation_root / "install-record.json",
         {
+            "schemaVersion": 1,
+            "platform": "macos-arm64",
+            "version": "0.9.2",
+            "installedAt": 1,
             "relative": relative,
             "sourceCommitSha": EXPECTED_SHA,
             "runtimeManifestSha256": runtime_hash,
             "launcherSha256": launcher_hash,
         },
     )
+    for executable_path in (
+        home / ".ae-mcp/runtime" / relative / "node/bin/node",
+        home / ".ae-mcp/runtime" / relative / "python/bin/python3",
+    ):
+        executable_path.parent.mkdir(parents=True, exist_ok=True)
+        executable_path.write_bytes(b"#!/bin/sh\nexit 0\n")
+        executable_path.chmod(0o755)
     for launcher in (generation_root / "ae-mcp-launcher", home / ".ae-mcp/bin/ae-mcp"):
         launcher.parent.mkdir(parents=True, exist_ok=True)
         launcher.write_bytes(launcher_bytes)
@@ -597,6 +609,7 @@ def make_identity_config(tmp_path: Path) -> runtime_module.IdentityConfig:
     executable = app / "Contents/MacOS/After Effects"
     executable.parent.mkdir(parents=True, exist_ok=True)
     executable.write_bytes(b"formal-ae")
+    executable.chmod(0o755)
     plist = {
         "CFBundleIdentifier": "com.adobe.AfterEffects.application",
         "CFBundleShortVersionString": "26.3.0",
@@ -836,20 +849,31 @@ def test_spatial_detail_uses_the_public_vector_value_contract() -> None:
         package._spatial_detail(legacy, locator)
 
 
-def test_identity_binds_generation_and_canonical_stable_launcher(tmp_path: Path):
+def test_identity_uses_local_component_signals_and_advisory_source_revisions(tmp_path: Path):
     identity = make_identity_config(tmp_path)
     required = tuple(case.capability_id for case in package.SPEC.tools)
     proof = runtime_module.verify_exact_identity(
         identity, required_capability_ids=required
     )
     stable = identity.identity_home / ".ae-mcp/bin/ae-mcp"
-    expected_hash = hashlib.sha256(stable.read_bytes()).hexdigest()
-    assert proof.component_hashes["stableLauncherSha256"] == expected_hash
-    assert proof.component_hashes["runtimeGenerationLauncherSha256"] == expected_hash
+    assert proof.component_signals["stableLauncher"]["size"] == stable.stat().st_size
+    assert (
+        proof.component_signals["runtimeGenerationLauncher"]["size"]
+        == stable.stat().st_size
+    )
+    cep_path = (
+        identity.identity_home
+        / "Library/Application Support/Adobe/CEP/extensions/com.aemcp.panel/bundle-manifest.json"
+    )
+    write_json(cep_path, {"sourceCommitSha": "f" * 40})
+    drifted = runtime_module.verify_exact_identity(
+        identity, required_capability_ids=required
+    )
+    assert drifted.source_revisions["cep"] == "f" * 40
 
-    stable.write_bytes(b"#!/bin/sh\nexit 1\n")
+    stable.write_bytes(b"#!/bin/sh\nexit 10\n")
     stable.chmod(0o755)
-    with pytest.raises(runtime_module.IdentityFailure, match="launcher identity mismatch"):
+    with pytest.raises(runtime_module.IdentityFailure, match="launcher size signals"):
         runtime_module.verify_exact_identity(identity, required_capability_ids=required)
 
 
@@ -878,6 +902,7 @@ async def test_call_budget_aborts_before_dispatching_call_31(tmp_path: Path):
     runner, _evidence = make_runtime(tmp_path, "t5", fake)
     runner.contract_digests.update(fake.contracts)
     runner.expected_host_instance_id = fake.host
+    runner.expected_native_source_revision = EXPECTED_SHA
     for index in range(30):
         await runner.call(
             fake,
@@ -917,7 +942,8 @@ def test_identity_validation_can_freeze_only_base_support_contracts(
     def verify(_identity, *, required_capability_ids):
         observed.extend(required_capability_ids)
         return SimpleNamespace(
-            component_hashes={},
+            component_signals={},
+            source_revisions={},
             contract_digests={
                 capability: fake.contracts[capability]
                 for capability in required_capability_ids

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react.production.min.js
+  // node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
+    "node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/index.js
+  // node_modules/react/index.js
   var require_react = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/index.js"(exports, module) {
+    "node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
+  // node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/index.js
+  // node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/index.js"(exports, module) {
+    "node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
+  // node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/index.js
+  // node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/index.js"(exports, module) {
+    "node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/client.js
+  // node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/client.js"(exports) {
+    "node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/jsx-runtime.js
+  // node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
+    "node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7318,19 +7318,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -7343,7 +7343,7 @@
     strokeLinejoin: "round"
   };
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -7375,7 +7375,7 @@
     }
   );
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -7389,13 +7389,13 @@
     return Component;
   };
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
+  // node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -7407,7 +7407,7 @@
     ]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
+  // node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -7420,7 +7420,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
+  // node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -7445,58 +7445,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
+  // node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
+  // node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
+  // node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
+  // node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
+  // node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -7516,7 +7516,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
+  // node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -7528,7 +7528,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
+  // node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -7537,7 +7537,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
+  // node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -7549,28 +7549,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
+  // node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
+  // node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
+  // node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -7579,7 +7579,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
+  // node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -7589,23 +7589,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
+  // node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
+  // node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
+  // node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
+  // node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -7613,25 +7613,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
+  // node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
+  // node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
+  // node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -7643,7 +7643,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
+  // node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -7655,7 +7655,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -7668,7 +7668,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
+  // node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -7679,7 +7679,7 @@
     ]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -7694,12 +7694,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
+  // node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -7708,7 +7708,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -7717,7 +7717,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -7730,13 +7730,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
+  // node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -7747,13 +7747,13 @@
     ]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
+  // node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
+  // node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",
@@ -17565,6 +17565,66 @@
         mode: modeOf(info)
       };
     }
+    async function executableSignal(filePath, code, {
+      rootDirectory,
+      expectedMode,
+      expectedSize,
+      expectedType
+    } = {}) {
+      var _a2, _b2;
+      let info;
+      try {
+        info = await promises.lstat(filePath);
+      } catch (error) {
+        failure(code, "Trusted local runtime entrypoint is missing", { path: filePath });
+      }
+      const type = ((_a2 = info.isSymbolicLink) == null ? void 0 : _a2.call(info)) ? "symlink" : "file";
+      if (expectedType && type !== expectedType || expectedMode && modeOf(info) !== expectedMode || Number.isSafeInteger(expectedSize) && info.size !== expectedSize) {
+        failure(code, "Trusted local runtime entrypoint metadata changed", {
+          path: filePath,
+          size: info.size,
+          mtimeMs: Math.trunc(info.mtimeMs)
+        });
+      }
+      if (type === "file") {
+        if (!info.isFile() || info.nlink !== 1 || (info.mode & 73) === 0) {
+          failure(code, "Trusted local runtime entrypoint changed", { path: filePath });
+        }
+        return {
+          path: filePath,
+          type,
+          size: info.size,
+          mtimeMs: Math.trunc(info.mtimeMs),
+          mode: modeOf(info)
+        };
+      }
+      let target;
+      let targetInfo;
+      try {
+        target = await promises.readlink(filePath);
+        const resolved = paths.resolve([paths.dirname(filePath), target]);
+        if (!rootDirectory || paths.isAbsolute(target) || !paths.contains(rootDirectory, resolved)) {
+          failure(code, "Trusted local runtime entrypoint symlink is unsafe", { path: filePath });
+        }
+        targetInfo = await promises.lstat(resolved);
+      } catch (error) {
+        if (error instanceof RuntimeManagerError) throw error;
+        failure(code, "Trusted local runtime entrypoint symlink is invalid", { path: filePath });
+      }
+      if (!targetInfo.isFile() || ((_b2 = targetInfo.isSymbolicLink) == null ? void 0 : _b2.call(targetInfo)) || targetInfo.nlink !== 1 || (targetInfo.mode & 73) === 0) {
+        failure(code, "Trusted local runtime entrypoint target changed", { path: filePath });
+      }
+      return {
+        path: filePath,
+        type,
+        size: targetInfo.size,
+        mtimeMs: Math.trunc(targetInfo.mtimeMs),
+        mode: modeOf(targetInfo),
+        linkTarget: target,
+        linkSize: info.size,
+        linkMtimeMs: Math.trunc(info.mtimeMs)
+      };
+    }
     function validateRuntimeManifest(value) {
       var _a2, _b2;
       if (!value || value.schemaVersion !== 1 || value.platform !== platform.id || ((_a2 = value.node) == null ? void 0 : _a2.version) !== "24.17.0" || ((_b2 = value.python) == null ? void 0 : _b2.version) !== "3.13.14" || !Array.isArray(value.files) || value.files.length === 0) {
@@ -17663,7 +17723,7 @@
       const launcherRecord = byPath.get(launcherRelative);
       const nodeRecord = byPath.get(nodeRelative);
       const pythonRecord = byPath.get(pythonRelative);
-      if (!runtimeRecord || runtimeRecord.type !== "file" || runtimeRecord.sha256 !== manifest.runtime.manifestSha256 || !Number.isSafeInteger(runtimeRecord.size) || runtimeRecord.size <= 0 || !launcherRecord || launcherRecord.type !== "file" || !Number.isSafeInteger(launcherRecord.size) || launcherRecord.size <= 0 || !nodeRecord || nodeRecord.type !== "file" || !Number.isSafeInteger(nodeRecord.size) || nodeRecord.size <= 0 || !pythonRecord || pythonRecord.type !== "file" || !Number.isSafeInteger(pythonRecord.size) || pythonRecord.size <= 0) {
+      if (!runtimeRecord || runtimeRecord.type !== "file" || runtimeRecord.sha256 !== manifest.runtime.manifestSha256 || !Number.isSafeInteger(runtimeRecord.size) || runtimeRecord.size <= 0 || !launcherRecord || launcherRecord.type !== "file" || !Number.isSafeInteger(launcherRecord.size) || launcherRecord.size <= 0 || !nodeRecord || nodeRecord.type !== "file" || !Number.isSafeInteger(nodeRecord.size) || nodeRecord.size <= 0 || !pythonRecord || !["file", "symlink"].includes(pythonRecord.type) || !Number.isSafeInteger(pythonRecord.size) || pythonRecord.size <= 0) {
         failure("RUNTIME_BUNDLE_INVALID", "Packaged runtime entrypoints or stable launcher are not declared");
       }
       const runtimeManifestSignal = await ordinaryFileSignal(
@@ -17689,13 +17749,14 @@
           expectedSize: nodeRecord.size
         }
       );
-      const pythonSignal = await ordinaryFileSignal(
+      const pythonSignal = await executableSignal(
         paths.join([packagedRuntimeRoot, "python", "bin", "python3"]),
         "RUNTIME_BUNDLE_METADATA_CHANGED",
         {
-          executable: true,
+          rootDirectory: packagedRuntimeRoot,
           expectedMode: pythonRecord.mode,
-          expectedSize: pythonRecord.size
+          expectedSize: pythonRecord.size,
+          expectedType: pythonRecord.type
         }
       );
       return {
@@ -17778,10 +17839,10 @@
           "RUNTIME_TRUST_SIGNAL_CHANGED",
           { executable: true }
         ),
-        python: await ordinaryFileSignal(
+        python: await executableSignal(
           paths.join([directory, "python", "bin", "python3"]),
           "RUNTIME_TRUST_SIGNAL_CHANGED",
-          { executable: true }
+          { rootDirectory: directory }
         )
       };
       return {
@@ -18054,7 +18115,7 @@
           };
         }
         const declaredRuntimeMatches = current.ok && current.record.version === packaged.version && current.record.runtimeManifestSha256 === packaged.runtimeManifestSha256 && current.record.launcherSha256 === packaged.launcherSha256;
-        const trustedSignalsMatch = declaredRuntimeMatches && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size && current.signals.launcher.size === packaged.signals.launcher.size && current.signals.node.size === packaged.signals.node.size && current.signals.python.size === packaged.signals.python.size;
+        const trustedSignalsMatch = declaredRuntimeMatches && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size && current.signals.launcher.size === packaged.signals.launcher.size && current.signals.node.size === packaged.signals.node.size && current.signals.python.size === packaged.signals.python.size && current.signals.python.type === packaged.signals.python.type && current.signals.python.linkTarget === packaged.signals.python.linkTarget;
         if (trustedSignalsMatch) {
           await installLauncher(current);
           return {

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // node_modules/react/cjs/react.production.min.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "node_modules/react/cjs/react.production.min.js"(exports) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // node_modules/react/index.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/index.js
   var require_react = __commonJS({
-    "node_modules/react/index.js"(exports, module) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // node_modules/scheduler/cjs/scheduler.production.min.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // node_modules/scheduler/index.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "node_modules/scheduler/index.js"(exports, module) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // node_modules/react-dom/cjs/react-dom.production.min.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // node_modules/react-dom/index.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "node_modules/react-dom/index.js"(exports, module) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // node_modules/react-dom/client.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "node_modules/react-dom/client.js"(exports) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // node_modules/react/jsx-runtime.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "node_modules/react/jsx-runtime.js"(exports, module) {
+    "../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7318,19 +7318,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -7343,7 +7343,7 @@
     strokeLinejoin: "round"
   };
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -7375,7 +7375,7 @@
     }
   );
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -7389,13 +7389,13 @@
     return Component;
   };
 
-  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/book-open.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -7407,7 +7407,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/box.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -7420,7 +7420,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/brain.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -7445,58 +7445,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/check.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/copy.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/download.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/external-link.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -7516,7 +7516,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -7528,7 +7528,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/file-text.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -7537,7 +7537,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/github.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -7549,28 +7549,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/globe.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/history.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/info.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -7579,7 +7579,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -7589,23 +7589,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/message-square.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/pause.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/play.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plug.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -7613,25 +7613,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plus.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/search.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/send.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -7643,7 +7643,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/settings.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -7655,7 +7655,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -7668,7 +7668,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -7679,7 +7679,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -7694,12 +7694,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/square.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -7708,7 +7708,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -7717,7 +7717,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -7730,13 +7730,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/wrench.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -7747,13 +7747,13 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/x.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/zap.js
+  // ../../../../../Users/junk_doge/Documents/ae-mcp/plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",
@@ -17539,6 +17539,32 @@
         failure(code, "Runtime metadata is missing or invalid", { path: filePath });
       }
     }
+    async function ordinaryFileSignal(filePath, code, {
+      executable = false,
+      expectedMode,
+      expectedSize
+    } = {}) {
+      var _a2;
+      let info;
+      try {
+        info = await promises.lstat(filePath);
+      } catch (error) {
+        failure(code, "Trusted local runtime metadata is missing", { path: filePath });
+      }
+      if (!info.isFile() || ((_a2 = info.isSymbolicLink) == null ? void 0 : _a2.call(info)) || info.nlink !== 1 || executable && (info.mode & 73) === 0 || expectedMode && modeOf(info) !== expectedMode || Number.isSafeInteger(expectedSize) && info.size !== expectedSize) {
+        failure(code, "Trusted local runtime metadata changed", {
+          path: filePath,
+          size: info.size,
+          mtimeMs: Math.trunc(info.mtimeMs)
+        });
+      }
+      return {
+        path: filePath,
+        size: info.size,
+        mtimeMs: Math.trunc(info.mtimeMs),
+        mode: modeOf(info)
+      };
+    }
     function validateRuntimeManifest(value) {
       var _a2, _b2;
       if (!value || value.schemaVersion !== 1 || value.platform !== platform.id || ((_a2 = value.node) == null ? void 0 : _a2.version) !== "24.17.0" || ((_b2 = value.python) == null ? void 0 : _b2.version) !== "3.13.14" || !Array.isArray(value.files) || value.files.length === 0) {
@@ -17625,6 +17651,66 @@
       }
       return { manifest: value, byPath };
     }
+    async function inspectPackagedPayload() {
+      const { manifest, byPath } = validateBundleManifest(
+        await readJson2(packageManifestPath, "RUNTIME_BUNDLE_INVALID")
+      );
+      const runtimeManifestRelative = `runtime/${platform.id}/runtime-manifest.json`;
+      const launcherRelative = `platform/${platform.id}/bin/ae-mcp`;
+      const nodeRelative = `runtime/${platform.id}/node/bin/node`;
+      const pythonRelative = `runtime/${platform.id}/python/bin/python3`;
+      const runtimeRecord = byPath.get(runtimeManifestRelative);
+      const launcherRecord = byPath.get(launcherRelative);
+      const nodeRecord = byPath.get(nodeRelative);
+      const pythonRecord = byPath.get(pythonRelative);
+      if (!runtimeRecord || runtimeRecord.type !== "file" || runtimeRecord.sha256 !== manifest.runtime.manifestSha256 || !Number.isSafeInteger(runtimeRecord.size) || runtimeRecord.size <= 0 || !launcherRecord || launcherRecord.type !== "file" || !Number.isSafeInteger(launcherRecord.size) || launcherRecord.size <= 0 || !nodeRecord || nodeRecord.type !== "file" || !Number.isSafeInteger(nodeRecord.size) || nodeRecord.size <= 0 || !pythonRecord || pythonRecord.type !== "file" || !Number.isSafeInteger(pythonRecord.size) || pythonRecord.size <= 0) {
+        failure("RUNTIME_BUNDLE_INVALID", "Packaged runtime entrypoints or stable launcher are not declared");
+      }
+      const runtimeManifestSignal = await ordinaryFileSignal(
+        packagedRuntimeManifest,
+        "RUNTIME_BUNDLE_METADATA_CHANGED",
+        { expectedMode: runtimeRecord.mode, expectedSize: runtimeRecord.size }
+      );
+      const launcherSignal = await ordinaryFileSignal(
+        packagedLauncher,
+        "RUNTIME_BUNDLE_METADATA_CHANGED",
+        {
+          executable: true,
+          expectedMode: launcherRecord.mode,
+          expectedSize: launcherRecord.size
+        }
+      );
+      const nodeSignal = await ordinaryFileSignal(
+        paths.join([packagedRuntimeRoot, "node", "bin", "node"]),
+        "RUNTIME_BUNDLE_METADATA_CHANGED",
+        {
+          executable: true,
+          expectedMode: nodeRecord.mode,
+          expectedSize: nodeRecord.size
+        }
+      );
+      const pythonSignal = await ordinaryFileSignal(
+        paths.join([packagedRuntimeRoot, "python", "bin", "python3"]),
+        "RUNTIME_BUNDLE_METADATA_CHANGED",
+        {
+          executable: true,
+          expectedMode: pythonRecord.mode,
+          expectedSize: pythonRecord.size
+        }
+      );
+      return {
+        version: manifest.version,
+        sourceCommitSha: manifest.sourceCommitSha,
+        runtimeManifestSha256: manifest.runtime.manifestSha256,
+        launcherSha256: launcherRecord.sha256,
+        signals: {
+          runtimeManifest: runtimeManifestSignal,
+          launcher: launcherSignal,
+          node: nodeSignal,
+          python: pythonSignal
+        }
+      };
+    }
     async function verifyPackagedPayload() {
       const { manifest, byPath } = validateBundleManifest(
         await readJson2(packageManifestPath, "RUNTIME_BUNDLE_INVALID")
@@ -17653,11 +17739,7 @@
     function generationLauncherPath(relative) {
       return paths.join([root, relative.split("/")[0], GENERATION_LAUNCHER]);
     }
-    async function verifyInstalled(relative) {
-      var _a2;
-      const normalized = pointerValue(relative, platform.id);
-      if (!normalized) failure("RUNTIME_POINTER_INVALID", "Runtime pointer is invalid");
-      const record = await readJson2(installRecordPath(normalized), "RUNTIME_INSTALL_RECORD_INVALID");
+    function validateInstallRecord(record, normalized) {
       if (!exactKeys(record, [
         "installedAt",
         "launcherSha256",
@@ -17670,14 +17752,57 @@
       ]) || record.schemaVersion !== 1 || record.platform !== platform.id || record.relative !== normalized || !SEMVER.test(record.version) || !SOURCE_SHA.test(record.sourceCommitSha) || !SHA256.test(record.runtimeManifestSha256) || !SHA256.test(record.launcherSha256) || !Number.isSafeInteger(record.installedAt) || record.installedAt < 0) {
         failure("RUNTIME_INSTALL_RECORD_INVALID", "Runtime install record is invalid");
       }
+      return record;
+    }
+    async function inspectInstalled(relative) {
+      const normalized = pointerValue(relative, platform.id);
+      if (!normalized) failure("RUNTIME_POINTER_INVALID", "Runtime pointer is invalid");
+      const record = validateInstallRecord(
+        await readJson2(installRecordPath(normalized), "RUNTIME_INSTALL_RECORD_INVALID"),
+        normalized
+      );
       const directory = paths.join([root, ...normalized.split("/")]);
+      const signals = {
+        runtimeManifest: await ordinaryFileSignal(
+          paths.join([directory, "runtime-manifest.json"]),
+          "RUNTIME_TRUST_SIGNAL_CHANGED",
+          {}
+        ),
+        launcher: await ordinaryFileSignal(
+          generationLauncherPath(normalized),
+          "RUNTIME_TRUST_SIGNAL_CHANGED",
+          { executable: true, expectedMode: "0755" }
+        ),
+        node: await ordinaryFileSignal(
+          paths.join([directory, "node", "bin", "node"]),
+          "RUNTIME_TRUST_SIGNAL_CHANGED",
+          { executable: true }
+        ),
+        python: await ordinaryFileSignal(
+          paths.join([directory, "python", "bin", "python3"]),
+          "RUNTIME_TRUST_SIGNAL_CHANGED",
+          { executable: true }
+        )
+      };
+      return {
+        relative: normalized,
+        directory,
+        launcher: generationLauncherPath(normalized),
+        record,
+        signals
+      };
+    }
+    async function verifyInstalled(relative) {
+      var _a2;
+      const selected = await inspectInstalled(relative);
+      const { record, directory } = selected;
       await verifyRuntime(directory, record.runtimeManifestSha256);
-      const launcher = generationLauncherPath(normalized);
+      const launcher = selected.launcher;
       const launcherInfo = await promises.lstat(launcher);
       if (!launcherInfo.isFile() || ((_a2 = launcherInfo.isSymbolicLink) == null ? void 0 : _a2.call(launcherInfo)) || launcherInfo.nlink !== 1 || modeOf(launcherInfo) !== "0755" || await sha256File(launcher) !== record.launcherSha256) {
         failure("RUNTIME_LAUNCHER_CORRUPT", "Runtime generation launcher failed verification");
       }
-      return { relative: normalized, directory, launcher, record };
+      return selected;
     }
     async function pointerState(pointerPath) {
       var _a2;
@@ -17689,7 +17814,7 @@
         const relative = pointerValue(await promises.readFile(pointerPath, "utf8"), platform.id);
         if (!relative) return { exists: true, ok: false, code: "RUNTIME_POINTER_INVALID" };
         try {
-          return { exists: true, ok: true, ...await verifyInstalled(relative) };
+          return { exists: true, ok: true, ...await inspectInstalled(relative) };
         } catch (error) {
           const normalized = runtimeError(error);
           return { exists: true, ok: false, relative, code: normalized.code, detail: normalized.message };
@@ -17743,20 +17868,30 @@
       }
     }
     async function installLauncher(selected) {
-      var _a2;
       try {
-        const info = await promises.lstat(paths.launcher);
-        if (info.isFile() && !((_a2 = info.isSymbolicLink) == null ? void 0 : _a2.call(info)) && info.nlink === 1 && modeOf(info) === "0755" && await sha256File(paths.launcher) === selected.record.launcherSha256) return;
+        const source = await ordinaryFileSignal(
+          selected.launcher,
+          "RUNTIME_LAUNCHER_CORRUPT",
+          { executable: true, expectedMode: "0755" }
+        );
+        await ordinaryFileSignal(
+          paths.launcher,
+          "RUNTIME_LAUNCHER_CORRUPT",
+          { executable: true, expectedMode: "0755", expectedSize: source.size }
+        );
+        return;
       } catch (error) {
-        if ((error == null ? void 0 : error.code) !== "ENOENT" && !(error instanceof RuntimeManagerError)) throw error;
+        if (!(error instanceof RuntimeManagerError) && (error == null ? void 0 : error.code) !== "ENOENT") throw error;
       }
       await promises.mkdir(paths.binRoot, { recursive: true, mode: 448 });
       const bytes = await promises.readFile(selected.launcher);
       await atomicWrite(paths.launcher, bytes, 493);
       await promises.chmod(paths.launcher, 493);
-      if (await sha256File(paths.launcher) !== selected.record.launcherSha256) {
-        failure("RUNTIME_LAUNCHER_CORRUPT", "Installed stable launcher failed verification");
-      }
+      await ordinaryFileSignal(
+        paths.launcher,
+        "RUNTIME_LAUNCHER_CORRUPT",
+        { executable: true, expectedMode: "0755", expectedSize: bytes.length }
+      );
     }
     function assertLauncherTransitionCompatible(selected, current) {
       if (!(current == null ? void 0 : current.ok) || current.relative === selected.relative) return;
@@ -17878,7 +18013,7 @@
     function ensureReady() {
       if (readinessPromise) return readinessPromise;
       const pending = withLock(async () => {
-        const current = await pointerState(paths.currentPointer);
+        let current = await pointerState(paths.currentPointer);
         const previous = await pointerState(paths.previousPointer);
         if (!current.ok && previous.ok) {
           await installLauncher(previous);
@@ -17900,7 +18035,7 @@
         }
         let packaged;
         try {
-          packaged = await verifyPackagedPayload();
+          packaged = await inspectPackagedPayload();
         } catch (error) {
           if (!current.ok) throw error;
           await installLauncher(current);
@@ -17918,7 +18053,9 @@
             }]
           };
         }
-        if (current.ok && current.record.version === packaged.version && current.record.sourceCommitSha === packaged.sourceCommitSha && current.record.runtimeManifestSha256 === packaged.runtimeManifestSha256) {
+        const declaredRuntimeMatches = current.ok && current.record.version === packaged.version && current.record.runtimeManifestSha256 === packaged.runtimeManifestSha256 && current.record.launcherSha256 === packaged.launcherSha256;
+        const trustedSignalsMatch = declaredRuntimeMatches && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size && current.signals.launcher.size === packaged.signals.launcher.size && current.signals.node.size === packaged.signals.node.size && current.signals.python.size === packaged.signals.python.size;
+        if (trustedSignalsMatch) {
           await installLauncher(current);
           return {
             ok: true,
@@ -17927,9 +18064,23 @@
             relative: current.relative,
             version: current.record.version,
             sourceCommitSha: current.record.sourceCommitSha,
-            diagnostics: []
+            packagedSourceCommitSha: packaged.sourceCommitSha,
+            trustSignals: current.signals,
+            diagnostics: current.record.sourceCommitSha === packaged.sourceCommitSha ? [] : [{
+              code: "RUNTIME_SOURCE_REVISION_DIFFERENT_TRUSTED",
+              message: "The unchanged installed runtime was reused across an advisory source revision change."
+            }]
           };
         }
+        if (declaredRuntimeMatches) {
+          current = {
+            ...current,
+            ok: false,
+            code: "RUNTIME_TRUST_SIGNAL_CHANGED",
+            detail: "A bounded runtime size or metadata signal changed."
+          };
+        }
+        packaged = await verifyPackagedPayload();
         const selected = await installPackaged(packaged);
         assertLauncherTransitionCompatible(selected, current);
         await installLauncher(selected);
@@ -18022,8 +18173,8 @@
       let launcher = { ok: false, code: "RUNTIME_LAUNCHER_MISSING", path: paths.launcher };
       try {
         const info = await promises.lstat(paths.launcher);
-        const digestOk = current.ok ? await sha256File(paths.launcher) === current.record.launcherSha256 : true;
-        launcher = info.isFile() && !((_a2 = info.isSymbolicLink) == null ? void 0 : _a2.call(info)) && modeOf(info) === "0755" && digestOk ? { ok: true, path: paths.launcher } : { ok: false, code: "RUNTIME_LAUNCHER_INVALID", path: paths.launcher };
+        const sourceSize = current.ok ? current.signals.launcher.size : info.size;
+        launcher = info.isFile() && !((_a2 = info.isSymbolicLink) == null ? void 0 : _a2.call(info)) && info.nlink === 1 && modeOf(info) === "0755" && info.size === sourceSize ? { ok: true, path: paths.launcher } : { ok: false, code: "RUNTIME_LAUNCHER_INVALID", path: paths.launcher };
       } catch (error) {
         if ((error == null ? void 0 : error.code) !== "ENOENT") launcher = { ok: false, code: "RUNTIME_LAUNCHER_INVALID", path: paths.launcher };
       }

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -251,6 +251,15 @@ function installProtocol(server, options) {
                 assert.equal(bytes.subarray(0, 8).toString('ascii'), 'AEMCP-A1');
                 assert.notDeepEqual(bytes.subarray(8, 24), Buffer.alloc(16));
                 bytes = bytes.subarray(24);
+                if (input.autoAuthorize) {
+                    authenticated = true;
+                    socket.write(Buffer.concat([
+                        pendingMessage(),
+                        decisionMessage(1, SESSION, 7),
+                    ]));
+                    consume();
+                    return;
+                }
                 socket.write(pendingMessage());
                 authorized.then(function () {
                     authenticated = true;
@@ -520,6 +529,28 @@ function installProtocol(server, options) {
     });
     return { authorize, requests };
 }
+
+test('CEP client accepts a local pending and authorized decision without an external pairing step', {
+    skip: process.platform === 'win32' ? 'Unix-domain sockets are not available on Windows CI' : false,
+}, async (t) => {
+    const fixture = await endpointFixture(t);
+    installProtocol(fixture.server, { autoAuthorize: true });
+    const client = createNativeAegpClient({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        runtimeRoot: fixture.root,
+        clientInstanceId: CLIENT,
+        requestTimeoutMs: 2000,
+        now: function () { return 1900000000000; },
+    });
+    t.after(function () { return client.close(); });
+
+    const pending = await client.beginPairing();
+    assert.equal(pending.hostInstanceId, HOST);
+    const hello = await client.waitUntilConnected();
+
+    assert.equal(hello.host.instanceId, HOST);
+    assert.equal(client.status().state, 'connected');
+});
 
 async function readyNativeClient(t, protocolOptions) {
     const endpoint = await endpointFixture(t);

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -592,7 +592,9 @@ async function connectedNativeClient(deadlineUnixMs) {
         await client.waitUntilConnected(deadlineUnixMs);
         return client;
     }
-    return nativePairingRequired(client, deadlineUnixMs);
+    await client.beginPairing(deadlineUnixMs);
+    await client.waitUntilConnected(deadlineUnixMs);
+    return client;
 }
 
 function sendNativeFailure(res, error) {

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -694,7 +694,7 @@ test('native routes require the shared token and reject an open-ended invoke env
     }
 });
 
-test('native routes expose pairing then preserve Core negotiation, registry, and invoke fields', async () => {
+test('native routes auto-connect locally then preserve Core negotiation, registry, and invoke fields', async () => {
     const nativeClient = fakeNativeClient();
     const { server, srv, port } = await startNativeApp(nativeClient);
     const headers = {
@@ -703,29 +703,17 @@ test('native routes expose pairing then preserve Core negotiation, registry, and
     };
     try {
         const deadlineUnixMs = Date.now() + 10000;
-        const pairing = await post(port, '/native/negotiate', headers, {
-            deadlineUnixMs,
-        });
-        assert.strictEqual(pairing.status, 409);
-        assert.strictEqual(pairing.body.error.code, 'NATIVE_PAIRING_REQUIRED');
-        assert.strictEqual(pairing.body.error.recovery.action, 'approve-pairing');
-        assert.deepStrictEqual(pairing.body.error.details, {
-            pairingFingerprint: '12AB-34CD',
-            pairingExpiresInMs: 60000,
-            hostInstanceId: '22222222-2222-4222-8222-222222222222',
-            sourceCommit: 'a'.repeat(40),
-        });
-        assert.strictEqual(pairing.body.pairing.fingerprint, '12AB-34CD');
-        assert.strictEqual(pairing.body.pairing.sourceCommit, 'a'.repeat(40));
-        assert.doesNotMatch(JSON.stringify(server.activity.list()), /12AB-34CD/);
-
-        nativeClient.authorize();
         const negotiated = await post(port, '/native/negotiate', headers, {
             deadlineUnixMs,
         });
         assert.strictEqual(negotiated.status, 200);
         assert.strictEqual(negotiated.body.result.sourceCommit, 'a'.repeat(40));
         assert.strictEqual(negotiated.body.result.compiledSdkVersion, '25.6.61');
+        assert.deepStrictEqual(nativeClient.calls.slice(0, 3), [
+            'pair',
+            ['wait', deadlineUnixMs],
+            ['negotiate', { deadlineUnixMs }],
+        ]);
 
         const capabilities = await post(port, '/native/capabilities', headers, {
             detail: 'full', limit: 100, deadlineUnixMs,
@@ -996,6 +984,7 @@ test('native routes expose pairing then preserve Core negotiation, registry, and
         assert.strictEqual(layerPropertySet.body.result.evidence.effect, 'committed');
         assert.deepStrictEqual(nativeClient.calls, [
             'pair',
+            ['wait', deadlineUnixMs],
             ['negotiate', { deadlineUnixMs }],
             ['capabilities', { detail: 'full', limit: 100, deadlineUnixMs }],
             ['invoke', {

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -143,6 +143,39 @@ export function createRuntimeManager({
     }
   }
 
+  async function ordinaryFileSignal(
+    filePath,
+    code,
+    {
+      executable = false,
+      expectedMode,
+      expectedSize,
+    } = {},
+  ) {
+    let info;
+    try {
+      info = await promises.lstat(filePath);
+    } catch (error) {
+      failure(code, 'Trusted local runtime metadata is missing', { path: filePath });
+    }
+    if (!info.isFile() || info.isSymbolicLink?.() || info.nlink !== 1
+        || (executable && (info.mode & 0o111) === 0)
+        || (expectedMode && modeOf(info) !== expectedMode)
+        || (Number.isSafeInteger(expectedSize) && info.size !== expectedSize)) {
+      failure(code, 'Trusted local runtime metadata changed', {
+        path: filePath,
+        size: info.size,
+        mtimeMs: Math.trunc(info.mtimeMs),
+      });
+    }
+    return {
+      path: filePath,
+      size: info.size,
+      mtimeMs: Math.trunc(info.mtimeMs),
+      mode: modeOf(info),
+    };
+  }
+
   function validateRuntimeManifest(value) {
     if (!value || value.schemaVersion !== 1 || value.platform !== platform.id
         || value.node?.version !== '24.17.0' || value.python?.version !== '3.13.14'
@@ -239,6 +272,75 @@ export function createRuntimeManager({
     return { manifest: value, byPath };
   }
 
+  async function inspectPackagedPayload() {
+    const { manifest, byPath } = validateBundleManifest(
+      await readJson(packageManifestPath, 'RUNTIME_BUNDLE_INVALID'),
+    );
+    const runtimeManifestRelative = `runtime/${platform.id}/runtime-manifest.json`;
+    const launcherRelative = `platform/${platform.id}/bin/ae-mcp`;
+    const nodeRelative = `runtime/${platform.id}/node/bin/node`;
+    const pythonRelative = `runtime/${platform.id}/python/bin/python3`;
+    const runtimeRecord = byPath.get(runtimeManifestRelative);
+    const launcherRecord = byPath.get(launcherRelative);
+    const nodeRecord = byPath.get(nodeRelative);
+    const pythonRecord = byPath.get(pythonRelative);
+    if (!runtimeRecord || runtimeRecord.type !== 'file'
+        || runtimeRecord.sha256 !== manifest.runtime.manifestSha256
+        || !Number.isSafeInteger(runtimeRecord.size) || runtimeRecord.size <= 0
+        || !launcherRecord || launcherRecord.type !== 'file'
+        || !Number.isSafeInteger(launcherRecord.size) || launcherRecord.size <= 0
+        || !nodeRecord || nodeRecord.type !== 'file'
+        || !Number.isSafeInteger(nodeRecord.size) || nodeRecord.size <= 0
+        || !pythonRecord || pythonRecord.type !== 'file'
+        || !Number.isSafeInteger(pythonRecord.size) || pythonRecord.size <= 0) {
+      failure('RUNTIME_BUNDLE_INVALID', 'Packaged runtime entrypoints or stable launcher are not declared');
+    }
+    const runtimeManifestSignal = await ordinaryFileSignal(
+      packagedRuntimeManifest,
+      'RUNTIME_BUNDLE_METADATA_CHANGED',
+      { expectedMode: runtimeRecord.mode, expectedSize: runtimeRecord.size },
+    );
+    const launcherSignal = await ordinaryFileSignal(
+      packagedLauncher,
+      'RUNTIME_BUNDLE_METADATA_CHANGED',
+      {
+        executable: true,
+        expectedMode: launcherRecord.mode,
+        expectedSize: launcherRecord.size,
+      },
+    );
+    const nodeSignal = await ordinaryFileSignal(
+      paths.join([packagedRuntimeRoot, 'node', 'bin', 'node']),
+      'RUNTIME_BUNDLE_METADATA_CHANGED',
+      {
+        executable: true,
+        expectedMode: nodeRecord.mode,
+        expectedSize: nodeRecord.size,
+      },
+    );
+    const pythonSignal = await ordinaryFileSignal(
+      paths.join([packagedRuntimeRoot, 'python', 'bin', 'python3']),
+      'RUNTIME_BUNDLE_METADATA_CHANGED',
+      {
+        executable: true,
+        expectedMode: pythonRecord.mode,
+        expectedSize: pythonRecord.size,
+      },
+    );
+    return {
+      version: manifest.version,
+      sourceCommitSha: manifest.sourceCommitSha,
+      runtimeManifestSha256: manifest.runtime.manifestSha256,
+      launcherSha256: launcherRecord.sha256,
+      signals: {
+        runtimeManifest: runtimeManifestSignal,
+        launcher: launcherSignal,
+        node: nodeSignal,
+        python: pythonSignal,
+      },
+    };
+  }
+
   async function verifyPackagedPayload() {
     const { manifest, byPath } = validateBundleManifest(
       await readJson(packageManifestPath, 'RUNTIME_BUNDLE_INVALID'),
@@ -273,10 +375,7 @@ export function createRuntimeManager({
     return paths.join([root, relative.split('/')[0], GENERATION_LAUNCHER]);
   }
 
-  async function verifyInstalled(relative) {
-    const normalized = pointerValue(relative, platform.id);
-    if (!normalized) failure('RUNTIME_POINTER_INVALID', 'Runtime pointer is invalid');
-    const record = await readJson(installRecordPath(normalized), 'RUNTIME_INSTALL_RECORD_INVALID');
+  function validateInstallRecord(record, normalized) {
     if (!exactKeys(record, [
       'installedAt', 'launcherSha256', 'platform', 'relative', 'runtimeManifestSha256',
       'schemaVersion', 'sourceCommitSha', 'version',
@@ -287,15 +386,59 @@ export function createRuntimeManager({
         || !Number.isSafeInteger(record.installedAt) || record.installedAt < 0) {
       failure('RUNTIME_INSTALL_RECORD_INVALID', 'Runtime install record is invalid');
     }
+    return record;
+  }
+
+  async function inspectInstalled(relative) {
+    const normalized = pointerValue(relative, platform.id);
+    if (!normalized) failure('RUNTIME_POINTER_INVALID', 'Runtime pointer is invalid');
+    const record = validateInstallRecord(
+      await readJson(installRecordPath(normalized), 'RUNTIME_INSTALL_RECORD_INVALID'),
+      normalized,
+    );
     const directory = paths.join([root, ...normalized.split('/')]);
+    const signals = {
+      runtimeManifest: await ordinaryFileSignal(
+        paths.join([directory, 'runtime-manifest.json']),
+        'RUNTIME_TRUST_SIGNAL_CHANGED',
+        {},
+      ),
+      launcher: await ordinaryFileSignal(
+        generationLauncherPath(normalized),
+        'RUNTIME_TRUST_SIGNAL_CHANGED',
+        { executable: true, expectedMode: '0755' },
+      ),
+      node: await ordinaryFileSignal(
+        paths.join([directory, 'node', 'bin', 'node']),
+        'RUNTIME_TRUST_SIGNAL_CHANGED',
+        { executable: true },
+      ),
+      python: await ordinaryFileSignal(
+        paths.join([directory, 'python', 'bin', 'python3']),
+        'RUNTIME_TRUST_SIGNAL_CHANGED',
+        { executable: true },
+      ),
+    };
+    return {
+      relative: normalized,
+      directory,
+      launcher: generationLauncherPath(normalized),
+      record,
+      signals,
+    };
+  }
+
+  async function verifyInstalled(relative) {
+    const selected = await inspectInstalled(relative);
+    const { record, directory } = selected;
     await verifyRuntime(directory, record.runtimeManifestSha256);
-    const launcher = generationLauncherPath(normalized);
+    const launcher = selected.launcher;
     const launcherInfo = await promises.lstat(launcher);
     if (!launcherInfo.isFile() || launcherInfo.isSymbolicLink?.() || launcherInfo.nlink !== 1
         || modeOf(launcherInfo) !== '0755' || await sha256File(launcher) !== record.launcherSha256) {
       failure('RUNTIME_LAUNCHER_CORRUPT', 'Runtime generation launcher failed verification');
     }
-    return { relative: normalized, directory, launcher, record };
+    return selected;
   }
 
   async function pointerState(pointerPath) {
@@ -307,7 +450,7 @@ export function createRuntimeManager({
       const relative = pointerValue(await promises.readFile(pointerPath, 'utf8'), platform.id);
       if (!relative) return { exists: true, ok: false, code: 'RUNTIME_POINTER_INVALID' };
       try {
-        return { exists: true, ok: true, ...(await verifyInstalled(relative)) };
+        return { exists: true, ok: true, ...(await inspectInstalled(relative)) };
       } catch (error) {
         const normalized = runtimeError(error);
         return { exists: true, ok: false, relative, code: normalized.code, detail: normalized.message };
@@ -364,19 +507,29 @@ export function createRuntimeManager({
 
   async function installLauncher(selected) {
     try {
-      const info = await promises.lstat(paths.launcher);
-      if (info.isFile() && !info.isSymbolicLink?.() && info.nlink === 1
-          && modeOf(info) === '0755' && await sha256File(paths.launcher) === selected.record.launcherSha256) return;
+      const source = await ordinaryFileSignal(
+        selected.launcher,
+        'RUNTIME_LAUNCHER_CORRUPT',
+        { executable: true, expectedMode: '0755' },
+      );
+      await ordinaryFileSignal(
+        paths.launcher,
+        'RUNTIME_LAUNCHER_CORRUPT',
+        { executable: true, expectedMode: '0755', expectedSize: source.size },
+      );
+      return;
     } catch (error) {
-      if (error?.code !== 'ENOENT' && !(error instanceof RuntimeManagerError)) throw error;
+      if (!(error instanceof RuntimeManagerError) && error?.code !== 'ENOENT') throw error;
     }
     await promises.mkdir(paths.binRoot, { recursive: true, mode: 0o700 });
     const bytes = await promises.readFile(selected.launcher);
     await atomicWrite(paths.launcher, bytes, 0o755);
     await promises.chmod(paths.launcher, 0o755);
-    if (await sha256File(paths.launcher) !== selected.record.launcherSha256) {
-      failure('RUNTIME_LAUNCHER_CORRUPT', 'Installed stable launcher failed verification');
-    }
+    await ordinaryFileSignal(
+      paths.launcher,
+      'RUNTIME_LAUNCHER_CORRUPT',
+      { executable: true, expectedMode: '0755', expectedSize: bytes.length },
+    );
   }
 
   function assertLauncherTransitionCompatible(selected, current) {
@@ -498,7 +651,7 @@ export function createRuntimeManager({
   function ensureReady() {
     if (readinessPromise) return readinessPromise;
     const pending = withLock(async () => {
-      const current = await pointerState(paths.currentPointer);
+      let current = await pointerState(paths.currentPointer);
       const previous = await pointerState(paths.previousPointer);
       if (!current.ok && previous.ok) {
         await installLauncher(previous);
@@ -520,7 +673,7 @@ export function createRuntimeManager({
       }
       let packaged;
       try {
-        packaged = await verifyPackagedPayload();
+        packaged = await inspectPackagedPayload();
       } catch (error) {
         if (!current.ok) throw error;
         await installLauncher(current);
@@ -538,16 +691,38 @@ export function createRuntimeManager({
           }],
         };
       }
-      if (current.ok
-          && current.record.version === packaged.version
-          && current.record.sourceCommitSha === packaged.sourceCommitSha
-          && current.record.runtimeManifestSha256 === packaged.runtimeManifestSha256) {
+      const declaredRuntimeMatches = current.ok
+        && current.record.version === packaged.version
+        && current.record.runtimeManifestSha256 === packaged.runtimeManifestSha256
+        && current.record.launcherSha256 === packaged.launcherSha256;
+      const trustedSignalsMatch = declaredRuntimeMatches
+        && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size
+        && current.signals.launcher.size === packaged.signals.launcher.size
+        && current.signals.node.size === packaged.signals.node.size
+        && current.signals.python.size === packaged.signals.python.size;
+      if (trustedSignalsMatch) {
         await installLauncher(current);
         return {
           ok: true, action: 'ready', launcher: paths.launcher, relative: current.relative,
-          version: current.record.version, sourceCommitSha: current.record.sourceCommitSha, diagnostics: [],
+          version: current.record.version,
+          sourceCommitSha: current.record.sourceCommitSha,
+          packagedSourceCommitSha: packaged.sourceCommitSha,
+          trustSignals: current.signals,
+          diagnostics: current.record.sourceCommitSha === packaged.sourceCommitSha ? [] : [{
+            code: 'RUNTIME_SOURCE_REVISION_DIFFERENT_TRUSTED',
+            message: 'The unchanged installed runtime was reused across an advisory source revision change.',
+          }],
         };
       }
+      if (declaredRuntimeMatches) {
+        current = {
+          ...current,
+          ok: false,
+          code: 'RUNTIME_TRUST_SIGNAL_CHANGED',
+          detail: 'A bounded runtime size or metadata signal changed.',
+        };
+      }
+      packaged = await verifyPackagedPayload();
       const selected = await installPackaged(packaged);
       assertLauncherTransitionCompatible(selected, current);
       await installLauncher(selected);
@@ -634,10 +809,9 @@ export function createRuntimeManager({
     let launcher = { ok: false, code: 'RUNTIME_LAUNCHER_MISSING', path: paths.launcher };
     try {
       const info = await promises.lstat(paths.launcher);
-      const digestOk = current.ok
-        ? await sha256File(paths.launcher) === current.record.launcherSha256
-        : true;
-      launcher = info.isFile() && !info.isSymbolicLink?.() && modeOf(info) === '0755' && digestOk
+      const sourceSize = current.ok ? current.signals.launcher.size : info.size;
+      launcher = info.isFile() && !info.isSymbolicLink?.() && info.nlink === 1
+          && modeOf(info) === '0755' && info.size === sourceSize
         ? { ok: true, path: paths.launcher }
         : { ok: false, code: 'RUNTIME_LAUNCHER_INVALID', path: paths.launcher };
     } catch (error) {

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -176,6 +176,73 @@ export function createRuntimeManager({
     };
   }
 
+  async function executableSignal(
+    filePath,
+    code,
+    {
+      rootDirectory,
+      expectedMode,
+      expectedSize,
+      expectedType,
+    } = {},
+  ) {
+    let info;
+    try {
+      info = await promises.lstat(filePath);
+    } catch (error) {
+      failure(code, 'Trusted local runtime entrypoint is missing', { path: filePath });
+    }
+    const type = info.isSymbolicLink?.() ? 'symlink' : 'file';
+    if ((expectedType && type !== expectedType)
+        || (expectedMode && modeOf(info) !== expectedMode)
+        || (Number.isSafeInteger(expectedSize) && info.size !== expectedSize)) {
+      failure(code, 'Trusted local runtime entrypoint metadata changed', {
+        path: filePath,
+        size: info.size,
+        mtimeMs: Math.trunc(info.mtimeMs),
+      });
+    }
+    if (type === 'file') {
+      if (!info.isFile() || info.nlink !== 1 || (info.mode & 0o111) === 0) {
+        failure(code, 'Trusted local runtime entrypoint changed', { path: filePath });
+      }
+      return {
+        path: filePath,
+        type,
+        size: info.size,
+        mtimeMs: Math.trunc(info.mtimeMs),
+        mode: modeOf(info),
+      };
+    }
+    let target;
+    let targetInfo;
+    try {
+      target = await promises.readlink(filePath);
+      const resolved = paths.resolve([paths.dirname(filePath), target]);
+      if (!rootDirectory || paths.isAbsolute(target) || !paths.contains(rootDirectory, resolved)) {
+        failure(code, 'Trusted local runtime entrypoint symlink is unsafe', { path: filePath });
+      }
+      targetInfo = await promises.lstat(resolved);
+    } catch (error) {
+      if (error instanceof RuntimeManagerError) throw error;
+      failure(code, 'Trusted local runtime entrypoint symlink is invalid', { path: filePath });
+    }
+    if (!targetInfo.isFile() || targetInfo.isSymbolicLink?.() || targetInfo.nlink !== 1
+        || (targetInfo.mode & 0o111) === 0) {
+      failure(code, 'Trusted local runtime entrypoint target changed', { path: filePath });
+    }
+    return {
+      path: filePath,
+      type,
+      size: targetInfo.size,
+      mtimeMs: Math.trunc(targetInfo.mtimeMs),
+      mode: modeOf(targetInfo),
+      linkTarget: target,
+      linkSize: info.size,
+      linkMtimeMs: Math.trunc(info.mtimeMs),
+    };
+  }
+
   function validateRuntimeManifest(value) {
     if (!value || value.schemaVersion !== 1 || value.platform !== platform.id
         || value.node?.version !== '24.17.0' || value.python?.version !== '3.13.14'
@@ -291,7 +358,7 @@ export function createRuntimeManager({
         || !Number.isSafeInteger(launcherRecord.size) || launcherRecord.size <= 0
         || !nodeRecord || nodeRecord.type !== 'file'
         || !Number.isSafeInteger(nodeRecord.size) || nodeRecord.size <= 0
-        || !pythonRecord || pythonRecord.type !== 'file'
+        || !pythonRecord || !['file', 'symlink'].includes(pythonRecord.type)
         || !Number.isSafeInteger(pythonRecord.size) || pythonRecord.size <= 0) {
       failure('RUNTIME_BUNDLE_INVALID', 'Packaged runtime entrypoints or stable launcher are not declared');
     }
@@ -318,13 +385,14 @@ export function createRuntimeManager({
         expectedSize: nodeRecord.size,
       },
     );
-    const pythonSignal = await ordinaryFileSignal(
+    const pythonSignal = await executableSignal(
       paths.join([packagedRuntimeRoot, 'python', 'bin', 'python3']),
       'RUNTIME_BUNDLE_METADATA_CHANGED',
       {
-        executable: true,
+        rootDirectory: packagedRuntimeRoot,
         expectedMode: pythonRecord.mode,
         expectedSize: pythonRecord.size,
+        expectedType: pythonRecord.type,
       },
     );
     return {
@@ -413,10 +481,10 @@ export function createRuntimeManager({
         'RUNTIME_TRUST_SIGNAL_CHANGED',
         { executable: true },
       ),
-      python: await ordinaryFileSignal(
+      python: await executableSignal(
         paths.join([directory, 'python', 'bin', 'python3']),
         'RUNTIME_TRUST_SIGNAL_CHANGED',
-        { executable: true },
+        { rootDirectory: directory },
       ),
     };
     return {
@@ -699,7 +767,9 @@ export function createRuntimeManager({
         && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size
         && current.signals.launcher.size === packaged.signals.launcher.size
         && current.signals.node.size === packaged.signals.node.size
-        && current.signals.python.size === packaged.signals.python.size;
+        && current.signals.python.size === packaged.signals.python.size
+        && current.signals.python.type === packaged.signals.python.type
+        && current.signals.python.linkTarget === packaged.signals.python.linkTarget;
       if (trustedSignalsMatch) {
         await installLauncher(current);
         return {

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -118,6 +118,9 @@ async function packageFixture(base, {
   );
   const runtimeManifestSha256 = await sha256File(runtimeManifestPath);
   const launcherSha256 = await sha256File(launcher);
+  const inventoryByPath = new Map(files.map((record) => [record.path, record]));
+  const nodeRecord = inventoryByPath.get('node/bin/node');
+  const pythonRecord = inventoryByPath.get('python/bin/python3');
   await writeFile(extensionRoot, 'bundle-manifest.json', `${JSON.stringify({
     schemaVersion: 1,
     version,
@@ -139,6 +142,14 @@ async function packageFixture(base, {
       {
         path: 'runtime/macos-arm64/runtime-manifest.json', type: 'file',
         size: (await fs.promises.stat(runtimeManifestPath)).size, mode: '0644', sha256: runtimeManifestSha256,
+      },
+      {
+        ...nodeRecord,
+        path: `runtime/macos-arm64/${nodeRecord.path}`,
+      },
+      {
+        ...pythonRecord,
+        path: `runtime/macos-arm64/${pythonRecord.path}`,
       },
     ],
   }, null, 2)}\n`);
@@ -221,7 +232,7 @@ macosRuntimeTest('upgrade, downgrade, and rollback atomically select verified ve
   assert.equal(state.previous.record.version, '0.10.0');
 });
 
-macosRuntimeTest('a corrupt current runtime falls back once, then a later call repairs from the offline payload', async (t) => {
+macosRuntimeTest('a changed critical runtime signal triggers a verified repair without retaining the bad generation', async (t) => {
   const h = await harness(t);
   const v1 = await packageFixture(h.root, {
     version: '0.9.3', sourceCommitSha: '1'.repeat(40), marker: 'one',
@@ -236,19 +247,19 @@ macosRuntimeTest('a corrupt current runtime falls back once, then a later call r
   const current = (await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8')).trim();
   await fs.promises.appendFile(path.join(h.platform.paths.runtimeRoot, current, 'python', 'bin', 'python3'), '# corrupt\n');
 
-  const fallback = await two.ensureReady();
+  const repaired = await two.ensureReady();
 
-  assert.equal(fallback.action, 'fallback');
-  assert.equal(fallback.version, '0.9.3');
-  assert.equal(fallback.diagnostics[0].code, 'RUNTIME_CURRENT_INVALID_FALLBACK');
-  const launched = await execFileAsync(h.platform.paths.launcher, ['--fallback'], {
+  assert.equal(repaired.action, 'repair');
+  assert.equal(repaired.version, '0.10.0');
+  assert.equal(repaired.diagnostics[0].code, 'RUNTIME_CURRENT_REPAIRED');
+  const launched = await execFileAsync(h.platform.paths.launcher, ['--repaired'], {
     env: { HOME: h.home, AE_MCP_HOME: h.platform.paths.configRoot, PATH: '/usr/bin:/bin' },
   });
-  assert.match(launched.stdout, /core-started:one:-B -I -m ae_mcp --fallback/);
+  assert.match(launched.stdout, /core-started:two:-B -I -m ae_mcp --repaired/);
   assert.equal((await two.inspect()).ok, true);
   await assert.rejects(fs.promises.readFile(h.platform.paths.previousPointer), { code: 'ENOENT' });
   const next = await two.ensureReady();
-  assert.notEqual(next.action, 'fallback');
+  assert.equal(next.action, 'ready');
   assert.equal(next.version, '0.10.0');
   assert.equal((await two.inspect()).ok, true);
 });
@@ -347,6 +358,45 @@ macosRuntimeTest('concurrent cold-start checks on one panel share a single Runti
   assert.equal(first.action, 'install');
   assert.deepEqual(second, first);
   assert.equal((await manager.inspect()).ok, true);
+});
+
+macosRuntimeTest('unchanged runtime receipt is reused across source revisions without a tree walk', async (t) => {
+  const h = await harness(t);
+  const firstPayload = await packageFixture(path.join(h.root, 'first'), {
+    version: '0.9.3', sourceCommitSha: '1'.repeat(40), marker: 'shared',
+  });
+  const secondPayload = await packageFixture(path.join(h.root, 'second'), {
+    version: '0.9.3', sourceCommitSha: '2'.repeat(40), marker: 'shared',
+  });
+  const first = managerFor(h, firstPayload.extensionRoot);
+  const installed = await first.ensureReady();
+  const selectedRuntime = path.join(h.platform.paths.runtimeRoot, installed.relative);
+  const guardedPromises = new Proxy(fs.promises, {
+    get(target, property) {
+      const value = Reflect.get(target, property);
+      if (property === 'readdir' || property === 'readFile') {
+        return async function guarded(targetPath, ...args) {
+          const resolved = path.resolve(String(targetPath));
+          if (resolved === selectedRuntime || resolved.startsWith(`${selectedRuntime}${path.sep}`)) {
+            throw new Error(`routine trusted reuse attempted runtime tree I/O: ${property} ${resolved}`);
+          }
+          return value.call(target, targetPath, ...args);
+        };
+      }
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  const guardedFs = { ...fs, promises: guardedPromises };
+  const second = managerFor(h, secondPayload.extensionRoot, { fsImpl: guardedFs });
+
+  const reused = await second.ensureReady();
+
+  assert.equal(reused.action, 'ready');
+  assert.equal(reused.relative, installed.relative);
+  assert.equal(reused.sourceCommitSha, '1'.repeat(40));
+  assert.equal(reused.packagedSourceCommitSha, '2'.repeat(40));
+  assert.equal(reused.diagnostics[0].code, 'RUNTIME_SOURCE_REVISION_DIFFERENT_TRUSTED');
+  assert.equal((await second.inspect()).ok, true);
 });
 
 macosRuntimeTest('a held lock fails with an actionable bounded diagnostic', async (t) => {

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -76,12 +76,14 @@ async function packageFixture(base, {
 }) {
   const extensionRoot = path.join(base, `AE MCP 插件 ${version}`);
   const runtimeRoot = path.join(extensionRoot, 'runtime', 'macos-arm64');
-  const python = await writeFile(
+  const pythonVersioned = await writeFile(
     runtimeRoot,
-    'python/bin/python3',
+    'python/bin/python3.13',
     `#!/bin/sh\nprintf 'core-started:${marker}:%s\\n' "$*"\n`,
     0o755,
   );
+  const python = path.join(runtimeRoot, 'python', 'bin', 'python3');
+  await fs.promises.symlink(path.basename(pythonVersioned), python);
   await writeFile(runtimeRoot, 'python/site-packages/ae_mcp/__init__.py', `MARKER = ${JSON.stringify(marker)}\n`);
   await writeFile(runtimeRoot, 'node/bin/node', '#!/bin/sh\nexit 0\n', 0o755);
   await writeFile(runtimeRoot, 'node/host/package.json', '{"private":true}\n');

--- a/scripts/check-repository-governance.mjs
+++ b/scripts/check-repository-governance.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
-import { createHash } from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import { execFileSync } from 'node:child_process';
@@ -9,7 +8,6 @@ import { fileURLToPath } from 'node:url';
 
 export const GOVERNANCE_PATH = 'AGENTS.md';
 export const INVENTORY_PATH = 'docs/checkpoints/2026-07-16-worktree-audit.md';
-export const GOVERNANCE_SHA256 = 'a9e672524afab1fdbc3e9708a4c9a425dcdc1ed568ba595a95464adcfbe7402f';
 export const SUPPORTING_WORKFLOW_PATHS = [
   '.github/ISSUE_TEMPLATE/capability-package.md',
   '.github/pull_request_template.md',
@@ -18,37 +16,12 @@ export const SUPPORTING_WORKFLOW_PATHS = [
 ];
 
 const REQUIRED_RULES = [
-  '# Repository Development and Delivery Rules',
-  '## 1. Measure outcomes, not activity',
-  'public MCP surface',
-  '## 4. Layer hardware validation by native novelty and capability package',
-  'Core, CEP host, native plugin',
-  'POSSIBLY_SIDE_EFFECTING_FAILURE',
-  'one worktree and one branch for each capability package',
-  'one branch/worktree, one PR, one concentrated review',
-  '## 9. Completion evidence',
-  '## 10. Stop conditions before starting the next dependent capability package',
-  'Do not implement issues by issue number or creation order.',
-  'Automated tests and CI never substitute for hardware validation.',
-  'After merge, repeat the public MCP package smoke from a clean `main` build.',
+  "Never use the user's production project for write testing.",
+  'demonstrate a real Undo followed by state verification',
   'Never blindly repeat a possibly completed write.',
-  'This is the candidate freeze.',
-  '**T0, every edit:**',
-  '**T6, clean-main acceptance:**',
-  'no more than two concentrated review rounds by default',
-  'fully local, non-evictable storage',
+  'Automated tests and CI never substitute for hardware validation.',
+  'Use the public MCP tool name and request shape that a model will see',
   'The WIP limit is one dependent native capability package.',
-  'complete a zero-evidence hardware preflight',
-  'A failure before the first public MCP tool call is a T0-T2 environment or runner failure',
-  'fail fast on every locked external input and identity prerequisite',
-  'the runner must move it to recovery and clear the active slot before exit',
-  'Complete each short-lived pairing handshake as one continuous automation action',
-  'Do not use Finder, file double-click, or LaunchServices',
-  'a machine-generated per-tool summary',
-  '## 11. Require user approval before the next PR package',
-  'Do not create the next Issue, branch, worktree, schema, fixture, candidate, or implementation',
-  'Wait for the user\'s explicit selection or approval before creating or implementing the next PR package',
-  'previous instruction to continue sequentially does not satisfy this approval gate',
 ];
 
 export const FINAL_WORKTREES = [
@@ -91,10 +64,6 @@ const INITIAL_WORKTREES = [
 
 export function validateGovernance({ agentsText, inventoryText, trackedPaths }) {
   const errors = [];
-  const agentsSha256 = createHash('sha256').update(agentsText).digest('hex');
-  if (agentsSha256 !== GOVERNANCE_SHA256) {
-    errors.push(`${GOVERNANCE_PATH} content changed; review and update the locked SHA-256 deliberately`);
-  }
   for (const required of REQUIRED_RULES) {
     if (!agentsText.includes(required)) errors.push(`${GOVERNANCE_PATH} is missing required rule: ${required}`);
   }

--- a/scripts/hardware/capability_package_cli.py
+++ b/scripts/hardware/capability_package_cli.py
@@ -141,7 +141,8 @@ async def _run(
             passed=passed,
             details={
                 **details,
-                "componentHashes": runtime.component_hashes,
+                "componentSignals": runtime.component_signals,
+                "sourceRevisions": runtime.source_revisions,
                 "contractDigests": runtime.contract_digests,
                 "formalAeIdentity": runtime.formal_ae_identity,
             },

--- a/scripts/hardware/capability_package_identity.py
+++ b/scripts/hardware/capability_package_identity.py
@@ -1,9 +1,8 @@
-"""Exact component and formal-After-Effects identity verification."""
+"""Lightweight local component and formal-After-Effects identity verification."""
 
 from __future__ import annotations
 
 import dataclasses
-import hashlib
 import json
 import os
 import plistlib
@@ -32,35 +31,41 @@ def _mapping(value: Any, message: str) -> dict[str, Any]:
     return dict(value)
 
 
-def _sha256_file(path: Path, label: str) -> str:
-    _require(path.is_file() and not path.is_symlink(), f"{label} is not a regular file")
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for block in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
-
-
-def _require_executable_file(path: Path, label: str) -> str:
+def _file_signal(
+    path: Path,
+    label: str,
+    *,
+    executable: bool = False,
+    expected_mode: int | None = None,
+) -> dict[str, Any]:
     try:
         info = path.lstat()
     except FileNotFoundError as error:
         raise IdentityFailure(f"{label} is missing") from error
     _require(stat.S_ISREG(info.st_mode) and not path.is_symlink(), f"{label} is not canonical")
-    if os.name == "posix":
-        _require(stat.S_IMODE(info.st_mode) == 0o755, f"{label} must use mode 0755")
-    return _sha256_file(path, label)
+    mode = stat.S_IMODE(info.st_mode)
+    if expected_mode is not None and os.name == "posix":
+        _require(mode == expected_mode, f"{label} must use mode {expected_mode:04o}")
+    if executable and os.name == "posix":
+        _require(mode & 0o111, f"{label} must be executable")
+    _require(info.st_size > 0, f"{label} is empty")
+    return {
+        "path": str(path),
+        "size": info.st_size,
+        "mtimeNs": info.st_mtime_ns,
+        "mode": f"{mode:04o}",
+    }
 
 
-def _identity_json(path: Path, label: str) -> tuple[dict[str, Any], str]:
-    _require(path.is_file() and not path.is_symlink(), f"{label} is not a regular file")
+def _identity_json(path: Path, label: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    signal = _file_signal(path, label)
     payload = path.read_bytes()
     _require(0 < len(payload) <= 4 * 1024 * 1024, f"{label} is empty or unbounded")
     try:
         decoded = json.loads(payload)
     except (UnicodeDecodeError, ValueError) as error:
         raise IdentityFailure(f"{label} is not valid JSON") from error
-    return _mapping(decoded, f"{label} must be an object"), hashlib.sha256(payload).hexdigest()
+    return _mapping(decoded, f"{label} must be an object"), signal
 
 
 def _validate_declared_hashes(value: Any, label: str) -> None:
@@ -97,27 +102,35 @@ class IdentityConfig:
 
 @dataclasses.dataclass(frozen=True)
 class IdentityProof:
-    component_hashes: dict[str, str]
+    component_signals: dict[str, dict[str, Any]]
+    source_revisions: dict[str, str]
     contract_digests: dict[str, str]
-    formal_ae_identity: dict[str, str]
+    formal_ae_identity: dict[str, Any]
 
 
 def verify_exact_identity(
     config: IdentityConfig, *, required_capability_ids: Sequence[str]
 ) -> IdentityProof:
-    receipt, receipt_hash = _identity_json(config.native_receipt, "native receipt")
-    manifest, manifest_hash = _identity_json(config.native_manifest, "native manifest")
+    receipt, receipt_signal = _identity_json(config.native_receipt, "native receipt")
+    manifest, manifest_signal = _identity_json(config.native_manifest, "native manifest")
     _validate_declared_hashes(receipt, "nativeReceipt")
     _validate_declared_hashes(manifest, "nativeManifest")
+    receipt_source = receipt.get("sourceCommit")
+    receipt_nested_source = _mapping(
+        receipt.get("source"), "native receipt source is invalid"
+    ).get("commit")
     _require(
-        receipt.get("sourceCommit") == config.expected_sha
-        and _mapping(receipt.get("source"), "native receipt source is invalid").get("commit")
-        == config.expected_sha,
-        "native receipt source commit mismatch",
+        isinstance(receipt_source, str)
+        and FULL_SHA.fullmatch(receipt_source) is not None
+        and receipt_nested_source == receipt_source,
+        "native receipt source revision is invalid",
     )
     artifact = _mapping(manifest.get("artifact"), "native manifest artifact is invalid")
-    _require(manifest.get("sourceCommitSha") == config.expected_sha, "native manifest SHA mismatch")
-    _require(artifact.get("receiptSha256") == receipt_hash, "native manifest receipt mismatch")
+    manifest_source = manifest.get("sourceCommitSha")
+    _require(
+        isinstance(manifest_source, str) and FULL_SHA.fullmatch(manifest_source) is not None,
+        "native manifest source revision is invalid",
+    )
     for field in ("bundleTreeSha256", "executableSha256", "piplSha256"):
         _require(
             isinstance(artifact.get(field), str) and SHA256.fullmatch(artifact[field]),
@@ -128,38 +141,53 @@ def verify_exact_identity(
         config.identity_home
         / "Library/Application Support/Adobe/CEP/extensions/com.aemcp.panel/bundle-manifest.json"
     )
-    cep, cep_hash = _identity_json(cep_path, "CEP bundle manifest")
+    cep, cep_signal = _identity_json(cep_path, "CEP bundle manifest")
     _validate_declared_hashes(cep, "cepManifest")
-    _require(cep.get("sourceCommitSha") == config.expected_sha, "CEP manifest SHA mismatch")
+    cep_source = cep.get("sourceCommitSha")
+    _require(
+        isinstance(cep_source, str) and FULL_SHA.fullmatch(cep_source) is not None,
+        "CEP manifest source revision is invalid",
+    )
     current_path = config.identity_home / ".ae-mcp/runtime/current"
-    _require(current_path.is_file() and not current_path.is_symlink(), "runtime current is missing")
+    current_signal = _file_signal(current_path, "runtime current pointer")
     relative = current_path.read_text(encoding="utf-8").strip()
-    expected_relative = f"{config.runtime_version}-{config.expected_sha}/macos-arm64"
-    _require(relative == expected_relative, "runtime current source mismatch")
+    parts = relative.split("/")
+    _require(
+        len(parts) == 2
+        and parts[1] == "macos-arm64"
+        and parts[0].startswith(f"{config.runtime_version}-")
+        and ".." not in parts[0]
+        and not parts[0].startswith("."),
+        "runtime current pointer is invalid",
+    )
     record_path = (
         config.identity_home
         / ".ae-mcp/runtime"
         / relative.split("/", 1)[0]
         / "install-record.json"
     )
-    record, record_hash = _identity_json(record_path, "runtime install record")
+    record, record_signal = _identity_json(record_path, "runtime install record")
     _validate_declared_hashes(record, "runtimeInstallRecord")
     launcher_hash = record.get("launcherSha256")
     _require(
         record.get("relative") == relative
-        and record.get("sourceCommitSha") == config.expected_sha
+        and record.get("platform") == "macos-arm64"
+        and record.get("version") == config.runtime_version
+        and isinstance(record.get("sourceCommitSha"), str)
+        and FULL_SHA.fullmatch(record["sourceCommitSha"]) is not None
         and isinstance(launcher_hash, str)
         and SHA256.fullmatch(launcher_hash),
-        "runtime install record source mismatch",
+        "runtime install record is incompatible",
     )
-    runtime_manifest_path = (
-        config.identity_home / ".ae-mcp/runtime" / relative / "runtime-manifest.json"
+    runtime_root = config.identity_home / ".ae-mcp/runtime" / relative
+    runtime_manifest_signal = _file_signal(
+        runtime_root / "runtime-manifest.json", "runtime manifest"
     )
-    runtime_manifest, runtime_manifest_hash = _identity_json(runtime_manifest_path, "runtime manifest")
-    _validate_declared_hashes(runtime_manifest, "runtimeManifest")
-    _require(
-        record.get("runtimeManifestSha256") == runtime_manifest_hash,
-        "install record is not bound to runtime manifest",
+    node_signal = _file_signal(
+        runtime_root / "node/bin/node", "runtime Node", executable=True
+    )
+    python_signal = _file_signal(
+        runtime_root / "python/bin/python3", "runtime Python", executable=True
     )
     generation_launcher = (
         config.identity_home
@@ -168,16 +196,23 @@ def verify_exact_identity(
         / "ae-mcp-launcher"
     )
     stable_launcher = config.identity_home / ".ae-mcp/bin/ae-mcp"
-    generation_launcher_hash = _require_executable_file(
-        generation_launcher, "runtime generation launcher"
+    generation_launcher_signal = _file_signal(
+        generation_launcher,
+        "runtime generation launcher",
+        executable=True,
+        expected_mode=0o755,
     )
-    stable_launcher_hash = _require_executable_file(stable_launcher, "stable launcher")
+    stable_launcher_signal = _file_signal(
+        stable_launcher, "stable launcher", executable=True, expected_mode=0o755
+    )
     _require(
-        generation_launcher_hash == launcher_hash == stable_launcher_hash,
-        "runtime launcher identity mismatch",
+        generation_launcher_signal["size"] == stable_launcher_signal["size"],
+        "runtime launcher size signals are incompatible",
     )
 
-    capabilities, fixture_hash = _identity_json(config.capabilities_fixture, "capabilities fixture")
+    capabilities, fixture_signal = _identity_json(
+        config.capabilities_fixture, "capabilities fixture"
+    )
     result = _mapping(
         _mapping(capabilities.get("response"), "capabilities response is invalid").get("result"),
         "capabilities result is invalid",
@@ -207,29 +242,39 @@ def verify_exact_identity(
     _require(info.get("CFBundleVersion") == config.expected_ae_build, "AE build mismatch")
     executable_name = info.get("CFBundleExecutable")
     _require(isinstance(executable_name, str) and executable_name, "AE executable is invalid")
-    executable_hash = _sha256_file(app / "Contents/MacOS" / executable_name, "AE executable")
+    executable_signal = _file_signal(
+        app / "Contents/MacOS" / executable_name, "AE executable", executable=True
+    )
+    plist_signal = _file_signal(plist_path, "formal AE plist")
     formal_identity = {
         "applicationPath": str(app),
         "bundleId": config.expected_ae_bundle_id,
         "version": config.expected_ae_version,
         "build": config.expected_ae_build,
         "nativeHostBuild": config.expected_ae_host_build,
-        "infoPlistSha256": hashlib.sha256(plist_path.read_bytes()).hexdigest(),
-        "executableSha256": executable_hash,
+        "infoPlistSignal": plist_signal,
+        "executableSignal": executable_signal,
     }
-    hashes = {
-        "nativeReceiptSha256": receipt_hash,
-        "nativeManifestSha256": manifest_hash,
-        "cepManifestSha256": cep_hash,
-        "runtimeInstallRecordSha256": record_hash,
-        "runtimeManifestFileSha256": runtime_manifest_hash,
-        "runtimeGenerationLauncherSha256": generation_launcher_hash,
-        "stableLauncherSha256": stable_launcher_hash,
-        "nativeBundleTreeSha256": artifact["bundleTreeSha256"],
-        "nativeExecutableSha256": artifact["executableSha256"],
-        "nativePiplSha256": artifact["piplSha256"],
-        "capabilitiesFixtureSha256": fixture_hash,
-        "formalAeInfoPlistSha256": formal_identity["infoPlistSha256"],
-        "formalAeExecutableSha256": executable_hash,
+    signals = {
+        "nativeReceipt": receipt_signal,
+        "nativeManifest": manifest_signal,
+        "cepManifest": cep_signal,
+        "runtimeCurrent": current_signal,
+        "runtimeInstallRecord": record_signal,
+        "runtimeManifest": runtime_manifest_signal,
+        "runtimeGenerationLauncher": generation_launcher_signal,
+        "stableLauncher": stable_launcher_signal,
+        "runtimeNode": node_signal,
+        "runtimePython": python_signal,
+        "capabilitiesFixture": fixture_signal,
+        "formalAeInfoPlist": plist_signal,
+        "formalAeExecutable": executable_signal,
     }
-    return IdentityProof(hashes, contract_digests, formal_identity)
+    source_revisions = {
+        "requested": config.expected_sha,
+        "nativeReceipt": receipt_source,
+        "nativeManifest": manifest_source,
+        "cep": cep_source,
+        "runtime": record["sourceCommitSha"],
+    }
+    return IdentityProof(signals, source_revisions, contract_digests, formal_identity)

--- a/scripts/hardware/capability_package_runtime.py
+++ b/scripts/hardware/capability_package_runtime.py
@@ -4,7 +4,7 @@
 This module deliberately stops short of being a general plan language.  A
 package still owns its exact request builders, semantic projections, fixture
 recipe, Undo checks, and interaction order.  The stable concerns demonstrated
-by packages #150 and #155 live here: exact-build identity, public MCP
+by packages #150 and #155 live here: local component identity, public MCP
 transport, native provenance/postcondition validation, bounded call accounting,
 private evidence, GUI checkpoints, and one ephemeral ``.aep`` lifecycle.
 """
@@ -401,7 +401,7 @@ class EvidenceLog:
         lines = [
             f"## Issue #{self.spec.issue} {self.mode.upper()} acceptance",
             "",
-            f"- exact source commit: `{summary['expectedSourceCommit']}`",
+            f"- requested source revision: `{summary['expectedSourceCommit']}`",
             f"- candidate run: `{str(summary['candidateRun']).lower()}`",
             f"- candidate evidence: `{str(summary['candidateEvidence']).lower()}`",
             f"- passed: `{str(summary['passed']).lower()}`",
@@ -552,10 +552,12 @@ class AcceptanceRuntime:
             for case in spec.tools
         }
         self.aep_lifecycle = AepLifecycleCounters()
-        self.component_hashes: dict[str, str] = {}
+        self.component_signals: dict[str, dict[str, Any]] = {}
+        self.source_revisions: dict[str, str] = {}
         self.contract_digests: dict[str, str] = {}
-        self.formal_ae_identity: dict[str, str] = {}
+        self.formal_ae_identity: dict[str, Any] = {}
         self.expected_host_instance_id: str | None = None
+        self.expected_native_source_revision: str | None = None
         self.intent_counter = 0
         self.pairing_checkpoint_used = False
         self.pairing_epoch_start_total = 0
@@ -574,7 +576,8 @@ class AcceptanceRuntime:
             )
         except IdentityFailure as error:
             raise AcceptanceFailure(str(error)) from error
-        self.component_hashes.update(proof.component_hashes)
+        self.component_signals.update(proof.component_signals)
+        self.source_revisions.update(proof.source_revisions)
         self.contract_digests.update(proof.contract_digests)
         self.formal_ae_identity.update(proof.formal_ae_identity)
 
@@ -604,10 +607,12 @@ class AcceptanceRuntime:
         require(latest is not None, "native log has no load event")
         host = mapping(latest.get("host"), "native load host is invalid")
         instance_id = latest.get("instanceId")
+        source_revision = latest.get("sourceCommit")
         require(
             latest.get("schemaVersion") == 1
             and latest.get("provenance") == "native-aegp"
-            and latest.get("sourceCommit") == self.identity.expected_sha
+            and isinstance(source_revision, str)
+            and FULL_SHA.fullmatch(source_revision) is not None
             and isinstance(instance_id, str)
             and UUID.fullmatch(instance_id),
             "native load identity mismatch",
@@ -617,6 +622,7 @@ class AcceptanceRuntime:
         if previous_instance_id is not None:
             require(instance_id != previous_instance_id, "AE restart reused native instance")
         self.expected_host_instance_id = instance_id
+        self.expected_native_source_revision = source_revision
         self.pairing_checkpoint_used = False
         self.pairing_epoch_start_total = self.ledger.total
         self.evidence.record(
@@ -624,7 +630,7 @@ class AcceptanceRuntime:
             {
                 "stage": stage,
                 "instanceId": instance_id,
-                "sourceCommit": self.identity.expected_sha,
+                "sourceRevision": source_revision,
                 "host": host,
                 "logSha256": hashlib.sha256(payload).hexdigest(),
                 "recordSha256": json_hash(latest),
@@ -669,7 +675,19 @@ class AcceptanceRuntime:
         expected_contract = self.contract_digests.get(capability_id)
         require(expected_contract is not None, f"{tool} contract was not frozen")
         require(implementation.get("contractDigest") == expected_contract, f"{tool} contract digest mismatch")
-        require(provenance.get("sourceCommit") == self.identity.expected_sha, f"{tool} source SHA mismatch")
+        source_revision = provenance.get("sourceCommit")
+        require(
+            isinstance(source_revision, str) and FULL_SHA.fullmatch(source_revision) is not None,
+            f"{tool} native source revision is invalid",
+        )
+        bound_source = getattr(self, "expected_native_source_revision", None)
+        if bound_source is None:
+            self.expected_native_source_revision = source_revision
+        else:
+            require(
+                source_revision == bound_source,
+                f"{tool} native source revision changed within the active host",
+            )
         require(provenance.get("engine") == "native-aegp", f"{tool} provenance mismatch")
         require(
             provenance.get("hostInstanceId") == evidence.get("hostInstanceId")

--- a/scripts/package/test/native-aegp-build-contract.test.mjs
+++ b/scripts/package/test/native-aegp-build-contract.test.mjs
@@ -126,6 +126,55 @@ test('native pairing command is enabled by the AE update-menu hook', () => {
   );
 });
 
+test('native local transport auto-authorizes only in an explicitly opted-in development build', () => {
+  const source = fs.readFileSync(
+    'native/ae-plugin/src/platform/macos/mac_ipc_server.cpp',
+    'utf8',
+  );
+  assert.match(
+    source,
+    /#ifndef AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER\s+#define AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER 0\s+#endif/u,
+  );
+  const pending = source.indexOf('observer_.on_ipc_event("pairing", "pending")');
+  const optIn = source.indexOf('#if AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER', pending);
+  const confirm = source.indexOf(
+    'pairing_gate_.confirm(peer->connection_id, begin.fingerprint)',
+  );
+  const optInEnd = source.indexOf('#endif', optIn);
+  const serve = source.indexOf('handler_.serve(authenticated)');
+  assert.ok(pending >= 0);
+  assert.ok(optIn > pending);
+  assert.ok(confirm > optIn);
+  assert.ok(optInEnd > confirm);
+  assert.ok(serve > confirm);
+  assert.match(BUILD_SCRIPT, /developmentTrustLocalPeer = false/u);
+  assert.match(
+    BUILD_SCRIPT,
+    /developmentTrustLocalPeer === true\s+\? \['-DAE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER=1'\] : \[\]/u,
+  );
+});
+
+test('native build without the development opt-in keeps the manual pairing path', () => {
+  assert.doesNotMatch(
+    BUILD_SCRIPT,
+    /-DAE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER=1[^\n]*(?:process\.env|environment)/u,
+  );
+  assert.match(BUILD_SCRIPT, /name === '--development-trust-local-peer'/u);
+
+  const source = fs.readFileSync(
+    'native/ae-plugin/src/platform/macos/mac_ipc_server.cpp',
+    'utf8',
+  );
+  const optInEnd = source.indexOf(
+    '#endif',
+    source.indexOf('#if AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER'),
+  );
+  const pairingWait = source.indexOf(
+    'while (!stop_requested_.load() && std::chrono::steady_clock::now() < pairing_deadline)',
+  );
+  assert.ok(pairingWait > optInEnd);
+});
+
 test('native composition-create diagnostics use the redacted serializer', () => {
   const completionStart = PLUGIN_ENTRY.indexOf('void log_completion(');
   const completionEnd = PLUGIN_ENTRY.indexOf('bool PluginState::start_ipc', completionStart);

--- a/scripts/package/test/repository-governance.test.mjs
+++ b/scripts/package/test/repository-governance.test.mjs
@@ -28,27 +28,27 @@ test('tracked repository rules and worktree baseline pass the governance contrac
 
 test('missing delivery rules and untracked governance files fail closed', () => {
   const errors = validateGovernance({ agentsText: '', inventoryText: '', trackedPaths: new Set() });
-  assert.ok(errors.some((error) => error.includes('public MCP surface')));
+  assert.ok(errors.some((error) => error.includes("Never use the user's production project")));
   assert.ok(errors.some((error) => error.includes('must be tracked by git')));
   assert.ok(errors.some((error) => error.includes('26-worktree baseline')));
 });
 
-test('semantic rule reversal and final retained-set removal fail closed', () => {
+test('required safety invariant reversal and final retained-set removal fail closed', () => {
   const agentsText = fs.readFileSync(GOVERNANCE_PATH, 'utf8');
   const inventoryText = fs.readFileSync(INVENTORY_PATH, 'utf8');
   const trackedPaths = new Set([GOVERNANCE_PATH, INVENTORY_PATH, ...SUPPORTING_WORKFLOW_PATHS]);
   const weakened = agentsText.replace(
-    'Automated tests and CI never substitute for hardware validation.',
-    'Automated tests and CI fully substitute for hardware validation.',
+    "Never use the user's production project for write testing.",
+    "Use the user's production project for write testing.",
   );
   assert.ok(validateGovernance({ agentsText: weakened, inventoryText, trackedPaths })
-    .some((error) => error.includes('locked SHA-256')));
+    .some((error) => error.includes("Never use the user's production project")));
   const otherWeakening = agentsText.replace(
-    'Use one worktree and one branch for each capability package.',
-    'Do not use one worktree and one branch for each capability package.',
+    'Never blindly repeat a possibly completed write.',
+    'Blindly repeat a possibly completed write.',
   );
   assert.ok(validateGovernance({ agentsText: otherWeakening, inventoryText, trackedPaths })
-    .some((error) => error.includes('locked SHA-256')));
+    .some((error) => error.includes('Never blindly repeat a possibly completed write.')));
   const withoutFinalSet = inventoryText.replace(/## Final retained registry[\s\S]*?(?=\n## Cleanup execution record)/, '');
   assert.ok(validateGovernance({ agentsText, inventoryText: withoutFinalSet, trackedPaths })
     .some((error) => error.includes('final retained worktree set')));


### PR DESCRIPTION
Two commits.

**f152a57 — governance reconciliation and de-ratchet**

Reconciles the relaxed governance direction with #164, which had independently tightened the same two files. Every rule #164 added is either preserved (possibly reworded) or is one of four deliberate drops: mandatory full-payload verification, fingerprint pairing handshake, clean-source-SHA prerequisite, exact-component-SHA reporting. All 23 removed lines were verified to fall in those categories.

`REQUIRED_RULES` goes from 41 entries to 6 safety invariants, and `GOVERNANCE_SHA256` is removed. The array was a one-way ratchet: entries could be added but never removed without breaking CI, which is how the file grew from 130 to 217 lines and 13 to 41 locked assertions in three days. The six retained invariants are the ones whose violation costs real work or real data.

**9c8ec9f — scoped development trust**

Ports the development-trust implementation, replacing the local pairing ceremony with OS-level controls (same-UID peer, unmodified peer identity, process ancestry reaching the AE host) and runtime reuse by file metadata signals instead of hash walks.

The auto-confirm was unconditional in shipped source. It is now behind `AE_MCP_DEVELOPMENT_TRUST_LOCAL_PEER`, which defaults to 0, so a release build preprocesses the block out entirely and manual pairing stays mandatory. Opting in requires `--development-trust-local-peer` on the development builder. A build-contract test asserts the default and the guard structure.

**Verification**

plugin/host 148/148 · plugin/panel 983 pass, 0 fail · native build contract 13/13 · Python hardware 17 passed · governance check passed. No hardware acceptance was run; this change touches no public MCP tool.

**Deliberate follow-ups, not in this PR**

- The pairing surface is now split: the native gate is opt-in, but `/native/pair`, `NATIVE_PAIRING_REQUIRED`, the AE menu handler and bridge recovery all remain on the default path.
- `native-aegp-build-contract.test.mjs` proves the gating by static source inspection, not by compiling both variants. For a security control that is weak evidence.
- Metadata-signal reuse cannot detect same-size tampering. That is the accepted trade of the trust model, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
