### PR TITLE
tools: cut lookup cost with a brief index and a documented harness contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ Thumbs.db
 .worktrees/
 .local-workspace-archive/
 .superpowers/sdd/
+.cache/capability-package-index/
 plugin/panel/ae_viewer_*.png

--- a/scripts/generate_capability_package_index.py
+++ b/scripts/generate_capability_package_index.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Generate fail-closed JSON indexes for capability-package briefs.
+
+With no BRIEF arguments, every ``docs/capability-packages/*.md`` file is
+indexed. Derived files are written below ``.cache/capability-package-index``.
+Use ``-`` with ``--source-name`` to validate a brief supplied on stdin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BRIEF_ROOT = REPOSITORY_ROOT / "docs/capability-packages"
+DEFAULT_OUTPUT_ROOT = REPOSITORY_ROOT / ".cache/capability-package-index"
+HEADING = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})([A-Za-z0-9_-]*)\s*$")
+PUBLIC_TOOL = re.compile(r"\bae_[A-Za-z][A-Za-z0-9_]*\b")
+CAPABILITY_ID = re.compile(r"\bae(?:\.[a-z0-9-]+){2,}\b")
+JSON_PROPERTY = r'^\s*"{tool}"\s*:\s*\{{'
+
+
+class ParseFailure(ValueError):
+    """The brief does not expose enough structure for a trustworthy index."""
+
+
+@dataclass(frozen=True)
+class HeadingRange:
+    level: int
+    title: str
+    start: int
+    end: int
+    path: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FenceRange:
+    language: str
+    start: int
+    end: int
+    content_start: int
+    content_end: int
+
+
+@dataclass(frozen=True)
+class Table:
+    header: tuple[str, ...]
+    rows: tuple[tuple[int, tuple[str, ...]], ...]
+    start: int
+    end: int
+
+
+def _plain(value: str) -> str:
+    return re.sub(r"[`*]", "", value).strip()
+
+
+def _normalized(value: str) -> str:
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", _plain(value))
+    value = value.replace("colour", "color")
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def _range(start: int, end: int) -> dict[str, int]:
+    return {"start": start, "end": end}
+
+
+def _split_table_row(line: str) -> tuple[str, ...]:
+    value = line.strip()
+    if value.startswith("|"):
+        value = value[1:]
+    if value.endswith("|"):
+        value = value[:-1]
+    return tuple(cell.strip() for cell in re.split(r"(?<!\\)\|", value))
+
+
+def _is_separator(row: Sequence[str]) -> bool:
+    return bool(row) and all(
+        re.fullmatch(r":?-{3,}:?", cell.replace(" ", "")) is not None for cell in row
+    )
+
+
+def _headings(lines: Sequence[str]) -> list[HeadingRange]:
+    raw: list[tuple[int, int, str]] = []
+    for line_number, line in enumerate(lines, 1):
+        match = HEADING.match(line)
+        if match:
+            raw.append((line_number, len(match.group(1)), match.group(2).strip()))
+    if not raw or raw[0][1] != 1:
+        raise ParseFailure("document must begin with one level-1 heading")
+
+    result: list[HeadingRange] = []
+    stack: list[tuple[int, str]] = []
+    for index, (start, level, title) in enumerate(raw):
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+        path = tuple(member for _, member in stack) + (title,)
+        stack.append((level, title))
+        end = len(lines)
+        for next_start, next_level, _ in raw[index + 1 :]:
+            if next_level <= level:
+                end = next_start - 1
+                break
+        result.append(HeadingRange(level, title, start, end, path))
+    return result
+
+
+def _fences(lines: Sequence[str]) -> list[FenceRange]:
+    result: list[FenceRange] = []
+    index = 0
+    while index < len(lines):
+        match = FENCE.match(lines[index])
+        if match is None:
+            index += 1
+            continue
+        marker = match.group(1)
+        language = match.group(2).lower()
+        close = re.compile(rf"^\s*{re.escape(marker[0])}{{{len(marker)},}}\s*$")
+        for candidate in range(index + 1, len(lines)):
+            if close.match(lines[candidate]):
+                result.append(
+                    FenceRange(
+                        language=language,
+                        start=index + 1,
+                        end=candidate + 1,
+                        content_start=index + 2,
+                        content_end=candidate,
+                    )
+                )
+                index = candidate + 1
+                break
+        else:
+            raise ParseFailure(f"unclosed fenced block at line {index + 1}")
+    return result
+
+
+def _tables(lines: Sequence[str]) -> list[Table]:
+    result: list[Table] = []
+    index = 0
+    while index + 1 < len(lines):
+        if not lines[index].lstrip().startswith("|"):
+            index += 1
+            continue
+        header = _split_table_row(lines[index])
+        separator = _split_table_row(lines[index + 1])
+        if len(header) != len(separator) or not _is_separator(separator):
+            index += 1
+            continue
+        rows: list[tuple[int, tuple[str, ...]]] = []
+        candidate = index + 2
+        while candidate < len(lines) and lines[candidate].lstrip().startswith("|"):
+            cells = _split_table_row(lines[candidate])
+            if len(cells) != len(header):
+                raise ParseFailure(f"table row at line {candidate + 1} has the wrong column count")
+            rows.append((candidate + 1, cells))
+            candidate += 1
+        result.append(Table(header, tuple(rows), index + 1, candidate))
+        index = candidate
+    return result
+
+
+def _section_at(headings: Sequence[HeadingRange], line: int) -> HeadingRange:
+    candidates = [heading for heading in headings if heading.start <= line <= heading.end]
+    if not candidates:
+        raise ParseFailure(f"line {line} is outside the document heading structure")
+    return max(candidates, key=lambda heading: heading.level)
+
+
+def _has_ancestor(
+    headings: Sequence[HeadingRange], line: int, pattern: re.Pattern[str]
+) -> bool:
+    return any(
+        heading.start <= line <= heading.end and pattern.search(_normalized(heading.title))
+        for heading in headings
+    )
+
+
+def _tool_registry(tables: Sequence[Table]) -> tuple[Table, list[dict[str, Any]]]:
+    registries = [
+        table
+        for table in tables
+        if any(_normalized(cell) == "public mcp tool" for cell in table.header)
+    ]
+    if len(registries) != 1:
+        raise ParseFailure(
+            f"expected one 'Public MCP tool' registry table, found {len(registries)}"
+        )
+    table = registries[0]
+    tool_column = next(
+        index
+        for index, cell in enumerate(table.header)
+        if _normalized(cell) == "public mcp tool"
+    )
+    tools: list[dict[str, Any]] = []
+    for line, cells in table.rows:
+        matches = PUBLIC_TOOL.findall(_plain(cells[tool_column]))
+        if len(matches) != 1:
+            raise ParseFailure(f"public-tool row at line {line} does not name exactly one tool")
+        name = matches[0]
+        capabilities = [
+            match
+            for cell in cells
+            for match in CAPABILITY_ID.findall(_plain(cell))
+        ]
+        kinds = [
+            _normalized(cell)
+            for cell in cells
+            if _normalized(cell) in {"read", "write"}
+        ]
+        if kinds:
+            kind = kinds[0]
+        elif name.startswith(("ae_get", "ae_list", "ae_read", "ae_inspect")):
+            kind = "read"
+        elif name.startswith(("ae_add", "ae_create", "ae_delete", "ae_set", "ae_apply")):
+            kind = "write"
+        else:
+            raise ParseFailure(f"cannot determine read/write kind for {name} at line {line}")
+        tools.append(
+            {
+                "name": name,
+                "kind": kind,
+                "nativeCapability": capabilities[0] if capabilities else None,
+                "registryLine": line,
+            }
+        )
+    names = [tool["name"] for tool in tools]
+    if not names or len(names) != len(set(names)):
+        raise ParseFailure("public-tool registry is empty or contains duplicate tool names")
+    return table, tools
+
+
+def _json_property_range(lines: Sequence[str], fence: FenceRange, tool: str) -> tuple[int, int] | None:
+    pattern = re.compile(JSON_PROPERTY.format(tool=re.escape(tool)))
+    start: int | None = None
+    balance = 0
+    in_string = False
+    escaped = False
+    for line_number in range(fence.content_start, fence.content_end + 1):
+        line = lines[line_number - 1]
+        if start is None:
+            if pattern.match(line) is None:
+                continue
+            start = line_number
+            fragment = line[line.index("{") :]
+        else:
+            fragment = line
+        for character in fragment:
+            if escaped:
+                escaped = False
+            elif character == "\\" and in_string:
+                escaped = True
+            elif character == '"':
+                in_string = not in_string
+            elif not in_string and character == "{":
+                balance += 1
+            elif not in_string and character == "}":
+                balance -= 1
+        if start is not None and balance == 0:
+            return start, line_number
+    if start is not None:
+        raise ParseFailure(f"unbalanced JSON object for {tool} at line {start}")
+    return None
+
+
+def _schema_contract(
+    lines: Sequence[str],
+    headings: Sequence[HeadingRange],
+    fences: Sequence[FenceRange],
+    registry: Table,
+    tool: str,
+) -> dict[str, Any]:
+    schema_fences = [
+        fence
+        for fence in fences
+        if fence.language == "json"
+        and _has_ancestor(headings, fence.start, re.compile(r"\bschemas?\b"))
+    ]
+    explicit: list[dict[str, Any]] = []
+    occupied: set[int] = set()
+    for index, fence in enumerate(schema_fences):
+        located = _json_property_range(lines, fence, tool)
+        if located is not None:
+            occupied.add(index)
+            section = _section_at(headings, fence.start)
+            explicit.append(
+                {
+                    "section": section.title,
+                    "lineRange": _range(*located),
+                }
+            )
+    if explicit:
+        shared = []
+        for index, fence in enumerate(schema_fences):
+            if index in occupied:
+                continue
+            section = _section_at(headings, fence.start)
+            shared.append(
+                {
+                    "section": section.title,
+                    "lineRange": _range(fence.content_start, fence.content_end),
+                }
+            )
+        return {"status": "explicit", "toolBlocks": explicit, "sharedBlocks": shared}
+
+    named_schema = re.compile(r'^\s*"ae_[A-Za-z][A-Za-z0-9_]*"\s*:\s*\{')
+    if any(
+        named_schema.match(lines[line_number - 1])
+        for fence in schema_fences
+        for line_number in range(fence.content_start, fence.content_end + 1)
+    ):
+        raise ParseFailure(
+            f"schema blocks name other public tools but omit {tool}; refusing narrative fallback"
+        )
+
+    section = _section_at(headings, registry.start)
+    return {
+        "status": "narrative",
+        "toolBlocks": [],
+        "sharedBlocks": [
+            {"section": section.title, "lineRange": _range(section.start, section.end)}
+        ],
+        "note": (
+            "No explicit JSON schema block names this tool; the range is the "
+            "brief's shared public contract and is not represented as JSON Schema."
+        ),
+    }
+
+
+def _execution_path(
+    lines: Sequence[str],
+    headings: Sequence[HeadingRange],
+    fences: Sequence[FenceRange],
+) -> dict[str, Any]:
+    matches: list[dict[str, Any]] = []
+    for fence in fences:
+        text = "\n".join(lines[fence.content_start - 1 : fence.content_end])
+        if re.search(r"public MCP", text, re.IGNORECASE) and "->" in text:
+            section = _section_at(headings, fence.start)
+            matches.append(
+                {
+                    "section": section.title,
+                    "lineRange": _range(fence.content_start, fence.content_end),
+                    "text": text.strip(),
+                }
+            )
+    if not matches:
+        raise ParseFailure("no fenced public-MCP execution path was found")
+    return {"paths": matches}
+
+
+def _tool_aliases(tool: dict[str, Any]) -> set[str]:
+    name = re.sub(r"^ae_", "", tool["name"])
+    words = _normalized(name).split()
+    if words and words[0] in {"add", "apply", "create", "delete", "get", "list", "set"}:
+        words = words[1:]
+    aliases = {" ".join(words[index:]) for index in range(len(words))}
+    capability = tool.get("nativeCapability")
+    if capability:
+        cap_words = _normalized(capability).split()
+        aliases.update(" ".join(cap_words[index:]) for index in range(len(cap_words)))
+    return {alias for alias in aliases if alias}
+
+
+def _matching_row(tool: dict[str, Any], rows: Iterable[tuple[int, tuple[str, ...]]]) -> list[
+    tuple[int, tuple[str, ...]]
+]:
+    aliases = _tool_aliases(tool)
+    matches = []
+    for line, cells in rows:
+        first = _normalized(cells[0])
+        exact_tool = tool["name"] in _plain(cells[0])
+        if exact_tool or any(
+            first == alias
+            or alias.endswith(" " + first)
+            or alias.startswith(first + " ")
+            for alias in aliases
+        ):
+            matches.append((line, cells))
+    return matches
+
+
+def _paragraphs(lines: Sequence[str]) -> list[tuple[int, int, str]]:
+    result = []
+    start: int | None = None
+    content: list[str] = []
+    in_fence = False
+    for line_number, line in enumerate((*lines, ""), 1):
+        if FENCE.match(line):
+            in_fence = not in_fence
+        excluded = (
+            in_fence
+            or not line.strip()
+            or HEADING.match(line) is not None
+            or line.lstrip().startswith("|")
+        )
+        if excluded:
+            if content and start is not None:
+                result.append((start, line_number - 1, " ".join(part.strip() for part in content)))
+            start = None
+            content = []
+        else:
+            if start is None:
+                start = line_number
+            content.append(line)
+    return result
+
+
+def _undo_model(
+    lines: Sequence[str],
+    headings: Sequence[HeadingRange],
+    tables: Sequence[Table],
+    tool: dict[str, Any],
+) -> dict[str, Any]:
+    if tool["kind"] == "read":
+        return {
+            "disposition": "not-applicable",
+            "lineRanges": [_range(tool["registryLine"], tool["registryLine"])],
+            "description": "The public-tool registry classifies this tool as a read.",
+        }
+
+    undo_tables = [
+        table
+        for table in tables
+        if any("undo" in _normalized(cell).split() for cell in table.header)
+    ]
+    row_matches = [
+        (table, row)
+        for table in undo_tables
+        for row in _matching_row(tool, table.rows)
+    ]
+    if len(row_matches) == 1:
+        _, (line, cells) = row_matches[0]
+        description = " | ".join(_plain(cell) for cell in cells[1:])
+        normalized = _normalized(description)
+        disposition = (
+            "not-undoable"
+            if "not undoable" in normalized or "undo none" in normalized
+            else "real-ae-undo"
+        )
+        return {
+            "disposition": disposition,
+            "lineRanges": [_range(line, line)],
+            "description": description,
+        }
+    if len(row_matches) > 1:
+        raise ParseFailure(f"multiple Undo rows ambiguously match {tool['name']}")
+
+    candidates = []
+    for start, end, text in _paragraphs(lines):
+        if not _has_ancestor(headings, start, re.compile(r"(fixture|interaction|undo|acceptance)")):
+            continue
+        normalized = _normalized(text)
+        if "undo" in normalized.split() and re.search(r"\b(each|every|all)\b.*\bwrite", normalized):
+            candidates.append((start, end, text))
+    if not candidates:
+        raise ParseFailure(f"no reliable Undo model was found for write tool {tool['name']}")
+    start, end, description = candidates[0]
+    return {
+        "disposition": "real-ae-undo",
+        "lineRanges": [_range(start, end)],
+        "description": description,
+    }
+
+
+def _acceptance_disposition(
+    headings: Sequence[HeadingRange],
+    tables: Sequence[Table],
+    tool: dict[str, Any],
+) -> dict[str, Any]:
+    sections = [
+        heading
+        for heading in headings
+        if heading.level == 2 and "acceptance" in _normalized(heading.title).split()
+    ]
+    if not sections:
+        raise ParseFailure("no level-2 acceptance section was found")
+    matching_rows = []
+    for table in tables:
+        if not any(section.start <= table.start <= section.end for section in sections):
+            continue
+        for line, cells in table.rows:
+            if tool["name"] in " | ".join(cells):
+                matching_rows.append(
+                    {
+                        "lineRange": _range(line, line),
+                        "description": " | ".join(_plain(cell) for cell in cells),
+                    }
+                )
+    if matching_rows:
+        return {
+            "disposition": "required",
+            "basis": "tool-specific acceptance row",
+            "lineRanges": [row["lineRange"] for row in matching_rows],
+            "details": [row["description"] for row in matching_rows],
+        }
+    section = sections[0]
+    return {
+        "disposition": "required",
+        "basis": "package-level acceptance section",
+        "lineRanges": [_range(section.start, section.end)],
+    }
+
+
+def build_index(text: str, source_name: str) -> dict[str, Any]:
+    lines = text.splitlines()
+    if not lines:
+        raise ParseFailure("brief is empty")
+    headings = _headings(lines)
+    fences = _fences(lines)
+    tables = _tables(lines)
+    registry, tools = _tool_registry(tables)
+    execution = _execution_path(lines, headings, fences)
+
+    indexed_tools = []
+    for tool in tools:
+        indexed_tools.append(
+            {
+                **tool,
+                "schema": _schema_contract(lines, headings, fences, registry, tool["name"]),
+                "executionPath": execution,
+                "undoModel": _undo_model(lines, headings, tables, tool),
+                "acceptance": _acceptance_disposition(headings, tables, tool),
+            }
+        )
+    return {
+        "schemaVersion": 1,
+        "source": {
+            "path": source_name,
+            "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "lineCount": len(lines),
+        },
+        "sections": [
+            {
+                "name": heading.title,
+                "level": heading.level,
+                "path": list(heading.path),
+                "lineRange": _range(heading.start, heading.end),
+            }
+            for heading in headings
+        ],
+        "tools": indexed_tools,
+    }
+
+
+def _write_if_changed(path: Path, content: str) -> bool:
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+    return True
+
+
+def _arguments(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "briefs",
+        nargs="*",
+        help="Markdown briefs to index; defaults to docs/capability-packages/*.md; use - for stdin",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help=f"derived output directory (default: {DEFAULT_OUTPUT_ROOT.relative_to(REPOSITORY_ROOT)})",
+    )
+    parser.add_argument("--stdout", action="store_true", help="print one index instead of writing it")
+    parser.add_argument("--source-name", help="source path recorded when BRIEF is -")
+    parsed = parser.parse_args(argv)
+    if parsed.stdout and len(parsed.briefs) != 1:
+        parser.error("--stdout requires exactly one explicit brief")
+    if "-" in parsed.briefs:
+        if len(parsed.briefs) != 1 or not parsed.source_name:
+            parser.error("stdin requires exactly one '-' brief and --source-name")
+    elif parsed.source_name:
+        parser.error("--source-name is only valid with stdin")
+    return parsed
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _arguments(argv)
+    briefs = arguments.briefs or [
+        str(path.relative_to(REPOSITORY_ROOT))
+        for path in sorted(DEFAULT_BRIEF_ROOT.glob("*.md"))
+    ]
+    if not briefs:
+        print("error: no capability-package briefs were found", file=sys.stderr)
+        return 2
+
+    parsed: list[tuple[str, dict[str, Any]]] = []
+    failures: list[str] = []
+    for brief in briefs:
+        if brief == "-":
+            source_name = arguments.source_name
+            text = sys.stdin.read()
+        else:
+            path = Path(brief)
+            if not path.is_absolute():
+                path = REPOSITORY_ROOT / path
+            source_name = (
+                str(path.relative_to(REPOSITORY_ROOT))
+                if path.is_relative_to(REPOSITORY_ROOT)
+                else str(path)
+            )
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as error:
+                failures.append(f"{source_name}: could not read brief: {error}")
+                continue
+        try:
+            parsed.append((source_name, build_index(text, source_name)))
+        except ParseFailure as error:
+            failures.append(f"{source_name}: {error}")
+
+    if failures:
+        for failure in failures:
+            print(f"error: {failure}", file=sys.stderr)
+        print("No indexes written because at least one brief was not reliable to parse.", file=sys.stderr)
+        return 2
+
+    rendered = [
+        (source, json.dumps(index, ensure_ascii=False, indent=2) + "\n")
+        for source, index in parsed
+    ]
+    if arguments.stdout:
+        sys.stdout.write(rendered[0][1])
+        return 0
+
+    changed = 0
+    for source, content in rendered:
+        output = arguments.output_dir / f"{Path(source).stem}.index.json"
+        wrote = _write_if_changed(output, content)
+        changed += int(wrote)
+        print(f"{'wrote' if wrote else 'unchanged'} {output}")
+    print(f"indexed={len(rendered)} changed={changed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hardware/README.md
+++ b/scripts/hardware/README.md
@@ -3,6 +3,162 @@
 These scripts call the same public MCP tools that a model sees. They do not
 call Core handlers, the CEP HTTP bridge, or the native socket directly.
 
+## Shared capability-package runtime contract
+
+This is the lookup contract for `capability_package_runtime.py`. It describes
+the checked-in implementation, not a broader runner design. The shortest map is:
+
+| Concern | Shared runtime owns | Package driver owns |
+| --- | --- | --- |
+| Public transport | MCP session creation and one-object JSON decoding | Requests, call order, and semantic assertions |
+| Package declaration | Tool rows, capability IDs, kinds, and call limits | The actual `PackageSpec` values |
+| Verification | Native envelope, provenance, audit, digest, effect, and basic Undo claims | Before/after projections, interaction invariants, and post-Undo readback |
+| Lifecycle | One active ephemeral fixture's admission, identity, counters, recovery, and archive move | The fixture recipe and every AE action requested at a checkpoint |
+| Evidence | Redacted event stream, summary, completion table, and public-call ledger | Calling `mark_tool_passed` only after package semantics really pass |
+
+The module intentionally stops before becoming a plan language: exact request
+builders, semantic projections, fixture recipes, Undo checks, and interaction
+order remain package code
+(`capability_package_runtime.py:2-9`).
+
+### What the runtime provides
+
+- `ToolCase` declares one public tool, native capability, read/write kind, and
+  maximum primary invocations. `PackageSpec` requires 5-15 package tools
+  (5-30 for a milestone), unique names/keys, and bounded T4/T5/T6 targets and
+  hard limits. Support tools contribute required capabilities but do not get
+  package matrix rows (`capability_package_runtime.py:127-206`).
+- `CallLedger` accepts only `preflight`, `t4`, `t5`, and `t6`. Preflight is
+  fixed at target/hard limit 7; other limits come from `PackageSpec`. Every call
+  routed through `AcceptanceRuntime.call` is counted by tool and phase, including
+  support calls and expected errors (`capability_package_runtime.py:247-294`,
+  `805-855`).
+- `LiveSessionFactory` launches only the supplied stable launcher, constructs a
+  deliberately small environment, initializes MCP over stdio with a 45-second
+  read timeout, and snapshots `tools/list`. A public result is accepted only
+  when it contains exactly one text block decoding to a JSON object
+  (`capability_package_runtime.py:422-476`).
+- `validate_machine_identity` delegates to the exact-identity checker and saves
+  its component signals, source revisions, contract digests, and formal-AE
+  identity. `bind_latest_native_load` separately binds subsequent results to the
+  newest valid formal-AE load record and optionally proves an AE restart changed
+  the native instance (`capability_package_runtime.py:557-629`).
+- Successful calls must agree on native engine, capability/version/contract,
+  source revision, host and session, audit/request identities, effect, and
+  verified postcondition digest. Writes additionally require the declared Undo
+  envelope and replay flag (`capability_package_runtime.py:647-803`).
+- `intent()` returns a run-scoped deterministic-shape idempotency key with a
+  per-runtime counter; it is not stable across runs because the evidence run ID
+  is part of its hash (`capability_package_runtime.py:631-636`).
+
+### What a package driver must implement
+
+The shared CLI constructs identity, fixture, evidence, session, and runtime
+objects, calls `package_factory(runtime, fixture_name)`, then awaits
+`package.run()` (`capability_package_cli.py:79-120`). A package driver therefore
+must supply:
+
+1. a concrete `PackageSpec` and factory;
+2. an async `run()` that selects the behavior for `runtime.mode`;
+3. the disposable fixture recipe, request arguments, operation ordering, and
+   semantic before/after projections;
+4. calls to `validate_machine_identity`, `bind_latest_native_load`,
+   `require_tools`, and `runtime.call` at the appropriate points;
+5. independent package assertions around every write and its real Undo or
+   documented alternative;
+6. `mark_tool_passed` only after that tool's complete acceptance row has passed;
+   and
+7. a details mapping returned from `run()` for the completion summary.
+
+The runtime validates the native response envelope, but it does not know whether
+a package-specific value is correct. `mark_tool_passed` merely changes the row
+and optional Undo counters; it performs no readback itself
+(`capability_package_runtime.py:857-870`). `EvidenceLog.finish` serializes the
+matrix it is given and does not require every row to be passed
+(`capability_package_runtime.py:348-390`). Matrix completeness is therefore a
+driver invariant, not an automatic runtime gate.
+
+### Checkpoint semantics
+
+`runtime.checkpoint(kind, details)` records `checkpoint-requested`, awaits the
+configured handler, then records `checkpoint-completed`
+(`capability_package_runtime.py:638-641`). The default stdin handler:
+
+1. emits one JSON `CHECKPOINT_REQUIRED` line with a random checkpoint ID;
+2. reads exactly one line from stdin; and
+3. accepts only JSON with that same ID and `status="completed"`.
+
+EOF, malformed JSON, a mismatched ID, or any other status fails the run
+(`capability_package_runtime.py:479-507`). Completion is only an
+acknowledgement. The handler does not inspect AE or prove the requested GUI
+action occurred; the driver must perform the public readback or other
+postcondition after the acknowledgement.
+
+### Fixture lifecycle hooks
+
+- `FixturePolicy` requires an absolute `.aep` path, absolute recovery root,
+  positive retention, and exactly the `ephemeral-validation` lifecycle
+  (`capability_package_runtime.py:209-222`).
+- Call `require_fixture_absent()` before creation. It rejects any existing path,
+  including a symlink, rather than overwriting it
+  (`capability_package_runtime.py:872-876`).
+- After the first in-place save, `mark_fixture_created()` requires a nonempty
+  regular non-symlink file, hashes it, sets `created=1`, and records
+  `activeFixtureCount=1` and `saveAsCopies=0`
+  (`capability_package_runtime.py:878-911`).
+- `recover_zero_call_fixture()` acts only when the ledger is still zero, the
+  fixture was marked created, and the path still exists. It moves that exact
+  file to a new run directory under recovery and records a cleanup condition;
+  it does not delete it (`capability_package_runtime.py:913-956`).
+- `archive_fixture()` first checkpoints a save-in-place, close, and formal-AE
+  quit. It rejects recovery roots inside Adobe scan roots, then moves the file
+  into a unique run directory and verifies size and SHA-256 after the move
+  (`capability_package_runtime.py:962-1020`).
+
+The shared CLI invokes zero-call recovery only from its failed-run `finally`
+block (`capability_package_cli.py:123-152`). A custom wrapper gets no automatic
+recovery merely by constructing `AcceptanceRuntime`; it must reproduce that
+finally-path or use the shared CLI.
+
+### Mode selection
+
+The ledger recognizes all four modes, but the runtime does not decide whether a
+package is entitled to T4 or what each mode does
+(`capability_package_runtime.py:247-266`). The shared CLI exposes all four
+choices (`capability_package_cli.py:37-50`); a package-specific CLI may expose a
+smaller set. The package's `run()` owns the mode branch and must reject an
+inapplicable mode.
+
+`EvidenceLog` labels only T5/T6 as candidate runs, and
+`candidateEvidence=true` is assigned only when such a run finishes with
+`passed=true`. Preflight and T4 remain non-candidate even when successful
+(`capability_package_runtime.py:300-317`, `348-373`).
+
+### Evidence emission and failure edges
+
+The evidence directory is forced to mode `0700`. The runtime writes an
+append-only NDJSON event stream and exclusive summary JSON/completion Markdown
+files at mode `0600`; values are redacted before persistence
+(`capability_package_runtime.py:297-390`). Keys matching token, secret,
+fingerprint, socket, private path, fixture/project path, or home are replaced
+entirely. Private macOS and Windows user-path substrings in other strings are
+also replaced (`capability_package_runtime.py:40-47`, `110-124`).
+
+Three edges are easy to misread:
+
+- `AcceptanceRuntime.call` checks capacity before dispatch but reserves the
+  ledger entry and emits request/response events only after `session.call`
+  returns. A transport exception can therefore leave the count unchanged; zero
+  new ledger entries do not prove a write was not dispatched
+  (`capability_package_runtime.py:805-827`).
+- A decoded `POSSIBLY_SIDE_EFFECTING_FAILURE` is recorded, then immediately
+  raises `PossiblySideEffectingStop`. The runtime never retries it
+  (`capability_package_runtime.py:828-840`).
+- Every individual NDJSON event carries `candidateEvidence=false`; only the
+  final summary can set it true after a passing T5/T6 run. Consumers must read
+  the summary rather than infer candidate status from an event row
+  (`capability_package_runtime.py:324-380`).
+
 ## Native editing milestone #167
 
 `issue167_native_media_acceptance.py` drives the frozen 22-tool Effect Stack,

--- a/scripts/package/test/capability-package-index.test.mjs
+++ b/scripts/package/test/capability-package-index.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+const generator = path.join(repositoryRoot, 'scripts/generate_capability_package_index.py');
+
+function runGenerator(args) {
+  return spawnSync('python3', [generator, ...args], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('indexes every tracked capability brief deterministically', () => {
+  const outputRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-brief-index-'));
+  const first = runGenerator(['--output-dir', outputRoot]);
+  assert.equal(first.status, 0, first.stderr);
+
+  const briefs = fs.readdirSync(path.join(repositoryRoot, 'docs/capability-packages'))
+    .filter((name) => name.endsWith('.md'))
+    .sort();
+  const indexes = fs.readdirSync(outputRoot).sort();
+  assert.deepEqual(indexes, briefs.map((name) => name.replace(/\.md$/u, '.index.json')));
+
+  const indexPath = path.join(outputRoot, 'issue157-keyframe-authoring.index.json');
+  const firstBytes = fs.readFileSync(indexPath);
+  const firstMtime = fs.statSync(indexPath).mtimeMs;
+  const parsed = JSON.parse(firstBytes);
+  assert.equal(parsed.tools.length, 7);
+  assert.deepEqual(
+    parsed.tools.map((entry) => entry.name),
+    [
+      'ae_getLayerPropertyKeyframeDetails',
+      'ae_addLayerPropertyKeyframe',
+      'ae_setLayerPropertyKeyframeValue',
+      'ae_setLayerPropertyKeyframeInterpolation',
+      'ae_setLayerPropertyKeyframeTemporalEase',
+      'ae_setLayerPropertyKeyframeBehavior',
+      'ae_deleteLayerPropertyKeyframe',
+    ],
+  );
+  assert.ok(parsed.tools.every((entry) => entry.schema.status === 'narrative'));
+  assert.deepEqual(parsed.tools[0].schema.sharedBlocks[0].lineRange, { start: 13, end: 50 });
+  assert.deepEqual(parsed.tools[1].undoModel.lineRanges, [{ start: 72, end: 82 }]);
+
+  const second = runGenerator(['--output-dir', outputRoot]);
+  assert.equal(second.status, 0, second.stderr);
+  assert.deepEqual(fs.readFileSync(indexPath), firstBytes);
+  assert.equal(fs.statSync(indexPath).mtimeMs, firstMtime);
+});
+
+test('fails closed and writes no index when required brief structure is absent', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-bad-brief-'));
+  const brief = path.join(root, 'bad.md');
+  const output = path.join(root, 'derived');
+  fs.writeFileSync(brief, [
+    '# Incomplete package brief',
+    '',
+    '## Public surface',
+    '',
+    '| Public MCP tool | Effect |',
+    '| --- | --- |',
+    '| `ae_setSomething` | write |',
+    '',
+  ].join('\n'));
+
+  const result = runGenerator([brief, '--output-dir', output]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /no fenced public-MCP execution path/u);
+  assert.equal(fs.existsSync(output), false);
+});
+
+test('does not disguise a missing per-tool JSON schema as narrative', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-partial-schema-'));
+  const brief = path.join(root, 'partial.md');
+  const output = path.join(root, 'derived');
+  fs.writeFileSync(brief, [
+    '# Partial package brief',
+    '',
+    '## Public surface',
+    '',
+    '| Public MCP tool | Effect |',
+    '| --- | --- |',
+    '| `ae_setFirst` | write |',
+    '| `ae_setSecond` | write |',
+    '',
+    '## Public schemas',
+    '',
+    '```json',
+    '{',
+    '  "ae_setFirst": { "type": "object" }',
+    '}',
+    '```',
+    '',
+    '## Execution path',
+    '',
+    '```text',
+    'public MCP -> Core -> native RPC -> AE state',
+    '```',
+    '',
+    '## Undo model',
+    '',
+    'Every write receives one real AE Undo.',
+    '',
+    '## Acceptance',
+    '',
+    'Every public tool is required in package acceptance.',
+    '',
+  ].join('\n'));
+
+  const result = runGenerator([brief, '--output-dir', output]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /schema blocks name other public tools but omit ae_setSecond/u);
+  assert.equal(fs.existsSync(output), false);
+});


### PR DESCRIPTION
Eight hours of agent session logs showed where the time actually goes. The cost is **finding**, not understanding.

| File | Reads | Lines |
|---|---|---|
| `docs/capability-packages/text-shape-marker.md` | 193 | 1565 |
| `native/ae-plugin/src/aegp/plugin_entry.cpp` | 146 | 7992 |
| `scripts/hardware/capability_package_runtime.py` | 103 | — |
| `native/ae-plugin/src/core/rpc_codec.cpp` | 48 | 7067 |

Nearly every read was a slice. Shell commands outnumbered edits 2139 to 285, with `rg`/`sed`/`grep`/`find` alone accounting for 745 of them.

**The index generator** turns any capability-package brief into tool-to-line-range lookups. Measured honestly on three composition-settings tools: the observed grep-then-slice pattern costs six large-brief reads; regeneration plus one combined slice costs two brief reads and one index read. A 50% reduction in total reads — useful, not transformative.

The index is derived, so it is generated to a gitignored path rather than committed. A committed index drifts from its source, which is the defect class this repository keeps hitting. There is deliberately no CI staleness gate: the index is regenerated, not maintained, and a gate would make it one more thing to keep in sync.

**Documenting the shared runtime contract mattered more than the index.** Describing what `capability_package_runtime.py` actually does, rather than what it intends, surfaced three gaps nobody had noticed:

- `AcceptanceRuntime.call` records ledger and request/response evidence only *after* `session.call` returns, so an unchanged ledger does not prove a write was never dispatched. `AGENTS.md` §6 says a transport timeout does not prove a write did not occur — and the harness was relying on exactly that inference.
- Checkpoint acknowledgement, matrix pass marking and matrix completeness are driver-owned and never independently verified by the runtime.
- Custom acceptance wrappers do not get the shared CLI's zero-call fixture recovery unless they reproduce its finally path, so an orphaned `.aep` can escape through that seam.

This PR documents the contract as it stands rather than changing behaviour; the three gaps are filed separately.

**Verification:** governance passed; Node 395 tests, 389 passed 6 skipped; pytest 1112 selected, 1108 passed 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
