### PR TITLE
Profile bundle identity verification for development and release

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -449,11 +449,13 @@ jobs:
           [[ -x "$runtime_node" ]]
           "$runtime_node" scripts/package/stage-platform-bundle.mjs \
             --platform macos-arm64 \
+            --profile release-audit \
             --version "$VERSION" \
             --out "$GITHUB_WORKSPACE/build/stage/macos-arm64"
           "$runtime_node" scripts/package/verify-platform-bundle.mjs \
             --root "$GITHUB_WORKSPACE/build/stage/macos-arm64" \
             --platform macos-arm64 \
+            --profile release-audit \
             --version "$VERSION"
 
       - name: Import ephemeral Developer ID and notarization credentials
@@ -712,12 +714,14 @@ jobs:
           if (-not (Test-Path -LiteralPath $runtimeNode -PathType Leaf)) { throw 'bundled Node is missing' }
           & $runtimeNode scripts/package/stage-platform-bundle.mjs `
             --platform windows-x64 `
+            --profile release-audit `
             --version $env:VERSION `
             --out (Join-Path $env:GITHUB_WORKSPACE 'build\stage\windows-x64')
           if ($LASTEXITCODE -ne 0) { throw 'Windows bundle staging failed' }
           & $runtimeNode scripts/package/verify-platform-bundle.mjs `
             --root (Join-Path $env:GITHUB_WORKSPACE 'build\stage\windows-x64') `
             --platform windows-x64 `
+            --profile release-audit `
             --version $env:VERSION
           if ($LASTEXITCODE -ne 0) { throw 'Windows bundle verification failed' }
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,20 @@ endpoint and peer identity, but there is no connection code, fingerprint
 confirmation, or build flag on the single-user development path.
 
 Close every After Effects, AfterFX, and aerender process before installing. The development
-installer verifies the build receipt and installed copy, and installs the loadable bundle at
+installer validates the receipt shape, product version, protocol metadata, platform, architecture,
+entrypoint, signature, and installed copy, and installs the loadable bundle at
 `~/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/AeMcpNative.plugin`:
 
 ```bash
 node native/ae-plugin/install-dev-macos.mjs install \
   --artifact-dir "$BUILD_DIR"
 ```
+
+The default `development` identity profile records source revisions but does not reject an
+otherwise compatible locally built artifact only because its source commit or recorded payload
+hashes differ. Product-version equality remains required because no compatibility range exists.
+Use `--profile release-audit` for an explicit exact-source, exact-receipt, and exact-artifact audit;
+release workflows select that profile themselves.
 
 That MediaCore namespace is kept strict: it is either empty during a transaction or contains only
 the active `AeMcpNative.plugin`. Transaction records and every complete stage, backup, failed, or

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,7 +227,8 @@ node native/ae-plugin/verify-macos.mjs \
 例行启动与验收按组件集记录各自的源码 revision 和安装回执，并校验 canonical path、组件/协议版本、
 文件大小、mode 与修改时间等有界信号；只有观察到矛盾、或明确执行 release/security 审计时才升级为内容哈希。
 
-安装前必须关闭所有 After Effects、AfterFX 和 aerender 进程。开发安装器会校验构建回执和安装后的副本，
+安装前必须关闭所有 After Effects、AfterFX 和 aerender 进程。开发安装器会校验回执结构、产品版本、
+协议元数据、平台、架构、入口点、签名和安装后的副本，
 最终安装位置为
 `~/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/AeMcpNative.plugin`：
 
