### PR TITLE
Fix local acceptance identity seams

### DIFF
--- a/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
+++ b/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
@@ -7,6 +7,7 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
 import plistlib
 import sys
 from pathlib import Path
@@ -896,16 +897,21 @@ def test_identity_accepts_direct_in_runtime_python_symlink(tmp_path: Path):
     assert proof.component_signals["runtimePython"]["targetPath"] == str(target)
 
 
+UNSAFE_RUNTIME_PYTHON_SYMLINKS = [
+    ("symlink", "/bin/sh", "must be relative"),
+    ("escaping", "../../../../../../../outside-python", "escapes the runtime"),
+    ("symlink", "missing-python", "is dangling"),
+    ("chain", "python3-link", "direct regular file"),
+    ("directory", "python3.13", "direct regular file"),
+]
+if os.name == "posix":
+    UNSAFE_RUNTIME_PYTHON_SYMLINKS.append(
+        ("non-executable", "python3.13", "must be executable")
+    )
+
+
 @pytest.mark.parametrize(
-    ("target_kind", "target_value", "message"),
-    [
-        ("symlink", "/bin/sh", "must be relative"),
-        ("escaping", "../../../../../../../outside-python", "escapes the runtime"),
-        ("symlink", "missing-python", "is dangling"),
-        ("chain", "python3-link", "direct regular file"),
-        ("non-executable", "python3.13", "must be executable"),
-        ("directory", "python3.13", "direct regular file"),
-    ],
+    ("target_kind", "target_value", "message"), UNSAFE_RUNTIME_PYTHON_SYMLINKS
 )
 def test_identity_rejects_unsafe_runtime_python_symlink(
     tmp_path: Path, target_kind: str, target_value: str, message: str

--- a/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
+++ b/packages/bridge/tests/test_issue157_hardware_acceptance_driver.py
@@ -877,6 +877,108 @@ def test_identity_uses_local_component_signals_and_advisory_source_revisions(tmp
         runtime_module.verify_exact_identity(identity, required_capability_ids=required)
 
 
+def test_identity_accepts_direct_in_runtime_python_symlink(tmp_path: Path):
+    identity = make_identity_config(tmp_path)
+    python = identity.identity_home / ".ae-mcp/runtime" / (
+        f"0.9.2-{EXPECTED_SHA}/macos-arm64/python/bin/python3"
+    )
+    target = python.with_name("python3.13")
+    python.rename(target)
+    python.symlink_to("python3.13")
+
+    proof = runtime_module.verify_exact_identity(
+        identity,
+        required_capability_ids=tuple(case.capability_id for case in package.SPEC.tools),
+    )
+
+    assert proof.component_signals["runtimePython"]["path"] == str(python)
+    assert proof.component_signals["runtimePython"]["symlinkTarget"] == "python3.13"
+    assert proof.component_signals["runtimePython"]["targetPath"] == str(target)
+
+
+@pytest.mark.parametrize(
+    ("target_kind", "target_value", "message"),
+    [
+        ("symlink", "/bin/sh", "must be relative"),
+        ("escaping", "../../../../../../../outside-python", "escapes the runtime"),
+        ("symlink", "missing-python", "is dangling"),
+        ("chain", "python3-link", "direct regular file"),
+        ("non-executable", "python3.13", "must be executable"),
+        ("directory", "python3.13", "direct regular file"),
+    ],
+)
+def test_identity_rejects_unsafe_runtime_python_symlink(
+    tmp_path: Path, target_kind: str, target_value: str, message: str
+):
+    identity = make_identity_config(tmp_path)
+    python = identity.identity_home / ".ae-mcp/runtime" / (
+        f"0.9.2-{EXPECTED_SHA}/macos-arm64/python/bin/python3"
+    )
+    target = python.with_name("python3.13")
+    python.rename(target)
+    if target_kind == "chain":
+        intermediate = python.with_name(target_value)
+        intermediate.symlink_to(target.name)
+        python.symlink_to(intermediate.name)
+    elif target_kind == "escaping":
+        outside = tmp_path / "outside-python"
+        outside.write_bytes(b"#!/bin/sh\nexit 0\n")
+        outside.chmod(0o755)
+        python.symlink_to(target_value)
+    elif target_kind == "non-executable":
+        target.chmod(0o644)
+        python.symlink_to(target_value)
+    elif target_kind == "directory":
+        target.unlink()
+        target.mkdir()
+        python.symlink_to(target_value)
+    else:
+        python.symlink_to(target_value)
+
+    with pytest.raises(runtime_module.IdentityFailure, match=message):
+        runtime_module.verify_exact_identity(
+            identity,
+            required_capability_ids=tuple(case.capability_id for case in package.SPEC.tools),
+        )
+
+
+@pytest.mark.asyncio
+async def test_issue157_completion_uses_component_signals_and_source_revisions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class PassingPackage:
+        def __init__(self, runtime: runtime_module.AcceptanceRuntime, **_kwargs: Any) -> None:
+            self.runtime = runtime
+
+        async def run(self) -> dict[str, bool]:
+            self.runtime.component_signals["runtimePython"] = {"size": 1}
+            self.runtime.source_revisions["runtime"] = EXPECTED_SHA
+            return {"finalized": True}
+
+    monkeypatch.setattr(acceptance_cli, "Issue157Package", PassingPackage)
+    arguments = SimpleNamespace(
+        expected_sha=EXPECTED_SHA,
+        fixture_path=tmp_path / "fixture.aep",
+        recovery_archive_root=tmp_path / "recovery",
+        native_receipt=tmp_path / "receipt.json",
+        native_manifest=tmp_path / "manifest.json",
+        evidence_dir=tmp_path / "evidence",
+        contract_fixture=tmp_path / "capabilities.json",
+        formal_ae_app=tmp_path / "Formal AE.app",
+        identity_home=tmp_path,
+        launcher=tmp_path / ".ae-mcp/bin/ae-mcp",
+        fixture_name="Issue157 Keyframe Authoring Fixture",
+        mode="preflight",
+    )
+
+    assert await acceptance_cli._run(arguments) == 0
+    summary = json.loads(next(arguments.evidence_dir.glob("*.summary.json")).read_text())
+    details = summary["details"]
+    assert details["componentSignals"] == {"runtimePython": {"size": 1}}
+    assert details["sourceRevisions"] == {"runtime": EXPECTED_SHA}
+    assert "componentHashes" not in details
+
+
 def test_cli_launcher_is_canonical_under_identity_home(tmp_path: Path):
     common = [
         "--mode", "t5",

--- a/scripts/hardware/capability_package_identity.py
+++ b/scripts/hardware/capability_package_identity.py
@@ -57,6 +57,48 @@ def _file_signal(
     }
 
 
+def _runtime_python_signal(path: Path, runtime_root: Path) -> dict[str, Any]:
+    """Return a signal for the runtime Python, allowing its direct local alias."""
+    try:
+        path.lstat()
+    except FileNotFoundError as error:
+        raise IdentityFailure("runtime Python is missing") from error
+    if not path.is_symlink():
+        return _file_signal(path, "runtime Python", executable=True)
+
+    try:
+        target_text = os.readlink(path)
+    except OSError as error:
+        raise IdentityFailure("runtime Python symlink is unreadable") from error
+    target = Path(target_text)
+    _require(not target.is_absolute(), "runtime Python symlink target must be relative")
+    target_path = path.parent / target
+    try:
+        target_info = target_path.lstat()
+    except FileNotFoundError as error:
+        raise IdentityFailure("runtime Python symlink target is dangling") from error
+    _require(
+        stat.S_ISREG(target_info.st_mode) and not target_path.is_symlink(),
+        "runtime Python symlink target must be a direct regular file",
+    )
+    try:
+        resolved_root = runtime_root.resolve(strict=True)
+        resolved_target = target_path.resolve(strict=True)
+        resolved_target.relative_to(resolved_root)
+    except (FileNotFoundError, OSError, ValueError) as error:
+        raise IdentityFailure("runtime Python symlink target escapes the runtime") from error
+
+    signal = _file_signal(target_path, "runtime Python symlink target", executable=True)
+    signal.update(
+        {
+            "path": str(path),
+            "symlinkTarget": target_text,
+            "targetPath": str(resolved_target),
+        }
+    )
+    return signal
+
+
 def _identity_json(path: Path, label: str) -> tuple[dict[str, Any], dict[str, Any]]:
     signal = _file_signal(path, label)
     payload = path.read_bytes()
@@ -186,8 +228,8 @@ def verify_exact_identity(
     node_signal = _file_signal(
         runtime_root / "node/bin/node", "runtime Node", executable=True
     )
-    python_signal = _file_signal(
-        runtime_root / "python/bin/python3", "runtime Python", executable=True
+    python_signal = _runtime_python_signal(
+        runtime_root / "python/bin/python3", runtime_root
     )
     generation_launcher = (
         config.identity_home

--- a/scripts/hardware/capability_package_identity.py
+++ b/scripts/hardware/capability_package_identity.py
@@ -9,7 +9,7 @@ import plistlib
 import re
 import stat
 from collections.abc import Mapping, Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -70,9 +70,11 @@ def _runtime_python_signal(path: Path, runtime_root: Path) -> dict[str, Any]:
         target_text = os.readlink(path)
     except OSError as error:
         raise IdentityFailure("runtime Python symlink is unreadable") from error
-    target = Path(target_text)
-    _require(not target.is_absolute(), "runtime Python symlink target must be relative")
-    target_path = path.parent / target
+    target_is_absolute = (
+        PurePosixPath(target_text).is_absolute() or Path(target_text).is_absolute()
+    )
+    _require(not target_is_absolute, "runtime Python symlink target must be relative")
+    target_path = path.parent / target_text
     try:
         target_info = target_path.lstat()
     except FileNotFoundError as error:

--- a/scripts/hardware/issue157_keyframe_authoring_acceptance.py
+++ b/scripts/hardware/issue157_keyframe_authoring_acceptance.py
@@ -131,7 +131,8 @@ async def _run(arguments: argparse.Namespace) -> int:
             passed=passed,
             details={
                 **details,
-                "componentHashes": runtime.component_hashes,
+                "componentSignals": runtime.component_signals,
+                "sourceRevisions": runtime.source_revisions,
                 "contractDigests": runtime.contract_digests,
                 "formalAeIdentity": runtime.formal_ae_identity,
             },


### PR DESCRIPTION
## Outcome

Repairs the two remaining acceptance seams after the local-development trust-model change:

- accept the packaged runtime's direct relative `python3 -> python3.13` symlink while rejecting POSIX/native absolute, escaping, dangling, chained, non-file, and—on POSIX—non-executable targets;
- migrate the Issue #157 completion finalizer from removed `componentHashes` output to `componentSignals` and `sourceRevisions`.

This PR does not change RuntimeManager, native pairing, public MCP schemas, product capabilities, or legacy package runners.

## Validation

- independent concentrated review: GO, no current blocker;
- focused bridge/identity tests: 25 passed;
- syntax compilation and `git diff --check`: passed;
- required CI #288: Windows Python, Windows JS/contract, and Linux packaging/release all passed. The first Windows Python attempt hit the 30-minute runner timeout without an assertion failure; the exact failed-job rerun passed in 59 seconds;
- tested source revision: `b224a8523146c7224eb36c1868d0deecc10f9760`.

## Formal AE candidate smoke

Lightweight deployment reused the existing compatible runtime generation and installed only the changed development CEP/native path. No Runtime tree hash walk and no cross-component source-SHA equality gate ran.

- formal host: After Effects 26.3 build 87;
- native: product 0.9.2, SDK 25.6.61, wire v1, canonical native source revision `b224a852…`;
- runtime: product 0.9.2, compatible existing generation `98721e2…` (revision recorded as advisory only);
- local connection: public MCP connected without a code/fingerprint ceremony;
- public read: `ae_getProjectBitDepth` returned 8 bpc with native provenance, audit and verified postcondition;
- public write: `ae_setProjectBitDepth(16)` returned committed, Undo available, audit request `mcp-c435f33e61af4a6a8fbe861b5ec95790`, and verified postcondition;
- independent public readback returned 16 bpc;
- one real After Effects Undo was executed, and a fresh native read returned the 8 bpc baseline;
- one `ephemeral-validation` fixture was created, saved, restored to baseline, and moved to recoverable archive; active fixture count is 0.

Computer Use could not acquire AE's accessibility state (`get_app_state: timeoutReached`), so the real Undo was invoked through the public panel MCP on AE's main thread rather than by OS automation. No OS screenshot/automation fallback was used.

## Scope and follow-up

This narrow PR proves the local trust path is runnable and repairs the first legacy completion seam. Full migration of all remaining legacy acceptance runners remains a separate package after this PR completes clean-main revalidation.