@@ -235,6 +236,11 @@ node native/ae-plugin/verify-macos.mjs \
 node native/ae-plugin/install-dev-macos.mjs install \
   --artifact-dir "$BUILD_DIR"
 ```
+
+默认的 `development` 身份档会记录源码 revision，但不会仅因源码提交或已记录 payload 哈希不同而拒绝
+其他方面兼容的本地构建。由于目前没有版本兼容区间，产品版本相等仍是硬门禁。显式 release/security
+审计使用 `--profile release-audit`，它恢复 exact-source、exact-receipt 和 exact-artifact 校验；
+发布工作流会自行选择该档。
 
 MediaCore 命名空间采用严格约束：事务进行中允许为空，其余时间只能包含当前生效的
 `AeMcpNative.plugin`。事务记录以及完整的 stage、backup、failed、replaced bundle 全部保存在 Adobe

--- a/native/ae-plugin/install-dev-macos.mjs
+++ b/native/ae-plugin/install-dev-macos.mjs
@@ -9,6 +9,11 @@ import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 
 import { verifyMacPlugin } from './verify-macos.mjs';
+import {
+  DEVELOPMENT_IDENTITY_PROFILE,
+  normalizeIdentityVerificationProfile,
+  requiresExactIdentity,
+} from '../../scripts/package/lib/identity-verification-profile.mjs';
 
 const MODULE_PATH = fileURLToPath(import.meta.url);
 const BUNDLE_NAME = 'AeMcpNative.plugin';
@@ -312,14 +317,16 @@ async function loadSourceArtifact(artifactDir, dependencies) {
     }),
     'verified source artifact',
   );
-  if (!isDeepStrictEqual(observed, receipt.artifact)) {
+  const exactIdentity = requiresExactIdentity(dependencies.verificationProfile);
+  if (exactIdentity && !isDeepStrictEqual(observed, receipt.artifact)) {
     throw installerError(
       'AE_PLUGIN_RECEIPT_MISMATCH',
       'verified source bundle does not match its complete build receipt artifact record',
     );
   }
-  await assertEmbeddedSourceCommit(bundlePath, receipt.sourceCommit);
+  if (exactIdentity) await assertEmbeddedSourceCommit(bundlePath, receipt.sourceCommit);
   return {
+    artifact: exactIdentity ? receipt.artifact : observed,
     bundlePath,
     receipt,
     receiptSha256: crypto.createHash('sha256').update(receiptBytes).digest('hex'),
@@ -727,7 +734,7 @@ function defaultIsProcessAlive(pid) {
   }
 }
 
-function dependenciesFor(overrides = {}) {
+function dependenciesFor(overrides = {}, verificationProfile = DEVELOPMENT_IDENTITY_PROFILE) {
   return {
     acquireStateGuard: overrides.acquireStateGuard ?? defaultAcquireStateGuard,
     assertAeStopped: overrides.assertAeStopped ?? defaultAssertAeStopped,
@@ -752,6 +759,7 @@ function dependenciesFor(overrides = {}) {
     )),
     syncDirectory: overrides.syncDirectory ?? syncDirectory,
     verifyBundle: overrides.verifyBundle ?? verifyMacPlugin,
+    verificationProfile: normalizeIdentityVerificationProfile(verificationProfile),
   };
 }
 
@@ -792,10 +800,13 @@ async function verifyDisabled(bundlePath, expected, dependencies, label, sourceC
     await dependencies.verifyBundle({ bundlePath, allowManagedDisabledName: true }),
     label,
   );
-  if (!isDeepStrictEqual(observed, expected)) {
+  const exactIdentity = requiresExactIdentity(dependencies.verificationProfile);
+  if (exactIdentity && !isDeepStrictEqual(observed, expected)) {
     throw installerError('AE_PLUGIN_RECEIPT_MISMATCH', `${label} does not match its recorded hash set`);
   }
-  if (sourceCommit) await assertEmbeddedSourceCommit(bundlePath, sourceCommit);
+  if (exactIdentity && sourceCommit) {
+    await assertEmbeddedSourceCommit(bundlePath, sourceCommit);
+  }
   return observed;
 }
 
@@ -804,10 +815,11 @@ async function verifyTarget(target, expected, dependencies, label, sourceCommit 
     await dependencies.verifyBundle({ bundlePath: target }),
     label,
   );
-  if (!isDeepStrictEqual(observed, expected)) {
+  const exactIdentity = requiresExactIdentity(dependencies.verificationProfile);
+  if (exactIdentity && !isDeepStrictEqual(observed, expected)) {
     throw installerError('AE_PLUGIN_RECEIPT_MISMATCH', `${label} does not match its recorded hash set`);
   }
-  if (sourceCommit) await assertEmbeddedSourceCommit(target, sourceCommit);
+  if (exactIdentity && sourceCommit) await assertEmbeddedSourceCommit(target, sourceCommit);
   return observed;
 }
 
@@ -1451,9 +1463,10 @@ export async function installDevMacPlugin({
   artifactDir,
   mediaCoreRoot = defaultMediaCoreRoot(),
   stateBaseRoot = defaultStateBaseRoot(mediaCoreRoot),
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   dependencies: dependencyOverrides,
 }) {
-  const dependencies = dependenciesFor(dependencyOverrides);
+  const dependencies = dependenciesFor(dependencyOverrides, verificationProfile);
   requireMac(dependencies);
   await dependencies.assertAeStopped();
   const source = await loadSourceArtifact(artifactDir, dependencies);
@@ -1510,7 +1523,7 @@ export async function installDevMacPlugin({
     await dependencies.copyBundle(source.bundlePath, stage);
     await verifyDisabled(
       stage,
-      source.receipt.artifact,
+      source.artifact,
       dependencies,
       'staged native artifact',
       source.receipt.sourceCommit,
@@ -1533,7 +1546,7 @@ export async function installDevMacPlugin({
       targetName: BUNDLE_NAME,
       sourceCommit: source.receipt.sourceCommit,
       buildReceiptSha256: source.receiptSha256,
-      installedArtifact: source.receipt.artifact,
+      installedArtifact: source.artifact,
       previous: {
         present: previousArtifact !== null,
         artifact: previousArtifact,
@@ -1585,7 +1598,7 @@ export async function installDevMacPlugin({
       await writeJsonAtomic(transactionPath, transaction);
       await verifyTarget(
         target,
-        source.receipt.artifact,
+        source.artifact,
         dependencies,
         'installed native artifact',
         source.receipt.sourceCommit,
@@ -1607,7 +1620,7 @@ export async function installDevMacPlugin({
         target,
         productVersion: source.receipt.productVersion,
         sourceCommit: source.receipt.sourceCommit,
-        artifact: source.receipt.artifact,
+        artifact: source.artifact,
         previous: {
           present: previousArtifact !== null,
           artifact: previousArtifact,
@@ -2047,7 +2060,7 @@ async function reconcileCurrentTransaction({ dependencies, stateStore, target, t
       }
       desired = matchingTips[0]?.value.transactionId ?? null;
     }
-    if (desired) {
+    if (desired && requiresExactIdentity(dependencies.verificationProfile)) {
       await assertEmbeddedSourceCommit(target, byId.get(desired).value.sourceCommit);
     }
   }
@@ -2151,10 +2164,11 @@ export async function rollbackDevMacPlugin({
   transactionId,
   mediaCoreRoot = defaultMediaCoreRoot(),
   stateBaseRoot = defaultStateBaseRoot(mediaCoreRoot),
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   dependencies: dependencyOverrides,
 }) {
   assertTransactionId(transactionId);
-  const dependencies = dependenciesFor(dependencyOverrides);
+  const dependencies = dependenciesFor(dependencyOverrides, verificationProfile);
   requireMac(dependencies);
   await dependencies.assertAeStopped();
   const roots = await prepareRoots(mediaCoreRoot, stateBaseRoot);
@@ -2329,9 +2343,10 @@ export async function rollbackDevMacPlugin({
 export async function recoverDevMacPlugin({
   mediaCoreRoot = defaultMediaCoreRoot(),
   stateBaseRoot = defaultStateBaseRoot(mediaCoreRoot),
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   dependencies: dependencyOverrides,
 } = {}) {
-  const dependencies = dependenciesFor(dependencyOverrides);
+  const dependencies = dependenciesFor(dependencyOverrides, verificationProfile);
   requireMac(dependencies);
   await dependencies.assertAeStopped();
   const roots = await prepareRoots(mediaCoreRoot, stateBaseRoot);
@@ -2359,20 +2374,35 @@ export async function recoverDevMacPlugin({
 }
 
 function parseCli(argv) {
-  if (argv.length === 3 && argv[0] === 'install' && argv[1] === '--artifact-dir'
-      && path.isAbsolute(argv[2])) {
-    return { action: 'install', artifactDir: argv[2] };
+  const args = [...argv];
+  let verificationProfile = DEVELOPMENT_IDENTITY_PROFILE;
+  const profileIndex = args.indexOf('--profile');
+  if (profileIndex !== -1) {
+    if (profileIndex + 1 >= args.length || args.indexOf('--profile', profileIndex + 1) !== -1) {
+      throw installerError('AE_PLUGIN_ARGUMENT_INVALID', 'verification profile is invalid');
+    }
+    verificationProfile = args[profileIndex + 1];
+    args.splice(profileIndex, 2);
   }
-  if (argv.length === 3 && argv[0] === 'rollback' && argv[1] === '--transaction'
-      && UUID_V4.test(argv[2])) {
-    return { action: 'rollback', transactionId: argv[2] };
+  try {
+    normalizeIdentityVerificationProfile(verificationProfile);
+  } catch {
+    throw installerError('AE_PLUGIN_ARGUMENT_INVALID', 'verification profile is invalid');
   }
-  if (argv.length === 1 && argv[0] === 'recover') {
-    return { action: 'recover' };
+  if (args.length === 3 && args[0] === 'install' && args[1] === '--artifact-dir'
+      && path.isAbsolute(args[2])) {
+    return { action: 'install', artifactDir: args[2], verificationProfile };
+  }
+  if (args.length === 3 && args[0] === 'rollback' && args[1] === '--transaction'
+      && UUID_V4.test(args[2])) {
+    return { action: 'rollback', transactionId: args[2], verificationProfile };
+  }
+  if (args.length === 1 && args[0] === 'recover') {
+    return { action: 'recover', verificationProfile };
   }
   throw installerError(
     'AE_PLUGIN_ARGUMENT_INVALID',
-    'usage: install --artifact-dir /absolute/build-output | rollback --transaction <uuid> | recover',
+    'usage: install --artifact-dir /absolute/build-output [--profile development|release-audit] | rollback --transaction <uuid> [--profile development|release-audit] | recover [--profile development|release-audit]',
   );
 }
 
@@ -2395,11 +2425,19 @@ if (path.resolve(process.argv[1] ?? '') === MODULE_PATH) {
     const command = parseCli(process.argv.slice(2));
     let result;
     if (command.action === 'install') {
-      result = await installDevMacPlugin({ artifactDir: command.artifactDir });
+      result = await installDevMacPlugin({
+        artifactDir: command.artifactDir,
+        verificationProfile: command.verificationProfile,
+      });
     } else if (command.action === 'rollback') {
-      result = await rollbackDevMacPlugin({ transactionId: command.transactionId });
+      result = await rollbackDevMacPlugin({
+        transactionId: command.transactionId,
+        verificationProfile: command.verificationProfile,
+      });
     } else {
-      result = await recoverDevMacPlugin();
+      result = await recoverDevMacPlugin({
+        verificationProfile: command.verificationProfile,
+      });
     }
     process.stdout.write(`${JSON.stringify({ ok: true, result })}\n`);
   } catch (error) {

--- a/scripts/hardware/README.md
+++ b/scripts/hardware/README.md
@@ -205,6 +205,15 @@ Routine starts verify canonical paths, component/protocol versions, sizes,
 modes, and modification times; content hashing is reserved for a contradictory
 signal or an explicitly requested release/security audit.
 
+The package staging/verifier and native development installer use the
+`development` identity profile by default. It keeps protocol, product-version,
+platform, architecture, entrypoint, load, and Adobe scan-root protections, but
+records source-revision drift and does not gate on full payload hashes or deep
+receipt identity. Release and security-audit entry points must select
+`--profile release-audit`; the release workflows and signing freeze do so
+explicitly. Product-version equality remains strict in both profiles because
+the current product contract has no version compatibility range.
+
 The frozen package matrix has eight public acceptance rows: three reads and
 five writes. `ae_listProjectItems` is an existing support read used only for
 independent project-count and duplicate readback; its descriptor is pinned by

--- a/scripts/package/freeze-signed-manifests.mjs
+++ b/scripts/package/freeze-signed-manifests.mjs
@@ -115,6 +115,7 @@ export async function freezeSignedManifests({
     platform,
     version,
     sourceCommitSha,
+    verificationProfile: 'release-audit',
   });
   return Object.freeze({
     sourceStageSha256,

--- a/scripts/package/lib/identity-verification-profile.mjs
+++ b/scripts/package/lib/identity-verification-profile.mjs
@@ -1,0 +1,24 @@
+export const DEVELOPMENT_IDENTITY_PROFILE = 'development';
+export const RELEASE_AUDIT_IDENTITY_PROFILE = 'release-audit';
+
+const PROFILES = new Set([
+  DEVELOPMENT_IDENTITY_PROFILE,
+  RELEASE_AUDIT_IDENTITY_PROFILE,
+]);
+
+export function normalizeIdentityVerificationProfile(
+  value = DEVELOPMENT_IDENTITY_PROFILE,
+) {
+  if (!PROFILES.has(value)) {
+    const error = new TypeError(
+      `identity verification profile must be ${[...PROFILES].join(' or ')}`,
+    );
+    error.code = 'IDENTITY_VERIFICATION_PROFILE_INVALID';
+    throw error;
+  }
+  return value;
+}
+
+export function requiresExactIdentity(profile) {
+  return normalizeIdentityVerificationProfile(profile) === RELEASE_AUDIT_IDENTITY_PROFILE;
+}

--- a/scripts/package/lib/native-plugin-manifest.mjs
+++ b/scripts/package/lib/native-plugin-manifest.mjs
@@ -16,6 +16,11 @@ import {
   sha256File,
   writeCanonicalJson,
 } from './manifest.mjs';
+import {
+  DEVELOPMENT_IDENTITY_PROFILE,
+  normalizeIdentityVerificationProfile,
+  requiresExactIdentity,
+} from './identity-verification-profile.mjs';
 
 export const NATIVE_PLUGIN_ROOT = path.posix.dirname(NATIVE_PLUGIN_MANIFEST_PATH);
 export const NATIVE_PLUGIN_MANIFEST_NAME = path.posix.basename(NATIVE_PLUGIN_MANIFEST_PATH);
@@ -276,7 +281,7 @@ export function validateNativePluginManifest(value) {
   return value;
 }
 
-async function assertExactDirectoryEntries(directory, expected, label) {
+async function assertDirectoryEntries(directory, expected, label, exactIdentity) {
   const metadata = await fs.promises.lstat(directory).catch(() => null);
   if (!metadata?.isDirectory() || metadata.isSymbolicLink()) {
     throw nativeError(
@@ -286,10 +291,15 @@ async function assertExactDirectoryEntries(directory, expected, label) {
   }
   const entries = (await fs.promises.readdir(directory)).sort();
   const wanted = [...expected].sort();
-  if (JSON.stringify(entries) !== JSON.stringify(wanted)) {
+  const matches = exactIdentity
+    ? JSON.stringify(entries) === JSON.stringify(wanted)
+    : wanted.every((entry) => entries.includes(entry));
+  if (!matches) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH',
-      label + ' file set is not exact',
+      exactIdentity
+        ? label + ' file set is not exact'
+        : label + ' is missing a required entry',
     );
   }
 }
@@ -330,6 +340,7 @@ function assertReceiptMatchesCandidate(
   expectedVersion,
   expectedSourceCommit,
   evidence,
+  exactIdentity,
 ) {
   if (receipt.productVersion !== expectedVersion) {
     throw nativeError(
@@ -337,7 +348,7 @@ function assertReceiptMatchesCandidate(
       'native product version does not match the platform bundle',
     );
   }
-  if (receipt.sourceCommit !== expectedSourceCommit) {
+  if (exactIdentity && receipt.sourceCommit !== expectedSourceCommit) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
       'native source commit does not match the platform bundle',
@@ -442,7 +453,7 @@ function assertManifestMatchesReceipt(manifest, receipt, evidence) {
   }
 }
 
-async function verifyArtifact(bundlePath, receipt, dependencies) {
+async function verifyArtifact(bundlePath, receipt, dependencies, exactIdentity) {
   const actual = validateNativeArtifact(
     await verifierFrom(dependencies)({
       bundlePath,
@@ -450,13 +461,13 @@ async function verifyArtifact(bundlePath, receipt, dependencies) {
     }),
     'observed native artifact',
   );
-  if (!sameCanonical(actual, receipt.artifact)) {
+  if (exactIdentity && !sameCanonical(actual, receipt.artifact)) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_ARTIFACT_MISMATCH',
       'observed native artifact does not match its build receipt',
     );
   }
-  await assertEmbeddedSourceCommit(bundlePath, receipt.sourceCommit);
+  if (exactIdentity) await assertEmbeddedSourceCommit(bundlePath, receipt.sourceCommit);
   return actual;
 }
 
@@ -464,20 +475,25 @@ export async function verifyNativePluginStage({
   root,
   productVersion,
   sourceCommitSha,
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   candidateRepoRoot,
   dependencies = {},
 } = {}) {
+  const profile = normalizeIdentityVerificationProfile(verificationProfile);
+  const exactIdentity = requiresExactIdentity(profile);
   const nativeRoot = path.resolve(String(root ?? ''));
-  await assertExactDirectoryEntries(
+  await assertDirectoryEntries(
     nativeRoot,
     [NATIVE_PLUGIN_MANIFEST_NAME, NATIVE_PLUGIN_PAYLOAD_ROOT],
     'native plug-in stage',
+    exactIdentity,
   );
   const payloadRoot = path.join(nativeRoot, NATIVE_PLUGIN_PAYLOAD_ROOT);
-  await assertExactDirectoryEntries(
+  await assertDirectoryEntries(
     payloadRoot,
     [NATIVE_PLUGIN_BUNDLE_NAME, NATIVE_PLUGIN_RECEIPT_NAME],
     'native plug-in payload',
+    exactIdentity,
   );
   const manifestPath = path.join(nativeRoot, NATIVE_PLUGIN_MANIFEST_NAME);
   const manifest = validateNativePluginManifest(
@@ -489,15 +505,22 @@ export async function verifyNativePluginStage({
       'native manifest version does not match the platform bundle',
     );
   }
-  if (manifest.sourceCommitSha !== sourceCommitSha) {
+  if (exactIdentity && manifest.sourceCommitSha !== sourceCommitSha) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH',
       'native manifest source does not match the platform bundle',
     );
   }
   const evidence = await candidateEvidence(path.resolve(String(candidateRepoRoot ?? '')));
+  if (manifest.protocol.schemaSha256 !== evidence.protocolSchemaSha256) {
+    throw nativeError(
+      'BUNDLE_NATIVE_PLUGIN_PROTOCOL_MISMATCH',
+      'native manifest RPC protocol digest does not match the candidate schema',
+    );
+  }
   const receiptPath = path.join(payloadRoot, NATIVE_PLUGIN_RECEIPT_NAME);
-  if (await sha256File(receiptPath) !== manifest.artifact.receiptSha256) {
+  if (exactIdentity
+      && await sha256File(receiptPath) !== manifest.artifact.receiptSha256) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_HASH_MISMATCH',
       'native build receipt digest does not match its manifest',
@@ -506,12 +529,19 @@ export async function verifyNativePluginStage({
   const receipt = validateNativeBuildReceipt(
     await readJsonFile(receiptPath, 'BUNDLE_NATIVE_PLUGIN_RECEIPT_INVALID'),
   );
-  assertReceiptMatchesCandidate(receipt, productVersion, sourceCommitSha, evidence);
-  assertManifestMatchesReceipt(manifest, receipt, evidence);
+  assertReceiptMatchesCandidate(
+    receipt,
+    productVersion,
+    sourceCommitSha,
+    evidence,
+    exactIdentity,
+  );
+  if (exactIdentity) assertManifestMatchesReceipt(manifest, receipt, evidence);
   await verifyArtifact(
     path.join(payloadRoot, NATIVE_PLUGIN_BUNDLE_NAME),
     receipt,
     dependencies,
+    exactIdentity,
   );
   return manifest;
 }
@@ -521,9 +551,12 @@ export async function stageNativePluginArtifact({
   destinationRoot,
   productVersion,
   sourceCommitSha,
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   candidateRepoRoot,
   dependencies = {},
 } = {}) {
+  const profile = normalizeIdentityVerificationProfile(verificationProfile);
+  const exactIdentity = requiresExactIdentity(profile);
   if (!PRODUCT_VERSION_PATTERN.test(productVersion ?? '')) {
     throw nativeError(
       'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
@@ -538,10 +571,11 @@ export async function stageNativePluginArtifact({
   }
   const source = path.resolve(String(sourceRoot ?? ''));
   const destination = path.resolve(String(destinationRoot ?? ''));
-  await assertExactDirectoryEntries(
+  await assertDirectoryEntries(
     source,
     [NATIVE_PLUGIN_BUNDLE_NAME, NATIVE_PLUGIN_RECEIPT_NAME],
     'native build output',
+    exactIdentity,
   );
   const evidence = await candidateEvidence(path.resolve(String(candidateRepoRoot ?? '')));
   const sourceReceipt = validateNativeBuildReceipt(
@@ -555,11 +589,13 @@ export async function stageNativePluginArtifact({
     productVersion,
     sourceCommitSha,
     evidence,
+    exactIdentity,
   );
   await verifyArtifact(
     path.join(source, NATIVE_PLUGIN_BUNDLE_NAME),
     sourceReceipt,
     dependencies,
+    exactIdentity,
   );
   const existing = await fs.promises.lstat(destination).catch(() => null);
   if (existing) {
@@ -589,6 +625,7 @@ export async function stageNativePluginArtifact({
       root: destination,
       productVersion,
       sourceCommitSha,
+      verificationProfile: profile,
       candidateRepoRoot,
       dependencies,
     });

--- a/scripts/package/stage-platform-bundle.mjs
+++ b/scripts/package/stage-platform-bundle.mjs
@@ -22,6 +22,11 @@ import {
   NATIVE_PLUGIN_ROOT,
   stageNativePluginArtifact,
 } from './lib/native-plugin-manifest.mjs';
+import {
+  DEVELOPMENT_IDENTITY_PROFILE,
+  normalizeIdentityVerificationProfile,
+  requiresExactIdentity,
+} from './lib/identity-verification-profile.mjs';
 import { validateRuntimeManifest } from './lib/runtime-manifest.mjs';
 import { verifyPlatformBundle } from './verify-platform-bundle.mjs';
 
@@ -97,7 +102,7 @@ function validateHelperInput(value, platform) {
   return value;
 }
 
-async function copyHelperPayload(sourceRoot, destinationRoot, manifest) {
+async function copyHelperPayload(sourceRoot, destinationRoot, manifest, verificationProfile) {
   await fs.promises.mkdir(destinationRoot, { recursive: true });
   const sourceManifest = path.join(sourceRoot, 'helper-manifest.json');
   await fs.promises.copyFile(
@@ -118,7 +123,8 @@ async function copyHelperPayload(sourceRoot, destinationRoot, manifest) {
         `hard-linked helper payload is forbidden: ${record.path}`,
       );
     }
-    if (await sha256File(source) !== record.sha256) {
+    if (requiresExactIdentity(verificationProfile)
+        && await sha256File(source) !== record.sha256) {
       throw bundleError('BUNDLE_HASH_MISMATCH', `helper input SHA-256 mismatch: ${record.path}`);
     }
     await fs.promises.mkdir(path.dirname(destination), { recursive: true });
@@ -138,9 +144,11 @@ export async function stagePlatformBundle({
   outDir,
   repoRoot,
   sourceCommitSha,
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   inputs = {},
   dependencies = {},
 } = {}) {
+  const profile = normalizeIdentityVerificationProfile(verificationProfile);
   if (!PLATFORM_IDS.has(platform)) throw bundleError('BUNDLE_PLATFORM_INVALID', `unsupported platform: ${platform}`);
   if (!SEMVER_PATTERN.test(version ?? '')) throw bundleError('BUNDLE_VERSION_INVALID', `invalid semver: ${version}`);
   if (!SOURCE_SHA_PATTERN.test(sourceCommitSha ?? '')) {
@@ -193,7 +201,12 @@ export async function stagePlatformBundle({
   try {
     await copyTree(pluginRoot, temporary, { filter: pluginFilter });
     await copyTree(runtimeRoot, path.join(temporary, 'runtime', platform));
-    await copyHelperPayload(helperRoot, path.join(temporary, 'platform', platform), helperManifest);
+    await copyHelperPayload(
+      helperRoot,
+      path.join(temporary, 'platform', platform),
+      helperManifest,
+      profile,
+    );
     await copyTree(toolsRoot, path.join(temporary, 'bundled-tools'));
     await fs.promises.mkdir(path.join(temporary, 'metadata'), { recursive: true });
     await fs.promises.copyFile(
@@ -208,6 +221,7 @@ export async function stagePlatformBundle({
         destinationRoot: path.join(temporary, ...NATIVE_PLUGIN_ROOT.split('/')),
         productVersion: version,
         sourceCommitSha,
+        verificationProfile: profile,
         candidateRepoRoot: resolvedRepoRoot,
         dependencies,
       });
@@ -250,6 +264,7 @@ export async function stagePlatformBundle({
       platform,
       version,
       sourceCommitSha,
+      verificationProfile: profile,
       candidateRepoRoot: resolvedRepoRoot,
       dependencies,
     });
@@ -315,6 +330,7 @@ function parseArgs(argv) {
     '--native-plugin-artifact',
     '--out',
     '--platform',
+    '--profile',
     '--version',
   ]);
   for (let index = 0; index < argv.length; index += 1) {
@@ -332,7 +348,9 @@ function parseArgs(argv) {
     platform: values.get('--platform'),
     version: values.get('--version'),
     outDir: values.get('--out'),
+    verificationProfile: values.get('--profile') ?? DEVELOPMENT_IDENTITY_PROFILE,
   };
+  normalizeIdentityVerificationProfile(parsed.verificationProfile);
   if (values.has('--native-plugin-artifact')) {
     parsed.inputs = { nativePluginRoot: values.get('--native-plugin-artifact') };
   }

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -428,6 +428,7 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
     outDir,
     repoRoot,
     sourceCommitSha: SOURCE_COMMIT_SHA,
+    verificationProfile: 'release-audit',
     ...overrides,
   };
   return {
@@ -437,7 +438,12 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
     runtimeRoot,
     helperRoot,
     input,
-    verifyInput: { root: outDir, platform, version: PRODUCT_VERSION },
+    verifyInput: {
+      root: outDir,
+      platform,
+      version: PRODUCT_VERSION,
+      verificationProfile: 'release-audit',
+    },
     exists(relative) {
       return fs.existsSync(path.join(outDir, ...relative.split('/')));
     },

--- a/scripts/package/test/native-aegp-dev-install.test.mjs
+++ b/scripts/package/test/native-aegp-dev-install.test.mjs
@@ -742,7 +742,7 @@ test('rollback restores the installed target after target-to-replaced post-renam
   await assert.rejects(payloadAt(replaced), { code: 'ENOENT' });
 });
 
-test('complete artifact receipt comparison rejects a single changed hash', async (t) => {
+test('release-audit profile rejects a single changed receipt hash', async (t) => {
   const state = await fixture(t);
   const mismatched = {
     ...artifactFor('one'),
@@ -758,6 +758,7 @@ test('complete artifact receipt comparison rejects a single changed hash', async
     installDevMacPlugin({
       artifactDir,
       mediaCoreRoot: state.mediaCoreRoot,
+      verificationProfile: 'release-audit',
       dependencies: dependencies(),
     }),
     { code: 'AE_PLUGIN_RECEIPT_MISMATCH' },
@@ -782,7 +783,7 @@ test('receipt product version is bound to the verified native bundle identity', 
   );
 });
 
-test('receipt source commit must also be embedded in the native executable bytes', async (t) => {
+test('release-audit profile requires the receipt source in executable bytes', async (t) => {
   const state = await fixture(t);
   const artifactDir = await makeArtifact(state.root, 'build-unbound', 'one');
   await writeFile(
@@ -794,10 +795,40 @@ test('receipt source commit must also be embedded in the native executable bytes
     installDevMacPlugin({
       artifactDir,
       mediaCoreRoot: state.mediaCoreRoot,
+      verificationProfile: 'release-audit',
       dependencies: dependencies(),
     }),
     { code: 'AE_PLUGIN_RECEIPT_MISMATCH' },
   );
+});
+
+test('development profile trusts the verified artifact over stale receipt identity', async (t) => {
+  const state = await fixture(t);
+  const mismatched = {
+    ...artifactFor('one'),
+    bundleTreeSha256: 'c'.repeat(64),
+  };
+  const artifactDir = await makeArtifact(
+    state.root,
+    'build-development-profile',
+    'one',
+    { receiptArtifact: mismatched },
+  );
+  await writeFile(
+    path.join(artifactDir, 'AeMcpNative.plugin', 'Contents', 'MacOS', 'AeMcpNative'),
+    'fake-mach-o-without-the-receipt-source',
+    'utf8',
+  );
+
+  const installed = await installDevMacPlugin({
+    artifactDir,
+    mediaCoreRoot: state.mediaCoreRoot,
+    dependencies: dependencies(),
+  });
+
+  assert.deepEqual(installed.artifact, artifactFor('one'));
+  assert.equal(await payloadAt(state.target), 'one');
+  await assertScanRootExactly(state, true);
 });
 
 for (const transition of ['install.prepared', 'install.old_moved', 'install.candidate_moved']) {
@@ -1658,6 +1689,20 @@ test('production CLI exposes no target override and returns structured errors', 
       assert.equal(response.ok, false);
       assert.equal(response.error.code, 'AE_PLUGIN_ARGUMENT_INVALID');
       assert.doesNotMatch(response.error.message, /--target/u);
+      return true;
+    },
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      installerPath,
+      'recover',
+      '--profile',
+      'unknown',
+    ]),
+    (error) => {
+      const response = JSON.parse(error.stderr);
+      assert.equal(response.ok, false);
+      assert.equal(response.error.code, 'AE_PLUGIN_ARGUMENT_INVALID');
       return true;
     },
   );

--- a/scripts/package/test/stage-platform-bundle.test.mjs
+++ b/scripts/package/test/stage-platform-bundle.test.mjs
@@ -70,6 +70,53 @@ test('macOS stage explicitly opts in a verified native plug-in artifact', async 
   await assert.doesNotReject(verifyPlatformBundle(h.verifyInput));
 });
 
+test('development staging tolerates stale helper hashes while release-audit rejects them', async (t) => {
+  const development = await makeStageHarness(t, 'macos-arm64');
+  const developmentHelper = path.join(
+    development.helperRoot,
+    'bin',
+    'ae-mcp-platform-helper',
+  );
+  await fs.promises.appendFile(developmentHelper, Buffer.from([0]));
+  await assert.doesNotReject(stagePlatformBundle({
+    ...development.input,
+    verificationProfile: 'development',
+  }));
+
+  const release = await makeStageHarness(t, 'macos-arm64');
+  const releaseHelper = path.join(release.helperRoot, 'bin', 'ae-mcp-platform-helper');
+  await fs.promises.appendFile(releaseHelper, Buffer.from([0]));
+  await assert.rejects(
+    stagePlatformBundle(release.input),
+    { code: 'BUNDLE_HASH_MISMATCH' },
+  );
+});
+
+test('development native staging records source drift while release-audit rejects it', async (t) => {
+  const mismatchedSource = 'f'.repeat(40);
+  const development = await makeNativeStageHarness(
+    t,
+    'macos-arm64',
+    { sourceCommitSha: mismatchedSource },
+  );
+  await assert.doesNotReject(stagePlatformBundle({
+    ...development.input,
+    verificationProfile: 'development',
+  }));
+  assert.equal(development.manifest().sourceCommitSha, mismatchedSource);
+  assert.equal(development.nativeManifest().sourceCommitSha, SOURCE_COMMIT_SHA);
+
+  const release = await makeNativeStageHarness(
+    t,
+    'macos-arm64',
+    { sourceCommitSha: mismatchedSource },
+  );
+  await assert.rejects(
+    stagePlatformBundle(release.input),
+    { code: 'BUNDLE_NATIVE_PLUGIN_SOURCE_MISMATCH' },
+  );
+});
+
 test('identical native inputs produce byte-identical native and bundle manifests', async (t) => {
   const left = await makeNativeStageHarness(t);
   const right = await makeNativeStageHarness(t);
@@ -294,7 +341,12 @@ test('CLI candidate resolution requires exact clean HEAD and strict arguments', 
     parseStagePlatformBundleArgs([
       '--platform=macos-arm64', '--version', '0.9.2', '--out', 'build/stage',
     ]),
-    { platform: 'macos-arm64', version: '0.9.2', outDir: 'build/stage' },
+    {
+      platform: 'macos-arm64',
+      version: '0.9.2',
+      outDir: 'build/stage',
+      verificationProfile: 'development',
+    },
   );
   assert.deepEqual(
     parseStagePlatformBundleArgs([
@@ -307,8 +359,32 @@ test('CLI candidate resolution requires exact clean HEAD and strict arguments', 
       platform: 'macos-arm64',
       version: '0.9.2',
       outDir: 'build/stage',
+      verificationProfile: 'development',
       inputs: { nativePluginRoot: '/private/tmp/native-build' },
     },
+  );
+  assert.deepEqual(
+    parseStagePlatformBundleArgs([
+      '--platform', 'macos-arm64',
+      '--profile', 'release-audit',
+      '--version', '0.9.2',
+      '--out', 'build/stage',
+    ]),
+    {
+      platform: 'macos-arm64',
+      version: '0.9.2',
+      outDir: 'build/stage',
+      verificationProfile: 'release-audit',
+    },
+  );
+  assert.throws(
+    () => parseStagePlatformBundleArgs([
+      '--platform', 'macos-arm64',
+      '--profile', 'unknown',
+      '--version', '0.9.2',
+      '--out', 'build/stage',
+    ]),
+    { code: 'IDENTITY_VERIFICATION_PROFILE_INVALID' },
   );
   assert.throws(
     () => parseStagePlatformBundleArgs([

--- a/scripts/package/test/verify-platform-bundle.test.mjs
+++ b/scripts/package/test/verify-platform-bundle.test.mjs
@@ -4,7 +4,10 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { stagePlatformBundle } from '../stage-platform-bundle.mjs';
-import { verifyPlatformBundle } from '../verify-platform-bundle.mjs';
+import {
+  parseVerifyPlatformBundleArgs,
+  verifyPlatformBundle,
+} from '../verify-platform-bundle.mjs';
 import { canonicalJson, sha256File, validateBundleManifest } from '../lib/manifest.mjs';
 import { buildLicenseInventory, buildRuntimeSpdx } from '../lib/runtime-evidence.mjs';
 import {
@@ -22,6 +25,39 @@ function universalMachOBytes(cpuTypes) {
   cpuTypes.forEach((cpu, index) => bytes.writeUInt32BE(cpu, 8 + (index * 20)));
   return bytes;
 }
+
+test('verification CLI defaults to development and accepts explicit release-audit', () => {
+  assert.deepEqual(
+    parseVerifyPlatformBundleArgs([
+      '--root', '/tmp/stage', '--platform', 'macos-arm64', '--version', '0.9.2',
+    ]),
+    {
+      root: '/tmp/stage',
+      platform: 'macos-arm64',
+      version: '0.9.2',
+      verificationProfile: 'development',
+    },
+  );
+  assert.deepEqual(
+    parseVerifyPlatformBundleArgs([
+      '--root', '/tmp/stage', '--platform', 'macos-arm64',
+      '--profile', 'release-audit', '--version', '0.9.2',
+    ]),
+    {
+      root: '/tmp/stage',
+      platform: 'macos-arm64',
+      version: '0.9.2',
+      verificationProfile: 'release-audit',
+    },
+  );
+  assert.throws(
+    () => parseVerifyPlatformBundleArgs([
+      '--root', '/tmp/stage', '--platform', 'macos-arm64',
+      '--profile', 'unknown', '--version', '0.9.2',
+    ]),
+    { code: 'IDENTITY_VERIFICATION_PROFILE_INVALID' },
+  );
+});
 
 test('verification accepts an untouched platform bundle without network access', async (t) => {
   const h = await makeStageHarness(t, 'macos-arm64');
@@ -116,6 +152,124 @@ test('verification rejects a tampered native executable byte', async (t) => {
     verifyPlatformBundle(h.verifyInput),
     { code: 'BUNDLE_HASH_MISMATCH' },
   );
+});
+
+test('development profile skips exact byte identity while release-audit remains strict', async (t) => {
+  const h = await makeStageHarness(t, 'macos-arm64');
+  await stagePlatformBundle(h.input);
+  await h.flipByte('client/index.html');
+
+  await assert.doesNotReject(verifyPlatformBundle({
+    ...h.verifyInput,
+    verificationProfile: 'development',
+  }));
+  await assert.rejects(
+    verifyPlatformBundle(h.verifyInput),
+    { code: 'BUNDLE_HASH_MISMATCH' },
+  );
+});
+
+test('development profile records source drift while release-audit gates it', async (t) => {
+  const h = await makeStageHarness(t, 'macos-arm64');
+  await stagePlatformBundle(h.input);
+  const mismatchedSource = 'f'.repeat(40);
+
+  await assert.doesNotReject(verifyPlatformBundle({
+    ...h.verifyInput,
+    sourceCommitSha: mismatchedSource,
+    verificationProfile: 'development',
+  }));
+  await assert.rejects(
+    verifyPlatformBundle({
+      ...h.verifyInput,
+      sourceCommitSha: mismatchedSource,
+    }),
+    { code: 'BUNDLE_SOURCE_COMMIT_MISMATCH' },
+  );
+});
+
+test('development native verification relaxes identity but preserves compatibility gates', async (t) => {
+  await t.test('source revision drift is accepted', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    await h.mutateNativeReceipt((receipt) => {
+      receipt.sourceCommit = 'f'.repeat(40);
+      receipt.source.commit = receipt.sourceCommit;
+    });
+
+    await assert.doesNotReject(verifyPlatformBundle({
+      ...h.verifyInput,
+      verificationProfile: 'development',
+    }));
+  });
+
+  await t.test('extra staged native evidence is accepted but scan-root siblings are not', async (subtest) => {
+    const h = await makeNativeStageHarness(subtest);
+    await stagePlatformBundle(h.input);
+    await fs.promises.writeFile(h.nativePath('unexpected.txt'), 'development evidence\n');
+    await rewriteStageManifests(h);
+
+    await assert.doesNotReject(verifyPlatformBundle({
+      ...h.verifyInput,
+      verificationProfile: 'development',
+    }));
+
+    const sibling = path.join(h.outDir, 'artifacts', 'native-plugin', 'unbound.txt');
+    await fs.promises.writeFile(sibling, 'unexpected scan-root sibling\n');
+    await rewriteStageManifests(h);
+    await assert.rejects(
+      verifyPlatformBundle({
+        ...h.verifyInput,
+        verificationProfile: 'development',
+      }),
+      { code: 'BUNDLE_NATIVE_PLUGIN_FILE_SET_MISMATCH' },
+    );
+  });
+
+  for (const fixture of [
+    {
+      name: 'RPC protocol digest',
+      code: 'BUNDLE_NATIVE_PLUGIN_PROTOCOL_MISMATCH',
+      mutate(receipt) {
+        receipt.protocolSchemaSha256 = 'f'.repeat(64);
+      },
+    },
+    {
+      name: 'product version',
+      code: 'BUNDLE_NATIVE_PLUGIN_VERSION_MISMATCH',
+      mutate(receipt) {
+        receipt.productVersion = '0.1.0';
+      },
+    },
+    {
+      name: 'entrypoint',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.entryPoint = 'WrongNativeMain';
+      },
+    },
+    {
+      name: 'architecture',
+      code: 'BUNDLE_NATIVE_PLUGIN_ARTIFACT_INVALID',
+      mutate(receipt) {
+        receipt.artifact.architecture = 'x86_64';
+      },
+    },
+  ]) {
+    await t.test(`${fixture.name} still blocks`, async (subtest) => {
+      const h = await makeNativeStageHarness(subtest);
+      await stagePlatformBundle(h.input);
+      await h.mutateNativeReceipt(fixture.mutate);
+
+      await assert.rejects(
+        verifyPlatformBundle({
+          ...h.verifyInput,
+          verificationProfile: 'development',
+        }),
+        { code: fixture.code },
+      );
+    });
+  }
 });
 
 test('verification rejects native semantic drift after outer digests are refreshed', async (t) => {

--- a/scripts/package/verify-platform-bundle.mjs
+++ b/scripts/package/verify-platform-bundle.mjs
@@ -27,6 +27,11 @@ import {
   NATIVE_PLUGIN_ROOT,
   verifyNativePluginStage,
 } from './lib/native-plugin-manifest.mjs';
+import {
+  DEVELOPMENT_IDENTITY_PROFILE,
+  normalizeIdentityVerificationProfile,
+  requiresExactIdentity,
+} from './lib/identity-verification-profile.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const ADOBE_SDK_LOCKED_FILE_DIGESTS = new Set([
@@ -77,7 +82,7 @@ function validateHelperManifest(value, platform) {
   return value;
 }
 
-async function verifyEntry(expected, actual) {
+async function verifyEntry(expected, actual, exactIdentity) {
   if (!actual || expected.type !== actual.type || expected.size !== actual.size
       || expected.mode !== actual.mode
       || (expected.type === 'symlink'
@@ -85,12 +90,12 @@ async function verifyEntry(expected, actual) {
         && expected.linkTarget !== actual.linkTarget)) {
     throw bundleError('BUNDLE_FILE_METADATA_MISMATCH', `bundle metadata mismatch: ${expected.path}`);
   }
-  if (expected.sha256 !== actual.sha256) {
+  if (exactIdentity && expected.sha256 !== actual.sha256) {
     throw bundleError('BUNDLE_HASH_MISMATCH', `bundle SHA-256 mismatch: ${expected.path}`);
   }
 }
 
-async function verifyRuntimeInventory(root, platform, runtimeManifest) {
+async function verifyRuntimeInventory(root, platform, runtimeManifest, exactIdentity) {
   const runtimeRoot = path.join(root, 'runtime', platform);
   const actual = await collectManifestEntries(runtimeRoot, { omit: ['runtime-manifest.json'] });
   const actualByPath = new Map(actual.map((entry) => [entry.path, entry]));
@@ -103,7 +108,9 @@ async function verifyRuntimeInventory(root, platform, runtimeManifest) {
       || expected.some((entry) => !actualByPath.has(entry.path))) {
     throw bundleError('BUNDLE_RUNTIME_MANIFEST_INVALID', 'runtime manifest file set does not match payload');
   }
-  for (const entry of expected) await verifyEntry(entry, actualByPath.get(entry.path));
+  for (const entry of expected) {
+    await verifyEntry(entry, actualByPath.get(entry.path), exactIdentity);
+  }
 }
 
 async function verifySupportContract(root, platform) {
@@ -129,14 +136,20 @@ async function verifySupportContract(root, platform) {
   }
 }
 
-async function verifyRuntimeEvidence(root, platform, runtimeManifest, bundleManifest) {
+async function verifyRuntimeEvidence(
+  root,
+  platform,
+  runtimeManifest,
+  bundleManifest,
+  exactIdentity,
+) {
   const runtimeRoot = path.join(root, 'runtime', platform);
   const sbomPath = path.join(runtimeRoot, 'sbom.spdx.json');
   const licenseInventoryPath = path.join(runtimeRoot, 'license-inventory.json');
-  if (await sha256File(sbomPath) !== bundleManifest.runtime.sbomSha256) {
+  if (exactIdentity && await sha256File(sbomPath) !== bundleManifest.runtime.sbomSha256) {
     throw bundleError('BUNDLE_HASH_MISMATCH', 'runtime SPDX SBOM SHA-256 mismatch');
   }
-  if (await sha256File(licenseInventoryPath)
+  if (exactIdentity && await sha256File(licenseInventoryPath)
       !== bundleManifest.runtime.licenseInventorySha256) {
     throw bundleError('BUNDLE_HASH_MISMATCH', 'runtime license inventory SHA-256 mismatch');
   }
@@ -209,10 +222,10 @@ async function verifyHostRuntime(root, platform, entries) {
   requireFile(`node_modules/express/${entryRelative.split(path.sep).join('/')}`);
 }
 
-async function verifyHelper(root, platform, manifest) {
+async function verifyHelper(root, platform, manifest, exactIdentity) {
   const helperRoot = path.join(root, 'platform', platform);
   const helperManifestPath = path.join(helperRoot, 'helper-manifest.json');
-  if (await sha256File(helperManifestPath) !== manifest.helper.manifestSha256) {
+  if (exactIdentity && await sha256File(helperManifestPath) !== manifest.helper.manifestSha256) {
     throw bundleError('BUNDLE_HASH_MISMATCH', 'helper manifest SHA-256 mismatch');
   }
   const helper = validateHelperManifest(await readJsonFile(helperManifestPath), platform);
@@ -235,7 +248,7 @@ async function verifyHelper(root, platform, manifest) {
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       throw bundleError('BUNDLE_HELPER_IDENTITY_INVALID', 'helper file path escapes helper root');
     }
-    if (await sha256File(filePath) !== record.sha256) {
+    if (exactIdentity && await sha256File(filePath) !== record.sha256) {
       throw bundleError('BUNDLE_HASH_MISMATCH', `helper payload SHA-256 mismatch: ${record.path}`);
     }
     if (record.architecture === 'script') {
@@ -348,9 +361,12 @@ export async function verifyPlatformBundle({
   platform,
   version,
   sourceCommitSha,
+  verificationProfile = DEVELOPMENT_IDENTITY_PROFILE,
   candidateRepoRoot = REPO_ROOT,
   dependencies = {},
 } = {}) {
+  const profile = normalizeIdentityVerificationProfile(verificationProfile);
+  const exactIdentity = requiresExactIdentity(profile);
   if (!PLATFORM_IDS.has(platform)) throw bundleError('BUNDLE_PLATFORM_INVALID', `unsupported platform: ${platform}`);
   const resolvedRoot = path.resolve(String(root ?? ''));
   const manifestPath = path.join(resolvedRoot, 'bundle-manifest.json');
@@ -361,7 +377,8 @@ export async function verifyPlatformBundle({
   if (manifest.version !== version) {
     throw bundleError('BUNDLE_VERSION_MISMATCH', `expected ${version}, received ${manifest.version}`);
   }
-  if (sourceCommitSha !== undefined && manifest.sourceCommitSha !== sourceCommitSha) {
+  if (exactIdentity && sourceCommitSha !== undefined
+      && manifest.sourceCommitSha !== sourceCommitSha) {
     throw bundleError('BUNDLE_SOURCE_COMMIT_MISMATCH', 'bundle source commit does not match candidate');
   }
   const actual = await collectManifestEntries(resolvedRoot, { omit: ['bundle-manifest.json'] });
@@ -370,7 +387,9 @@ export async function verifyPlatformBundle({
       || manifest.files.some((entry) => !actualByPath.has(entry.path))) {
     throw bundleError('BUNDLE_FILE_SET_MISMATCH', 'bundle file set does not match manifest');
   }
-  for (const entry of manifest.files) await verifyEntry(entry, actualByPath.get(entry.path));
+  for (const entry of manifest.files) {
+    await verifyEntry(entry, actualByPath.get(entry.path), exactIdentity);
+  }
   const nativeNamespace = path.posix.dirname(NATIVE_PLUGIN_ROOT);
   const nativeNamespaceEntries = actual.filter((entry) => (
     entry.path === nativeNamespace
@@ -396,7 +415,8 @@ export async function verifyPlatformBundle({
     const nativeManifestEntry = actualByPath.get(NATIVE_PLUGIN_MANIFEST_PATH);
     if (!nativeManifestEntry
         || nativeManifestEntry.type !== 'file'
-        || nativeManifestEntry.sha256 !== manifest.nativePlugin.manifestSha256) {
+        || (exactIdentity
+          && nativeManifestEntry.sha256 !== manifest.nativePlugin.manifestSha256)) {
       throw bundleError(
         'BUNDLE_NATIVE_PLUGIN_HASH_MISMATCH',
         'native plug-in manifest reference does not match the staged file',
@@ -406,21 +426,29 @@ export async function verifyPlatformBundle({
       root: path.join(resolvedRoot, ...NATIVE_PLUGIN_ROOT.split('/')),
       productVersion: manifest.version,
       sourceCommitSha: manifest.sourceCommitSha,
+      verificationProfile: profile,
       candidateRepoRoot,
       dependencies,
     });
   }
 
   const runtimeManifestPath = path.join(resolvedRoot, 'runtime', platform, 'runtime-manifest.json');
-  if (await sha256File(runtimeManifestPath) !== manifest.runtime.manifestSha256) {
+  if (exactIdentity
+      && await sha256File(runtimeManifestPath) !== manifest.runtime.manifestSha256) {
     throw bundleError('BUNDLE_HASH_MISMATCH', 'runtime manifest SHA-256 mismatch');
   }
   const runtimeManifest = validateRuntimeManifest(await readJsonFile(runtimeManifestPath), platform);
-  await verifyRuntimeInventory(resolvedRoot, platform, runtimeManifest);
-  await verifyRuntimeEvidence(resolvedRoot, platform, runtimeManifest, manifest);
+  await verifyRuntimeInventory(resolvedRoot, platform, runtimeManifest, exactIdentity);
+  await verifyRuntimeEvidence(
+    resolvedRoot,
+    platform,
+    runtimeManifest,
+    manifest,
+    exactIdentity,
+  );
   await verifyHostRuntime(resolvedRoot, platform, actual);
   await verifySupportContract(resolvedRoot, platform);
-  await verifyHelper(resolvedRoot, platform, manifest);
+  await verifyHelper(resolvedRoot, platform, manifest, exactIdentity);
   assertProductionFileSet(actual, platform);
   await verifyNativeFiles(resolvedRoot, platform, actual);
   return manifest;
@@ -428,7 +456,7 @@ export async function verifyPlatformBundle({
 
 function parseArgs(argv) {
   const values = new Map();
-  const allowed = new Set(['--root', '--platform', '--version']);
+  const allowed = new Set(['--root', '--platform', '--profile', '--version']);
   for (let index = 0; index < argv.length; index += 1) {
     const item = argv[index];
     const equal = item.indexOf('=');
@@ -437,8 +465,17 @@ function parseArgs(argv) {
     if (!allowed.has(key) || !value || values.has(key)) throw new Error(`invalid argument: ${item}`);
     values.set(key, value);
   }
-  for (const key of allowed) if (!values.has(key)) throw new Error(`${key} is required`);
-  return { root: values.get('--root'), platform: values.get('--platform'), version: values.get('--version') };
+  for (const key of ['--root', '--platform', '--version']) {
+    if (!values.has(key)) throw new Error(`${key} is required`);
+  }
+  const verificationProfile = values.get('--profile') ?? DEVELOPMENT_IDENTITY_PROFILE;
+  normalizeIdentityVerificationProfile(verificationProfile);
+  return {
+    root: values.get('--root'),
+    platform: values.get('--platform'),
+    version: values.get('--version'),
+    verificationProfile,
+  };
 }
 
 async function main() {

--- a/scripts/phase0/run-signing-probe-macos.sh
+++ b/scripts/phase0/run-signing-probe-macos.sh
@@ -19,12 +19,12 @@ esac
 
 version="$(node -e 'const fs=require("node:fs"); const p=require("node:path"); process.stdout.write(JSON.parse(fs.readFileSync(p.join(process.argv[1],"bundle-manifest.json"),"utf8")).version)' "$stage_root")"
 source_commit_sha="$(node -e 'const fs=require("node:fs"); const p=require("node:path"); process.stdout.write(JSON.parse(fs.readFileSync(p.join(process.argv[1],"bundle-manifest.json"),"utf8")).sourceCommitSha)' "$stage_root")"
-node scripts/package/verify-platform-bundle.mjs --root "$stage_root" --platform macos-arm64 --version "$version" >/dev/null
+node scripts/package/verify-platform-bundle.mjs --root "$stage_root" --platform macos-arm64 --profile release-audit --version "$version" >/dev/null
 source_stage_sha="$(/usr/bin/shasum -a 256 "$stage_root/bundle-manifest.json" | /usr/bin/awk '{print $1}')"
 mkdir -p "$out_root"
 /usr/bin/ditto --noqtn "$stage_root" "$out_root/work"
 node scripts/package/verify-platform-bundle.mjs \
-  --root "$out_root/work" --platform macos-arm64 --version "$version" >/dev/null
+  --root "$out_root/work" --platform macos-arm64 --profile release-audit --version "$version" >/dev/null
 
 bash scripts/package/sign-macos-nested.sh \
   --root "$out_root/work" --evidence "$out_root/nested-evidence.json"
@@ -59,7 +59,7 @@ node --input-type=module -e '
 '
 
 node scripts/package/verify-platform-bundle.mjs \
-  --root "$stage_root" --platform macos-arm64 --version "$version" >/dev/null
+  --root "$stage_root" --platform macos-arm64 --profile release-audit --version "$version" >/dev/null
 unchanged_stage_sha="$(/usr/bin/shasum -a 256 "$stage_root/bundle-manifest.json" | /usr/bin/awk '{print $1}')"
 [[ "$unchanged_stage_sha" = "$source_stage_sha" ]] \
   || { printf '%s\n' 'PHASE0_STAGE_CHANGED: unsigned source stage changed during probe' >&2; exit 1; }

--- a/scripts/phase0/run-signing-probe-windows.ps1
+++ b/scripts/phase0/run-signing-probe-windows.ps1
@@ -32,7 +32,7 @@ if (Test-Path -LiteralPath $out) { throw 'PHASE0_OUTPUT_EXISTS: disposable outpu
 $manifestPath = Join-Path $stage 'bundle-manifest.json'
 $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
 $sourceCommitSha = [string]$manifest.sourceCommitSha
-& node scripts/package/verify-platform-bundle.mjs --root $stage --platform windows-x64 --version ([string]$manifest.version) | Out-Null
+& node scripts/package/verify-platform-bundle.mjs --root $stage --platform windows-x64 --profile release-audit --version ([string]$manifest.version) | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'PHASE0_STAGE_INVALID: unsigned stage verification failed' }
 $sourceStageSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
 
@@ -40,7 +40,7 @@ $sourceStageSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256)
 $work = Join-Path $out 'work'
 & robocopy.exe $stage $work /E /COPY:DAT /DCOPY:DAT /R:0 /W:0 /NFL /NDL /NJH /NJS /NP | Out-Null
 if ($LASTEXITCODE -gt 7) { throw 'PHASE0_COPY_FAILED: unsigned stage copy failed' }
-& node scripts/package/verify-platform-bundle.mjs --root $work --platform windows-x64 --version ([string]$manifest.version) | Out-Null
+& node scripts/package/verify-platform-bundle.mjs --root $work --platform windows-x64 --profile release-audit --version ([string]$manifest.version) | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'PHASE0_COPY_INVALID: copied work verification failed' }
 
 & scripts/package/sign-windows-nested.ps1 -Root $work -Evidence (Join-Path $out 'nested-evidence.json')
@@ -74,7 +74,7 @@ await assemblePhase0SigningEvidence({
 '@
 if ($LASTEXITCODE -ne 0) { throw 'PHASE0_EVIDENCE_INVALID: aggregate evidence failed' }
 
-& node scripts/package/verify-platform-bundle.mjs --root $stage --platform windows-x64 --version ([string]$manifest.version) | Out-Null
+& node scripts/package/verify-platform-bundle.mjs --root $stage --platform windows-x64 --profile release-audit --version ([string]$manifest.version) | Out-Null
 if ($LASTEXITCODE -ne 0) { throw 'PHASE0_STAGE_CHANGED: source stage verification failed after probe' }
 $unchangedStageSha256 = (Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($unchangedStageSha256 -ne $sourceStageSha256) {

--- a/scripts/release/run-signing-plan.mjs
+++ b/scripts/release/run-signing-plan.mjs
@@ -830,6 +830,7 @@ export async function runReleaseSigning(input, dependencies = {}) {
       platform: validated.platform,
       version: validated.version,
       sourceCommitSha: validated.candidateSha,
+      verificationProfile: 'release-audit',
     });
   } catch {
     throw new Error('unsigned source stage changed during signing');

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -1044,6 +1044,7 @@ test('signed RC workflow uses pinned platform, signing, evidence, and finalizati
 
   assert.equal((workflow.match(/stage-platform-bundle\.mjs/g) || []).length, 2);
   assert.ok((workflow.match(/verify-platform-bundle\.mjs/g) || []).length >= 2);
+  assert.equal((workflow.match(/--profile release-audit/g) || []).length, 4);
   assert.equal((workflow.match(/const report = await runReleaseSigning/g) || []).length, 2);
   assert.equal((workflow.match(/await writeSigningReport/g) || []).length, 2);
   assert.match(workflow, /buildArtifactManifest/);


### PR DESCRIPTION
## What changed

- Adds explicit `development` and `release-audit` identity-verification profiles shared by bundle staging, bundle verification, native plug-in staging, and the macOS development installer.
- Makes development/preflight the default for local agent-owned builds. This profile treats source revisions, complete payload hashes, deep artifact/receipt equality, and exact native file sets as diagnostic identity signals rather than compatibility gates.
- Pins release workflows, signing probes, signing-plan execution, and signed-manifest freezing to `release-audit`, preserving exact source, hash, receipt, artifact, and file-set checks.
- Keeps protocol schema digest, native contract/capability validation, product version, platform, architecture, entrypoint, load structure, required files, and scan-root protections strict in both profiles.
- Documents both profiles in the user and hardware-runner documentation.

## Why

PR #175 migrated RuntimeManager and the hardware runner to the development trust model, but the bundle/helper and native development-installer layers still assumed that every component must have the same exact repository SHA and payload identity. TSM hardware preflight therefore stopped before the first public MCP call even when wire, product, platform, and native contracts were compatible.

The repository policy says a source-revision mismatch alone is not proof of incompatibility. This PR completes that migration without weakening release/audit verification.

## Product-version decision

Product-version equality remains strict in both profiles. The current negotiation surface can validate wire version, capability/contract digests, and protocol schema digest, but it has no compatibility-range mechanism for product versions. Relaxing this gate now would remove the only product-version compatibility protection.

## Validation

- `node --test scripts/package/test/*.test.mjs` — 399 passed, 6 skipped, 0 failed
- `node --test scripts/release/test/*.test.mjs` — 123 passed, 1 existing TODO, 0 failed
- `npm test` in `plugin/host` — 147 passed, 0 failed
- `node scripts/check-repository-governance.mjs` — passed
- `git diff --check` — passed

New negative tests prove that development still rejects protocol-schema mismatch, product-version mismatch, wrong entrypoint, wrong architecture, and scan-root siblings. Release-audit tests prove exact receipt hashes, embedded source identity, payload hashes, source revisions, and native exact-file-set checks remain enforced.

## Non-goals

- No TSM capability implementation or acceptance-driver changes
- No wire, capability, Undo, platform, architecture, entrypoint, load, or scan-root contract changes
- No product-version compatibility-range design