### PR TITLE
feat(panel): add an opt-in development runtime path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ These rules apply to human developers and coding agents working in this reposito
 - Do not implement issues by issue number or creation order. Maintain P0/P1/P2/P3 priorities based on dependency and user value.
 - Work on one dependent P0 capability package at a time. A capability package normally groups about 5-15 tightly related tools that share an AEGP SDK suite, dispatcher, fixture, Undo model, or user scenario. Small infrastructure changes and isolated fixes may remain single-Issue packages when they do not belong to a tool family.
 - Prefer 6-10 tools for a normal capability package. Before implementation, freeze a short package brief containing any optional child Issues, public MCP schemas, capability/interaction matrix, native novelty, disposable fixture, Undo model, executable acceptance path, and explicit non-goals. Do not split the frozen package into one branch or PR per simple tool.
-- A capability package may retain multiple child Issues and acceptance checklists, but it uses one branch/worktree, one PR, one concentrated review, one exact-candidate hardware acceptance run, and one clean-`main` hardware revalidation. Close each child Issue only when its own acceptance result passed in the package evidence.
-- The package closure loop is: design the public MCP schemas and interaction matrix -> implement with incremental unit/contract/compile tests -> independent diff review -> CI -> exact-build package hardware validation -> merge -> rebuild/reinstall from `main` -> package hardware revalidation -> close accepted child Issues and update their parent epic.
+- A capability package may retain multiple child Issues and acceptance checklists, but it uses one branch/worktree, one PR, one concentrated review, and one bounded HDEV real-AE run. HDEV is development evidence only. Close each child Issue only when its own development acceptance result passed; the target release milestone separately aggregates changed capabilities for packaged acceptance.
+- The ordinary package closure loop is: design the public MCP schemas and interaction matrix -> implement with incremental unit/contract/compile tests -> independent diff review -> T3/CI -> bounded HDEV real-AE validation -> merge -> publish `development-verified` evidence -> close accepted implementation Issues and update the target release milestone. At release freeze, build one packaged candidate, run the aggregate changed-capability T5 matrix, then run packaged clean-install/upgrade/rollback T6.
 - Parallel work is allowed only when it is genuinely independent and cannot cause mixed builds, shared-fixture conflicts, or premature assumptions about an unmerged interface.
-- The WIP limit is one dependent native capability package. That package may use at most three coordinated implementation tracks (native, Core/bridge/public MCP, and tests/fixture), but they share one schema freeze, one branch/worktree, and one acceptance matrix. Do not begin the next dependent package before the current package passes clean-`main` revalidation.
+- The WIP limit is one dependent native capability package. That package may use at most three coordinated implementation tracks (native, Core/bridge/public MCP, and tests/fixture), but they share one schema freeze, one branch/worktree, and one acceptance matrix. Do not begin the next dependent package before the current package is merged with required HDEV evidence and reaches the product-direction checkpoint.
 - Treat schedule targets as scope alarms, not permission to weaken evidence: package framing should normally take 2-4 hours, implementation 1-2.5 working days, concentrated review and CI 0.5-1 day, and the prepared hardware session 60-90 minutes excluding deterministic build time. When a target is exceeded, cut unrelated scope or repair the environment instead of accumulating more infrastructure inside the package.
 - Workflow infrastructure must remove a measured repeated cost from the active acceptance path and is timeboxed to one working day unless the user explicitly promotes it. Otherwise record it as a follow-up and continue the capability package.
 
@@ -42,21 +42,21 @@ public MCP tool
 
 ## 4. Layer hardware validation by native novelty and capability package
 
-- **Local development trust model:** on the maintainer's single-user development Mac, files just built, copied, or atomically installed by the active agent-owned workflow are trusted by default. Routine development, AE restart, T4, T5, and T6 must not rehash the complete runtime tree or require Core, CEP, native, protocol, runner, and evidence to share one full repository SHA. Use the install receipt, canonical path, component version, file size, and modification time as inexpensive change signals; escalate to content hashing only after an observed inconsistency or for an explicitly requested release/security audit. Hash verification for external downloads such as the Adobe SDK archive remains allowed.
+- **Local development trust model:** on the maintainer's single-user development Mac, files just built, copied, or atomically installed by the active agent-owned workflow are trusted by default. Routine development, AE restart, T4, and HDEV must not rehash the complete runtime tree or require Core, CEP, native, protocol, runner, and evidence to share one full repository SHA. Use the install receipt, canonical path, component version, file size, and modification time as inexpensive change signals; escalate to content hashing only after an observed inconsistency. Packaged release-candidate T5/T6 use the strict release-audit identity boundary, including exact source/artifact identity, complete payload verification, RuntimeManager manifest alignment, and the existing release gates. Hash verification for external downloads such as the Adobe SDK archive remains allowed.
 - The local development MCP path must not require a connection code, fingerprint confirmation, or pairing ceremony. Same-user local IPC and filesystem permissions are sufficient during development. Authentication, pairing, signing, and hostile same-UID process defenses belong to a later release/remote/multi-user security milestone unless a concrete exploit is reproduced on the active path.
 - When a package introduces a new AEGP SDK suite, object-lifecycle rule, main-thread mechanism, or other unverified native primitive, run one narrow intermediate hardware smoke as soon as that primitive is testable. Once the mechanism is proven, do not redeploy for each simple tool built on it.
-- Complete the package with one prepared real-machine run through the public MCP surface that exercises every included tool and their important interactions in the same disposable AE fixture. Batch the structured response, AE state, native provenance, audit, recovery, and write-tool Undo evidence.
+- Complete the package with one prepared HDEV run through the public MCP surface that exercises every new native primitive and one justified representative per shared adapter, locator, and Undo family in the same disposable AE fixture. Batch the structured response, AE state, native provenance, audit, recovery, and representative write-tool Undo evidence.
 - Any package whose acceptance depends on AE loading, lifecycle, GUI state, main-thread behavior, CEP/native communication, or project mutation still requires this package-level real-machine validation before merge.
 - Automated tests and CI never substitute for hardware validation.
-- Record the candidate source revision and installed component receipts for traceability, but do not make full-repository SHA equality a runtime or acceptance gate. Abort only on an observed incompatible protocol/component version, wrong canonical path, failed load, or contradictory AE result.
-- After merge, repeat the public MCP package smoke from a clean `main` build. It must touch every included public tool, cover each accepted optional child Issue, and verify real Undo for every included write. Do not rely on the pre-merge installation.
+- Record each development component's source revision and installed receipt for traceability, but do not make full-repository SHA equality an HDEV gate. Abort on an observed incompatible protocol/component version, wrong canonical path, failed load, or contradictory AE result. The later packaged release boundary retains exact identity checks.
+- After merge, add the package's changed-capability matrix and HDEV disposition to the target release milestone. Do not relabel or reuse HDEV as packaged T5/T6 evidence.
 - Use a dedicated disposable AE project. Never use the user's production project for write testing.
 - Prepare GUI access, permissions, no-sleep state, fixture path, canonical plugin path, and log locations in one preflight instead of discovering them through repeated user interruptions.
-- Before T4 or T5, complete a zero-evidence hardware preflight that proves the selected runtime/current pointer, stable launcher, CEP, native plug-in, and protocol metadata can communicate; the formal AE absolute path, GUI, fixture runner, and log directories are usable; and the runner can create or reset, save, reopen from inside AE, and archive its single disposable fixture. The preflight uses lightweight receipts/metadata and does not perform a full runtime hash walk or a pairing ceremony. A preflight creates no candidate acceptance evidence and does not count as a T4/T5 hardware run.
-- A failure before the first public MCP tool call is a T0-T2 environment or runner failure, not a failed candidate hardware acceptance. Repair and falsify it at the lowest applicable tier before returning to T4/T5.
-- After concentrated review has no unresolved blocker and all source, generated bundles, documentation, license metadata, fixtures, and evidence schemas are committed, designate that source revision/build as the candidate freeze. Run T3 and required CI once; except for the single narrow smoke allowed for a genuinely new native primitive, do not begin candidate hardware acceptance until they pass.
+- Before T4, HDEV, or packaged T5, complete a zero-evidence hardware preflight that proves the selected Core/CEP/native component set and protocol metadata can communicate; the formal AE absolute path, GUI, fixture runner, and log directories are usable; and the runner can create or reset, save, reopen from inside AE, and archive its single disposable fixture. Development preflight uses lightweight receipts/metadata and does not perform a full runtime hash walk or a pairing ceremony. It creates no candidate acceptance evidence.
+- A failure before the first public MCP tool call is a T0-T2 environment or runner failure, not a failed HDEV or packaged candidate acceptance. Repair and falsify it at the lowest applicable tier before returning to hardware.
+- After concentrated review has no unresolved blocker and all source, generated bundles, documentation, fixtures, and evidence schemas are committed, run T3 and required CI once before HDEV. A packaged candidate freeze is a later release-milestone boundary covering all changed capabilities since the previous release.
 - After candidate freeze, create a replacement only for a reproduced acceptance blocker or a defect that demonstrably invalidates the package evidence. Batch all known blockers into one fix set, rerun only the affected lower test tiers, perform a focused re-review, and then create one replacement candidate. The replacement must pass required CI before any T5 acceptance evidence is collected.
-- The normal target is one candidate and one full CI run. At most one replacement candidate is allowed for a reproduced blocker; that replacement gets its own required CI run, while already-passing unaffected local tiers need not be repeated. The normal hardware target remains one successful candidate session and one clean-`main` session. Exceeding these targets must be explained in the completion evidence; it is not a reason to weaken a gate.
+- The ordinary PR target is one T3/CI run and one successful HDEV session. A packaged release normally uses one candidate T5 session and one T6 clean-install/upgrade/rollback session. Exceeding either budget must be explained in the applicable completion evidence; it is not a reason to weaken a gate.
 
 ## 5. Keep review feedback from expanding P0
 
@@ -78,18 +78,19 @@ Use the lowest test tier that can falsify the current change, then escalate at p
 - **T0, every edit:** formatting, syntax, lint, or a single focused unit test; target seconds.
 - **T1, each tool or adapter:** schema, codec, suite adapter, structured-error, and postcondition contract tests; target 1-5 minutes.
 - **T2, package integration:** affected native compile tests, Core/CEP integration, shared fixture, interaction corpus, and generated-file checks; target 10-30 minutes.
-- **T3, frozen candidate:** the relevant full repository regression plus required CI; run once for each candidate or approved replacement after concentrated or focused replacement review.
+- **T3, reviewed source or release freeze:** the relevant full repository regression plus required CI; run once for the ordinary reviewed source and once for each packaged release candidate or approved replacement.
 - **T4, optional native-novelty smoke:** one narrow real-AE check only when the package introduces an unverified suite, object lifecycle, or main-thread mechanism.
-- **T5, candidate acceptance:** one public-MCP package run on real AE using the recorded candidate build receipts.
-- **T6, clean-main acceptance:** one rebuild/reinstall and package smoke from the merge commit that touches every included public tool, covers each accepted optional child Issue, and verifies real Undo for every included write.
+- **HDEV, ordinary development real-AE smoke:** reuse the current compatible development installation, exercise every new native primitive and one justified representative per shared adapter/locator/Undo family, and always emit `validationProfile=development`, `candidateRun=false`, and `candidateEvidence=false`.
+- **T5, packaged release-candidate acceptance:** run the complete changed-capability matrix accumulated since the previous release against the frozen release-audit artifact.
+- **T6, packaged release revalidation:** prove clean install, upgrade, rollback, and the release artifact boundary. It is not a per-PR clean-`main` replay.
 
-Do not rerun T3, T5, or T6 after every small fix. A failed higher tier should drive the smallest reproducing lower-tier test first; return to the higher tier only after the fix set is complete.
+Do not rerun T3, HDEV, T5, or T6 after every small fix. A failed higher tier should drive the smallest reproducing lower-tier test first; return to the higher tier only after the fix set is complete.
 
-For an agent-owned installed generation on the single-user development machine, reuse is the default. Check only the canonical pointer, install receipt, component version, size, and modification time on routine starts. Do not perform a full payload hash walk at T4, T5, T6, or AE restart. Escalate to selective/content verification only when those inexpensive signals change, AE reports an incompatible component/protocol, an actual result is contradictory, or a release/security audit explicitly requests it.
+For an agent-owned development installation on the single-user machine, reuse is the default. Check only the canonical path, install receipt, component version, size, and modification time on routine starts. Do not perform a full payload hash walk at T4, HDEV, or AE restart. Escalate to selective/content verification when those inexpensive signals change, AE reports an incompatible component/protocol, or an actual result is contradictory. Packaged T5/T6 deliberately cross the strict release-audit boundary.
 
 ### 5.2 Batch independent acceptance defects before repair
 
-During a diagnostic T4, or after a T5/T6 run has already failed, do not stop and modify source after the first ordinary assertion failure. Continue every independent case whose evidence remains trustworthy and whose fixture state is either unchanged or restored, then repair the collected blockers as one fix set.
+During a diagnostic T4, or after an HDEV/T5/T6 run has already failed, do not stop and modify source after the first ordinary assertion failure. Continue every independent case whose evidence remains trustworthy and whose fixture state is either unchanged or restored, then repair the collected blockers as one fix set.
 
 - The runner must record each case as `PASS`, `FAIL`, `BLOCKED`, or `INDETERMINATE`, together with the failing layer, side-effect status, state-reconciliation result, dependency impact, and evidence identifiers.
 - Continue after a failure only when it is read-only or definitively `not-started`, or when any completed write has been reconciled against AE state and audit evidence and the fixture baseline has been verified as restored.
@@ -135,7 +136,7 @@ Before creating, retaining, moving, or archiving an `.aep`, determine and record
 5. whether the user explicitly requested persistent retention.
 
 - If long-term value cannot be demonstrated, do not retain the project permanently under an Issue or candidate directory; use a dated recovery archive with a cleanup condition.
-- One T5/T6 hardware session may have only one active fixture. Retry by resetting or deterministically rebuilding that fixture; do not accumulate projects through repeated Save As operations.
+- One HDEV/T5/T6 hardware session may have only one active fixture. Retry by resetting or deterministically rebuilding that fixture; do not accumulate projects through repeated Save As operations.
 - If an agent-created `ephemeral-validation` fixture fails before the first public tool call, has no AE mutation, and has no unresolved diagnostic value, the runner must move it to recovery and clear the active slot before exit. Once any public call or possible write dispatch occurred, reconcile AE state and audit evidence before resetting, archiving, or retrying.
 - Issue and evidence directories should normally store the fixture ID, lifecycle, owner, rebuild recipe, source revision/build receipt, public MCP request/response, before/after state, audit, Undo, and result—not a complete `.aep`.
 - When a candidate is superseded, archive its ephemeral project by default. An old build identifier is traceability metadata, not a reason for permanent retention.
@@ -176,7 +177,7 @@ Treat this Skip -> Continue sequence as established project knowledge. Do not re
 
 ## 9. Completion evidence
 
-A capability-package completion report must include:
+A capability-package development completion report must include:
 
 - package PR, parent Epic, any optional child Issue links and dispositions, per-tool acceptance disposition, tested source revision/build receipt, and merge commit;
 - the public MCP request and structured response;
@@ -184,21 +185,23 @@ A capability-package completion report must include:
 - native/AEGP provenance and observed component/protocol versions;
 - audit evidence with sensitive values and private paths redacted;
 - Undo and recovery evidence for writes;
-- CI/review status and the clean-`main` hardware revalidation;
+- CI/review status, the required HDEV disposition, and the explicit status `development-verified` rather than `release-accepted`;
 - remaining risks and their follow-up issue classification.
-- package-efficiency counters: included tools, review rounds, candidate builds, full CI runs, candidate/main hardware runs, first-hardware-pass result, environment/pairing interruptions, and elapsed time from scope freeze to clean-`main` acceptance.
+- package-efficiency counters: included tools, review rounds, T3/CI runs, HDEV runs, first-hardware-pass result, environment/pairing interruptions, and elapsed time from scope freeze to merged development verification.
 - a machine-generated per-tool summary containing public-call counts, request/result disposition, before/after state, Undo result, component build receipts/versions, host instances, audit/postcondition IDs, and fixture lifecycle. PR and Issue updates should consume this generated summary instead of manually transcribing repeated evidence.
 
 Do not claim completion using only "tests passed", "CI is green", "the plugin compiled", or "the PR merged".
+
+The target release milestone retains the complete changed-capability matrix since the previous release. Its separate release completion report adds the frozen packaged source/artifact identity, strict release-audit results, aggregate T5, clean-install/upgrade/rollback T6, and the status `release-accepted`. Only packaged T5/T6 may use that status.
 
 ## 10. Stop conditions before starting the next dependent capability package
 
 Do not proceed to the next dependent capability package when any of the following is true:
 
-- the current public MCP acceptance test has not passed on real AE;
+- the current required HDEV public MCP smoke has not passed on real AE;
 - an installed component or protocol is observed to be incompatible with the active public-MCP path;
 - a write produced an indeterminate result whose AE state and audit outcome are unreconciled;
-- the PR is merged but clean `main` has not been rebuilt, reinstalled, and reverified;
+- the PR is merged but its development evidence, Issue disposition, or fixture disposition is incomplete;
 - the test fixture, logs, or workspace state cannot distinguish the tested build from an older installation;
 - a new task would hide or work around the current failure instead of resolving it.
 
@@ -206,11 +209,11 @@ These stop conditions are delivery controls, not reasons to add unrelated harden
 
 ## 11. Require user approval before the next PR package
 
-After every capability-package or standalone product PR completes its full closure loop—including merge, clean-`main` revalidation, Issue/Epic updates, evidence publication, and fixture disposition—stop work before beginning another PR package.
+After every capability-package or standalone product PR completes its ordinary closure loop—including merge, required HDEV, Issue/release-milestone updates, evidence publication, and fixture disposition—stop work before beginning another PR package.
 
 - Perform only the bounded read-only inventory needed to prepare the decision. Do not create the next Issue, branch, worktree, schema, fixture, candidate, or implementation, and do not mutate backlog priorities before approval.
 - Present the user with the just-completed package status and any remaining risks, followed by two to four next-package candidates ordered by dependency and user value.
-- For each candidate, state the target user workflow, proposed 6-10 public tools or bounded standalone outcome, shared SDK suite/primitive, native novelty, dependencies, expected T5/T6 call budget, principal risks, and explicit non-goals.
+- For each candidate, state the target user workflow, proposed 6-10 public tools or bounded standalone outcome, shared SDK suite/primitive, native novelty, dependencies, expected HDEV budget and contribution to the later packaged release matrix, principal risks, and explicit non-goals.
 - Recommend one direction with concrete reasoning, but treat it as a proposal rather than authorization.
 - Wait for the user's explicit selection or approval before creating or implementing the next PR package. Silence, an earlier backlog order, an existing open Issue, or a previous instruction to continue sequentially does not satisfy this approval gate.
 

--- a/docs/CAPABILITY_PACKAGE_WORKFLOW.md
+++ b/docs/CAPABILITY_PACKAGE_WORKFLOW.md
@@ -15,7 +15,7 @@ The default delivery unit is one capability package containing 6-10 related publ
 
 An isolated bug or infrastructure fix may remain a single-Issue package. Do not create one PR per simple tool merely because each tool has a child Issue.
 
-The package owns one branch/worktree, one PR, one acceptance matrix, one concentrated review, one frozen candidate, one candidate hardware session, and one clean-`main` revalidation. T4-T6 apply to AE-dependent packages; a non-AE isolated fix uses the applicable lower tiers and records its observable acceptance check instead of manufacturing hardware evidence.
+The package owns one branch/worktree, one PR, one acceptance matrix, one concentrated review, and one bounded HDEV real-AE session. HDEV is permanently non-candidate development evidence. The target release milestone aggregates every changed-capability matrix since the previous release and later owns the strict packaged T5/T6 boundary. A non-AE isolated fix uses the applicable lower tiers and records its observable acceptance check instead of manufacturing hardware evidence.
 
 ## 2. Scope freeze before implementation
 
@@ -59,13 +59,13 @@ Do not open the group merely to test this: source evidence cannot distinguish no
 | Frame | 2-4 hours | Freeze schemas, matrix, fixture, native novelty, acceptance harness skeleton, exclusions | Matrix is reviewable and every included public tool has an observable result |
 | Native novelty smoke | 0-1 focused run | Only for an unverified suite, lifecycle, or main-thread mechanism | Primitive works in real AE or the package is redesigned |
 | Implement | 1-2.5 working days | Up to three coordinated tracks: native; Core/bridge/public MCP; tests/fixture | All matrix rows pass T0-T2 and generated artifacts are current |
-| Review, freeze, and CI | 0.5-1 day | Concentrated review and blocker fixes, freeze the candidate source and component receipts, then run T3 and required CI | No unresolved in-scope blocker; the candidate source passes T3 and CI |
-| Candidate hardware | 60-90 minutes plus deterministic build time | One continuous component-set package session on real AE | Every included public tool has evidence; writes have verified Undo, or the documented compensation evidence where the SDK provides none |
-| Merge and main | 0.5-1.5 hours plus build time | Merge, rebuild/reinstall from clean `main`, rerun package smoke | Merge SHA passes; any accepted child Issues can close |
+| Review and CI | 0.5-1 day | Concentrated review and blocker fixes, commit the development source and component receipts, then run T3 and required CI | No unresolved in-scope blocker; the reviewed source passes T3 and CI |
+| HDEV hardware | Bounded scenario, normally under 30 public calls | Reuse the compatible development installation; exercise every new native primitive and one representative per shared adapter/locator/Undo family | Public MCP, AE state, provenance, audit, postcondition, and representative real Undo agree; evidence says `candidateEvidence=false` |
+| Merge and milestone | 0.5-1 hour | Merge, close development-verified implementation Issues, add the changed-capability matrix to the target release milestone | PR is `development-verified`; it is not called `release-accepted` |
 
 These are scope alarms, not promises and not permission to drop evidence. When a phase exceeds its target, first remove unrelated work, repair the environment, or split a genuinely oversized package.
 
-Keep edit-level work local to the package worktree and run T0-T2 there. Complete the concentrated review, resolve blockers, and freeze the candidate source plus component receipts before the first branch publication and required CI run. Do not push every small edit and trigger a full remote matrix repeatedly. If a genuinely required human review can only occur on GitHub, publish a Draft explicitly as pre-candidate review input; any CI run on that unfrozen source is not candidate evidence and the completion report must explain the extra run.
+Keep edit-level work local to the package worktree and run T0-T2 there. Complete the concentrated review and resolve blockers before the required T3/CI run and HDEV. Do not push every small edit and trigger a full remote matrix repeatedly. If a genuinely required human review can only occur on GitHub, publish a Draft explicitly as review input.
 
 ## 4. Test escalation
 
@@ -76,12 +76,13 @@ Use the lowest tier that can disprove the current edit. Escalate only at the lis
 | T0 | Every edit | syntax, formatting, lint, one focused unit | Many times |
 | T1 | Each tool/adapter | schema, codec, suite adapter, error and postcondition contract | Per matrix row |
 | T2 | Package integration | affected native compile, Core/CEP bridge, fixture and interaction corpus, generated-file checks | At integration checkpoints |
-| T3 | Frozen candidate | relevant full repository regression and required CI | Once after review |
+| T3 | Reviewed development source | relevant full repository regression and required CI | Once after review |
 | T4 | New primitive only | narrow real-AE smoke for the unverified mechanism | Zero or one per package |
-| T5 | Candidate | full component-set public-MCP package acceptance | Once normally |
-| T6 | Clean main | rebuild/reinstall from the merge SHA plus a distinct, smaller replay — see section 8 | Once |
+| HDEV | Ordinary AE-changing PR | current compatible development install, every new native primitive plus justified representatives, always non-candidate | Once normally |
+| T5 | Packaged release candidate | full aggregate changed-capability matrix since the prior release under strict release-audit identity | Once normally per release candidate |
+| T6 | Packaged release artifact | clean install, upgrade, rollback, and release-boundary replay | Once normally per release |
 
-After a T3-T6 failure, first add or run the smallest reproducing T0-T2 test. Batch the complete fix set before returning to the expensive tier.
+After a T3/HDEV/T5/T6 failure, first add or run the smallest reproducing T0-T2 test. Batch the complete fix set before returning to the expensive tier.
 
 ## 5. Review disposition and timebox
 
@@ -89,7 +90,7 @@ Every finding receives one of three dispositions:
 
 | Class | Required evidence | Action in active package |
 |---|---|---|
-| Current blocker | Reproduced on the package acceptance path, or demonstrably breaks correctness, recovery, audit, Undo, or safe use | Fix before candidate freeze |
+| Current blocker | Reproduced on the package acceptance path, or demonstrably breaks correctness, recovery, audit, Undo, or safe use | Fix before HDEV or packaged release freeze, whichever boundary it affects |
 | Follow-up | Credible improvement that does not block the frozen outcome | Record a P1/P2 Issue and keep it out of the PR |
 | Out of scope | Hypothetical, duplicated, unsupported, or contrary to the product decision | Document why; do not implement |
 
@@ -97,64 +98,79 @@ Use no more than two concentrated review rounds by default. Investigation of a n
 
 Concurrency hardening, power-loss behavior, extreme installer recovery, signing/notarization, Windows expansion, generalized frameworks, Provider routing, Tool Library work, and AEGP/JSX resolution do not become P0 without acceptance-path evidence or an explicit user priority change.
 
-## 6. Candidate freeze
+## 6. Development review and release-candidate freeze
 
-Freeze the candidate source revision and installed component set after:
+Before ordinary HDEV:
 
 - all product source and generated bundles are committed;
 - schemas, fixtures, docs, license/policy metadata, and evidence format are final;
 - T0-T2 pass for the source and generated files under review;
-- concentrated review has no unresolved blocker;
-- the worktree is clean and every component has a compatible protocol/version
-  plus its own source revision and install receipt.
+- concentrated review has no unresolved blocker; and
+- every selected or reused component has a compatible protocol/version plus
+  its own source revision and development install receipt.
 
-Run the relevant T3 full regression and required CI on that frozen SHA. T5 hardware starts only after they pass. If T3 or CI finds a blocker, unfreeze the candidate, collect and batch the complete fix set, run focused lower-tier tests and review, then freeze one replacement candidate. The replacement SHA must pass required CI before T5; already-passing unaffected local tiers need not be repeated. After freeze, a new SHA is otherwise allowed only for a reproduced acceptance blocker or an evidence-invalidating defect. Do not deploy once per small fix.
+Run the relevant T3 regression and required CI, then HDEV. HDEV records the
+component revisions but remains `validationProfile=development`,
+`candidateRun=false`, and `candidateEvidence=false`. If it finds a blocker,
+collect the bounded trustworthy sweep, repair one batch, rerun affected lower
+tiers, and replay HDEV. It never becomes release evidence.
 
-Normal budget: one candidate build and one full CI run. A reproduced blocker may justify one replacement build and its required CI run. The hardware budget remains one successful candidate session and one clean-main session. Record the reason for any excess.
+At target-release freeze, aggregate all changed-capability matrices since the
+previous release and build one packaged candidate. This boundary retains exact
+source/artifact identity, full payload hashes, RuntimeManager manifest
+alignment, complete cross-component SHA checks, and all existing strict
+protocol/product/platform/architecture/entrypoint/load, signing, and scan-root
+gates. T5 starts only after the frozen artifact passes its required regression
+and CI. A reproduced release blocker may justify one replacement candidate.
 
 ## 7. Continuous hardware session
 
-Prepare before launching AE:
+Prepare before launching AE for HDEV:
 
 - formal AE absolute path, version, and build;
 - target machine unlocked/awake, required OS permissions, and normal GUI control;
 - Beta and unrelated AE processes closed;
 - canonical CEP/native paths and scan-root audit;
-- requested source revision, clean state, component versions, and installed receipts;
+- selected/reused component revisions, compatibility versions, and development
+  install receipts;
 - bounded canonical-path, size, mode, and modification-time signals for the
-  runtime generation, shared layer, and stable launcher;
+  selected Core checkout, CEP extension, and native plug-in;
 - disposable project/fixture, evidence root, logs, and known optional dialogs.
 
-Run the package in one continuous window:
+Run HDEV in one continuous window:
 
-1. Launch formal AE and verify host identity and canonical plug-in mapping.
-2. Verify automatic same-user/current-AE ancestry admission and the native
-   endpoint/peer-bound challenge.
-3. Create the disposable fixture once.
-4. Run every read tool and record the real AE state.
-5. For every write: record before state, invoke once, and record response/audit/after state; execute and verify real Undo only for Undoable operations, or run the documented compensating public write for an explicitly non-Undoable operation.
-6. Exercise the important inter-tool combinations from the matrix.
-7. Quit and relaunch AE once; verify a new host/session and repeat the package smoke.
-8. Emit one machine-readable evidence bundle and a redacted completion summary.
+1. Run read-only doctor, then launch the exact formal AE executable with the
+   child-only checkout override.
+2. Verify host identity, canonical plug-in mapping, compatible
+   protocol/product versions, and automatic same-user/current-AE admission.
+3. Save one empty `ephemeral-validation` project once.
+4. Exercise every new native primitive and one justified representative per
+   shared adapter, locator, and Undo family through public MCP.
+5. For each representative write, record before state, invoke once, record
+   response/audit/after state, execute real Undo when guaranteed, reacquire
+   locators, and independently verify restoration.
+6. Emit one machine-readable bundle with `candidateEvidence=false`, close AE,
+   and archive exactly one fixture with no Save As copies.
 
-Before candidate freeze, run a non-evidentiary hardware preflight for the
-actual prepared session. It must prove that the recorded Core/CEP/native/runtime
-component set is protocol-compatible and deployable, the formal AE path and GUI are available,
-the driver can create/reset/archive its one fixture, and any locator assumption
-needed by the package survives its planned Undo flow. Mark the output
-`candidateEvidence=false`; repair failures at T0-T2 and do not count them as
-T4/T5 candidate attempts.
+Before HDEV, run the read-only doctor for the selected components. It must
+prove that checkout Core, CEP/native development installation, formal AE path,
+and protocol metadata are compatible and usable without installing
+dependencies. Repair failures at T0-T2; they are not hardware attempts.
 
-One ledger must count every public MCP dispatch, including setup/support reads,
-expected-error probes, recovery calls, and package rows. Put stress, repeated
-calls, parameter combinations, and the broad error matrix in T2. T5/T6 should
-normally invoke each package tool only once or twice and stay at or below 30
-total public calls; abort before dispatching call 31 unless the frozen brief
-documents a risk that lower tiers cannot falsify.
+One ledger must count every public MCP dispatch. Put stress, repeated calls,
+parameter combinations, and the broad error matrix in T2. HDEV uses a frozen
+bounded plan; `core-native-write-undo@1` has exactly seven public calls and
+aborts before call eight. Release T5/T6 own separate frozen aggregate budgets.
 
 If a write returns `POSSIBLY_SIDE_EFFECTING_FAILURE`, stop retries and reconcile AE state plus audit first.
 
-Commit the package acceptance driver with the package. The same driver serves both hardware tiers, running the full candidate plan at T5 and the smaller clean-`main` plan at T6; two drivers would let the tiers drift apart. The driver must call the public MCP surface, support the package's real dynamic locators and generation changes, create a fresh intent key for each new write while reusing that key for reconciliation, and bind its evidence to separately verified Core/CEP/native/runtime component identities and protocol compatibility. A hashed test plan is explicit authorization for the disposable fixture only; it does not prove the production approval/elicitation path unless the package explicitly exercises that path. Temporary `/private/tmp` clients are not acceptance assets.
+Commit the HDEV plan and driver with the workflow. It must call public MCP,
+support real dynamic locators and generation changes, use a fresh intent key
+for each new write while reusing that key for reconciliation, and bind evidence
+to separately recorded selected/reused component identities and protocol
+compatibility. HDEV evidence cannot be copied into or promoted as packaged
+candidate evidence. Release T5/T6 use the aggregate release harness and strict
+artifact identity boundary.
 
 Do not introduce a generalized plan language speculatively. Promote repeated driver code into a shared runner only after at least two capability packages demonstrate the same stable need; a shared runner must not infer exact component identity from native self-report or model an invented response/Undo contract.
 
@@ -177,9 +193,9 @@ they may route the project to Beta or another host.
 **Validate the driver's expectations against the published contract at T1 or
 T2.** A driver asserted `replayed=true` for a repeated write key where the
 public schema, the Core tests and the native dispatcher all specify
-`DUPLICATE_REQUEST`. The candidate behaved correctly; the assertion was wrong;
+`DUPLICATE_REQUEST`. The tool behavior was correct; the assertion was wrong;
 it surfaced on real hardware at call four. A driver expectation that contradicts
-the contract is a lower-tier defect and must never reach T5.
+the contract is a lower-tier defect and must never reach HDEV or packaged T5.
 
 **The native replay fence lives as long as the host process, and Undo does not
 clear it.** A rerun that reuses an operation key from an earlier run in the same
@@ -190,33 +206,42 @@ two rules do not conflict, but the driver has to distinguish them.
 
 ## 8. Merge and completion
 
-After candidate acceptance:
+After HDEV:
 
-1. Merge the single package PR.
-2. Build and install every relevant component from a clean merge commit.
-3. Run T6 with the same harness on a **distinct, smaller plan** than T5. T6 exists to prove the merge and a clean build, not to repeat T5 — replaying every thin wrapper a second time buys little and costs a whole hardware session. See "What T6 must replay" below.
-4. Fill `docs/templates/capability-package-completion.md`.
-5. Close only optional child Issues that passed, then update the parent Epic.
+1. Publish the machine-generated summary and mark the PR
+   `development-verified`, never `release-accepted`.
+2. Merge the single package PR.
+3. Close only implementation Issues whose development matrix passed.
+4. Add the complete changed-capability matrix and HDEV disposition to the
+   target release milestone.
+5. Finish fixture disposition and stop at the next-package direction checkpoint.
+
+At release freeze, T5 runs the aggregate matrix against the packaged
+release-audit artifact. T6 then uses a distinct plan to prove clean install,
+upgrade, rollback, and the packaged boundary rather than replaying every thin
+wrapper.
 
 ### What T6 must replay
 
-T5 proves the capability. T6 proves that merging it and rebuilding from clean
-`main` did not break it. Those are different questions, so the plans differ.
+T5 proves the aggregate changed-capability release candidate. T6 proves that
+the packaged artifact installs, upgrades, rolls back, and still exposes its
+critical paths. Those are different questions, so the plans differ.
 
 T6 must replay:
 
-- every native primitive the package introduced, on its first clean build;
+- every native primitive introduced since the previous release, on its first
+  packaged clean install;
 - one representative tool per family that shares an already-proven primitive —
   if one sibling works from a clean install, the others exercise the same path;
-- every tool whose implementation changed after the candidate hardware run,
+- every tool whose implementation changed after packaged T5,
   including anything touched by a replacement candidate;
 - anything that touches install, staging, generated bundles or component
-  identity, because those are precisely what the merge and rebuild changed;
-- at least one real Undo per distinct Undo model in the package, not per tool.
+  identity, because those are precisely what packaging and installation change;
+- at least one real Undo per distinct Undo model in the release matrix, not per tool.
 
-T6 may skip a thin setter that shares its primitive, its Undo model and its
-locator scheme with a tool already replayed, and whose implementation is
-byte-identical to the candidate. Record what was skipped and on which ground;
+T6 may skip a thin setter that shares its primitive, Undo model, and locator
+scheme with a tool already replayed, and whose packaged implementation is
+byte-identical to T5. Record what was skipped and on which ground;
 an unexplained omission is not a reduction, it is a gap.
 
 This is a deliberate trade. A selective replay can miss an integration defect
@@ -225,7 +250,7 @@ specific rather than left to judgement. If a package cannot say plainly which of
 its tools are thin wrappers over an already-replayed path, it does not yet
 understand its own shape and should replay everything.
 
-Component identity is recorded **once per session**, with per-tool records
+Packaged component identity is recorded **once per session**, with per-tool records
 carrying only deltas. Repeating an invariant component set in every per-tool
 record inflates the evidence bundle without adding traceability.
 
@@ -234,21 +259,26 @@ record inflates the evidence bundle without adding traceability.
 Record these counters in the completion report:
 
 - included tools and accepted optional child Issues;
-- elapsed time from scope freeze to clean-main acceptance;
+- elapsed time from scope freeze to merged development verification;
 - review rounds and finding dispositions;
-- candidate builds and candidate SHA changes;
-- full CI runs;
-- T4, T5, and T6 hardware runs;
-- first candidate hardware pass/fail;
+- development component syncs and source revisions;
+- T3/CI runs;
+- T4 and HDEV hardware runs;
+- first HDEV pass/fail;
 - environment, GUI, and permission interruptions;
 - follow-up work created outside the active package.
 
-Useful targets are 6-10 tools per package, no more than two review rounds, no more than two candidate builds, and exactly one T5 plus one T6 run under normal conditions. These counters diagnose process waste; they are not substitutes for functional evidence.
+Useful ordinary-PR targets are 6-10 tools per package, no more than two review
+rounds, one T3/CI run, and one successful HDEV. Release-level counters
+separately record candidate builds, aggregate T5, and packaged T6. These
+counters diagnose process waste; they are not substitutes for functional evidence.
 
 ## 10. WIP and exceptions
 
 - Keep one dependent native capability package in flight.
 - The package may have up to three coordinated implementation tracks, but only one schema freeze and acceptance matrix.
 - One truly independent auxiliary package may proceed only if it cannot mix builds, fixtures, interfaces, or hardware state.
-- Do not start the next dependent package until clean-main acceptance finishes.
+- Do not start the next dependent package until the current PR is merged,
+  development evidence and Issue/release-milestone dispositions are published,
+  the fixture is archived, and the user selects the next direction.
 - A one-day workflow improvement is allowed only when it removes a measured repeated cost on the active path. Larger infrastructure work needs explicit user promotion.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -168,17 +168,28 @@ This is the stable-launcher contract. The v0.9.3 macOS Panel emits the expanded 
 
 ### Developer Install
 
-Only a development checkout requires `uv`, Node/npm, and local build/signing tools. This is not the normal-user install path. Close every After Effects / AfterFX process first. On macOS, the script preflights required source files and non-destructively moves strictly named transaction artifacts left by older installers out of Adobe's CEP scan root. It then creates its unique staging tree in the private off-scan state directory `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/`. After copying and verifying the complete tree, it atomically renames the candidate into place; the scan root retains only the active `com.aemcp.panel`. The old panel remains as the unique backup in that private state directory, is restored automatically on swap failure, and is named in an absolute restore command after success. The Windows script continues to use transaction directories beside its target with the same rollback contract.
+Only a development checkout requires `uv`, Node/npm, and local build/signing tools. This is not the normal-user install path. Dependency installation is an explicit, one-time bootstrap; daily commands never run `uv sync`, `npm ci`, portable-runtime packaging, or a release installer. For a full bootstrap, set `AE_MCP_SDK_ARCHIVE` and `AE_MCP_SDK_ROOT` (or pass the matching CLI options), close every After Effects / AfterFX process, then run:
 
 ```bash
-uv sync --all-packages --group dev
-(cd plugin/host && npm ci)
-(cd plugin/sidecar && npm ci)
-(cd plugin/panel && npm ci && npm run build)
-./scripts/install-plugin-dev-macos.sh
+node scripts/dev/ae-mcp-dev.mjs bootstrap --component all \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
 ```
 
-After the same dependency synchronization on Windows, run:
+After bootstrap, inspect or update only the component being changed:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs doctor --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+node scripts/dev/ae-mcp-dev.mjs sync --component core --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+Core sync performs no copy and asks the caller to restart the MCP session. CEP sync rebuilds the panel and uses the existing off-scan, atomic development installer. Native sync keeps the existing clean-commit, stopped-AE, SDK, installer, and formal-restart requirements. If a required dependency is absent, a daily command fails with a bootstrap recovery code instead of installing it.
+
+On macOS, the CEP installer preflights required source files and non-destructively moves strictly named transaction artifacts left by older installers out of Adobe's CEP scan root. It then creates its unique staging tree in the private off-scan state directory `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/`. After copying and verifying the complete tree, it atomically renames the candidate into place; the scan root retains only the active `com.aemcp.panel`. The old panel remains as the unique backup in that private state directory, is restored automatically on swap failure, and is named in an absolute restore command after success.
+
+Windows still uses the existing manual development path after dependency synchronization:
 
 ```powershell
 .\scripts\install-plugin-dev.ps1

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -183,9 +183,23 @@ node scripts/dev/ae-mcp-dev.mjs doctor --repo-root "$PWD" \
   --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
 node scripts/dev/ae-mcp-dev.mjs sync --component core --repo-root "$PWD" \
   --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+node scripts/dev/ae-mcp-dev.mjs launch-ae --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+node scripts/dev/ae-mcp-dev.mjs smoke --component core \
+  --scenario core-native-write-undo@1 \
+  --repo-root "$PWD" \
+  --fixture-path "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/active/hdev-core-native.aep" \
+  --recovery-archive-root "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/recovery" \
+  --evidence-dir "$HOME/Library/Application Support/AfterEffectsMCP/evidence/hdev-core-native" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
 ```
 
 Core sync performs no copy and asks the caller to restart the MCP session. CEP sync rebuilds the panel and uses the existing off-scan, atomic development installer. Native sync keeps the existing clean-commit, stopped-AE, SDK, installer, and formal-restart requirements. If a required dependency is absent, a daily command fails with a bootstrap recovery code instead of installing it.
+
+HDEV is ordinary development proof only. Its seven-call evidence always says
+`candidateRun=false` and `candidateEvidence=false`; it must never be promoted
+or copied into packaged release T5/T6 evidence. Packaged release candidates
+continue to use the strict release-audit identity and installation workflows.
 
 On macOS, the CEP installer preflights required source files and non-destructively moves strictly named transaction artifacts left by older installers out of Adobe's CEP scan root. It then creates its unique staging tree in the private off-scan state directory `~/Library/Application Support/AfterEffectsMCP/cep-panel-dev-v1/`. After copying and verifying the complete tree, it atomically renames the candidate into place; the scan root retains only the active `com.aemcp.panel`. The old panel remains as the unique backup in that private state directory, is restored automatically on swap failure, and is named in an absolute restore command after success.
 

--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -48,7 +48,8 @@ The Connection diagnostics report the selected version, full source commit, abso
 For a development-installed CEP extension only (the existing `.debug` marker is
 present and `bundle-manifest.json` is absent), setting `AE_MCP_DEV_RUNTIME` to
 an absolute source-checkout path starts that checkout's `.venv/bin/python3`
-with `-B -I -m ae_mcp`. This bypasses RuntimeManager installation and takes no
+with `-B -I -m ae_mcp`, using the canonical checkout as the child working
+directory. This bypasses RuntimeManager installation and takes no
 RuntimeManager lock; it never reads, writes, or repairs `current` or `previous`.
 The checkout must contain `pyproject.toml`, `packages/core/ae_mcp/__main__.py`,
 and an executable `.venv/bin/python3` or selection fails closed with

--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -48,8 +48,11 @@ The Connection diagnostics report the selected version, full source commit, abso
 For a development-installed CEP extension only (the existing `.debug` marker is
 present and `bundle-manifest.json` is absent), setting `AE_MCP_DEV_RUNTIME` to
 an absolute source-checkout path starts that checkout's `.venv/bin/python3`
-with `-B -I -m ae_mcp`, using the canonical checkout as the child working
-directory. This bypasses RuntimeManager installation and takes no
+with `-B -I -c` and a closed bootstrap that prepends only the checkout's
+`packages/core` before running `ae_mcp` as `__main__`, using the canonical
+checkout as the child working directory. This explicit path is required
+because isolated Python does not use the working directory or editable-install
+path files for module discovery. This bypasses RuntimeManager installation and takes no
 RuntimeManager lock; it never reads, writes, or repairs `current` or `previous`.
 The checkout must contain `pyproject.toml`, `packages/core/ae_mcp/__main__.py`,
 and an executable `.venv/bin/python3` or selection fails closed with

--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -43,6 +43,23 @@ The Connection diagnostics report the selected version, full source commit, abso
 
 连接诊断会报告所选版本、完整 source commit、绝对 launcher 路径、current/previous 健康状态和结构化错误码。`RUNTIME_HASH_MISMATCH`、`RUNTIME_INCOMPLETE`、`RUNTIME_POINTER_INVALID` 需要离线修复或回滚；`RUNTIME_MANAGER_LOCKED` 表示另一 Panel 正在修改 runtime 状态，应在该有界操作结束后重试。
 
+### Development checkout override / 开发 checkout 覆盖
+
+For a development-installed CEP extension only (the existing `.debug` marker is
+present and `bundle-manifest.json` is absent), setting `AE_MCP_DEV_RUNTIME` to
+an absolute source-checkout path starts that checkout's `.venv/bin/python3`
+with `-B -I -m ae_mcp`. This bypasses RuntimeManager installation and takes no
+RuntimeManager lock; it never reads, writes, or repairs `current` or `previous`.
+The checkout must contain `pyproject.toml`, `packages/core/ae_mcp/__main__.py`,
+and an executable `.venv/bin/python3` or selection fails closed with
+`RUNTIME_DEVELOPMENT_RUNTIME_INVALID`.
+
+Connection diagnostics label this state `DEVELOPMENT CHECKOUT`, report both the
+checkout and resolved interpreter paths, and include
+`RUNTIME_DEVELOPMENT_RUNTIME_SELECTED`. A packaged release extension rejects
+the variable with `RUNTIME_DEVELOPMENT_RUNTIME_RELEASE_REFUSED`; it never
+falls back to the production runtime manager.
+
 Initial support is Apple Silicon on macOS 14 or newer. Intel/Rosetta, signing/notarization, the formal installer, and Windows RuntimeManager changes are separate work.
 
 首期支持范围是 macOS 14 或更高版本的 Apple Silicon。Intel/Rosetta、签名与公证、正式安装器以及 Windows RuntimeManager 改动属于独立工作。

--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -58,6 +58,13 @@ The checkout must contain `pyproject.toml`, `packages/core/ae_mcp/__main__.py`,
 and an executable `.venv/bin/python3` or selection fails closed with
 `RUNTIME_DEVELOPMENT_RUNTIME_INVALID`.
 
+Daily doctor, launch, component sync, and HDEV use only this development
+boundary and never package a portable runtime or align the checkout to a
+RuntimeManager generation manifest. HDEV evidence is always non-candidate.
+Packaged release T5/T6 retain exact source/artifact identity, complete payload
+hashing, RuntimeManager manifest alignment, and the existing strict release
+gates; the development override does not weaken that boundary.
+
 Connection diagnostics label this state `DEVELOPMENT CHECKOUT`, report both the
 checkout and resolved interpreter paths, and include
 `RUNTIME_DEVELOPMENT_RUNTIME_SELECTED`. A packaged release extension rejects

--- a/docs/superpowers/plans/2026-07-28-agile-real-ae-development-loop.md
+++ b/docs/superpowers/plans/2026-07-28-agile-real-ae-development-loop.md
@@ -1,0 +1,1435 @@
+# Agile Real-AE Development Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a macOS development profile that reuses installed dependencies, updates only explicitly selected components, and proves current checkout behavior with a bounded public-MCP real-AE HDEV smoke while reserving full T5/T6 for packaged release candidates.
+
+**Architecture:** Keep the existing `AE_MCP_DEV_RUNTIME` panel boundary and bind its child process to the canonical checkout. Add a dependency-free Node CLI split into a pure command contract and a macOS executor; only the explicit `bootstrap` action may invoke dependency managers. Add a standalone seven-call Python HDEV driver whose evidence is permanently non-candidate, then update repository policy so ordinary capability PRs use HDEV and release candidates retain strict packaged T5/T6.
+
+**Tech Stack:** Node.js 24 ESM and `node:test`; CEP React/Node runtime manager; Python 3.13, asyncio, MCP SDK and pytest; existing macOS CEP/native atomic installers; After Effects 2026 public MCP and AEGP.
+
+## Global Constraints
+
+- Work only in `/Users/junk_doge/Documents/ae-mcp/.worktrees/dev-runtime-path` on `codex/dev-runtime-path`; do not touch the root checkout's #67/#69 changes.
+- `bootstrap` is the only command allowed to run `uv sync`, `npm ci`, or another dependency installer, and only after the user explicitly invokes it.
+- `doctor`, `launch-ae`, `sync`, and `smoke` must never run dependency installation, portable-runtime packaging, ZXP packaging, signing, or a release installer.
+- Core uses the canonical checkout's `.venv/bin/python3 -B -I -m ae_mcp`; it creates no RuntimeManager generation, pointer update, or RuntimeManager lock.
+- CEP keeps off-scan staging, tree-shape validation, atomic replacement, rollback, and zero checkout symlinks under Adobe scan roots.
+- Native reuses the installed Adobe SDK/Xcode toolchain but still requires a clean commit, AE stopped, the existing development installer, and a formal AE restart.
+- Both profiles retain strict wire version, capability digest, RPC schema digest, `productVersion`, platform, architecture, entrypoint, load-result, scan-root, and uncertain-write gates.
+- HDEV always emits `candidateRun=false`, `candidateEvidence=false`, and `validationProfile="development"`.
+- HDEV uses one `ephemeral-validation` `.aep`, no Save As copies after its initial naming save, real Undo, independent readback, audit/provenance checks, and recovery/archive accounting.
+- Full T5/T6 run only against a frozen packaged release candidate; this implementation does not run T5 or T6.
+- Do not add Windows support, dirty-worktree native identity, native incremental object caching, ZXP changes, new MCP tools, new AEGP suites, or changed tool behavior.
+- Any new invariant must be mutation-proved: break it, observe the intended test fail, restore it, and observe the test pass.
+
+## File Map
+
+### Product runtime
+
+- Modify `plugin/panel/src/cep/runtimeManager.js` — include the canonical checkout working directory in the selected development runtime.
+- Modify `plugin/panel/src/cep/mcpClient.js` — pass the selected development working directory to the child spawn without changing packaged runtime spawn behavior.
+- Modify `plugin/panel/test/runtimeManager.test.js` — prove live checkout selection, zero RuntimeManager mutation, and release refusal.
+- Modify `plugin/panel/test/mcpClient.test.js` — prove command, arguments, working directory, and source label reach the spawned process.
+- Modify `plugin/client/dist/app.js` — generated panel bundle; rebuild once after source changes.
+
+### Development orchestration
+
+- Create `scripts/dev/profile-contract.mjs` — parse commands and produce immutable, typed process plans; own the no-implicit-bootstrap invariant.
+- Create `scripts/dev/macos-development.mjs` — read-only doctor, exact formal-AE executable resolution, process checks, direct AE launch, and bounded process-step execution.
+- Create `scripts/dev/ae-mcp-dev.mjs` — CLI entrypoint, option validation, component selection, native temporary output allocation, structured execution receipts.
+- Create `scripts/dev/test/profile-contract.test.mjs` — pure parser/plan tests and forbidden-command mutation guard.
+- Create `scripts/dev/test/macos-development.test.mjs` — filesystem/process-injected doctor, launcher, and executor tests.
+- Create `scripts/dev/test/ae-mcp-dev.test.mjs` — CLI exit/output contract tests.
+
+### HDEV
+
+- Create `scripts/hardware/development_smoke_spec.py` — frozen seven-public-call scenario and closed assertions.
+- Create `scripts/hardware/development_smoke.py` — direct live-checkout MCP session, checkpoint handling, state/audit/Undo validation, private evidence, and fixture archival.
+- Create `packages/bridge/tests/test_development_smoke_driver.py` — fake-session, evidence, uncertain-write, call-budget, and mutation tests.
+- Modify `scripts/hardware/README.md` — HDEV command and explicit non-candidate semantics.
+
+### Policy and developer documentation
+
+- Modify `AGENTS.md` — introduce HDEV for ordinary AE-changing PRs and move full T5/T6 to packaged release-candidate scope.
+- Modify `docs/CAPABILITY_PACKAGE_WORKFLOW.md` — replace per-PR T5/T6 closure with T0-T3 + HDEV, and define release milestone aggregation.
+- Modify `docs/INSTALL.md` — separate one-time explicit bootstrap from daily doctor/sync/smoke commands.
+- Modify `docs/RUNTIME_MANAGER.md` — document exact development spawn/cwd behavior and packaged refusal.
+
+---
+
+### Task 1: Bind the panel's live Core process to the canonical checkout
+
+**Files:**
+- Modify: `plugin/panel/src/cep/runtimeManager.js:143-230`
+- Modify: `plugin/panel/src/cep/mcpClient.js:42-74,296-318`
+- Modify: `plugin/panel/test/runtimeManager.test.js:190-320`
+- Modify: `plugin/panel/test/mcpClient.test.js:120-175`
+- Modify: `docs/RUNTIME_MANAGER.md:43-66`
+- Modify generated: `plugin/client/dist/app.js`
+
+**Interfaces:**
+- Consumes: existing `selectDevelopmentRuntime()` result with `launcher`, `args`, and `checkoutPath`.
+- Produces: development selection `{launcher, args, cwd, checkoutPath, developmentRuntime:true}` and command spec `{command, args, cwd, source:"development-runtime"}`.
+
+- [ ] **Step 0: Bootstrap this isolated worktree once, only if dependencies are absent**
+
+Check:
+
+```bash
+test -x .venv/bin/python3
+test -d plugin/host/node_modules
+test -d plugin/sidecar/node_modules
+test -d plugin/panel/node_modules
+```
+
+Run only the missing setup commands:
+
+```bash
+uv sync --all-packages --group dev
+(cd plugin/host && npm ci)
+(cd plugin/sidecar && npm ci)
+(cd plugin/panel && npm ci)
+```
+
+Record which commands ran. Do not repeat them in Tasks 2-7 unless a lockfile or toolchain requirement changes.
+
+- [ ] **Step 1: Write the failing runtime-selection assertion**
+
+Add to the existing development checkout test:
+
+```js
+assert.equal(selected.cwd, canonicalCheckout);
+assert.equal(selected.checkoutPath, canonicalCheckout);
+```
+
+Run:
+
+```bash
+node --test plugin/panel/test/runtimeManager.test.js \
+  --test-name-pattern='development checkout bypasses'
+```
+
+Expected: FAIL because `selected.cwd` is currently `undefined`.
+
+- [ ] **Step 2: Return the canonical checkout as the child working directory**
+
+In `selectDevelopmentRuntime()` return:
+
+```js
+return {
+  ok: true,
+  action: 'development-runtime',
+  developmentRuntime: true,
+  checkoutPath: checkout,
+  launcher: interpreter,
+  args: ['-B', '-I', '-m', 'ae_mcp'],
+  cwd: checkout,
+  interpreter: {
+    path: interpreter,
+    resolvedPath: resolvedInterpreter,
+  },
+  diagnostics: [{
+    code: 'RUNTIME_DEVELOPMENT_RUNTIME_SELECTED',
+    message: `Development runtime selected from ${checkout}; no packaged runtime was verified or installed.`,
+  }],
+};
+```
+
+Run the same focused test. Expected: PASS.
+
+- [ ] **Step 3: Write the failing spawn propagation test**
+
+Extend `plugin/panel/test/mcpClient.test.js` so the injected `resolveCommand` returns:
+
+```js
+{
+  command: '/checkout/.venv/bin/python3',
+  args: ['-B', '-I', '-m', 'ae_mcp'],
+  cwd: '/checkout',
+  source: 'development-runtime',
+}
+```
+
+Capture the spawn options and assert:
+
+```js
+assert.equal(spawned.command, '/checkout/.venv/bin/python3');
+assert.deepEqual(spawned.args, ['-B', '-I', '-m', 'ae_mcp']);
+assert.equal(spawned.options.cwd, '/checkout');
+assert.equal(spawned.options.shell, false);
+```
+
+Run:
+
+```bash
+node --test plugin/panel/test/mcpClient.test.js \
+  --test-name-pattern='development checkout'
+```
+
+Expected: FAIL because `createMcpClient.start()` does not pass `cwd`.
+
+- [ ] **Step 4: Propagate `cwd` only for the selected development runtime**
+
+Return `cwd` from `resolveMcpCommand()`:
+
+```js
+return {
+  command: selected.launcher,
+  args: selected.args || [],
+  cwd: selected.cwd,
+  source: selected.developmentRuntime
+    ? 'development-runtime'
+    : (selected.action === 'fallback' ? 'runtime-fallback' : 'runtime-manager'),
+  runtime: selected,
+};
+```
+
+Add it conditionally to spawn options:
+
+```js
+const options = {
+  stdio: 'pipe',
+  windowsHide: true,
+  env: spawnEnv,
+  ...(commandSpec.cwd ? { cwd: commandSpec.cwd } : {}),
+};
+```
+
+Add a packaged-runtime assertion that `cwd` remains absent. Run the focused `mcpClient` and `runtimeManager` tests. Expected: PASS.
+
+- [ ] **Step 5: Rebuild the panel bundle once**
+
+Run:
+
+```bash
+(cd plugin/panel && npm run build)
+```
+
+Expected: `plugin/client/dist/app.js` changes and no other generated file changes.
+
+- [ ] **Step 6: Mutation-prove packaged release refusal**
+
+Using `apply_patch`, temporarily replace:
+
+```js
+if (!developmentBuild()) {
+```
+
+with:
+
+```js
+if (false) {
+```
+
+Run:
+
+```bash
+node --test plugin/panel/test/runtimeManager.test.js \
+  --test-name-pattern='packaged release build refuses'
+```
+
+Expected: FAIL because a packaged extension accepts the override. Restore the original condition with `apply_patch`, rerun, and expect PASS.
+
+- [ ] **Step 7: Document and commit**
+
+Update `docs/RUNTIME_MANAGER.md` to state that the development child uses the canonical checkout as `cwd`, while packaged launch behavior is unchanged.
+
+Run:
+
+```bash
+git diff --check
+node --test plugin/panel/test/runtimeManager.test.js \
+  plugin/panel/test/mcpClient.test.js \
+  plugin/panel/test/diagnostics.test.js
+```
+
+Expected: all tests PASS.
+
+Commit:
+
+```bash
+git add plugin/panel/src/cep/runtimeManager.js \
+  plugin/panel/src/cep/mcpClient.js \
+  plugin/panel/test/runtimeManager.test.js \
+  plugin/panel/test/mcpClient.test.js \
+  plugin/client/dist/app.js \
+  docs/RUNTIME_MANAGER.md
+git commit -m "fix(panel): bind development core to checkout"
+```
+
+---
+
+### Task 2: Define the pure development command contract
+
+**Files:**
+- Create: `scripts/dev/profile-contract.mjs`
+- Create: `scripts/dev/test/profile-contract.test.mjs`
+
+**Interfaces:**
+- Produces `parseDevelopmentCommand(argv, defaults) -> DevelopmentCommand`.
+- Produces `buildDevelopmentPlan(command, paths) -> DevelopmentPlan`.
+- Produces `assertDailyPlanSafe(plan) -> plan` or throws code `DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN`.
+- Later tasks consume plan steps shaped as `{id, component, kind, executable, args, cwd}`.
+
+- [ ] **Step 1: Write parser and plan-shape tests**
+
+Create tests for the five actions:
+
+```js
+const defaults = {
+  repoRoot: '/repo',
+  home: '/Users/developer',
+  formalAeApp: '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+};
+const parsed = parseDevelopmentCommand(['sync', '--component', 'cep'], defaults);
+assert.equal(parsed.action, 'sync');
+assert.deepEqual(parsed.components, ['cep']);
+assert.equal(parsed.repoRoot, '/repo');
+assert.equal(parsed.home, '/Users/developer');
+assert.equal(
+  parsed.formalAeApp,
+  '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+);
+assert.deepEqual(
+  parseDevelopmentCommand(['bootstrap', '--component', 'all'], defaults).components,
+  ['core', 'cep', 'native'],
+);
+assert.deepEqual(
+  parseDevelopmentCommand([
+    'smoke',
+    '--component', 'core',
+    '--component', 'cep',
+    '--scenario', 'core-native-write-undo@1',
+  ], defaults).components,
+  ['core', 'cep'],
+);
+assert.throws(
+  () => parseDevelopmentCommand(['sync', '--component', 'unknown'], defaults),
+  (error) => error.code === 'DEV_ARGUMENT_INVALID',
+);
+```
+
+Assert daily CEP sync contains panel build plus the existing dev installer, but no dependency step:
+
+```js
+const paths = {
+  repoRoot: '/repo',
+  uv: '/usr/local/bin/uv',
+  npm: '/usr/local/bin/npm',
+  node: '/usr/local/bin/node',
+  python: '/repo/.venv/bin/python3',
+  hostRoot: '/repo/plugin/host',
+  sidecarRoot: '/repo/plugin/sidecar',
+  panelRoot: '/repo/plugin/panel',
+  cepInstaller: '/repo/scripts/install-plugin-dev-macos.sh',
+  nativeBuilder: '/repo/native/ae-plugin/build-macos.mjs',
+  nativeInstaller: '/repo/native/ae-plugin/install-dev-macos.mjs',
+  sdkArchive: '/inputs/AfterEffectsSDK.zip',
+  sdkRoot: '/inputs/AfterEffectsSDK',
+  nativeOutput: '/private/tmp/ae-mcp-native-dev-test/artifact',
+  developmentSmoke: '/repo/scripts/hardware/development_smoke.py',
+};
+const syncCep = parseDevelopmentCommand(['sync', '--component', 'cep'], defaults);
+const plan = buildDevelopmentPlan(syncCep, paths);
+assert.deepEqual(plan.steps.map((step) => step.id), [
+  'cep-panel-build',
+  'cep-development-install',
+]);
+assert.equal(plan.dependencyBootstrapInvocations, 0);
+assert.equal(plan.releasePackagingInvocations, 0);
+```
+
+Run:
+
+```bash
+node --test scripts/dev/test/profile-contract.test.mjs
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 2: Implement closed command and step types**
+
+In `profile-contract.mjs`, define:
+
+```js
+export const COMPONENTS = Object.freeze(['core', 'cep', 'native']);
+export const DAILY_ACTIONS = Object.freeze(['doctor', 'launch-ae', 'sync', 'smoke']);
+
+export function developmentError(code, message, details = {}) {
+  return Object.assign(new Error(message), { code, ...details });
+}
+
+function processStep(id, component, kind, executable, args, cwd) {
+  return Object.freeze({
+    id, component, kind, executable,
+    args: Object.freeze([...args]),
+    cwd,
+  });
+}
+```
+
+Use exact step kinds:
+
+```js
+const DEPENDENCY_KIND = 'dependency-install';
+const RELEASE_KIND = 'release-package';
+const DAILY_ALLOWED_KINDS = new Set([
+  'build', 'development-install', 'public-smoke', 'read-only-check',
+]);
+```
+
+`parseDevelopmentCommand()` must reject duplicates, missing option values, relative paths, unknown actions, and unknown components with `DEV_ARGUMENT_INVALID`.
+For `smoke`, accept repeated unique `--component` options and compute `reused` as the
+ordered complement of `['core', 'cep', 'native']`.
+
+- [ ] **Step 3: Implement exact component plans**
+
+Use these exact process steps:
+
+```js
+// bootstrap core
+processStep(
+  'core-uv-sync', 'core', 'dependency-install',
+  paths.uv, ['sync', '--all-packages', '--group', 'dev'], paths.repoRoot,
+);
+
+// bootstrap CEP
+processStep('host-npm-ci', 'cep', 'dependency-install', paths.npm, ['ci'], paths.hostRoot);
+processStep('sidecar-npm-ci', 'cep', 'dependency-install', paths.npm, ['ci'], paths.sidecarRoot);
+processStep('panel-npm-ci', 'cep', 'dependency-install', paths.npm, ['ci'], paths.panelRoot);
+
+// daily CEP sync
+processStep('cep-panel-build', 'cep', 'build', paths.node, ['build.mjs'], paths.panelRoot);
+processStep(
+  'cep-development-install', 'cep', 'development-install',
+  '/bin/bash', [paths.cepInstaller], paths.repoRoot,
+);
+
+// daily native sync
+processStep(
+  'native-build', 'native', 'build', paths.node,
+  [
+    paths.nativeBuilder,
+    '--sdk-archive', paths.sdkArchive,
+    '--sdk-root', paths.sdkRoot,
+    '--output', paths.nativeOutput,
+  ],
+  paths.repoRoot,
+);
+processStep(
+  'native-development-install', 'native', 'development-install', paths.node,
+  [
+    paths.nativeInstaller,
+    'install', '--artifact-dir', paths.nativeOutput,
+    '--profile', 'development',
+  ],
+  paths.repoRoot,
+);
+```
+
+Core daily sync produces zero process steps and a structured action:
+
+```js
+{
+  component: 'core',
+  action: 'restart-mcp-session',
+  reason: 'live checkout requires no copy or RuntimeManager generation',
+}
+```
+
+- [ ] **Step 4: Enforce no implicit bootstrap**
+
+Implement:
+
+```js
+export function assertDailyPlanSafe(plan) {
+  if (!DAILY_ACTIONS.includes(plan.action)) return plan;
+  const forbidden = plan.steps.find(
+    (step) => step.kind === DEPENDENCY_KIND || step.kind === RELEASE_KIND,
+  );
+  if (forbidden) {
+    throw developmentError(
+      'DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN',
+      `${plan.action} may not execute ${forbidden.id}`,
+    );
+  }
+  return plan;
+}
+```
+
+Every non-bootstrap plan constructor must call it before returning.
+
+Run the full contract test. Expected: PASS.
+
+- [ ] **Step 5: Mutation-prove the daily safety guard**
+
+Temporarily add this step to CEP sync using `apply_patch`:
+
+```js
+processStep('forbidden-npm-ci', 'cep', 'dependency-install', paths.npm, ['ci'], paths.panelRoot),
+```
+
+Run:
+
+```bash
+node --test scripts/dev/test/profile-contract.test.mjs \
+  --test-name-pattern='daily plans reject dependency installation'
+```
+
+Expected: FAIL by throwing `DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN`. Restore, rerun, expect PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev/profile-contract.mjs \
+  scripts/dev/test/profile-contract.test.mjs
+git commit -m "feat(dev): define component-selective command plans"
+```
+
+---
+
+### Task 3: Implement the read-only doctor and exact formal-AE launcher
+
+**Files:**
+- Create: `scripts/dev/macos-development.mjs`
+- Create: `scripts/dev/test/macos-development.test.mjs`
+
+**Interfaces:**
+- Consumes `DevelopmentPlan` from Task 2.
+- Produces `inspectDevelopmentEnvironment(options) -> DoctorReport`.
+- Produces `launchDevelopmentAe(report, dependencies) -> LaunchReceipt`.
+- Produces `executeDevelopmentPlan(plan, dependencies) -> ExecutionReceipt`.
+- Produces `createDefaultMacosDependencies() -> MacosDevelopmentDependencies`.
+- Imports `developmentError` from `profile-contract.mjs`.
+
+- [ ] **Step 1: Write the doctor fail/pass tests**
+
+Build a temporary fixture with:
+
+```text
+repo/pyproject.toml
+repo/packages/core/ae_mcp/__main__.py
+repo/.venv/bin/python3
+cep/com.aemcp.panel/.debug
+formal.app/Contents/Info.plist
+formal.app/Contents/MacOS/After Effects
+```
+
+Inject `fs`, `execFile`, and `processInspector`. Assert the success report has exactly:
+
+```js
+{
+  schemaVersion: 1,
+  profile: 'development',
+  ok: true,
+  checkoutPath: canonicalRepo,
+  interpreterPath: canonicalPython,
+  formalAeApp: canonicalApp,
+  formalAeExecutable: canonicalExecutable,
+  checks: checks,
+  blockers: [],
+}
+```
+
+Then assert:
+
+```js
+assert.deepEqual(report.checks.map((check) => check.id), [
+  'checkout',
+  'core-entrypoint',
+  'core-interpreter',
+  'core-import',
+  'cep-development-marker',
+  'cep-release-manifest-absent',
+  'formal-ae-app',
+  'formal-ae-executable',
+]);
+assert.equal(report.checks.every((check) => check.ok), true);
+```
+
+Remove `.venv/bin/python3` and assert:
+
+```js
+assert.equal(report.ok, false);
+assert.deepEqual(report.blockers.map((item) => item.code), [
+  'DEV_CORE_INTERPRETER_MISSING',
+]);
+assert.equal(writes.length, 0);
+```
+
+Run:
+
+```bash
+node --test scripts/dev/test/macos-development.test.mjs \
+  --test-name-pattern='doctor'
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 2: Implement bounded read-only inspection**
+
+Export:
+
+```js
+export async function inspectDevelopmentEnvironment({
+  repoRoot,
+  home,
+  formalAeApp,
+  components = ['core'],
+  environment = process.env,
+  dependencies = createDefaultMacosDependencies(),
+}) {
+  const checkoutPath = await dependencies.realpath(repoRoot);
+  const checks = await inspectRequiredPaths({
+    checkoutPath, home, formalAeApp, components, environment, dependencies,
+  });
+  const blockers = checks.filter((check) => check.ok === false);
+  return Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    ok: blockers.length === 0,
+    checkoutPath,
+    interpreterPath: checks.find((check) => check.id === 'core-interpreter').path,
+    formalAeApp: checks.find((check) => check.id === 'formal-ae-app').path,
+    formalAeExecutable: checks.find((check) => check.id === 'formal-ae-executable').path,
+    checks: Object.freeze(checks),
+    blockers: Object.freeze(blockers),
+  });
+}
+```
+
+Rules:
+
+- implement private
+  `inspectRequiredPaths({checkoutPath, home, formalAeApp, components, environment, dependencies})`
+  in the same file; it returns the closed `checks` array described below and performs no write;
+- implement exported `createDefaultMacosDependencies()` in the same file with only Node `fs`,
+  `path`, `child_process.execFile`, `child_process.spawn`, and the bounded AE process inspector;
+- canonicalize `repoRoot`, `.venv/bin/python3`, CEP root, formal app, and formal executable;
+- reject symlinked `pyproject.toml`, Core entrypoint, formal app, and formal executable;
+- verify executable mode;
+- parse `CFBundleExecutable`, `CFBundleShortVersionString`, and `CFBundleVersion` using
+  `/usr/bin/plutil` with `shell:false`;
+- verify CEP `.debug` is present and `bundle-manifest.json` absent;
+- check, but do not create, `plugin/{host,sidecar,panel}/node_modules` only when
+  `components` includes `cep`; a Core-only sync must not be blocked by missing CEP source dependencies;
+- call the interpreter with `-B -I -c` and assert `ae_mcp.__file__` resolves beneath the canonical checkout;
+- report missing SDK inputs only when native was selected;
+- never call `mkdir`, `writeFile`, `rename`, `unlink`, or a package manager.
+
+- [ ] **Step 3: Write the launch tests**
+
+Assert a running AE returns `DEV_AE_ALREADY_RUNNING` and does not spawn. For a stopped AE, assert:
+
+```js
+assert.equal(spawned.file, report.formalAeExecutable);
+assert.deepEqual(spawned.args, []);
+assert.equal(spawned.options.cwd, path.dirname(report.formalAeExecutable));
+assert.equal(spawned.options.detached, true);
+assert.equal(spawned.options.stdio, 'ignore');
+assert.equal(spawned.options.env.AE_MCP_DEV_RUNTIME, report.checkoutPath);
+assert.equal(spawned.options.shell, false);
+assert.equal(calls.some((call) => call.file === '/bin/launchctl'), false);
+```
+
+Run the launch-focused test. Expected: FAIL.
+
+- [ ] **Step 4: Implement direct formal-AE launch**
+
+Export:
+
+```js
+export async function launchDevelopmentAe(report, {
+  processInspector,
+  spawn,
+  environment = process.env,
+  now = () => new Date(),
+}) {
+  if (await processInspector.afterEffectsRunning()) {
+    throw developmentError(
+      'DEV_AE_ALREADY_RUNNING',
+      'formal After Effects is already running',
+    );
+  }
+  const child = spawn(report.formalAeExecutable, [], {
+    cwd: path.dirname(report.formalAeExecutable),
+    detached: true,
+    stdio: 'ignore',
+    shell: false,
+    env: {...environment, AE_MCP_DEV_RUNTIME: report.checkoutPath},
+  });
+  child.unref();
+  return Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    pid: child.pid,
+    formalAeExecutable: report.formalAeExecutable,
+    checkoutPath: report.checkoutPath,
+    launchedAt: now().toISOString(),
+  });
+}
+```
+
+Require `report.ok === true`, no running `Adobe After Effects|AfterFX`, then spawn the exact executable with only the child environment extended:
+
+```js
+const child = spawn(report.formalAeExecutable, [], {
+  cwd: path.dirname(report.formalAeExecutable),
+  detached: true,
+  stdio: 'ignore',
+  shell: false,
+  env: {
+    ...environment,
+    AE_MCP_DEV_RUNTIME: report.checkoutPath,
+  },
+});
+child.unref();
+```
+
+Return `{schemaVersion:1, profile:"development", pid, formalAeExecutable, checkoutPath, launchedAt}`.
+
+- [ ] **Step 5: Implement step execution and structured receipts**
+
+`executeDevelopmentPlan()` must use `execFile`, never a shell string, and record:
+
+```js
+{
+  schemaVersion: 1,
+  profile: 'development',
+  action: plan.action,
+  components: plan.components,
+  steps: [{id, component, kind, exitCode: 0}],
+  dependencyBootstrapInvocations,
+  releasePackagingInvocations: 0,
+}
+```
+
+For every daily action, assert `dependencyBootstrapInvocations === 0`. Redact home/repo paths from public error messages while retaining absolute paths in the local private receipt object.
+
+- [ ] **Step 6: Run and commit**
+
+```bash
+node --test scripts/dev/test/macos-development.test.mjs
+git diff --check
+git add scripts/dev/macos-development.mjs \
+  scripts/dev/test/macos-development.test.mjs
+git commit -m "feat(dev): add read-only doctor and scoped AE launch"
+```
+
+Expected: all tests PASS.
+
+---
+
+### Task 4: Add explicit bootstrap, component sync, and the CLI
+
+**Files:**
+- Create: `scripts/dev/ae-mcp-dev.mjs`
+- Create: `scripts/dev/test/ae-mcp-dev.test.mjs`
+- Modify: `docs/INSTALL.md:171-190`
+
+**Interfaces:**
+- Consumes Task 2 parser/plans and Task 3 doctor/launcher/executor.
+- Produces CLI JSON `{ok, result}` on stdout or `{ok:false,error:{code,message,recovery}}` on stderr.
+- Produces no side effects before argument validation and doctor success.
+
+- [ ] **Step 1: Write CLI contract tests**
+
+Invoke an exported `main(argv, dependencies)` rather than spawning Node in unit tests:
+
+```js
+const result = await main([
+  'doctor',
+  '--repo-root', repoRoot,
+  '--formal-ae-app', formalAeApp,
+], harness.dependencies);
+assert.equal(result.exitCode, 0);
+assert.equal(result.output.result.profile, 'development');
+```
+
+Test these failures:
+
+```js
+['DEV_ARGUMENT_INVALID', 'DEV_DOCTOR_BLOCKED', 'DEV_AE_ALREADY_RUNNING']
+```
+
+Test `sync --component core` executes zero process steps and returns:
+
+```js
+{
+  selected: ['core'],
+  reused: ['cep', 'native'],
+  restart: ['mcp-session'],
+  dependencyBootstrapInvocations: 0,
+  releasePackagingInvocations: 0,
+}
+```
+
+Remove all three CEP `node_modules` directories from the test fixture and require the same
+Core-only result. Add a separate `sync --component cep` test that fails doctor with
+`DEV_CEP_DEPENDENCIES_MISSING`.
+
+Run:
+
+```bash
+node --test scripts/dev/test/ae-mcp-dev.test.mjs
+```
+
+Expected: FAIL because the CLI does not exist.
+
+- [ ] **Step 2: Implement CLI parsing and dependency injection**
+
+Use:
+
+```js
+export async function main(
+  argv = process.argv.slice(2),
+  dependencies = createDefaultMacosDependencies(),
+) {
+  const command = parseDevelopmentCommand(argv, dependencies.defaults);
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: command.repoRoot,
+    home: command.home,
+    formalAeApp: command.formalAeApp,
+    components: command.components,
+    dependencies,
+  });
+  if (!report.ok && command.action !== 'bootstrap') {
+    throw developmentError(
+      'DEV_DOCTOR_BLOCKED',
+      'development doctor reported blockers',
+      {recovery: report.blockers},
+    );
+  }
+  // dispatch exact action
+}
+```
+
+The file-level CLI block must catch errors, print one JSON line, and set `process.exitCode`; it must not expose credentials or private paths in error text.
+
+- [ ] **Step 3: Allocate native output safely**
+
+For native bootstrap/sync:
+
+```js
+const buildRoot = await fs.promises.mkdtemp('/private/tmp/ae-mcp-native-dev-');
+const nativeOutput = path.join(buildRoot, 'artifact');
+```
+
+Pass the absent `nativeOutput` to the existing builder. Keep the directory after successful install so the returned receipt can name `build-receipt.json`; on pre-build failure remove only the exact owned temporary directory. Never place output inside a worktree, Git common directory, Adobe scan root, or installer state root.
+
+- [ ] **Step 4: Enforce explicit bootstrap**
+
+`bootstrap` may execute dependency-install steps only after the literal action is present in `argv`. `doctor`, `launch-ae`, `sync`, and `smoke` must call `assertDailyPlanSafe()` before any process execution.
+
+Add the test:
+
+```js
+for (const action of ['doctor', 'launch-ae', 'sync', 'smoke']) {
+  const receipt = await harness.run(action);
+  assert.equal(receipt.dependencyBootstrapInvocations, 0);
+  assert.equal(receipt.releasePackagingInvocations, 0);
+}
+```
+
+- [ ] **Step 5: Wire existing CEP/native installers without weakening them**
+
+CEP sync must run exactly:
+
+```text
+node plugin/panel/build.mjs
+/bin/bash scripts/install-plugin-dev-macos.sh
+```
+
+Native sync must run exactly:
+
+```text
+node native/ae-plugin/build-macos.mjs --sdk-archive "$AE_SDK_ARCHIVE" --sdk-root "$AE_SDK_ROOT" --output "$native_output"
+node native/ae-plugin/install-dev-macos.mjs install --artifact-dir "$native_output" --profile development
+```
+
+Do not add a force flag, skip-AE-process flag, scan-root exception, or release-audit downgrade.
+
+- [ ] **Step 6: Document one-time versus daily commands**
+
+In `docs/INSTALL.md`, show:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs bootstrap --component all \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+and daily examples:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs doctor --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+node scripts/dev/ae-mcp-dev.mjs sync --component core --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+State explicitly that daily commands fail with a bootstrap instruction rather than installing dependencies.
+
+- [ ] **Step 7: Run and commit**
+
+```bash
+node --test scripts/dev/test/profile-contract.test.mjs \
+  scripts/dev/test/macos-development.test.mjs \
+  scripts/dev/test/ae-mcp-dev.test.mjs
+node scripts/check-repository-governance.mjs
+git diff --check
+git add scripts/dev/ae-mcp-dev.mjs \
+  scripts/dev/test/ae-mcp-dev.test.mjs \
+  docs/INSTALL.md
+git commit -m "feat(dev): orchestrate explicit bootstrap and component sync"
+```
+
+Expected: all tests and governance PASS.
+
+---
+
+### Task 5: Add the seven-call non-candidate HDEV driver
+
+**Files:**
+- Create: `scripts/hardware/development_smoke_spec.py`
+- Create: `scripts/hardware/development_smoke.py`
+- Create: `packages/bridge/tests/test_development_smoke_driver.py`
+- Modify: `scripts/dev/profile-contract.mjs`
+- Modify: `scripts/dev/test/profile-contract.test.mjs`
+
+**Interfaces:**
+- Produces scenario `core-native-write-undo@1`.
+- Produces CLI mode `hdev` with call hard limit 7.
+- Produces evidence summary schema:
+
+```python
+{
+    "schemaVersion": 1,
+    "validationProfile": "development",
+    "candidateRun": False,
+    "candidateEvidence": False,
+    "passed": bool,
+    "publicCalls": {
+        "target": 7,
+        "hardLimit": 7,
+        "total": int,
+        "byTool": dict[str, int],
+        "byPhase": dict[str, int],
+    },
+    "componentDisposition": {
+        "selected": list[str],
+        "reused": list[str],
+    },
+    "aepLifecycle": {
+        "created": int,
+        "canonicalRetained": int,
+        "evidenceSnapshotsRetained": int,
+        "archived": int,
+        "unclassified": int,
+        "saveAsCopies": int,
+    },
+}
+```
+
+- [ ] **Step 1: Freeze the executable scenario**
+
+In `development_smoke_spec.py`, define:
+
+```python
+SCENARIO_ID = "core-native-write-undo@1"
+CALL_HARD_LIMIT = 7
+CALLS = (
+    ("readiness", "ae_projectSummary"),
+    ("composition-create", "ae_createComposition"),
+    ("baseline-settings", "ae_getCompositionSettings"),
+    ("background-set", "ae_setCompositionBackgroundColor"),
+    ("changed-settings", "ae_getCompositionSettings"),
+    ("undo-reacquire", "ae_listProjectItems"),
+    ("undo-settings", "ae_getCompositionSettings"),
+)
+BASELINE_COLOR = {"red": 16, "green": 32, "blue": 48, "alpha": 255}
+CHANGED_COLOR = {"red": 64, "green": 96, "blue": 128, "alpha": 255}
+```
+
+Add an import-time invariant:
+
+```python
+assert len(CALLS) == CALL_HARD_LIMIT
+assert len({key for key, _ in CALLS}) == CALL_HARD_LIMIT
+```
+
+- [ ] **Step 2: Write fake-session tests first**
+
+Create tests that provide ordered fake responses and assert the exact request sequence:
+
+```python
+assert calls[1] == ("ae_createComposition", {
+    "name": "HDEV Core Native Fixture",
+    "width": 640,
+    "height": 360,
+    "duration": {"value": 5, "scale": 1},
+    "frame_rate": {"numerator": 24, "denominator": 1},
+    "pixel_aspect_ratio": {"numerator": 1, "denominator": 1},
+    "idempotency_key": "hdev-core-native-composition-0001",
+})
+assert calls[3][0] == "ae_setCompositionBackgroundColor"
+assert calls[3][1]["background_color"] == CHANGED_COLOR
+```
+
+Assert the driver:
+
+- saves the empty project once before the first public write;
+- validates baseline, changed, and restored complete settings snapshots;
+- performs one explicit real Undo checkpoint;
+- reacquires the composition locator after Undo;
+- archives exactly one fixture;
+- stops with exit 3 on `POSSIBLY_SIDE_EFFECTING_FAILURE`;
+- stops before call 8;
+- never retries a write.
+
+Run:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest \
+  packages/bridge/tests/test_development_smoke_driver.py -q
+```
+
+Expected: FAIL because the driver does not exist.
+
+- [ ] **Step 3: Implement the live-checkout MCP session**
+
+Launch Core with:
+
+```python
+StdioServerParameters(
+    command=str(checkout / ".venv/bin/python3"),
+    args=["-B", "-I", "-m", "ae_mcp"],
+    cwd=str(checkout),
+    env={
+        "AE_MCP_BACKEND": "ae-mcp",
+        "AE_MCP_PLUGIN_URL": plugin_url,
+        "HOME": str(identity_home),
+        "LANG": os.environ.get("LANG", "en_US.UTF-8"),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+        "TMPDIR": os.environ.get("TMPDIR", "/private/tmp"),
+    },
+)
+```
+
+Before session creation, verify the interpreter and `ae_mcp.__file__` resolve beneath `checkout`; do not use the stable RuntimeManager launcher.
+
+- [ ] **Step 4: Implement closed state and write evidence assertions**
+
+For every native response require:
+
+- one JSON text payload;
+- `engine == "native-aegp"` in provenance;
+- current formal host/session identifiers;
+- capability/contract digest;
+- audit ID and postcondition digest;
+- write `changed is True`;
+- `undo` object is present, with `available` and `verified` read separately.
+
+For the background setter require:
+
+```python
+require(before["backgroundColor"] == BASELINE_COLOR, "write before colour drifted")
+require(after["backgroundColor"] == CHANGED_COLOR, "write after colour drifted")
+```
+
+After the GUI Undo checkpoint, use `ae_listProjectItems(offset=0, limit=50)` to reacquire the named composition, then require restored background equals `BASELINE_COLOR`.
+
+- [ ] **Step 5: Implement private evidence and fixture lifecycle**
+
+Create evidence files with directory mode `0700` and file mode `0600`. Every event and summary must contain:
+
+```python
+"validationProfile": "development",
+"candidateRun": False,
+"candidateEvidence": False,
+```
+
+Parse `--selected-components` and `--reused-components` as closed, disjoint subsets of
+`core`, `cep`, and `native`. Require their union to contain all three components and persist
+them under `componentDisposition`.
+
+The successful lifecycle must be:
+
+```python
+{
+    "created": 1,
+    "canonicalRetained": 0,
+    "evidenceSnapshotsRetained": 0,
+    "archived": 1,
+    "unclassified": 0,
+    "saveAsCopies": 0,
+}
+```
+
+The initial checkpoint instructs AE to save the empty project at `fixturePath`. The final checkpoint instructs closing formal AE; only after process count is zero may the runner move the exact fixture to the recovery archive.
+
+- [ ] **Step 6: Wire the `smoke` command**
+
+Make the pure plan use:
+
+```js
+processStep(
+  'hdev-core-native-write-undo',
+  'core',
+  'public-smoke',
+  paths.python,
+  [
+    '-B', '-I',
+    paths.developmentSmoke,
+    '--scenario', 'core-native-write-undo@1',
+    '--selected-components', command.components.join(','),
+    '--reused-components',
+      COMPONENTS.filter((component) => !command.components.includes(component)).join(','),
+    '--checkout', paths.repoRoot,
+    '--fixture-path', command.fixturePath,
+    '--recovery-archive-root', command.recoveryRoot,
+    '--evidence-dir', command.evidenceDir,
+    '--formal-ae-app', command.formalAeApp,
+  ],
+  paths.repoRoot,
+);
+```
+
+Do not run `uv run` in daily smoke; use the already-verified checkout interpreter directly.
+
+- [ ] **Step 7: Mutation-prove evidence cannot become candidate evidence**
+
+Temporarily change the summary construction to:
+
+```python
+"candidateEvidence": True,
+```
+
+Run:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest \
+  packages/bridge/tests/test_development_smoke_driver.py \
+  -q -k candidate_evidence
+```
+
+Expected: FAIL. Restore `False`, rerun, expect PASS.
+
+- [ ] **Step 8: Run and commit**
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest \
+  packages/bridge/tests/test_development_smoke_driver.py -q
+node --test scripts/dev/test/profile-contract.test.mjs
+git diff --check
+git add scripts/hardware/development_smoke_spec.py \
+  scripts/hardware/development_smoke.py \
+  packages/bridge/tests/test_development_smoke_driver.py \
+  scripts/dev/profile-contract.mjs \
+  scripts/dev/test/profile-contract.test.mjs
+git commit -m "test(hardware): add non-candidate HDEV smoke"
+```
+
+Expected: all tests PASS.
+
+---
+
+### Task 6: Move ordinary PR hardware proof to HDEV and reserve T5/T6 for release
+
+**Files:**
+- Modify: `AGENTS.md:12-22,43-59,74-99,161-223`
+- Modify: `docs/CAPABILITY_PACKAGE_WORKFLOW.md:1-224`
+- Modify: `scripts/hardware/README.md:1-24`
+- Modify: `docs/INSTALL.md:171-205`
+- Modify: `docs/RUNTIME_MANAGER.md:43-70`
+
+**Interfaces:**
+- Consumes the exact `bootstrap`, `doctor`, `launch-ae`, `sync`, `smoke`, and HDEV evidence semantics implemented in Tasks 1-5.
+- Produces one canonical lifecycle policy; capability briefs reference it rather than redefining T5/T6 timing.
+
+- [ ] **Step 1: Rewrite the tier table without weakening real-AE proof**
+
+In `AGENTS.md`, retain T0-T3 and define:
+
+```text
+HDEV — ordinary development real-AE smoke. Reuse the current compatible
+development installation, exercise every new native primitive and one justified
+representative per shared adapter/locator/Undo family, and emit
+candidateEvidence=false.
+
+T5 — packaged release-candidate acceptance. Run the complete changed-capability
+matrix against the frozen artifact.
+
+T6 — packaged release clean-install/upgrade/rollback revalidation. Prove the
+release artifact and install boundary, not each ordinary PR.
+```
+
+Delete or rewrite every statement that still requires one T5 plus one clean-main T6 for each capability PR. Keep the rule that automated tests never substitute for real AE when product behavior changed.
+
+- [ ] **Step 2: Define merge and Issue disposition**
+
+State:
+
+- ordinary capability PR may merge after T0-T3, review, and its required HDEV;
+- its completion language is `development-verified`, never `release-accepted`;
+- implementation Issues may close at merge;
+- the target release milestone tracks all changed capabilities since the previous release;
+- only packaged T5/T6 can mark that milestone `release-accepted`.
+
+Keep the next-PR product-direction checkpoint after each merged standalone/capability PR.
+
+- [ ] **Step 3: Document commands and stop conditions**
+
+In `scripts/hardware/README.md`, add the exact HDEV command:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python3 -B -I \
+  scripts/hardware/development_smoke.py \
+  --scenario core-native-write-undo@1 \
+  --checkout "$PWD" \
+  --fixture-path "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/active/hdev-core-native.aep" \
+  --recovery-archive-root "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/recovery" \
+  --evidence-dir "$HOME/Library/Application Support/AfterEffectsMCP/evidence/hdev-core-native" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+Retain stop conditions for protocol incompatibility, uncertain writes, corrupted fixture baseline, AE crash, and failed load.
+
+- [ ] **Step 4: Run documentation and governance checks**
+
+```bash
+rg -n "one T5|one clean-main T6|exactly one T5|per capability PR" \
+  AGENTS.md docs/CAPABILITY_PACKAGE_WORKFLOW.md
+node scripts/check-repository-governance.mjs
+git diff --check
+```
+
+Expected: `rg` returns no stale per-PR requirement; governance and diff checks PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md \
+  docs/CAPABILITY_PACKAGE_WORKFLOW.md \
+  docs/INSTALL.md \
+  docs/RUNTIME_MANAGER.md \
+  scripts/hardware/README.md
+git commit -m "docs: separate HDEV from packaged release acceptance"
+```
+
+---
+
+### Task 7: Run the complete lower tiers, mutation proofs, and one real AE HDEV
+
+**Files:**
+- Verify all files from Tasks 1-6.
+- Do not commit private HDEV evidence, absolute private paths, `.aep` files, native build outputs, or dependency directories.
+
+**Interfaces:**
+- Consumes the complete development profile.
+- Produces a review-ready branch and one machine-readable HDEV evidence bundle with `candidateEvidence=false`.
+
+- [ ] **Step 1: Run formatting, syntax, and focused tests**
+
+```bash
+git diff --check
+node --check scripts/dev/profile-contract.mjs
+node --check scripts/dev/macos-development.mjs
+node --check scripts/dev/ae-mcp-dev.mjs
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python3 -m py_compile \
+  scripts/hardware/development_smoke.py \
+  scripts/hardware/development_smoke_spec.py
+node --test scripts/dev/test/profile-contract.test.mjs \
+  scripts/dev/test/macos-development.test.mjs \
+  scripts/dev/test/ae-mcp-dev.test.mjs
+PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest \
+  packages/bridge/tests/test_development_smoke_driver.py -q
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 2: Run affected panel, package, protocol, and governance suites**
+
+```bash
+node --test plugin/panel/test/runtimeManager.test.js \
+  plugin/panel/test/mcpClient.test.js \
+  plugin/panel/test/diagnostics.test.js
+node --test scripts/package/test/dev-install-contract.test.mjs \
+  scripts/package/test/native-aegp-dev-install.test.mjs
+node native/ae-plugin/protocol/protocol.test.mjs
+node scripts/check-repository-governance.mjs
+```
+
+Expected: all commands PASS. If the known #193 receipt-reuse panel test flakes once, record it and rerun only that exact test once; do not broaden scope or call it a product blocker unless it reproduces deterministically.
+
+- [ ] **Step 3: Repeat all three mutation proofs as one review bundle**
+
+Perform and restore these exact mutations one at a time:
+
+1. packaged release accepts `AE_MCP_DEV_RUNTIME` → release-refusal test FAILS;
+2. daily CEP sync contains `npm ci` → daily safety test FAILS;
+3. HDEV summary sets `candidateEvidence=true` → evidence test FAILS.
+
+After restoring all three, rerun their focused tests and require PASS. Finish with:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no mutation residue.
+
+- [ ] **Step 4: Verify doctor and changed-CEP sync without installing dependencies**
+
+Run:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs doctor \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+
+node scripts/dev/ae-mcp-dev.mjs sync --component cep \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+Require receipts with:
+
+```json
+{
+  "profile": "development",
+  "dependencyBootstrapInvocations": 0,
+  "releasePackagingInvocations": 0
+}
+```
+
+Also require no new RuntimeManager generation, `current`/`previous` pointer mutation, portable runtime, ZXP, or native install transaction.
+
+The sync receipt must report CEP as selected, native as reused, and Core as a live checkout
+rather than an installed/copied component. It must report `dependencyBootstrapInvocations=0`.
+
+- [ ] **Step 5: Launch formal AE with the scoped checkout environment**
+
+Ensure AE is closed, then run:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs launch-ae \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+Open the development CEP panel and verify Connection diagnostics visibly contains:
+
+```text
+DEVELOPMENT CHECKOUT
+$PWD
+$PWD/.venv/bin/python3
+RUNTIME_DEVELOPMENT_RUNTIME_SELECTED
+```
+
+Do not use `launchctl setenv`, Finder, a file double-click, or an alternate AE application.
+
+- [ ] **Step 6: Run the real seven-call HDEV**
+
+Run `dev smoke` with one absent fixture path and private evidence directory:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs smoke \
+  --scenario core-native-write-undo@1 \
+  --component core \
+  --component cep \
+  --repo-root "$PWD" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app" \
+  --fixture-path "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/active/hdev-core-native.aep" \
+  --recovery-archive-root "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/recovery" \
+  --evidence-dir "$HOME/Library/Application Support/AfterEffectsMCP/evidence/hdev-core-native"
+```
+
+At checkpoints:
+
+1. use formal AE to save the empty project once at the exact fixture path;
+2. execute exactly one real AE Undo when requested;
+3. after final readback, save in place, close the fixture, and quit formal AE;
+4. acknowledge each checkpoint by copying its emitted ID exactly:
+
+   ```python
+   checkpoint_id = checkpoint_event["checkpointId"]
+   acknowledgement = {
+       "checkpointId": checkpoint_id,
+       "status": "completed",
+   }
+   ```
+
+Require:
+
+- 7/7 public calls;
+- readiness, composition creation, baseline read, background write, changed read,
+  post-Undo reacquire, restored read all PASS;
+- one real Undo executed and verified;
+- current native provenance, audit, and postcondition agree;
+- `candidateRun=false`;
+- `candidateEvidence=false`;
+- `validationProfile=development`;
+- component disposition selected `["core", "cep"]` and reused `["native"]`;
+- fixture lifecycle created 1, archived 1, active 0, unclassified 0;
+- dependency bootstrap invocations 0;
+- release packaging invocations 0.
+
+- [ ] **Step 7: Review, commit any evidence-format-only correction, and push**
+
+If HDEV exposed a qualifying cross-layer contract or driver defect with unchanged product behavior, batch it, add a lower-tier regression, rerun only affected lower tiers, and replay HDEV once. Stop for any tool behavior change, widened package, new AEGP mechanism, relaxed gate, or unreconciled write.
+
+Then run:
+
+```bash
+git status --short
+git log --oneline origin/codex/dev-runtime-path..HEAD
+```
+
+Commit only tracked source/test/doc corrections:
+
+```bash
+git add plugin/panel/src/cep/runtimeManager.js \
+  plugin/panel/src/cep/mcpClient.js \
+  plugin/panel/test/runtimeManager.test.js \
+  plugin/panel/test/mcpClient.test.js \
+  plugin/client/dist/app.js \
+  scripts/dev/profile-contract.mjs \
+  scripts/dev/macos-development.mjs \
+  scripts/dev/ae-mcp-dev.mjs \
+  scripts/dev/test/profile-contract.test.mjs \
+  scripts/dev/test/macos-development.test.mjs \
+  scripts/dev/test/ae-mcp-dev.test.mjs \
+  scripts/hardware/development_smoke.py \
+  scripts/hardware/development_smoke_spec.py \
+  packages/bridge/tests/test_development_smoke_driver.py \
+  AGENTS.md \
+  docs/CAPABILITY_PACKAGE_WORKFLOW.md \
+  docs/INSTALL.md \
+  docs/RUNTIME_MANAGER.md \
+  scripts/hardware/README.md
+git commit -m "fix(dev): close HDEV integration gaps"
+```
+
+Skip that commit when there are no corrections. Never stage private evidence or `.aep` files.
+
+Push:
+
+```bash
+git push origin codex/dev-runtime-path
+```
+
+Update #194 with:
+
+- implementation commits;
+- selected/reused component list;
+- lower-tier totals;
+- all mutation fail/pass evidence;
+- HDEV seven-call summary and Undo result;
+- proof that no dependency bootstrap, runtime generation, ZXP, or release packaging ran;
+- explicit statement that T5/T6 were not run because this is development profile evidence.
+
+Do not merge until concentrated review and required CI are green.

--- a/docs/superpowers/specs/2026-07-28-agile-real-ae-development-loop-design.md
+++ b/docs/superpowers/specs/2026-07-28-agile-real-ae-development-loop-design.md
@@ -1,0 +1,347 @@
+# 敏捷开发与真实 AE 双轨验证设计
+
+日期：2026-07-28
+状态：已获用户批准，仓库自审通过，待用户复核
+范围：macOS 单用户开发路径、真实 AE 开发 smoke、能力包与发布验证策略
+实现分支：`codex/dev-runtime-path`
+前置提交：`0add90c feat(panel): add an opt-in development runtime path`
+
+## 1. 背景
+
+当前仓库把两个不同目标绑在了同一套流程里：
+
+1. 开发者需要尽快确认正在编辑的 Core、CEP 或 native 代码能通过 public MCP 在真实 After Effects 中运行。
+2. 发布者需要证明最终 packaged artifact 可从干净状态安装、升级、回滚并满足完整的身份与能力验收。
+
+两者都需要真实 AE，但成本和证据强度不同。现行能力包流程要求每个包在合并前执行 T5，并在合并后从 clean `main` 重建、重装再执行 T6。这已经减少了全树 hash，却仍把 runtime 打包、组件部署、候选冻结、完整矩阵和 clean-main 复验放进每个日常开发闭环。
+
+已完成的 `0add90c` 只解决 Core runtime 的一部分：开发 CEP 在显式设置
+`AE_MCP_DEV_RUNTIME` 时可直接启动 checkout 的 `.venv/bin/python3 -B -I -m ae_mcp`，
+不验证 packaged runtime manifest、不创建 RuntimeManager generation、不修改
+`current`/`previous`，也不获取 RuntimeManager lock。packaged release 会拒绝该变量，
+因此开发捷径不会进入发布运行时。
+
+本设计把“快速确认真实产品行为”和“证明发布候选完整性”拆为两个明确 profile，
+同时保留 public MCP、真实 AE、真实 Undo、协议兼容和加载真实性。
+
+## 2. 目标
+
+### 2.1 日常开发目标
+
+- 依赖只在首次配置或锁文件/工具链要求变化时 bootstrap。
+- 普通 edit → run 循环不得自动执行 `uv sync`、`npm ci`、portable runtime 打包、
+  ZXP 构建或 release installer。
+- 只构建、同步或重启实际发生变化的组件；未变化组件继续复用。
+- AE 相关产品行为改变后，用一条小型 public-MCP 真实 AE smoke 证明代码确实运行，
+  而不是只依赖 mock、bridge、codec 或 unit test。
+- 开发 smoke 必须明确标记为开发证据，不能被误用为发布验收。
+
+### 2.2 发布目标
+
+- 完整 T5/T6 移到 release-candidate / packaged-artifact 边界。
+- release 路径继续使用不可变构建、严格 artifact/receipt/file-set 身份验证、
+  clean install/upgrade/rollback 和完整能力矩阵。
+- 开发捷径不得改变 packaged release 的行为。
+
+## 3. 非目标
+
+- 不重写 ZXP、签名、公证或 release installer。
+- 不改变任何 public MCP tool 的输入、输出、Undo 模型或渲染结果。
+- 不增加新能力族或新 AEGP suite。
+- 不为 native 引入增量对象缓存、热加载或 dirty-worktree 身份协议。
+- 不在 Adobe CEP 或 native plug-in scan root 中放置指向 checkout 的 symlink。
+- 不在本 PR 增加 Windows 开发路径。
+- 不自动安装、升级或删除 Python、Node、npm、uv、Adobe SDK 或系统权限。
+- 不删除现有能力包 driver，也不改写历史 T5/T6 证据。
+
+## 4. 双轨模型
+
+### 4.1 Development profile
+
+Development profile 面向维护者本机的单用户、同 UID、受控 checkout。它包含三个阶段：
+
+| 阶段 | 目的 | 是否允许安装依赖 |
+|---|---|---|
+| `bootstrap` | 首次建立 Python/Node/SDK/CEP 基线 | 是，但必须显式调用 |
+| `sync` | 更新本轮变化的组件 | 否 |
+| `smoke` / `HDEV` | 通过 public MCP 验证真实 AE 行为 | 否 |
+
+`bootstrap` 与日常命令必须是不同入口。`sync` 或 `smoke` 发现依赖缺失、版本不兼容或
+锁文件已变化时，必须 fail closed，输出精确 bootstrap 指令；不得为了“方便”自行执行
+包管理器或联网安装。
+
+### 4.2 Release profile
+
+Release profile 只消费冻结的、可复现的 packaged candidate：
+
+- T5：验证最终 packaged candidate 的完整 public-MCP 能力矩阵。
+- T6：对最终候选执行 clean install、upgrade/rollback 或 clean-main/package 重放，
+  证明安装和发布边界没有改变候选行为。
+- `release-audit` 保持 exact source、全 payload hash、receipt 深度比对和 exact file set。
+- 发布失败不得回退到 development profile。
+
+## 5. 开发命令与组件计划
+
+新增一个 macOS 开发编排入口，命令形状如下；最终文件名可在实现计划中确定，但语义必须固定：
+
+```text
+dev bootstrap --component core|cep|native|all
+dev doctor
+dev launch-ae --app /absolute/Adobe After Effects 2026.app
+dev sync --component core|cep|native|all
+dev smoke --scenario <checked-in-scenario>
+```
+
+`bootstrap` 是唯一允许调用依赖管理器的入口，而且必须由用户显式执行；它不得被
+`doctor`、`launch-ae`、`sync` 或 `smoke` 间接调用。
+
+### 5.1 `doctor`
+
+`doctor` 只读检查：
+
+- checkout 为本地、绝对、非 dataless 路径；
+- `.venv/bin/python3` 存在、可执行，并能 import 当前 checkout 的 `ae_mcp`；
+- CEP 开发安装存在 `.debug`，且 packaged `bundle-manifest.json` 不存在；
+- 所需 `node_modules`、已构建 panel asset、native SDK 输入和已安装组件状态；
+- formal AE app 的 bundle、版本、build、executable；
+- canonical CEP/native 目标路径和开发 install receipt；
+- wire version、RPC schema digest、capability digest、productVersion、平台和架构兼容性。
+
+它只报告缺失项及对应 bootstrap/sync 动作，不修改文件、不启动 AE、不 hash 完整 runtime
+树，也不要求跨组件 full repository SHA 相等。
+
+### 5.2 `launch-ae`
+
+开发启动器：
+
+1. 要求传入 formal AE app 的绝对路径并解析其真实 `CFBundleExecutable`；
+2. 若 AE 已运行但没有可证明的 development checkout 选择，fail closed；
+3. 直接以 formal app 的真实 executable 启动进程，只给该进程树注入
+   `AE_MCP_DEV_RUNTIME=<canonical checkout>`；
+4. 不调用持久化的 `launchctl setenv`，不污染后续 Finder/GUI 启动的 AE；
+5. 等待 native load 与 panel readiness 的有界信号，然后把控制权交给 smoke。
+
+packaged CEP 继续拒绝 `AE_MCP_DEV_RUNTIME`。开发启动器不能修改这一门禁，也不能在拒绝后
+回退到 packaged RuntimeManager。
+
+### 5.3 Core
+
+Core 复用 `0add90c`：
+
+- 从 checkout 的 `.venv` 直接启动；
+- Python 源码修改不创建 RuntimeManager generation；
+- 不复制 portable runtime；
+- 不获取 RuntimeManager install lock；
+- diagnostics 明确显示 `DEVELOPMENT CHECKOUT`、canonical checkout 和 interpreter；
+- Core 变化只需重启 MCP child/session，不要求重装 CEP 或 native，也不要求重启 AE，
+  除非真实 host/session 状态已经无法安全复用。
+
+### 5.4 CEP / host / JSX
+
+CEP 首次安装仍使用现有受保护的开发 installer。日常 `sync --component cep`：
+
+- 复用现有 `node_modules`；
+- 只运行必要的本地 build，例如 panel bundle；
+- 绝不运行 `npm ci`；
+- 继续使用 off-scan staging、完整 shape 检查、原子替换和 rollback；
+- 不在 Adobe scan root 中创建 backup、staging 或 checkout symlink；
+- 需要 AE 关闭时明确停止并报告，不尝试在运行中的 CEP 上做不安全覆盖。
+
+首版允许 CEP component 自身做一次完整原子部署；优化目标是避免依赖重装和无关组件部署，
+不是绕过 scan-root 与 rollback 保护。若后续测量证明完整 CEP tree copy 仍是主要成本，
+再单独设计 manifest-bounded changed-file sync。
+
+### 5.5 Native AEGP plug-in
+
+`sync --component native`：
+
+- 复用已验证的 Adobe SDK archive/root、Xcode/clang/Rez 和现有开发 installer；
+- 不重新下载或安装任何依赖；
+- 继续要求 AE/aerender 全部关闭；
+- 使用 clean commit 构建受身份约束的 native artifact；
+- 使用 development identity profile 原子安装并保留 rollback；
+- 安装后必须重启 formal AE，并验证新 native load record。
+
+首版不允许 dirty-worktree native build。Core 和 CEP 可快速迭代；native 改动通过小型、
+可审查的临时提交获得明确 build identity。以后若 clean-commit 要求被实测为主要瓶颈，
+可另行设计 `HEAD + workspace digest + dirty=true` 的原生开发身份协议。
+
+### 5.6 组件选择
+
+用户或 agent 必须显式选择 component。首版不根据任意 Git diff 自动猜测最小组件集合。
+`--component all` 只构建/部署三个产品组件，仍不得运行 dependency bootstrap 或 release
+packaging。
+
+编排器可以提供只读建议，但遇到 shared protocol/schema/build input 时应建议扩大到相关组件，
+不能悄悄缩小范围。未知路径默认建议 `all`，而不是假定无需实机验证。
+
+## 6. HDEV：轻量真实 AE smoke
+
+HDEV 是开发 smoke，不是新的候选验收 tier。它必须：
+
+1. 通过 public MCP surface 发起调用；
+2. 证明响应来自当前 formal AE host/native load，而不是 mock、缓存或内部 handler；
+3. 验证 typed response、AE state、provenance、audit 和 postcondition 一致；
+4. 对写操作使用一个 `ephemeral-validation` fixture；
+5. 对每种受影响的 Undo 模型至少执行一次真实 Undo 并读回恢复状态；
+6. 遇到 `POSSIBLY_SIDE_EFFECTING_FAILURE` 时先 reconcile AE state 与 audit，禁止盲重试；
+7. 记录使用了 development profile、checkout、组件 receipts/versions 和 scenario；
+8. 复用现有 runner 语义输出 `candidateEvidence=false`，并增加
+   `validationProfile=development`；不得生成 T5/T6 completion disposition。
+
+HDEV 不要求：
+
+- candidate freeze；
+- 完整能力包工具矩阵；
+- clean-main rebuild/reinstall；
+- 每个薄 wrapper 的重复调用；
+- exact source SHA、全树 hash 或 deep receipt equality；
+- release completion report 或 Issue closure。
+
+### 6.1 Scenario 粒度
+
+每次 HDEV 运行一个 checked-in、可读的小型 scenario：
+
+- Core-only read/adapter 变化：readiness + 受影响 public tool +独立 readback。
+- CEP/transport 变化：readiness + 一个 native read；若修改 dispatch/uncertain-write
+  分类，再加一个 disposable write + Undo。
+- Native read primitive：一个真实 read 和来源验证。
+- Native write/Undo primitive：before → write → after → audit → real Undo → restored readback。
+- 新 suite、对象生命周期或 main-thread mechanism：允许额外的 narrow novelty smoke，
+  但仍不是完整 T5。
+
+一个包含多工具的能力包 HDEV 必须覆盖每个新增 native primitive，并在共享同一 primitive、
+adapter、locator 和 Undo 模型的工具族中至少选择一个代表工具。没有共享路径依据的工具不能
+仅凭“相似”被跳过。
+
+Scenario 必须有固定调用预算和明确 stop conditions。失败后可批量收集仍可信的独立案例，
+但不能把失败运行升级为通过证据。
+
+## 7. 门禁与安全不变量
+
+Development 与 release 都必须阻塞：
+
+- wire version 不兼容；
+- capability contract digest 不兼容；
+- native RPC schema digest 不兼容；
+- productVersion 不相等，直到存在明确的兼容区间协商；
+- platform/architecture/entrypoint 不匹配；
+- formal AE、CEP 或 native 实际加载失败；
+- Adobe scan-root 中出现意外文件或不安全路径；
+- 未 reconcile 的可能写入；
+- fixture baseline 无法恢复。
+
+Development 只记录、不因其单独阻塞：
+
+- exact source commit 漂移；
+- 全 runtime tree / 全 payload hash 漂移；
+- receipt 的 exact source/artifact 深度比对；
+- exact file set 差异，但 scan-root 意外文件保护仍保留。
+
+Release-audit 对上述 identity 项继续严格。
+
+## 8. 仓库策略变化
+
+`AGENTS.md` 与 `docs/CAPABILITY_PACKAGE_WORKFLOW.md` 调整为：
+
+- T0-T3 继续是普通 PR 的自动化测试与 review 层级。
+- AE 产品行为发生变化时，PR 合并前要求一次与风险相称的 HDEV；纯文档、纯静态测试或
+  不触及运行路径的变化可记录不适用理由。
+- 新 native primitive 仍需尽早做 narrow real-AE smoke，但复用现有开发环境。
+- 普通 capability PR 不再要求 candidate T5 + clean-main T6。
+- 完整 T5/T6 只在 release candidate / packaged artifact 冻结后运行。
+- “没有真实 AE 证据就不能声称 AE 行为已验证”保持不变；变化的是证据强度与运行时机，
+  不是把 hardware validation 删除。
+- standalone PR 完成后仍执行产品方向 checkpoint，但不再以每 PR clean-main T6 作为前置。
+
+能力 PR 在 T0-T3、review 和对应 HDEV 通过后可以合并并关闭实现 Issue，但其完成说明必须写
+`development-verified`，不能写 `release-accepted`。目标版本的 release milestone 单独追踪
+自上一个发布版本以来所有新增/变更 capability 的 packaged T5/T6；只有该 milestone 通过后
+才能声称这些能力已通过发布候选验收。
+
+现有 capability driver 的 `t5`/`t6` 模式保留，供 release candidate 聚合运行和历史重放。
+本 PR 不批量改写每个冻结 brief；新 brief 引用更新后的全局双轨策略。
+
+## 9. 错误处理与恢复
+
+- `doctor` 失败：零 public call、零候选证据、零自动安装；输出一个最小修复动作。
+- Core child 启动失败：保留 AE/CEP/native，不触发整套 reinstall。
+- CEP sync 失败：使用现有原子 rollback，保留上一份可运行 panel。
+- Native build 失败：不触碰已安装 native。
+- Native install 失败：使用现有 installer transaction/rollback；若恢复不完整立即停止。
+- AE 启动或 load 超时：报告 formal app、进程、load record 和最后 checkpoint，不循环重装。
+- 协议不兼容：立即停止，不允许 development drift profile 绕过。
+- HDEV 写入不确定：执行 state/audit reconciliation；无法 reconcile 则保留 fixture/evidence
+  并停止。
+
+## 10. 测试与验证
+
+### 10.1 自动化
+
+新增或扩展测试：
+
+- development CEP + `AE_MCP_DEV_RUNTIME` 选择 live checkout；
+- packaged CEP 拒绝变量且无 production fallback；
+- invalid checkout fail closed；
+- `doctor` 为只读，不创建 runtime generation、pointer、lock、安装目录或依赖；
+- `sync` 的命令计划从不包含 `uv sync`、`pip install`、`npm install`、`npm ci`、
+  portable runtime、ZXP 或 release installer；
+- component 选择只触发对应构建/部署；
+- native sync 仍要求 clean commit、AE stopped、development installer 和 load verification；
+- HDEV 输出 `candidateEvidence=false` 和 `validationProfile=development`；
+- protocol/productVersion/architecture/load 等保留门禁在真实不兼容时仍阻塞。
+
+所有新增 guard 必须做 mutation proof：
+
+- 删除 packaged-release refusal 后测试失败，恢复后通过；
+- 让 sync 偷跑一个 dependency bootstrap 命令后测试失败，恢复后通过；
+- 放松一个保留的协议门禁后跨层测试失败，恢复后通过；
+- 把 HDEV 错标为 candidate evidence 后测试失败，恢复后通过。
+
+### 10.2 本机真实 AE
+
+实现候选必须在现有依赖与已安装组件上完成一次 HDEV：
+
+1. 不运行 bootstrap、portable runtime 或 ZXP；
+2. 用 formal AE executable 启动并选择 live Core checkout；
+3. diagnostics 显示 `DEVELOPMENT CHECKOUT`；
+4. public readiness/read 成功并绑定当前 host/native load；
+5. 执行一个 disposable write、独立 readback、audit、真实 Undo 和恢复 readback；
+6. 关闭并归档唯一的 `ephemeral-validation` fixture；
+7. 报告本轮只更新了哪些组件、哪些组件被复用；
+8. 明确 `candidateEvidence=false` 和 `validationProfile=development`，不声称
+   T5/T6 或发布完成。
+
+## 11. 实施与 PR 边界
+
+本设计在 `codex/dev-runtime-path` / #194 内完成，因为所有改动服务同一个用户结果：
+“使用现有开发环境快速运行当前 checkout，并通过真实 AE 证明代表性产品行为”。
+
+实现必须在隔离 worktree 中进行，不触碰根 checkout 当前 #67/#69 的未提交改动。
+
+建议实施顺序：
+
+1. 补齐 `0add90c` 的 live-Core 启动、诊断和 release refusal 文档/测试。
+2. 写只读 doctor 与 formal-AE development launcher。
+3. 写显式 component sync 编排，复用现有 CEP/native 安装器。
+4. 增加最小 HDEV scenario 与 `candidateEvidence=false` /
+   `validationProfile=development` 证据格式。
+5. 修改 AGENTS/workflow 文档，把 HDEV 与 release T5/T6 分开。
+6. 完成自动化、mutation proof 和一次真实 AE HDEV。
+
+若实施发现必须改变 tool 行为、放松协议/productVersion/load/scan-root 门禁、允许 dirty native
+身份或修改 release artifact，立即停止并请求新的范围决策。
+
+## 12. 成功标准
+
+完成后，维护者应能：
+
+1. 在依赖已存在时修改 Core，重启开发 MCP 并在真实 AE 上验证，无 runtime generation copy；
+2. 修改 CEP 时只 build/deploy CEP，不运行 npm dependency install，不动 native；
+3. 修改 native 时复用 SDK/toolchain，只 build/install native，并在重启后验证新 load；
+4. 对真实 AE 行为运行一个 bounded HDEV，而不是每 PR 执行完整 T5/T6；
+5. 在 release candidate 时仍能运行严格 packaged T5/T6，且开发捷径无法进入 release。
+
+成功不能只用“测试通过”描述；必须同时有一次 public-MCP 真实 AE HDEV 结果，以及证明
+该运行没有重新安装依赖、没有创建 packaged runtime generation、没有执行 release packaging
+的命令/文件系统证据。

--- a/docs/superpowers/specs/2026-07-28-agile-real-ae-development-loop-design.md
+++ b/docs/superpowers/specs/2026-07-28-agile-real-ae-development-loop-design.md
@@ -1,7 +1,7 @@
 # 敏捷开发与真实 AE 双轨验证设计
 
 日期：2026-07-28
-状态：已获用户批准，仓库自审通过，待用户复核
+状态：已获用户批准，仓库自审与用户复核通过
 范围：macOS 单用户开发路径、真实 AE 开发 smoke、能力包与发布验证策略
 实现分支：`codex/dev-runtime-path`
 前置提交：`0add90c feat(panel): add an opt-in development runtime path`

--- a/packages/bridge/tests/test_development_smoke_driver.py
+++ b/packages/bridge/tests/test_development_smoke_driver.py
@@ -405,14 +405,18 @@ def test_checkout_verification_preserves_the_virtualenv_entrypoint(tmp_path):
     checkout = tmp_path / "checkout"
     interpreter = checkout / ".venv/bin/python3"
     core_package = checkout / "packages/core/ae_mcp"
+    bridge_package = checkout / "packages/bridge/ae_mcp_bridge"
     interpreter.parent.mkdir(parents=True)
     core_package.mkdir(parents=True)
+    bridge_package.mkdir(parents=True)
     interpreter.symlink_to(Path(sys.executable))
     (core_package / "__init__.py").write_text("", encoding="utf-8")
     (core_package / "__main__.py").write_text("", encoding="utf-8")
+    (bridge_package / "__init__.py").write_text("", encoding="utf-8")
 
-    verified_interpreter, core_root = driver._verify_checkout_core(checkout)
+    verified_interpreter, core_root, bridge_root = driver._verify_checkout_core(checkout)
 
     assert verified_interpreter == interpreter
     assert verified_interpreter.resolve() == Path(sys.executable).resolve()
     assert core_root == checkout / "packages/core"
+    assert bridge_root == checkout / "packages/bridge"

--- a/packages/bridge/tests/test_development_smoke_driver.py
+++ b/packages/bridge/tests/test_development_smoke_driver.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import stat
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -379,3 +380,22 @@ def test_component_disposition_is_closed_disjoint_and_complete(tmp_path):
                 "reused_components": ("cep", "native"),
             }
         )
+
+
+def test_driver_starts_under_the_isolated_interpreter_used_by_the_cli():
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-I",
+            str(HARDWARE / "development_smoke.py"),
+            "--help",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "core-native-write-undo@1" not in completed.stderr

--- a/packages/bridge/tests/test_development_smoke_driver.py
+++ b/packages/bridge/tests/test_development_smoke_driver.py
@@ -1,0 +1,381 @@
+"""Construction tests for the seven-call non-candidate HDEV driver."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HARDWARE = ROOT / "scripts/hardware"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    module_spec = importlib.util.spec_from_file_location(name, path)
+    assert module_spec is not None and module_spec.loader is not None
+    module = importlib.util.module_from_spec(module_spec)
+    sys.modules[name] = module
+    module_spec.loader.exec_module(module)
+    return module
+
+
+sys.path.insert(0, str(HARDWARE))
+spec = _load("development_smoke_spec", HARDWARE / "development_smoke_spec.py")
+driver = _load("development_smoke", HARDWARE / "development_smoke.py")
+
+HOST = "11111111-1111-4111-8111-111111111111"
+SESSION = "22222222-2222-4222-8222-222222222222"
+PROJECT = "33333333-3333-4333-8333-333333333333"
+COMP = "44444444-4444-4444-8444-444444444444"
+DIGEST = "a" * 64
+
+
+def _locator(*, generation: int = 1) -> dict:
+    return {
+        "kind": "composition",
+        "hostInstanceId": HOST,
+        "sessionId": SESSION,
+        "projectId": PROJECT,
+        "generation": generation,
+        "objectId": COMP,
+    }
+
+
+def _time(value: int, scale: int) -> dict:
+    from fractions import Fraction
+
+    return {
+        "value": value,
+        "scale": scale,
+        "secondsRational": str(Fraction(value, scale)),
+    }
+
+
+def _ratio(numerator: int, denominator: int) -> dict:
+    from fractions import Fraction
+
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "rational": str(Fraction(numerator, denominator)),
+    }
+
+
+def _settings(color: dict, *, generation: int = 1) -> dict:
+    return {
+        "name": "HDEV Core Native Fixture",
+        "width": 640,
+        "height": 360,
+        "duration": _time(5, 1),
+        "frameDuration": _time(1, 24),
+        "frameRate": _ratio(24, 1),
+        "pixelAspectRatio": _ratio(1, 1),
+        "backgroundColor": dict(color),
+        "workArea": {"start": _time(0, 1), "duration": _time(5, 1)},
+        "displayStartTime": _time(0, 1),
+        "layerCount": 0,
+        "compositionLocator": _locator(generation=generation),
+    }
+
+
+def _payload(capability: str, value: dict, *, write: bool = False) -> dict:
+    request_id = f"mcp-{capability.replace('.', '-')}"
+    postcondition = {
+        "verified": True,
+        "kind": f"{capability}-postcondition",
+        "algorithm": "sha256-rfc8785-jcs-v1",
+        "digest": DIGEST,
+    }
+    evidence = {
+        "engine": "native-aegp",
+        "hostInstanceId": HOST,
+        "sessionId": SESSION,
+        "requestId": request_id,
+        "capabilityId": capability,
+        "capabilityVersion": 1,
+        "startedAtUnixMs": 1,
+        "completedAtUnixMs": 2,
+        "effect": "committed" if write else "none",
+        "requestDigest": "b" * 64,
+        "postcondition": postcondition,
+    }
+    if write:
+        evidence["undo"] = {"available": True, "verified": False}
+    return {
+        "ok": True,
+        **({"replayed": False} if write else {}),
+        "value": value,
+        "implementation": {
+            "engine": "native-aegp",
+            "capabilityId": capability,
+            "capabilityVersion": 1,
+            "contractDigest": DIGEST,
+            "risk": "write" if write else "read",
+            "mutability": "mutating" if write else "read-only",
+            "idempotency": "required" if write else "not-applicable",
+            **({"undo": "single-group"} if write else {}),
+        },
+        "provenance": {
+            "engine": "native-aegp",
+            "selectedWireVersion": 1,
+            "pluginVersion": "0.9.2",
+            "compiledSdkVersion": "2026",
+            "sourceCommit": "c" * 40,
+            "hostInstanceId": HOST,
+            "sessionId": SESSION,
+            "sessionGeneration": 1,
+            "capabilitiesDigest": "d" * 64,
+        },
+        "audit": {
+            "requestId": request_id,
+            **({"evidenceRequestId": request_id} if write else {}),
+            **({"idempotencyKey": "fixture-key", "replayed": False} if write else {}),
+            "capabilityId": capability,
+            "capabilityVersion": 1,
+            "contractDigest": DIGEST,
+            "effect": "committed" if write else "none",
+            "requestDigest": "b" * 64,
+            "postconditionAlgorithm": "sha256-rfc8785-jcs-v1",
+            "postconditionDigest": DIGEST,
+            **({"undoAvailable": True, "undoVerified": False} if write else {}),
+            "startedAtUnixMs": 1,
+            "completedAtUnixMs": 2,
+        },
+        "evidence": evidence,
+    }
+
+
+def _responses() -> list[tuple[bool, dict]]:
+    baseline = _settings(spec.BASELINE_COLOR)
+    changed = _settings(spec.CHANGED_COLOR)
+    restored = _settings(spec.BASELINE_COLOR, generation=2)
+    return [
+        (False, _payload(
+            "ae.project.summary",
+            {"projectOpen": True, "projectName": "dev.aep", "itemCount": 0},
+        )),
+        (False, _payload(
+            "ae.composition.create",
+            {
+                "changed": True,
+                "name": "HDEV Core Native Fixture",
+                "compositionLocator": _locator(),
+                "projectItemCountBefore": 1,
+                "projectItemCountAfter": 2,
+                "layerCount": 0,
+                "width": 640,
+                "height": 360,
+                "duration": _time(5, 1),
+                "frameRate": _ratio(24, 1),
+                "pixelAspectRatio": _ratio(1, 1),
+            },
+            write=True,
+        )),
+        (False, _payload("ae.composition.settings.read", baseline)),
+        (False, _payload(
+            "ae.composition.background-color.set",
+            {
+                "changed": True,
+                "compositionLocator": _locator(),
+                "before": baseline,
+                "after": changed,
+            },
+            write=True,
+        )),
+        (False, _payload("ae.composition.settings.read", changed)),
+        (False, _payload(
+            "ae.project.items.list",
+            {
+                "projectLocator": {
+                    **_locator(generation=2),
+                    "kind": "project",
+                    "objectId": PROJECT,
+                },
+                "total": 1,
+                "offset": 0,
+                "limit": 50,
+                "returned": 1,
+                "hasMore": False,
+                "nextOffset": None,
+                "items": [{
+                    "locator": _locator(generation=2),
+                    "name": "HDEV Core Native Fixture",
+                    "type": "composition",
+                    "parentLocator": None,
+                }],
+            },
+        )),
+        (False, _payload("ae.composition.settings.read", restored)),
+    ]
+
+
+class FakeSession:
+    def __init__(self, responses: list[tuple[bool, dict]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+        self.tool_names = frozenset(tool for _, tool in spec.CALLS)
+
+    async def call(self, tool: str, arguments: dict):
+        self.calls.append((tool, arguments))
+        return self.responses.pop(0)
+
+
+def _config(tmp_path: Path) -> object:
+    fixture = tmp_path / "active" / "dev.aep"
+    fixture.parent.mkdir()
+    fixture.write_bytes(b"fixture")
+    return driver.DevelopmentSmokeConfig(
+        scenario=spec.SCENARIO_ID,
+        selected_components=("core",),
+        reused_components=("cep", "native"),
+        checkout=ROOT,
+        fixture_path=fixture,
+        recovery_root=tmp_path / "recovery",
+        evidence_dir=tmp_path / "evidence",
+        formal_ae_app=Path(
+            "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+        ),
+        plugin_url="http://127.0.0.1:11488",
+    )
+
+
+@pytest.mark.asyncio
+async def test_hdev_runs_exactly_seven_calls_real_undo_and_one_archive(tmp_path):
+    session = FakeSession(_responses())
+    checkpoints: list[tuple[str, dict]] = []
+    config = _config(tmp_path)
+
+    async def checkpoint(kind: str, details: dict) -> None:
+        checkpoints.append((kind, details))
+
+    async def ae_running() -> bool:
+        return False
+
+    result = await driver.run_development_smoke(
+        config,
+        session=session,
+        checkpoint=checkpoint,
+        after_effects_running=ae_running,
+    )
+
+    assert result.exit_code == 0
+    assert result.summary["passed"] is True
+    assert result.summary["publicCalls"]["total"] == 7
+    assert [tool for tool, _ in session.calls] == [tool for _, tool in spec.CALLS]
+    assert session.calls[1] == ("ae_createComposition", {
+        "name": "HDEV Core Native Fixture",
+        "width": 640,
+        "height": 360,
+        "duration": {"value": 5, "scale": 1},
+        "frame_rate": {"numerator": 24, "denominator": 1},
+        "pixel_aspect_ratio": {"numerator": 1, "denominator": 1},
+        "idempotency_key": "hdev-core-native-composition-0001",
+    })
+    assert session.calls[3][0] == "ae_setCompositionBackgroundColor"
+    assert session.calls[3][1]["background_color"] == spec.CHANGED_COLOR
+    assert [kind for kind, _ in checkpoints] == [
+        "save-empty-project",
+        "undo-background-change",
+        "close-formal-ae",
+    ]
+    assert result.summary["aepLifecycle"] == {
+        "created": 1,
+        "canonicalRetained": 0,
+        "evidenceSnapshotsRetained": 0,
+        "archived": 1,
+        "unclassified": 0,
+        "saveAsCopies": 0,
+    }
+    assert len(list((tmp_path / "recovery").glob("*.aep"))) == 1
+    assert not config.fixture_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_uncertain_write_stops_with_exit_three_without_retry(tmp_path):
+    responses = _responses()
+    responses[3] = (True, {
+        "ok": False,
+        "error": {
+            "code": "POSSIBLY_SIDE_EFFECTING_FAILURE",
+            "sideEffect": "may-have-occurred",
+        },
+    })
+    session = FakeSession(responses)
+
+    result = await driver.run_development_smoke(
+        _config(tmp_path),
+        session=session,
+        checkpoint=lambda *_: driver.completed_checkpoint(),
+        after_effects_running=lambda: driver.completed_process_check(False),
+    )
+
+    assert result.exit_code == 3
+    assert result.summary["passed"] is False
+    assert result.summary["stopReason"] == "possibly-side-effecting"
+    assert len(session.calls) == 4
+    assert [tool for tool, _ in session.calls].count(
+        "ae_setCompositionBackgroundColor"
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_call_budget_stops_before_call_eight(tmp_path):
+    session = FakeSession(_responses())
+    runner = driver.DevelopmentSmokeRunner(
+        _config(tmp_path),
+        checkpoint=lambda *_: driver.completed_checkpoint(),
+        after_effects_running=lambda: driver.completed_process_check(False),
+    )
+    runner.ledger.total = spec.CALL_HARD_LIMIT
+
+    with pytest.raises(driver.DevelopmentSmokeFailure, match="budget exhausted"):
+        await runner.public_call(session, "overflow", "ae_projectSummary", {})
+    assert session.calls == []
+
+
+def test_candidate_evidence_is_permanently_false_and_files_are_private(tmp_path):
+    evidence = driver.DevelopmentEvidence(tmp_path / "evidence")
+    evidence.record("probe", {"value": 1})
+    summary = evidence.finish(
+        passed=True,
+        public_calls={
+            "target": 7, "hardLimit": 7, "total": 7,
+            "byTool": {}, "byPhase": {},
+        },
+        component_disposition={
+            "selected": ["core"], "reused": ["cep", "native"],
+        },
+        aep_lifecycle={
+            "created": 1, "canonicalRetained": 0,
+            "evidenceSnapshotsRetained": 0, "archived": 1,
+            "unclassified": 0, "saveAsCopies": 0,
+        },
+    )
+
+    assert summary["validationProfile"] == "development"
+    assert summary["candidateRun"] is False
+    assert summary["candidateEvidence"] is False
+    event = json.loads(evidence.events_path.read_text().splitlines()[0])
+    assert event["candidateRun"] is False
+    assert event["candidateEvidence"] is False
+    assert stat.S_IMODE(evidence.root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(evidence.events_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(evidence.summary_path.stat().st_mode) == 0o600
+
+
+def test_component_disposition_is_closed_disjoint_and_complete(tmp_path):
+    with pytest.raises(driver.DevelopmentSmokeFailure):
+        driver.DevelopmentSmokeConfig(
+            **{
+                **_config(tmp_path).__dict__,
+                "selected_components": ("core", "cep"),
+                "reused_components": ("cep", "native"),
+            }
+        )

--- a/packages/bridge/tests/test_development_smoke_driver.py
+++ b/packages/bridge/tests/test_development_smoke_driver.py
@@ -399,3 +399,20 @@ def test_driver_starts_under_the_isolated_interpreter_used_by_the_cli():
 
     assert completed.returncode == 0, completed.stderr
     assert "core-native-write-undo@1" not in completed.stderr
+
+
+def test_checkout_verification_preserves_the_virtualenv_entrypoint(tmp_path):
+    checkout = tmp_path / "checkout"
+    interpreter = checkout / ".venv/bin/python3"
+    core_package = checkout / "packages/core/ae_mcp"
+    interpreter.parent.mkdir(parents=True)
+    core_package.mkdir(parents=True)
+    interpreter.symlink_to(Path(sys.executable))
+    (core_package / "__init__.py").write_text("", encoding="utf-8")
+    (core_package / "__main__.py").write_text("", encoding="utf-8")
+
+    verified_interpreter, core_root = driver._verify_checkout_core(checkout)
+
+    assert verified_interpreter == interpreter
+    assert verified_interpreter.resolve() == Path(sys.executable).resolve()
+    assert core_root == checkout / "packages/core"

--- a/packages/bridge/tests/test_development_smoke_driver.py
+++ b/packages/bridge/tests/test_development_smoke_driver.py
@@ -240,9 +240,7 @@ def _config(tmp_path: Path) -> object:
         fixture_path=fixture,
         recovery_root=tmp_path / "recovery",
         evidence_dir=tmp_path / "evidence",
-        formal_ae_app=Path(
-            "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
-        ),
+        formal_ae_app=tmp_path / "formal-ae.app",
         plugin_url="http://127.0.0.1:11488",
     )
 
@@ -366,9 +364,10 @@ def test_candidate_evidence_is_permanently_false_and_files_are_private(tmp_path)
     event = json.loads(evidence.events_path.read_text().splitlines()[0])
     assert event["candidateRun"] is False
     assert event["candidateEvidence"] is False
-    assert stat.S_IMODE(evidence.root.stat().st_mode) == 0o700
-    assert stat.S_IMODE(evidence.events_path.stat().st_mode) == 0o600
-    assert stat.S_IMODE(evidence.summary_path.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(evidence.root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(evidence.events_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(evidence.summary_path.stat().st_mode) == 0o600
 
 
 def test_component_disposition_is_closed_disjoint_and_complete(tmp_path):
@@ -401,6 +400,10 @@ def test_driver_starts_under_the_isolated_interpreter_used_by_the_cli():
     assert "core-native-write-undo@1" not in completed.stderr
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="a bare interpreter symlink cannot model a Windows virtualenv entrypoint",
+)
 def test_checkout_verification_preserves_the_virtualenv_entrypoint(tmp_path):
     checkout = tmp_path / "checkout"
     interpreter = checkout / ".venv/bin/python3"

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -17432,6 +17432,11 @@
   var SOURCE_SHA = /^[0-9a-f]{40}$/;
   var SHA256 = /^[0-9a-f]{64}$/;
   var DEVELOPMENT_RUNTIME_ENV = "AE_MCP_DEV_RUNTIME";
+  var DEVELOPMENT_CORE_BOOTSTRAP = [
+    "import runpy,sys",
+    "sys.path.insert(0,sys.argv[1])",
+    'runpy.run_module("ae_mcp",run_name="__main__")'
+  ].join(";");
   var RuntimeManagerError = class extends Error {
     constructor(code, message, details = {}) {
       super(message);
@@ -17576,7 +17581,8 @@
         );
       }
       const projectManifest = paths.join([checkout, "pyproject.toml"]);
-      const coreEntrypoint = paths.join([checkout, "packages", "core", "ae_mcp", "__main__.py"]);
+      const coreRoot = paths.join([checkout, "packages", "core"]);
+      const coreEntrypoint = paths.join([coreRoot, "ae_mcp", "__main__.py"]);
       const interpreter = paths.join([checkout, ".venv", "bin", "python3"]);
       let resolvedInterpreter;
       try {
@@ -17606,7 +17612,7 @@
         developmentRuntime: true,
         checkoutPath: checkout,
         launcher: interpreter,
-        args: ["-B", "-I", "-m", "ae_mcp"],
+        args: ["-B", "-I", "-c", DEVELOPMENT_CORE_BOOTSTRAP, coreRoot],
         cwd: checkout,
         interpreter: {
           path: interpreter,

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -9559,6 +9559,10 @@
     const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: "standard", version: null, arch: "arm64" });
     return Object.freeze({
       id: "macos-arm64",
+      // RuntimeManager needs the CEP process environment for its explicit,
+      // development-only direct-checkout override.  Keep it on the adapter so
+      // callers do not need to reach around the platform boundary.
+      env: deps.env,
       paths,
       fs: deps.fs,
       ...boundary,
@@ -17427,6 +17431,7 @@
   var SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
   var SOURCE_SHA = /^[0-9a-f]{40}$/;
   var SHA256 = /^[0-9a-f]{64}$/;
+  var DEVELOPMENT_RUNTIME_ENV = "AE_MCP_DEV_RUNTIME";
   var RuntimeManagerError = class extends Error {
     constructor(code, message, details = {}) {
       super(message);
@@ -17487,6 +17492,9 @@
   function randomHex(randomBytes, size = 8) {
     return Buffer.from(randomBytes(size)).toString("hex");
   }
+  function hasDevelopmentRuntimeOverride(environment = {}) {
+    return typeof (environment == null ? void 0 : environment[DEVELOPMENT_RUNTIME_ENV]) === "string" && environment[DEVELOPMENT_RUNTIME_ENV].trim().length > 0;
+  }
   function createRuntimeManager({
     platform,
     extensionRoot,
@@ -17507,7 +17515,8 @@
       }
     },
     lockTimeoutMs = 1e4,
-    lockPollMs = 25
+    lockPollMs = 25,
+    environment = (platform == null ? void 0 : platform.env) || ((_g) => (_g = ((_f) => (_f = ((_e) => (_e = globalThis.window) == null ? void 0 : _e.cep_node)()) == null ? void 0 : _f.process)()) == null ? void 0 : _g.env)() || ((_h) => (_h = globalThis.process) == null ? void 0 : _h.env)() || {}
   } = {}) {
     if (!platform || platform.id !== RUNTIME_PLATFORM) {
       failure("RUNTIME_PLATFORM_UNSUPPORTED", "RuntimeManager currently supports Apple Silicon macOS only");
@@ -17534,6 +17543,80 @@
     const packagedRuntimeManifest = paths.join([packagedRuntimeRoot, "runtime-manifest.json"]);
     const packagedLauncher = paths.join([extensionRoot, "platform", platform.id, "bin", "ae-mcp"]);
     const stableLauncherRecordPath = paths.join([root, STABLE_LAUNCHER_RECORD]);
+    const developmentMarkerPath = paths.join([extensionRoot, ".debug"]);
+    const developmentRuntimeInput = hasDevelopmentRuntimeOverride(environment) ? environment[DEVELOPMENT_RUNTIME_ENV].trim() : "";
+    function developmentBuild() {
+      return fs.existsSync(developmentMarkerPath) && !fs.existsSync(packageManifestPath);
+    }
+    async function selectDevelopmentRuntime() {
+      var _a2, _b2, _c2;
+      if (!developmentRuntimeInput) return null;
+      if (!developmentBuild()) {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_RELEASE_REFUSED",
+          `${DEVELOPMENT_RUNTIME_ENV} is refused by a packaged release build`
+        );
+      }
+      if (!paths.isAbsolute(developmentRuntimeInput)) {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_INVALID",
+          `${DEVELOPMENT_RUNTIME_ENV} must name an absolute source checkout path`
+        );
+      }
+      let checkout;
+      try {
+        checkout = await promises.realpath(developmentRuntimeInput);
+        const info = await promises.stat(checkout);
+        if (!info.isDirectory()) throw new Error("not a directory");
+      } catch {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_INVALID",
+          `${DEVELOPMENT_RUNTIME_ENV} does not resolve to a usable source checkout`,
+          { path: developmentRuntimeInput }
+        );
+      }
+      const projectManifest = paths.join([checkout, "pyproject.toml"]);
+      const coreEntrypoint = paths.join([checkout, "packages", "core", "ae_mcp", "__main__.py"]);
+      const interpreter = paths.join([checkout, ".venv", "bin", "python3"]);
+      let resolvedInterpreter;
+      try {
+        const [manifestInfo, entrypointInfo, interpreterInfo] = await Promise.all([
+          promises.lstat(projectManifest),
+          promises.lstat(coreEntrypoint),
+          promises.lstat(interpreter)
+        ]);
+        if (!manifestInfo.isFile() || ((_a2 = manifestInfo.isSymbolicLink) == null ? void 0 : _a2.call(manifestInfo)) || !entrypointInfo.isFile() || ((_b2 = entrypointInfo.isSymbolicLink) == null ? void 0 : _b2.call(entrypointInfo)) || !interpreterInfo.isFile() && !((_c2 = interpreterInfo.isSymbolicLink) == null ? void 0 : _c2.call(interpreterInfo)) || (interpreterInfo.mode & 73) === 0) {
+          throw new Error("required checkout entrypoint is invalid");
+        }
+        resolvedInterpreter = await promises.realpath(interpreter);
+        const resolvedInfo = await promises.stat(resolvedInterpreter);
+        if (!resolvedInfo.isFile() || (resolvedInfo.mode & 73) === 0) {
+          throw new Error("resolved interpreter is not executable");
+        }
+      } catch {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_INVALID",
+          `${DEVELOPMENT_RUNTIME_ENV} does not contain pyproject.toml, the core entrypoint, and an executable .venv/bin/python3`,
+          { path: checkout }
+        );
+      }
+      return {
+        ok: true,
+        action: "development-runtime",
+        developmentRuntime: true,
+        checkoutPath: checkout,
+        launcher: interpreter,
+        args: ["-B", "-I", "-m", "ae_mcp"],
+        interpreter: {
+          path: interpreter,
+          resolvedPath: resolvedInterpreter
+        },
+        diagnostics: [{
+          code: "RUNTIME_DEVELOPMENT_RUNTIME_SELECTED",
+          message: `Development runtime selected from ${checkout}; no packaged runtime was verified or installed.`
+        }]
+      };
+    }
     async function sha256File(filePath) {
       var _a2;
       const info = await promises.lstat(filePath);
@@ -18552,7 +18635,7 @@
     let readinessPromise = null;
     function ensureReady() {
       if (readinessPromise) return readinessPromise;
-      const pending = withLock(async () => {
+      const pending = developmentRuntimeInput ? selectDevelopmentRuntime() : withLock(async () => {
         let current = await pointerState(paths.currentPointer);
         const previous = await pointerState(paths.previousPointer);
         if (!current.ok && previous.ok) {
@@ -18675,6 +18758,12 @@
       return shared;
     }
     async function repair() {
+      if (developmentRuntimeInput) {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE",
+          "Repair is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout."
+        );
+      }
       return withLock(async () => {
         const packaged = await verifyPackagedPayload();
         const current = await pointerState(paths.currentPointer);
@@ -18701,6 +18790,12 @@
       });
     }
     async function rollback() {
+      if (developmentRuntimeInput) {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE",
+          "Rollback is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout."
+        );
+      }
       return withLock(async () => {
         const current = await pointerState(paths.currentPointer);
         const previous = await pointerState(paths.previousPointer);
@@ -18729,6 +18824,12 @@
       });
     }
     async function uninstall() {
+      if (developmentRuntimeInput) {
+        failure(
+          "RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE",
+          "Uninstall is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout."
+        );
+      }
       return withLock(async () => {
         await removePointer(paths.currentPointer);
         await removePointer(paths.previousPointer);
@@ -18769,6 +18870,29 @@
     }
     async function inspect() {
       var _a2;
+      if (developmentRuntimeInput) {
+        try {
+          const selected = await selectDevelopmentRuntime();
+          return {
+            ok: true,
+            developmentRuntime: true,
+            checkoutPath: selected.checkoutPath,
+            interpreter: selected.interpreter,
+            launcher: { ok: true, path: selected.launcher },
+            diagnostics: selected.diagnostics
+          };
+        } catch (error) {
+          const normalized = runtimeError(error);
+          return {
+            ok: false,
+            developmentRuntime: true,
+            code: normalized.code,
+            detail: normalized.message,
+            launcher: { ok: false, code: normalized.code },
+            diagnostics: [{ code: normalized.code, message: normalized.message }]
+          };
+        }
+      }
       const current = await pointerState(paths.currentPointer);
       const previous = await pointerState(paths.previousPointer);
       let launcher = { ok: false, code: "RUNTIME_LAUNCHER_MISSING", path: paths.launcher };
@@ -18784,6 +18908,25 @@
     async function resolveNode() {
       var _a2;
       const selected = await ensureReady();
+      if (selected.developmentRuntime) {
+        const node = await platform.resolveExecutable("node", {
+          minimumVersion: "24.17.0",
+          requiredArch: "arm64"
+        });
+        if (!node.ok) {
+          failure("RUNTIME_NODE_INVALID", "A development runtime requires an available Node 24 arm64 executable");
+        }
+        return {
+          ok: true,
+          nodePath: node.path,
+          version: node.version,
+          runtime: selected,
+          executable: {
+            ...node,
+            source: "development-path"
+          }
+        };
+      }
       const inspected = await inspectInstalled(selected.relative);
       const nodePath = paths.join([inspected.directory, "node", "bin", "node"]);
       const info = await promises.lstat(nodePath);
@@ -18853,13 +18996,14 @@
     const debugMarker = extRoot && adapter.paths.join([extRoot, ".debug"]);
     const bundleManifest = extRoot && adapter.paths.join([extRoot, "bundle-manifest.json"]);
     const developmentFallback = adapter.id === "macos-arm64" && debugMarker && adapter.fs.existsSync(debugMarker) && !adapter.fs.existsSync(bundleManifest);
-    if (adapter.id === "macos-arm64" && (runtimeManager || extRoot && !developmentFallback)) {
+    const developmentRuntimeOverride = hasDevelopmentRuntimeOverride(adapter.env);
+    if (adapter.id === "macos-arm64" && (runtimeManager || extRoot && (!developmentFallback || developmentRuntimeOverride))) {
       const manager = runtimeManager || createRuntimeManager({ platform: adapter, extensionRoot: extRoot });
       const selected = await manager.ensureReady();
       return {
         command: selected.launcher,
-        args: [],
-        source: selected.action === "fallback" ? "runtime-fallback" : "runtime-manager",
+        args: selected.args || [],
+        source: selected.developmentRuntime ? "development-runtime" : selected.action === "fallback" ? "runtime-fallback" : "runtime-manager",
         runtime: selected
       };
     }
@@ -34678,7 +34822,7 @@ data: ${JSON.stringify(payload)}
     runtimeManager,
     allowDevelopmentPath = false
   }) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e, _f, _g;
     const adapter = platform || createPlatformAdapter();
     const fileSystem = fs || adapter.fs;
     const fetcher = fetchImpl || globalThis.fetch;
@@ -34762,10 +34906,17 @@ data: ${JSON.stringify(payload)}
       try {
         const state = await runtimeManager.inspect();
         const current = ((_a = state.current) == null ? void 0 : _a.ok) ? state.current.record : null;
+        const developmentRuntime = state.developmentRuntime === true;
         items.push({
           id: "ae-mcp",
           ok: state.ok,
-          detail: state.ok ? `${current.version} \xB7 ${state.launcher.path} \xB7 ${current.sourceCommitSha}` : [(_b = state.current) == null ? void 0 : _b.code, (_c = state.launcher) == null ? void 0 : _c.code].filter(Boolean).join(" \xB7 "),
+          detail: state.ok && developmentRuntime ? [
+            "DEVELOPMENT CHECKOUT",
+            state.checkoutPath,
+            (_b = state.interpreter) == null ? void 0 : _b.path,
+            (_c = state.interpreter) == null ? void 0 : _c.resolvedPath,
+            (_e = (_d = state.diagnostics) == null ? void 0 : _d[0]) == null ? void 0 : _e.code
+          ].filter(Boolean).join(" \xB7 ") : state.ok ? `${current.version} \xB7 ${state.launcher.path} \xB7 ${current.sourceCommitSha}` : [(_f = state.current) == null ? void 0 : _f.code, (_g = state.launcher) == null ? void 0 : _g.code].filter(Boolean).join(" \xB7 "),
           fixHint: HINTS["ae-mcp"],
           action: { kind: "repair-runtime" }
         });
@@ -36157,7 +36308,11 @@ ${baseUrl}`),
       const bundleManifest = platform.paths.join([extRoot, "bundle-manifest.json"]);
       return platform.fs.existsSync(debugMarker) && !platform.fs.existsSync(bundleManifest);
     }, [extRoot, platform]);
-    const runtimeManager = import_react45.default.useMemo(() => platform.id === "macos-arm64" && !developmentRuntimeFallback ? createRuntimeManager({ platform, extensionRoot: extRoot }) : null, [developmentRuntimeFallback, extRoot, platform]);
+    const developmentRuntimeOverride = import_react45.default.useMemo(
+      () => hasDevelopmentRuntimeOverride(platform.env),
+      [platform]
+    );
+    const runtimeManager = import_react45.default.useMemo(() => platform.id === "macos-arm64" && (!developmentRuntimeFallback || developmentRuntimeOverride) ? createRuntimeManager({ platform, extensionRoot: extRoot }) : null, [developmentRuntimeFallback, developmentRuntimeOverride, extRoot, platform]);
     const [runtimeActivation, setRuntimeActivation] = import_react45.default.useState(() => ({
       state: runtimeManager ? "starting" : "ready",
       result: null,

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -17607,6 +17607,7 @@
         checkoutPath: checkout,
         launcher: interpreter,
         args: ["-B", "-I", "-m", "ae_mcp"],
+        cwd: checkout,
         interpreter: {
           path: interpreter,
           resolvedPath: resolvedInterpreter
@@ -19003,6 +19004,7 @@
       return {
         command: selected.launcher,
         args: selected.args || [],
+        cwd: selected.cwd,
         source: selected.developmentRuntime ? "development-runtime" : selected.action === "fallback" ? "runtime-fallback" : "runtime-manager",
         runtime: selected
       };
@@ -19224,7 +19226,8 @@
         const options = {
           stdio: "pipe",
           windowsHide: true,
-          env: spawnEnv
+          env: spawnEnv,
+          ...commandSpec.cwd ? { cwd: commandSpec.cwd } : {}
         };
         if (adapter) {
           const executable = { ok: true, id: "ae-mcp", path: commandSpec.command, argsPrefix: [], source: commandSpec.source || "runtime", version: null, arch: null };

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -17435,6 +17435,7 @@
   var DEVELOPMENT_CORE_BOOTSTRAP = [
     "import runpy,sys",
     "sys.path.insert(0,sys.argv[1])",
+    "sys.path.insert(0,sys.argv[2])",
     'runpy.run_module("ae_mcp",run_name="__main__")'
   ].join(";");
   var RuntimeManagerError = class extends Error {
@@ -17554,7 +17555,7 @@
       return fs.existsSync(developmentMarkerPath) && !fs.existsSync(packageManifestPath);
     }
     async function selectDevelopmentRuntime() {
-      var _a2, _b2, _c2;
+      var _a2, _b2, _c2, _d2;
       if (!developmentRuntimeInput) return null;
       if (!developmentBuild()) {
         failure(
@@ -17583,15 +17584,18 @@
       const projectManifest = paths.join([checkout, "pyproject.toml"]);
       const coreRoot = paths.join([checkout, "packages", "core"]);
       const coreEntrypoint = paths.join([coreRoot, "ae_mcp", "__main__.py"]);
+      const bridgeRoot = paths.join([checkout, "packages", "bridge"]);
+      const bridgeEntrypoint = paths.join([bridgeRoot, "ae_mcp_bridge", "__init__.py"]);
       const interpreter = paths.join([checkout, ".venv", "bin", "python3"]);
       let resolvedInterpreter;
       try {
-        const [manifestInfo, entrypointInfo, interpreterInfo] = await Promise.all([
+        const [manifestInfo, entrypointInfo, bridgeInfo, interpreterInfo] = await Promise.all([
           promises.lstat(projectManifest),
           promises.lstat(coreEntrypoint),
+          promises.lstat(bridgeEntrypoint),
           promises.lstat(interpreter)
         ]);
-        if (!manifestInfo.isFile() || ((_a2 = manifestInfo.isSymbolicLink) == null ? void 0 : _a2.call(manifestInfo)) || !entrypointInfo.isFile() || ((_b2 = entrypointInfo.isSymbolicLink) == null ? void 0 : _b2.call(entrypointInfo)) || !interpreterInfo.isFile() && !((_c2 = interpreterInfo.isSymbolicLink) == null ? void 0 : _c2.call(interpreterInfo)) || (interpreterInfo.mode & 73) === 0) {
+        if (!manifestInfo.isFile() || ((_a2 = manifestInfo.isSymbolicLink) == null ? void 0 : _a2.call(manifestInfo)) || !entrypointInfo.isFile() || ((_b2 = entrypointInfo.isSymbolicLink) == null ? void 0 : _b2.call(entrypointInfo)) || !bridgeInfo.isFile() || ((_c2 = bridgeInfo.isSymbolicLink) == null ? void 0 : _c2.call(bridgeInfo)) || !interpreterInfo.isFile() && !((_d2 = interpreterInfo.isSymbolicLink) == null ? void 0 : _d2.call(interpreterInfo)) || (interpreterInfo.mode & 73) === 0) {
           throw new Error("required checkout entrypoint is invalid");
         }
         resolvedInterpreter = await promises.realpath(interpreter);
@@ -17602,7 +17606,7 @@
       } catch {
         failure(
           "RUNTIME_DEVELOPMENT_RUNTIME_INVALID",
-          `${DEVELOPMENT_RUNTIME_ENV} does not contain pyproject.toml, the core entrypoint, and an executable .venv/bin/python3`,
+          `${DEVELOPMENT_RUNTIME_ENV} does not contain the Core/bridge entrypoints and an executable .venv/bin/python3`,
           { path: checkout }
         );
       }
@@ -17612,7 +17616,7 @@
         developmentRuntime: true,
         checkoutPath: checkout,
         launcher: interpreter,
-        args: ["-B", "-I", "-c", DEVELOPMENT_CORE_BOOTSTRAP, coreRoot],
+        args: ["-B", "-I", "-c", DEVELOPMENT_CORE_BOOTSTRAP, coreRoot, bridgeRoot],
         cwd: checkout,
         interpreter: {
           path: interpreter,

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -65,7 +65,7 @@ import { writeLogExport, revealInExplorer } from '../cep/logExportFs.js';
 import { reconcileStableJsonValue } from '../lib/stableValue.js';
 import { createPlatformAdapter } from '../cep/platform/index.js';
 import { readCepSystemPath } from '../cep/platform/paths.js';
-import { createRuntimeManager } from '../cep/runtimeManager.js';
+import { createRuntimeManager, hasDevelopmentRuntimeOverride } from '../cep/runtimeManager.js';
 import { createElicitationCoordinator } from '../lib/elicitationCoordinator.js';
 import { decideToolPlan } from '../../../shared/tool-approval.mjs';
 
@@ -572,11 +572,15 @@ function Shell({ cs }) {
     return platform.fs.existsSync(debugMarker)
       && !platform.fs.existsSync(bundleManifest);
   }, [extRoot, platform]);
+  const developmentRuntimeOverride = React.useMemo(
+    () => hasDevelopmentRuntimeOverride(platform.env),
+    [platform],
+  );
   const runtimeManager = React.useMemo(() => (
-    platform.id === 'macos-arm64' && !developmentRuntimeFallback
+    platform.id === 'macos-arm64' && (!developmentRuntimeFallback || developmentRuntimeOverride)
       ? createRuntimeManager({ platform, extensionRoot: extRoot })
       : null
-  ), [developmentRuntimeFallback, extRoot, platform]);
+  ), [developmentRuntimeFallback, developmentRuntimeOverride, extRoot, platform]);
   const [runtimeActivation, setRuntimeActivation] = React.useState(() => ({
     state: runtimeManager ? 'starting' : 'ready',
     result: null,

--- a/plugin/panel/src/cep/diagnostics.js
+++ b/plugin/panel/src/cep/diagnostics.js
@@ -167,11 +167,20 @@ export async function runDiagnostics({
     try {
       const state = await runtimeManager.inspect();
       const current = state.current?.ok ? state.current.record : null;
+      const developmentRuntime = state.developmentRuntime === true;
       items.push({
         id: 'ae-mcp',
         ok: state.ok,
-        detail: state.ok
-          ? `${current.version} · ${state.launcher.path} · ${current.sourceCommitSha}`
+        detail: state.ok && developmentRuntime
+          ? [
+            'DEVELOPMENT CHECKOUT',
+            state.checkoutPath,
+            state.interpreter?.path,
+            state.interpreter?.resolvedPath,
+            state.diagnostics?.[0]?.code,
+          ].filter(Boolean).join(' · ')
+          : state.ok
+            ? `${current.version} · ${state.launcher.path} · ${current.sourceCommitSha}`
           : [state.current?.code, state.launcher?.code].filter(Boolean).join(' · '),
         fixHint: HINTS['ae-mcp'],
         action: { kind: 'repair-runtime' },

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,7 +1,7 @@
 import { createNdjsonReader } from '../lib/ndjson.js';
 import { expertGuidanceEnv } from './externalClients.js';
 import { createPlatformAdapter } from './platform/index.js';
-import { createRuntimeManager } from './runtimeManager.js';
+import { createRuntimeManager, hasDevelopmentRuntimeOverride } from './runtimeManager.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const INITIALIZE_TIMEOUT_MS = 120000;
@@ -53,13 +53,17 @@ export async function resolveMcpCommand({
     && debugMarker
     && adapter.fs.existsSync(debugMarker)
     && !adapter.fs.existsSync(bundleManifest);
-  if (adapter.id === 'macos-arm64' && (runtimeManager || (extRoot && !developmentFallback))) {
+  const developmentRuntimeOverride = hasDevelopmentRuntimeOverride(adapter.env);
+  if (adapter.id === 'macos-arm64'
+      && (runtimeManager || (extRoot && (!developmentFallback || developmentRuntimeOverride)))) {
     const manager = runtimeManager || createRuntimeManager({ platform: adapter, extensionRoot: extRoot });
     const selected = await manager.ensureReady();
     return {
       command: selected.launcher,
-      args: [],
-      source: selected.action === 'fallback' ? 'runtime-fallback' : 'runtime-manager',
+      args: selected.args || [],
+      source: selected.developmentRuntime
+        ? 'development-runtime'
+        : (selected.action === 'fallback' ? 'runtime-fallback' : 'runtime-manager'),
       runtime: selected,
     };
   }

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -61,6 +61,7 @@ export async function resolveMcpCommand({
     return {
       command: selected.launcher,
       args: selected.args || [],
+      cwd: selected.cwd,
       source: selected.developmentRuntime
         ? 'development-runtime'
         : (selected.action === 'fallback' ? 'runtime-fallback' : 'runtime-manager'),
@@ -309,6 +310,7 @@ export function createMcpClient({
         stdio: 'pipe',
         windowsHide: true,
         env: spawnEnv,
+        ...(commandSpec.cwd ? { cwd: commandSpec.cwd } : {}),
       };
       if (adapter) {
         const executable = { ok: true, id: 'ae-mcp', path: commandSpec.command, argsPrefix: [], source: commandSpec.source || 'runtime', version: null, arch: null };

--- a/plugin/panel/src/cep/platform/macos.js
+++ b/plugin/panel/src/cep/platform/macos.js
@@ -8,6 +8,10 @@ export function createMacosAdapter(deps) {
   const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: 'standard', version: null, arch: 'arm64' });
   return Object.freeze({
     id: 'macos-arm64',
+    // RuntimeManager needs the CEP process environment for its explicit,
+    // development-only direct-checkout override.  Keep it on the adapter so
+    // callers do not need to reach around the platform boundary.
+    env: deps.env,
     paths,
     fs: deps.fs,
     ...boundary,

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -11,6 +11,11 @@ const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z
 const SOURCE_SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const DEVELOPMENT_RUNTIME_ENV = 'AE_MCP_DEV_RUNTIME';
+const DEVELOPMENT_CORE_BOOTSTRAP = [
+  'import runpy,sys',
+  'sys.path.insert(0,sys.argv[1])',
+  'runpy.run_module("ae_mcp",run_name="__main__")',
+].join(';');
 
 export class RuntimeManagerError extends Error {
   constructor(code, message, details = {}) {
@@ -183,7 +188,8 @@ export function createRuntimeManager({
     }
 
     const projectManifest = paths.join([checkout, 'pyproject.toml']);
-    const coreEntrypoint = paths.join([checkout, 'packages', 'core', 'ae_mcp', '__main__.py']);
+    const coreRoot = paths.join([checkout, 'packages', 'core']);
+    const coreEntrypoint = paths.join([coreRoot, 'ae_mcp', '__main__.py']);
     const interpreter = paths.join([checkout, '.venv', 'bin', 'python3']);
     let resolvedInterpreter;
     try {
@@ -217,7 +223,7 @@ export function createRuntimeManager({
       developmentRuntime: true,
       checkoutPath: checkout,
       launcher: interpreter,
-      args: ['-B', '-I', '-m', 'ae_mcp'],
+      args: ['-B', '-I', '-c', DEVELOPMENT_CORE_BOOTSTRAP, coreRoot],
       cwd: checkout,
       interpreter: {
         path: interpreter,

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -14,6 +14,7 @@ const DEVELOPMENT_RUNTIME_ENV = 'AE_MCP_DEV_RUNTIME';
 const DEVELOPMENT_CORE_BOOTSTRAP = [
   'import runpy,sys',
   'sys.path.insert(0,sys.argv[1])',
+  'sys.path.insert(0,sys.argv[2])',
   'runpy.run_module("ae_mcp",run_name="__main__")',
 ].join(';');
 
@@ -190,16 +191,20 @@ export function createRuntimeManager({
     const projectManifest = paths.join([checkout, 'pyproject.toml']);
     const coreRoot = paths.join([checkout, 'packages', 'core']);
     const coreEntrypoint = paths.join([coreRoot, 'ae_mcp', '__main__.py']);
+    const bridgeRoot = paths.join([checkout, 'packages', 'bridge']);
+    const bridgeEntrypoint = paths.join([bridgeRoot, 'ae_mcp_bridge', '__init__.py']);
     const interpreter = paths.join([checkout, '.venv', 'bin', 'python3']);
     let resolvedInterpreter;
     try {
-      const [manifestInfo, entrypointInfo, interpreterInfo] = await Promise.all([
+      const [manifestInfo, entrypointInfo, bridgeInfo, interpreterInfo] = await Promise.all([
         promises.lstat(projectManifest),
         promises.lstat(coreEntrypoint),
+        promises.lstat(bridgeEntrypoint),
         promises.lstat(interpreter),
       ]);
       if (!manifestInfo.isFile() || manifestInfo.isSymbolicLink?.()
           || !entrypointInfo.isFile() || entrypointInfo.isSymbolicLink?.()
+          || !bridgeInfo.isFile() || bridgeInfo.isSymbolicLink?.()
           || (!interpreterInfo.isFile() && !interpreterInfo.isSymbolicLink?.())
           || (interpreterInfo.mode & 0o111) === 0) {
         throw new Error('required checkout entrypoint is invalid');
@@ -212,7 +217,7 @@ export function createRuntimeManager({
     } catch {
       failure(
         'RUNTIME_DEVELOPMENT_RUNTIME_INVALID',
-        `${DEVELOPMENT_RUNTIME_ENV} does not contain pyproject.toml, the core entrypoint, and an executable .venv/bin/python3`,
+        `${DEVELOPMENT_RUNTIME_ENV} does not contain the Core/bridge entrypoints and an executable .venv/bin/python3`,
         { path: checkout },
       );
     }
@@ -223,7 +228,7 @@ export function createRuntimeManager({
       developmentRuntime: true,
       checkoutPath: checkout,
       launcher: interpreter,
-      args: ['-B', '-I', '-c', DEVELOPMENT_CORE_BOOTSTRAP, coreRoot],
+      args: ['-B', '-I', '-c', DEVELOPMENT_CORE_BOOTSTRAP, coreRoot, bridgeRoot],
       cwd: checkout,
       interpreter: {
         path: interpreter,

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -10,6 +10,7 @@ const LAYER_INSTANCE_ID = /^i-[0-9a-f]{16}$/;
 const SEMVER = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const SOURCE_SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
+const DEVELOPMENT_RUNTIME_ENV = 'AE_MCP_DEV_RUNTIME';
 
 export class RuntimeManagerError extends Error {
   constructor(code, message, details = {}) {
@@ -88,6 +89,11 @@ function randomHex(randomBytes, size = 8) {
   return Buffer.from(randomBytes(size)).toString('hex');
 }
 
+export function hasDevelopmentRuntimeOverride(environment = {}) {
+  return typeof environment?.[DEVELOPMENT_RUNTIME_ENV] === 'string'
+    && environment[DEVELOPMENT_RUNTIME_ENV].trim().length > 0;
+}
+
 export function createRuntimeManager({
   platform,
   extensionRoot,
@@ -108,6 +114,7 @@ export function createRuntimeManager({
   },
   lockTimeoutMs = 10000,
   lockPollMs = 25,
+  environment = platform?.env || globalThis.window?.cep_node?.process?.env || globalThis.process?.env || {},
 } = {}) {
   if (!platform || platform.id !== RUNTIME_PLATFORM) {
     failure('RUNTIME_PLATFORM_UNSUPPORTED', 'RuntimeManager currently supports Apple Silicon macOS only');
@@ -136,6 +143,91 @@ export function createRuntimeManager({
   const packagedRuntimeManifest = paths.join([packagedRuntimeRoot, 'runtime-manifest.json']);
   const packagedLauncher = paths.join([extensionRoot, 'platform', platform.id, 'bin', 'ae-mcp']);
   const stableLauncherRecordPath = paths.join([root, STABLE_LAUNCHER_RECORD]);
+  const developmentMarkerPath = paths.join([extensionRoot, '.debug']);
+  const developmentRuntimeInput = hasDevelopmentRuntimeOverride(environment)
+    ? environment[DEVELOPMENT_RUNTIME_ENV].trim() : '';
+
+  function developmentBuild() {
+    return fs.existsSync(developmentMarkerPath) && !fs.existsSync(packageManifestPath);
+  }
+
+  async function selectDevelopmentRuntime() {
+    if (!developmentRuntimeInput) return null;
+    // This is deliberately the same development/release boundary used by the
+    // panel's existing PATH fallback. A packaged extension must never accept
+    // an unverified source checkout merely because its process has this env.
+    if (!developmentBuild()) {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_RELEASE_REFUSED',
+        `${DEVELOPMENT_RUNTIME_ENV} is refused by a packaged release build`,
+      );
+    }
+    if (!paths.isAbsolute(developmentRuntimeInput)) {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_INVALID',
+        `${DEVELOPMENT_RUNTIME_ENV} must name an absolute source checkout path`,
+      );
+    }
+
+    let checkout;
+    try {
+      checkout = await promises.realpath(developmentRuntimeInput);
+      const info = await promises.stat(checkout);
+      if (!info.isDirectory()) throw new Error('not a directory');
+    } catch {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_INVALID',
+        `${DEVELOPMENT_RUNTIME_ENV} does not resolve to a usable source checkout`,
+        { path: developmentRuntimeInput },
+      );
+    }
+
+    const projectManifest = paths.join([checkout, 'pyproject.toml']);
+    const coreEntrypoint = paths.join([checkout, 'packages', 'core', 'ae_mcp', '__main__.py']);
+    const interpreter = paths.join([checkout, '.venv', 'bin', 'python3']);
+    let resolvedInterpreter;
+    try {
+      const [manifestInfo, entrypointInfo, interpreterInfo] = await Promise.all([
+        promises.lstat(projectManifest),
+        promises.lstat(coreEntrypoint),
+        promises.lstat(interpreter),
+      ]);
+      if (!manifestInfo.isFile() || manifestInfo.isSymbolicLink?.()
+          || !entrypointInfo.isFile() || entrypointInfo.isSymbolicLink?.()
+          || (!interpreterInfo.isFile() && !interpreterInfo.isSymbolicLink?.())
+          || (interpreterInfo.mode & 0o111) === 0) {
+        throw new Error('required checkout entrypoint is invalid');
+      }
+      resolvedInterpreter = await promises.realpath(interpreter);
+      const resolvedInfo = await promises.stat(resolvedInterpreter);
+      if (!resolvedInfo.isFile() || (resolvedInfo.mode & 0o111) === 0) {
+        throw new Error('resolved interpreter is not executable');
+      }
+    } catch {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_INVALID',
+        `${DEVELOPMENT_RUNTIME_ENV} does not contain pyproject.toml, the core entrypoint, and an executable .venv/bin/python3`,
+        { path: checkout },
+      );
+    }
+
+    return {
+      ok: true,
+      action: 'development-runtime',
+      developmentRuntime: true,
+      checkoutPath: checkout,
+      launcher: interpreter,
+      args: ['-B', '-I', '-m', 'ae_mcp'],
+      interpreter: {
+        path: interpreter,
+        resolvedPath: resolvedInterpreter,
+      },
+      diagnostics: [{
+        code: 'RUNTIME_DEVELOPMENT_RUNTIME_SELECTED',
+        message: `Development runtime selected from ${checkout}; no packaged runtime was verified or installed.`,
+      }],
+    };
+  }
 
   async function sha256File(filePath) {
     const info = await promises.lstat(filePath);
@@ -1226,7 +1318,9 @@ export function createRuntimeManager({
 
   function ensureReady() {
     if (readinessPromise) return readinessPromise;
-    const pending = withLock(async () => {
+    const pending = developmentRuntimeInput
+      ? selectDevelopmentRuntime()
+      : withLock(async () => {
       let current = await pointerState(paths.currentPointer);
       const previous = await pointerState(paths.previousPointer);
       if (!current.ok && previous.ok) {
@@ -1350,7 +1444,7 @@ export function createRuntimeManager({
           failedCode: current.code,
         }] : [],
       };
-    });
+      });
     const shared = pending.finally(() => {
       if (readinessPromise === shared) readinessPromise = null;
     });
@@ -1359,6 +1453,12 @@ export function createRuntimeManager({
   }
 
   async function repair() {
+    if (developmentRuntimeInput) {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE',
+        'Repair is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout.',
+      );
+    }
     return withLock(async () => {
       const packaged = await verifyPackagedPayload();
       const current = await pointerState(paths.currentPointer);
@@ -1382,6 +1482,12 @@ export function createRuntimeManager({
   }
 
   async function rollback() {
+    if (developmentRuntimeInput) {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE',
+        'Rollback is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout.',
+      );
+    }
     return withLock(async () => {
       const current = await pointerState(paths.currentPointer);
       const previous = await pointerState(paths.previousPointer);
@@ -1408,6 +1514,12 @@ export function createRuntimeManager({
   }
 
   async function uninstall() {
+    if (developmentRuntimeInput) {
+      failure(
+        'RUNTIME_DEVELOPMENT_RUNTIME_OPERATION_UNAVAILABLE',
+        'Uninstall is unavailable while AE_MCP_DEV_RUNTIME selects a source checkout.',
+      );
+    }
     return withLock(async () => {
       await removePointer(paths.currentPointer);
       await removePointer(paths.previousPointer);
@@ -1449,6 +1561,29 @@ export function createRuntimeManager({
   }
 
   async function inspect() {
+    if (developmentRuntimeInput) {
+      try {
+        const selected = await selectDevelopmentRuntime();
+        return {
+          ok: true,
+          developmentRuntime: true,
+          checkoutPath: selected.checkoutPath,
+          interpreter: selected.interpreter,
+          launcher: { ok: true, path: selected.launcher },
+          diagnostics: selected.diagnostics,
+        };
+      } catch (error) {
+        const normalized = runtimeError(error);
+        return {
+          ok: false,
+          developmentRuntime: true,
+          code: normalized.code,
+          detail: normalized.message,
+          launcher: { ok: false, code: normalized.code },
+          diagnostics: [{ code: normalized.code, message: normalized.message }],
+        };
+      }
+    }
     const current = await pointerState(paths.currentPointer);
     const previous = await pointerState(paths.previousPointer);
     let launcher = { ok: false, code: 'RUNTIME_LAUNCHER_MISSING', path: paths.launcher };
@@ -1467,6 +1602,25 @@ export function createRuntimeManager({
 
   async function resolveNode() {
     const selected = await ensureReady();
+    if (selected.developmentRuntime) {
+      const node = await platform.resolveExecutable('node', {
+        minimumVersion: '24.17.0',
+        requiredArch: 'arm64',
+      });
+      if (!node.ok) {
+        failure('RUNTIME_NODE_INVALID', 'A development runtime requires an available Node 24 arm64 executable');
+      }
+      return {
+        ok: true,
+        nodePath: node.path,
+        version: node.version,
+        runtime: selected,
+        executable: {
+          ...node,
+          source: 'development-path',
+        },
+      };
+    }
     const inspected = await inspectInstalled(selected.relative);
     const nodePath = paths.join([inspected.directory, 'node', 'bin', 'node']);
     const info = await promises.lstat(nodePath);

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -218,6 +218,7 @@ export function createRuntimeManager({
       checkoutPath: checkout,
       launcher: interpreter,
       args: ['-B', '-I', '-m', 'ae_mcp'],
+      cwd: checkout,
       interpreter: {
         path: interpreter,
         resolvedPath: resolvedInterpreter,

--- a/plugin/panel/test/diagnostics.test.js
+++ b/plugin/panel/test/diagnostics.test.js
@@ -149,6 +149,39 @@ test('runDiagnostics reports RuntimeManager provenance and corruption diagnostic
   assert.match(corrupt.find((item) => item.id === 'ae-mcp').detail, /RUNTIME_HASH_MISMATCH/);
 });
 
+test('runDiagnostics visibly labels a selected development checkout and interpreter', async () => {
+  const runtimeManager = {
+    async resolveNode() {
+      return {
+        ok: true,
+        version: '24.17.0',
+        nodePath: '/Users/tester/.local/bin/node',
+        runtime: { developmentRuntime: true },
+      };
+    },
+    async inspect() {
+      return {
+        ok: true,
+        developmentRuntime: true,
+        checkoutPath: '/Users/tester/Documents/ae-mcp',
+        interpreter: {
+          path: '/Users/tester/Documents/ae-mcp/.venv/bin/python3',
+          resolvedPath: '/Users/tester/.local/share/uv/python/python3.13',
+        },
+        launcher: { ok: true, path: '/Users/tester/Documents/ae-mcp/.venv/bin/python3' },
+        diagnostics: [{ code: 'RUNTIME_DEVELOPMENT_RUNTIME_SELECTED' }],
+      };
+    },
+  };
+
+  const items = await runDiagnostics({ ...makeDeps(), port: 11488, runtimeManager });
+  const runtime = items.find((item) => item.id === 'ae-mcp');
+  assert.equal(runtime.ok, true);
+  assert.match(runtime.detail, /DEVELOPMENT CHECKOUT/);
+  assert.match(runtime.detail, /Documents\/ae-mcp/);
+  assert.match(runtime.detail, /RUNTIME_DEVELOPMENT_RUNTIME_SELECTED/);
+});
+
 test('runDiagnostics inspects the RuntimeManager after resolveNode repairs it', async () => {
   const calls = [];
   let repaired = false;

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -121,6 +121,7 @@ test('resolveMcpCommand lets the macOS RuntimeManager verify and activate before
 
   assert.deepEqual(calls, ['ensureReady']);
   assert.equal(result.command, platform.paths.launcher);
+  assert.equal(result.cwd, undefined);
   assert.equal(result.source, 'runtime-manager');
   assert.equal(result.runtime.version, '0.9.3');
 });
@@ -137,6 +138,7 @@ test('resolveMcpCommand launches a selected development checkout interpreter dir
           developmentRuntime: true,
           launcher: '/Users/a/src/ae-mcp/.venv/bin/python3',
           args: ['-B', '-I', '-m', 'ae_mcp'],
+          cwd: '/Users/a/src/ae-mcp',
         };
       },
     },
@@ -144,6 +146,7 @@ test('resolveMcpCommand launches a selected development checkout interpreter dir
 
   assert.equal(result.command, '/Users/a/src/ae-mcp/.venv/bin/python3');
   assert.deepEqual(result.args, ['-B', '-I', '-m', 'ae_mcp']);
+  assert.equal(result.cwd, '/Users/a/src/ae-mcp');
   assert.equal(result.source, 'development-runtime');
 });
 
@@ -245,6 +248,24 @@ function spawnReplying(initResult) {
   };
   return { spawnImpl, getProc: () => proc };
 }
+
+test('createMcpClient spawns a selected development runtime in its checkout', async () => {
+  const { spawnImpl, getProc } = spawnReplying({});
+  const client = createMcpClient({
+    spawnImpl,
+    resolveCommand: async () => ({
+      command: '/checkout/.venv/bin/python3',
+      args: ['-B', '-I', '-m', 'ae_mcp'],
+      cwd: '/checkout',
+      source: 'development-runtime',
+    }),
+  });
+
+  await client.start();
+  assert.equal(getProc().spawnOptions.cwd, '/checkout');
+  assert.equal(getProc().spawnOptions.shell, false);
+  client.stop();
+});
 
 test('createMcpClient captures server instructions from the initialize result', async () => {
   const { spawnImpl } = spawnReplying({ instructions: 'SERVER_GUIDE' });

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -128,6 +128,7 @@ test('resolveMcpCommand lets the macOS RuntimeManager verify and activate before
 
 test('resolveMcpCommand launches a selected development checkout interpreter directly', async () => {
   const platform = fakeCommandPlatform({ launcher: '/Users/a/.ae-mcp/bin/ae-mcp' });
+  const bootstrap = 'import runpy,sys;sys.path.insert(0,sys.argv[1]);runpy.run_module("ae_mcp",run_name="__main__")';
   const result = await resolveMcpCommand({
     platform,
     extRoot: '/Users/a/Development/AE MCP',
@@ -137,7 +138,7 @@ test('resolveMcpCommand launches a selected development checkout interpreter dir
           action: 'development-runtime',
           developmentRuntime: true,
           launcher: '/Users/a/src/ae-mcp/.venv/bin/python3',
-          args: ['-B', '-I', '-m', 'ae_mcp'],
+          args: ['-B', '-I', '-c', bootstrap, '/Users/a/src/ae-mcp/packages/core'],
           cwd: '/Users/a/src/ae-mcp',
         };
       },
@@ -145,7 +146,9 @@ test('resolveMcpCommand launches a selected development checkout interpreter dir
   });
 
   assert.equal(result.command, '/Users/a/src/ae-mcp/.venv/bin/python3');
-  assert.deepEqual(result.args, ['-B', '-I', '-m', 'ae_mcp']);
+  assert.deepEqual(result.args, [
+    '-B', '-I', '-c', bootstrap, '/Users/a/src/ae-mcp/packages/core',
+  ]);
   assert.equal(result.cwd, '/Users/a/src/ae-mcp');
   assert.equal(result.source, 'development-runtime');
 });
@@ -251,17 +254,19 @@ function spawnReplying(initResult) {
 
 test('createMcpClient spawns a selected development runtime in its checkout', async () => {
   const { spawnImpl, getProc } = spawnReplying({});
+  const bootstrap = 'import runpy,sys;sys.path.insert(0,sys.argv[1]);runpy.run_module("ae_mcp",run_name="__main__")';
   const client = createMcpClient({
     spawnImpl,
     resolveCommand: async () => ({
       command: '/checkout/.venv/bin/python3',
-      args: ['-B', '-I', '-m', 'ae_mcp'],
+      args: ['-B', '-I', '-c', bootstrap, '/checkout/packages/core'],
       cwd: '/checkout',
       source: 'development-runtime',
     }),
   });
 
   await client.start();
+  assert.deepEqual(getProc().clientWrites[0].method, 'initialize');
   assert.equal(getProc().spawnOptions.cwd, '/checkout');
   assert.equal(getProc().spawnOptions.shell, false);
   client.stop();

--- a/plugin/panel/test/mcpClient.test.js
+++ b/plugin/panel/test/mcpClient.test.js
@@ -125,6 +125,28 @@ test('resolveMcpCommand lets the macOS RuntimeManager verify and activate before
   assert.equal(result.runtime.version, '0.9.3');
 });
 
+test('resolveMcpCommand launches a selected development checkout interpreter directly', async () => {
+  const platform = fakeCommandPlatform({ launcher: '/Users/a/.ae-mcp/bin/ae-mcp' });
+  const result = await resolveMcpCommand({
+    platform,
+    extRoot: '/Users/a/Development/AE MCP',
+    runtimeManager: {
+      async ensureReady() {
+        return {
+          action: 'development-runtime',
+          developmentRuntime: true,
+          launcher: '/Users/a/src/ae-mcp/.venv/bin/python3',
+          args: ['-B', '-I', '-m', 'ae_mcp'],
+        };
+      },
+    },
+  });
+
+  assert.equal(result.command, '/Users/a/src/ae-mcp/.venv/bin/python3');
+  assert.deepEqual(result.args, ['-B', '-I', '-m', 'ae_mcp']);
+  assert.equal(result.source, 'development-runtime');
+});
+
 test('resolveMcpCommand allows PATH only for an explicit .debug install without a bundle', async () => {
   const calls = [];
   const platform = fakeCommandPlatform({

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -243,6 +243,7 @@ macosRuntimeTest('development checkout bypasses manifests, generations, pointers
   assert.equal(selected.action, 'development-runtime');
   assert.equal(selected.developmentRuntime, true);
   assert.equal(selected.checkoutPath, canonicalCheckout);
+  assert.equal(selected.cwd, canonicalCheckout);
   assert.equal(selected.launcher, canonicalInterpreter);
   assert.deepEqual(selected.args, ['-B', '-I', '-m', 'ae_mcp']);
   assert.equal(selected.interpreter.path, canonicalInterpreter);

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -13,6 +13,11 @@ import { createRuntimeManager } from '../src/cep/runtimeManager.js';
 const execFileAsync = promisify(execFile);
 // These fixtures execute POSIX launchers and intentionally model macOS path semantics.
 const macosRuntimeTest = process.platform === 'win32' ? test.skip : test;
+const DEVELOPMENT_CORE_BOOTSTRAP = [
+  'import runpy,sys',
+  'sys.path.insert(0,sys.argv[1])',
+  'runpy.run_module("ae_mcp",run_name="__main__")',
+].join(';');
 
 function sha256(bytes) {
   return crypto.createHash('sha256').update(bytes).digest('hex');
@@ -245,7 +250,13 @@ macosRuntimeTest('development checkout bypasses manifests, generations, pointers
   assert.equal(selected.checkoutPath, canonicalCheckout);
   assert.equal(selected.cwd, canonicalCheckout);
   assert.equal(selected.launcher, canonicalInterpreter);
-  assert.deepEqual(selected.args, ['-B', '-I', '-m', 'ae_mcp']);
+  assert.deepEqual(selected.args, [
+    '-B',
+    '-I',
+    '-c',
+    DEVELOPMENT_CORE_BOOTSTRAP,
+    path.join(canonicalCheckout, 'packages', 'core'),
+  ]);
   assert.equal(selected.interpreter.path, canonicalInterpreter);
   assert.equal(selected.interpreter.resolvedPath, canonicalInterpreter);
   assert.equal(selected.diagnostics[0].code, 'RUNTIME_DEVELOPMENT_RUNTIME_SELECTED');
@@ -261,7 +272,8 @@ macosRuntimeTest('development checkout bypasses manifests, generations, pointers
     { code: 'ENOENT' },
   );
   const launched = await execFileAsync(selected.launcher, selected.args);
-  assert.match(launched.stdout, /development-core:development:-B -I -m ae_mcp/);
+  assert.match(launched.stdout, /development-core:development:-B -I -c/);
+  assert.match(launched.stdout, /packages\/core/);
   const inspected = await manager.inspect();
   assert.equal(inspected.ok, true);
   assert.equal(inspected.developmentRuntime, true);

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -16,6 +16,7 @@ const macosRuntimeTest = process.platform === 'win32' ? test.skip : test;
 const DEVELOPMENT_CORE_BOOTSTRAP = [
   'import runpy,sys',
   'sys.path.insert(0,sys.argv[1])',
+  'sys.path.insert(0,sys.argv[2])',
   'runpy.run_module("ae_mcp",run_name="__main__")',
 ].join(';');
 
@@ -202,6 +203,7 @@ async function developmentCheckout(h, marker = 'development') {
   const checkout = path.join(h.root, 'source checkout');
   await writeFile(checkout, 'pyproject.toml', '[tool.uv]\n');
   await writeFile(checkout, 'packages/core/ae_mcp/__main__.py', 'def main(): pass\n');
+  await writeFile(checkout, 'packages/bridge/ae_mcp_bridge/__init__.py', '');
   const interpreter = await writeFile(
     checkout,
     '.venv/bin/python3',
@@ -256,6 +258,7 @@ macosRuntimeTest('development checkout bypasses manifests, generations, pointers
     '-c',
     DEVELOPMENT_CORE_BOOTSTRAP,
     path.join(canonicalCheckout, 'packages', 'core'),
+    path.join(canonicalCheckout, 'packages', 'bridge'),
   ]);
   assert.equal(selected.interpreter.path, canonicalInterpreter);
   assert.equal(selected.interpreter.resolvedPath, canonicalInterpreter);
@@ -274,6 +277,7 @@ macosRuntimeTest('development checkout bypasses manifests, generations, pointers
   const launched = await execFileAsync(selected.launcher, selected.args);
   assert.match(launched.stdout, /development-core:development:-B -I -c/);
   assert.match(launched.stdout, /packages\/core/);
+  assert.match(launched.stdout, /packages\/bridge/);
   const inspected = await manager.inspect();
   assert.equal(inspected.ok, true);
   assert.equal(inspected.developmentRuntime, true);

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -182,9 +182,141 @@ function managerFor(h, extensionRoot, options = {}) {
     extensionRoot,
     cryptoImpl: crypto,
     randomBytes: crypto.randomBytes,
+    environment: {},
     ...options,
   });
 }
+
+async function developmentExtension(h) {
+  const extensionRoot = path.join(h.root, 'AE MCP development extension');
+  await writeFile(extensionRoot, '.debug', '<ExtensionList />\n');
+  return extensionRoot;
+}
+
+async function developmentCheckout(h, marker = 'development') {
+  const checkout = path.join(h.root, 'source checkout');
+  await writeFile(checkout, 'pyproject.toml', '[tool.uv]\n');
+  await writeFile(checkout, 'packages/core/ae_mcp/__main__.py', 'def main(): pass\n');
+  const interpreter = await writeFile(
+    checkout,
+    '.venv/bin/python3',
+    `#!/bin/sh\nprintf 'development-core:${marker}:%s\\n' "$*"\n`,
+    0o755,
+  );
+  return { checkout, interpreter };
+}
+
+macosRuntimeTest('development checkout bypasses manifests, generations, pointers, and RuntimeManager lock', async (t) => {
+  const h = await harness(t);
+  const extensionRoot = await developmentExtension(h);
+  const checkout = await developmentCheckout(h);
+  const current = 'sentinel-current\n';
+  const previous = 'sentinel-previous\n';
+  await fs.promises.mkdir(h.platform.paths.runtimeRoot, { recursive: true });
+  await fs.promises.writeFile(h.platform.paths.currentPointer, current);
+  await fs.promises.writeFile(h.platform.paths.previousPointer, previous);
+  let lockOpenCalls = 0;
+  const trackedPromises = new Proxy(fs.promises, {
+    get(target, property) {
+      const value = Reflect.get(target, property);
+      if (property === 'open') {
+        return async function trackedOpen(targetPath, ...args) {
+          if (path.resolve(String(targetPath))
+              === path.join(h.platform.paths.runtimeRoot, '.runtime-manager.lock')) {
+            lockOpenCalls += 1;
+          }
+          return value.call(target, targetPath, ...args);
+        };
+      }
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  const manager = managerFor(h, extensionRoot, {
+    fsImpl: { ...fs, promises: trackedPromises },
+    environment: { AE_MCP_DEV_RUNTIME: checkout.checkout },
+  });
+
+  const selected = await manager.ensureReady();
+  const canonicalCheckout = await fs.promises.realpath(checkout.checkout);
+  const canonicalInterpreter = path.join(canonicalCheckout, '.venv', 'bin', 'python3');
+
+  assert.equal(selected.action, 'development-runtime');
+  assert.equal(selected.developmentRuntime, true);
+  assert.equal(selected.checkoutPath, canonicalCheckout);
+  assert.equal(selected.launcher, canonicalInterpreter);
+  assert.deepEqual(selected.args, ['-B', '-I', '-m', 'ae_mcp']);
+  assert.equal(selected.interpreter.path, canonicalInterpreter);
+  assert.equal(selected.interpreter.resolvedPath, canonicalInterpreter);
+  assert.equal(selected.diagnostics[0].code, 'RUNTIME_DEVELOPMENT_RUNTIME_SELECTED');
+  assert.equal(lockOpenCalls, 0);
+  assert.equal(await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8'), current);
+  assert.equal(await fs.promises.readFile(h.platform.paths.previousPointer, 'utf8'), previous);
+  await assert.rejects(
+    fs.promises.lstat(path.join(h.platform.paths.runtimeRoot, 'generations')),
+    { code: 'ENOENT' },
+  );
+  await assert.rejects(
+    fs.promises.lstat(path.join(h.platform.paths.runtimeRoot, '.runtime-manager.lock')),
+    { code: 'ENOENT' },
+  );
+  const launched = await execFileAsync(selected.launcher, selected.args);
+  assert.match(launched.stdout, /development-core:development:-B -I -m ae_mcp/);
+  const inspected = await manager.inspect();
+  assert.equal(inspected.ok, true);
+  assert.equal(inspected.developmentRuntime, true);
+  assert.equal(inspected.checkoutPath, canonicalCheckout);
+});
+
+macosRuntimeTest('unset development runtime keeps the packaged RuntimeManager path unchanged', async (t) => {
+  const h = await harness(t);
+  const payload = await packageFixture(h.root, {
+    version: '0.9.3', sourceCommitSha: '1'.repeat(40), marker: 'production',
+  });
+  const manager = managerFor(h, payload.extensionRoot, { environment: {} });
+
+  const selected = await manager.ensureReady();
+
+  assert.equal(selected.action, 'install');
+  assert.equal(selected.developmentRuntime, undefined);
+  assert.equal(selected.launcher, h.platform.paths.launcher);
+  assert.match(await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8'), /^generations\/g-/);
+});
+
+macosRuntimeTest('a packaged release build refuses AE_MCP_DEV_RUNTIME without falling back', async (t) => {
+  const h = await harness(t);
+  const payload = await packageFixture(h.root, {
+    version: '0.9.3', sourceCommitSha: '1'.repeat(40), marker: 'release',
+  });
+  const checkout = await developmentCheckout(h, 'release');
+  const manager = managerFor(h, payload.extensionRoot, {
+    environment: { AE_MCP_DEV_RUNTIME: checkout.checkout },
+  });
+
+  await assert.rejects(
+    manager.ensureReady(),
+    (error) => error?.code === 'RUNTIME_DEVELOPMENT_RUNTIME_RELEASE_REFUSED',
+  );
+  await assert.rejects(fs.promises.lstat(h.platform.paths.runtimeRoot), { code: 'ENOENT' });
+});
+
+macosRuntimeTest('an invalid development checkout fails closed with a structured code', async (t) => {
+  const h = await harness(t);
+  const extensionRoot = await developmentExtension(h);
+  const missingCheckout = path.join(h.root, 'missing checkout');
+  const manager = managerFor(h, extensionRoot, {
+    environment: { AE_MCP_DEV_RUNTIME: missingCheckout },
+  });
+
+  await assert.rejects(
+    manager.ensureReady(),
+    (error) => error?.code === 'RUNTIME_DEVELOPMENT_RUNTIME_INVALID'
+      && /usable source checkout/i.test(error.message),
+  );
+  const inspected = await manager.inspect();
+  assert.equal(inspected.ok, false);
+  assert.equal(inspected.code, 'RUNTIME_DEVELOPMENT_RUNTIME_INVALID');
+  await assert.rejects(fs.promises.lstat(h.platform.paths.runtimeRoot), { code: 'ENOENT' });
+});
 
 async function seedLegacyGeneration(h, payload) {
   const generation = `${payload.version}-${payload.sourceCommitSha}`;

--- a/scripts/dev/ae-mcp-dev.mjs
+++ b/scripts/dev/ae-mcp-dev.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  buildDevelopmentPlan,
+  parseDevelopmentCommand,
+} from './profile-contract.mjs';
+import {
+  createDefaultMacosDependencies,
+  executeDevelopmentPlan,
+  inspectDevelopmentEnvironment,
+  launchDevelopmentAe,
+} from './macos-development.mjs';
+
+function defaultCommandValues() {
+  return Object.freeze({
+    repoRoot: process.cwd(),
+    home: os.homedir(),
+    formalAeApp: '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+  });
+}
+
+function publicRecovery(error) {
+  const recovery = error?.recovery;
+  if (!Array.isArray(recovery)) return undefined;
+  return recovery.map((item) => ({
+    id: item.id,
+    code: item.code,
+  }));
+}
+
+function failed(error) {
+  const code = typeof error?.code === 'string' ? error.code : 'DEV_COMMAND_FAILED';
+  return Object.freeze({
+    exitCode: code === 'DEV_ARGUMENT_INVALID' ? 2 : 1,
+    output: Object.freeze({
+      ok: false,
+      error: Object.freeze({
+        code,
+        message: String(error?.message || 'development command failed'),
+        ...(publicRecovery(error) ? { recovery: publicRecovery(error) } : {}),
+      }),
+    }),
+  });
+}
+
+function planPaths(command, report, dependencies, nativeOutput) {
+  const commands = dependencies.commands || {};
+  return Object.freeze({
+    repoRoot: command.repoRoot,
+    uv: commands.uv || 'uv',
+    npm: commands.npm || 'npm',
+    node: commands.node || process.execPath,
+    python: report.interpreterPath,
+    hostRoot: path.join(command.repoRoot, 'plugin', 'host'),
+    sidecarRoot: path.join(command.repoRoot, 'plugin', 'sidecar'),
+    panelRoot: path.join(command.repoRoot, 'plugin', 'panel'),
+    cepInstaller: path.join(command.repoRoot, 'scripts', 'install-plugin-dev-macos.sh'),
+    nativeBuilder: path.join(command.repoRoot, 'native', 'ae-plugin', 'build-macos.mjs'),
+    nativeInstaller: path.join(
+      command.repoRoot,
+      'native',
+      'ae-plugin',
+      'install-dev-macos.mjs',
+    ),
+    nativeOutput,
+    sdkArchive: command.sdkArchive
+      || dependencies.environment?.AE_MCP_SDK_ARCHIVE,
+    sdkRoot: command.sdkRoot || dependencies.environment?.AE_MCP_SDK_ROOT,
+    developmentSmoke: path.join(
+      command.repoRoot,
+      'scripts',
+      'hardware',
+      'development_smoke.py',
+    ),
+  });
+}
+
+function executionResult(plan, receipt) {
+  return Object.freeze({
+    selected: [...plan.components],
+    reused: [...plan.reused],
+    restart: plan.actions
+      .filter((item) => item.action === 'restart-mcp-session')
+      .map(() => 'mcp-session'),
+    steps: [...receipt.steps],
+    dependencyBootstrapInvocations: receipt.dependencyBootstrapInvocations,
+    releasePackagingInvocations: receipt.releasePackagingInvocations,
+  });
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  dependencies = createDefaultMacosDependencies(),
+) {
+  try {
+    const defaults = dependencies.defaults || defaultCommandValues();
+    const command = parseDevelopmentCommand(argv, defaults);
+    const environment = {
+      ...(dependencies.environment || process.env),
+      ...(command.sdkArchive ? { AE_MCP_SDK_ARCHIVE: command.sdkArchive } : {}),
+      ...(command.sdkRoot ? { AE_MCP_SDK_ROOT: command.sdkRoot } : {}),
+    };
+    const inspect = dependencies.inspectDevelopmentEnvironment
+      || inspectDevelopmentEnvironment;
+    const report = await inspect({
+      repoRoot: command.repoRoot,
+      home: command.home,
+      formalAeApp: command.formalAeApp,
+      components: command.components,
+      environment,
+      dependencies,
+    });
+    if (!report.ok && command.action !== 'bootstrap') {
+      const error = Object.assign(
+        new Error('development doctor reported blockers'),
+        {
+          code: 'DEV_DOCTOR_BLOCKED',
+          recovery: report.blockers,
+        },
+      );
+      throw error;
+    }
+
+    if (command.action === 'doctor') {
+      return Object.freeze({
+        exitCode: 0,
+        output: Object.freeze({ ok: true, result: report }),
+      });
+    }
+    if (command.action === 'launch-ae') {
+      const launch = dependencies.launchDevelopmentAe || launchDevelopmentAe;
+      const result = await launch(report, {
+        processInspector: dependencies.processInspector,
+        spawn: dependencies.spawn,
+        environment,
+        now: dependencies.now,
+      });
+      return Object.freeze({
+        exitCode: 0,
+        output: Object.freeze({ ok: true, result }),
+      });
+    }
+
+    let nativeOutput;
+    if (command.components.includes('native')) {
+      const mkdtemp = dependencies.mkdtemp || fs.promises.mkdtemp.bind(fs.promises);
+      const buildRoot = await mkdtemp('/private/tmp/ae-mcp-native-dev-');
+      nativeOutput = path.join(buildRoot, 'artifact');
+    }
+    const plan = buildDevelopmentPlan(
+      command,
+      planPaths(command, report, dependencies, nativeOutput),
+    );
+    const execute = dependencies.executeDevelopmentPlan || executeDevelopmentPlan;
+    const receipt = await execute(plan, {
+      execFile: dependencies.execFile,
+      environment,
+    });
+    return Object.freeze({
+      exitCode: 0,
+      output: Object.freeze({
+        ok: true,
+        result: executionResult(plan, receipt),
+      }),
+    });
+  } catch (error) {
+    return failed(error);
+  }
+}
+
+function cliEntry() {
+  main().then((result) => {
+    const stream = result.output.ok ? process.stdout : process.stderr;
+    stream.write(`${JSON.stringify(result.output)}\n`);
+    process.exitCode = result.exitCode;
+  }).catch((error) => {
+    process.stderr.write(`${JSON.stringify(failed(error).output)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  cliEntry();
+}

--- a/scripts/dev/ae-mcp-dev.mjs
+++ b/scripts/dev/ae-mcp-dev.mjs
@@ -170,6 +170,7 @@ export async function main(
     const execute = dependencies.executeDevelopmentPlan || executeDevelopmentPlan;
     const receipt = await execute(plan, {
       execFile: dependencies.execFile,
+      runInteractive: dependencies.runInteractive,
       environment,
     });
     if (command.action === 'sync' && command.components.includes('cep')) {

--- a/scripts/dev/ae-mcp-dev.mjs
+++ b/scripts/dev/ae-mcp-dev.mjs
@@ -93,6 +93,16 @@ function executionResult(plan, receipt) {
   });
 }
 
+function replaceableCepInstallState(command, report) {
+  if (command.action !== 'sync' || !command.components.includes('cep')) return false;
+  const allowed = new Set([
+    'DEV_CEP_MARKER_MISSING',
+    'DEV_CEP_RELEASE_MANIFEST_PRESENT',
+  ]);
+  return report.blockers.length > 0
+    && report.blockers.every((item) => allowed.has(item.code));
+}
+
 export async function main(
   argv = process.argv.slice(2),
   dependencies = createDefaultMacosDependencies(),
@@ -115,7 +125,8 @@ export async function main(
       environment,
       dependencies,
     });
-    if (!report.ok && command.action !== 'bootstrap') {
+    const replacingCepInstall = replaceableCepInstallState(command, report);
+    if (!report.ok && command.action !== 'bootstrap' && !replacingCepInstall) {
       const error = Object.assign(
         new Error('development doctor reported blockers'),
         {
@@ -161,6 +172,25 @@ export async function main(
       execFile: dependencies.execFile,
       environment,
     });
+    if (command.action === 'sync' && command.components.includes('cep')) {
+      const postSyncReport = await inspect({
+        repoRoot: command.repoRoot,
+        home: command.home,
+        formalAeApp: command.formalAeApp,
+        components: command.components,
+        environment,
+        dependencies,
+      });
+      if (!postSyncReport.ok) {
+        throw Object.assign(
+          new Error('development CEP sync did not pass post-install doctor'),
+          {
+            code: 'DEV_POST_SYNC_DOCTOR_BLOCKED',
+            recovery: postSyncReport.blockers,
+          },
+        );
+      }
+    }
     return Object.freeze({
       exitCode: 0,
       output: Object.freeze({

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -34,14 +34,19 @@ function inside(candidate, root) {
 async function ordinaryPath(dependencies, target, {
   directory = false,
   executable = false,
+  allowSymlink = false,
 } = {}) {
-  const info = await dependencies.fs.lstat(target);
-  if (info.isSymbolicLink()) throw new Error('symbolic path refused');
+  const linkInfo = await dependencies.fs.lstat(target);
+  if (linkInfo.isSymbolicLink() && !allowSymlink) throw new Error('symbolic path refused');
+  const resolved = await dependencies.realpath(target);
+  const info = linkInfo.isSymbolicLink()
+    ? await dependencies.fs.stat(resolved)
+    : linkInfo;
   if (directory ? !info.isDirectory() : !info.isFile()) {
     throw new Error(directory ? 'not a directory' : 'not a file');
   }
   if (executable && (info.mode & 0o111) === 0) throw new Error('not executable');
-  return dependencies.realpath(target);
+  return resolved;
 }
 
 async function inspectPath(checks, dependencies, {
@@ -50,6 +55,7 @@ async function inspectPath(checks, dependencies, {
   code,
   directory = false,
   executable = false,
+  allowSymlink = false,
   absent = false,
 }) {
   if (absent) {
@@ -66,7 +72,11 @@ async function inspectPath(checks, dependencies, {
     return target;
   }
   try {
-    const resolved = await ordinaryPath(dependencies, target, { directory, executable });
+    const resolved = await ordinaryPath(
+      dependencies,
+      target,
+      { directory, executable, allowSymlink },
+    );
     checks.push(frozenCheck(id, true, resolved));
     return resolved;
   } catch {
@@ -126,6 +136,7 @@ async function inspectRequiredPaths({
     target: interpreterCandidate,
     code: 'DEV_CORE_INTERPRETER_MISSING',
     executable: true,
+    allowSymlink: true,
   });
   const interpreterCheck = checks.at(-1);
   if (interpreterCheck.ok) {

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -1,0 +1,451 @@
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  DAILY_ACTIONS,
+  developmentError,
+} from './profile-contract.mjs';
+
+const execFileAsync = promisify(childProcess.execFile);
+const CORE_IMPORT_PROBE = [
+  'import pathlib,sys',
+  'sys.path.insert(0,sys.argv[1])',
+  'import ae_mcp',
+  'print(pathlib.Path(ae_mcp.__file__).resolve())',
+].join(';');
+
+function frozenCheck(id, ok, pathValue, code, details = {}) {
+  return Object.freeze({
+    id,
+    ok,
+    path: pathValue,
+    ...(ok ? {} : { code }),
+    ...details,
+  });
+}
+
+function inside(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function ordinaryPath(dependencies, target, {
+  directory = false,
+  executable = false,
+} = {}) {
+  const info = await dependencies.fs.lstat(target);
+  if (info.isSymbolicLink()) throw new Error('symbolic path refused');
+  if (directory ? !info.isDirectory() : !info.isFile()) {
+    throw new Error(directory ? 'not a directory' : 'not a file');
+  }
+  if (executable && (info.mode & 0o111) === 0) throw new Error('not executable');
+  return dependencies.realpath(target);
+}
+
+async function inspectPath(checks, dependencies, {
+  id,
+  target,
+  code,
+  directory = false,
+  executable = false,
+  absent = false,
+}) {
+  if (absent) {
+    try {
+      await dependencies.fs.lstat(target);
+      checks.push(frozenCheck(id, false, target, code));
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        checks.push(frozenCheck(id, true, target));
+      } else {
+        checks.push(frozenCheck(id, false, target, code));
+      }
+    }
+    return target;
+  }
+  try {
+    const resolved = await ordinaryPath(dependencies, target, { directory, executable });
+    checks.push(frozenCheck(id, true, resolved));
+    return resolved;
+  } catch {
+    checks.push(frozenCheck(id, false, target, code));
+    return target;
+  }
+}
+
+async function plistValue(dependencies, infoPlist, key) {
+  const result = await dependencies.execFile(
+    '/usr/bin/plutil',
+    ['-extract', key, 'raw', infoPlist],
+    { shell: false, encoding: 'utf8' },
+  );
+  const value = String(result.stdout || '').trim();
+  if (!value || value.includes('/') || value.includes('\0')) {
+    throw new Error(`invalid ${key}`);
+  }
+  return value;
+}
+
+async function inspectRequiredPaths({
+  checkoutPath,
+  home,
+  formalAeApp,
+  components,
+  environment,
+  dependencies,
+}) {
+  const checks = [];
+  const manifest = path.join(checkoutPath, 'pyproject.toml');
+  let checkoutOk = false;
+  try {
+    await ordinaryPath(dependencies, checkoutPath, { directory: true });
+    await ordinaryPath(dependencies, manifest);
+    checkoutOk = true;
+  } catch {
+    // The closed check below carries the only public diagnostic for this boundary.
+  }
+  checks.push(frozenCheck(
+    'checkout',
+    checkoutOk,
+    checkoutPath,
+    'DEV_CHECKOUT_INVALID',
+  ));
+
+  const coreRoot = path.join(checkoutPath, 'packages', 'core');
+  const coreEntrypoint = path.join(coreRoot, 'ae_mcp', '__main__.py');
+  await inspectPath(checks, dependencies, {
+    id: 'core-entrypoint',
+    target: coreEntrypoint,
+    code: 'DEV_CORE_ENTRYPOINT_MISSING',
+  });
+  const interpreterCandidate = path.join(checkoutPath, '.venv', 'bin', 'python3');
+  const interpreterPath = await inspectPath(checks, dependencies, {
+    id: 'core-interpreter',
+    target: interpreterCandidate,
+    code: 'DEV_CORE_INTERPRETER_MISSING',
+    executable: true,
+  });
+  const interpreterCheck = checks.at(-1);
+  if (interpreterCheck.ok) {
+    try {
+      const result = await dependencies.execFile(
+        interpreterPath,
+        ['-B', '-I', '-c', CORE_IMPORT_PROBE, coreRoot],
+        {
+          cwd: checkoutPath,
+          env: environment,
+          shell: false,
+          encoding: 'utf8',
+        },
+      );
+      const importedPath = String(result.stdout || '').trim();
+      const canonicalImported = await dependencies.realpath(importedPath);
+      if (!inside(canonicalImported, coreRoot)) throw new Error('import escaped checkout');
+      checks.push(frozenCheck(
+        'core-import',
+        true,
+        canonicalImported,
+        undefined,
+        { interpreterPath },
+      ));
+    } catch {
+      checks.push(frozenCheck(
+        'core-import',
+        false,
+        coreRoot,
+        'DEV_CORE_IMPORT_FAILED',
+        { interpreterPath },
+      ));
+    }
+  } else {
+    checks.push(frozenCheck(
+      'core-import',
+      true,
+      coreRoot,
+      undefined,
+      { skipped: true, reason: 'core-interpreter unavailable' },
+    ));
+  }
+
+  const cepRootCandidate = path.join(
+    home,
+    'Library',
+    'Application Support',
+    'Adobe',
+    'CEP',
+    'extensions',
+    'com.aemcp.panel',
+  );
+  let cepRoot = cepRootCandidate;
+  try {
+    cepRoot = await dependencies.realpath(cepRootCandidate);
+  } catch {
+    // The marker check below reports an absent install without creating it.
+  }
+  await inspectPath(checks, dependencies, {
+    id: 'cep-development-marker',
+    target: path.join(cepRoot, '.debug'),
+    code: 'DEV_CEP_MARKER_MISSING',
+  });
+  await inspectPath(checks, dependencies, {
+    id: 'cep-release-manifest-absent',
+    target: path.join(cepRoot, 'bundle-manifest.json'),
+    code: 'DEV_CEP_RELEASE_MANIFEST_PRESENT',
+    absent: true,
+  });
+
+  let canonicalApp = formalAeApp;
+  let appOk = false;
+  try {
+    canonicalApp = await ordinaryPath(dependencies, formalAeApp, { directory: true });
+    appOk = true;
+  } catch {
+    // Reported in the formal app check.
+  }
+  checks.push(frozenCheck(
+    'formal-ae-app',
+    appOk,
+    canonicalApp,
+    'DEV_FORMAL_AE_APP_INVALID',
+  ));
+
+  let formalAeExecutable = path.join(canonicalApp, 'Contents', 'MacOS', 'After Effects');
+  if (appOk) {
+    const infoPlist = path.join(canonicalApp, 'Contents', 'Info.plist');
+    try {
+      await ordinaryPath(dependencies, infoPlist);
+      const [executableName, productVersion, buildVersion] = await Promise.all([
+        plistValue(dependencies, infoPlist, 'CFBundleExecutable'),
+        plistValue(dependencies, infoPlist, 'CFBundleShortVersionString'),
+        plistValue(dependencies, infoPlist, 'CFBundleVersion'),
+      ]);
+      formalAeExecutable = path.join(canonicalApp, 'Contents', 'MacOS', executableName);
+      const canonicalExecutable = await ordinaryPath(
+        dependencies,
+        formalAeExecutable,
+        { executable: true },
+      );
+      if (!inside(canonicalExecutable, canonicalApp)) throw new Error('executable escaped app');
+      formalAeExecutable = canonicalExecutable;
+      checks.push(frozenCheck(
+        'formal-ae-executable',
+        true,
+        canonicalExecutable,
+        undefined,
+        { productVersion, buildVersion },
+      ));
+    } catch {
+      checks.push(frozenCheck(
+        'formal-ae-executable',
+        false,
+        formalAeExecutable,
+        'DEV_FORMAL_AE_EXECUTABLE_INVALID',
+      ));
+    }
+  } else {
+    checks.push(frozenCheck(
+      'formal-ae-executable',
+      true,
+      formalAeExecutable,
+      undefined,
+      { skipped: true, reason: 'formal AE app unavailable' },
+    ));
+  }
+
+  if (components.includes('cep')) {
+    for (const packageName of ['host', 'sidecar', 'panel']) {
+      await inspectPath(checks, dependencies, {
+        id: `cep-${packageName}-dependencies`,
+        target: path.join(checkoutPath, 'plugin', packageName, 'node_modules'),
+        code: 'DEV_CEP_DEPENDENCIES_MISSING',
+        directory: true,
+      });
+    }
+  }
+  if (components.includes('native')) {
+    await inspectPath(checks, dependencies, {
+      id: 'native-sdk-archive',
+      target: environment.AE_MCP_SDK_ARCHIVE || '',
+      code: 'DEV_NATIVE_SDK_ARCHIVE_MISSING',
+    });
+    await inspectPath(checks, dependencies, {
+      id: 'native-sdk-root',
+      target: environment.AE_MCP_SDK_ROOT || '',
+      code: 'DEV_NATIVE_SDK_ROOT_MISSING',
+      directory: true,
+    });
+  }
+
+  return checks;
+}
+
+export function createDefaultMacosDependencies() {
+  const execFile = (file, args, options = {}) => execFileAsync(file, args, options);
+  return Object.freeze({
+    fs: fs.promises,
+    realpath: fs.promises.realpath.bind(fs.promises),
+    execFile,
+    spawn: childProcess.spawn,
+    processInspector: Object.freeze({
+      async afterEffectsRunning() {
+        try {
+          await execFile('/usr/bin/pgrep', ['-f', 'Adobe After Effects|AfterFX'], {
+            shell: false,
+            encoding: 'utf8',
+          });
+          return true;
+        } catch (error) {
+          if (error?.code === 1) return false;
+          throw developmentError(
+            'DEV_AE_PROCESS_INSPECTION_FAILED',
+            'could not determine whether formal After Effects is running',
+          );
+        }
+      },
+    }),
+  });
+}
+
+export async function inspectDevelopmentEnvironment({
+  repoRoot,
+  home,
+  formalAeApp,
+  components = ['core'],
+  environment = process.env,
+  dependencies = createDefaultMacosDependencies(),
+}) {
+  const merged = {
+    ...createDefaultMacosDependencies(),
+    ...dependencies,
+    fs: dependencies.fs || fs.promises,
+    realpath: dependencies.realpath || fs.promises.realpath.bind(fs.promises),
+  };
+  let checkoutPath = repoRoot;
+  try {
+    checkoutPath = await merged.realpath(repoRoot);
+  } catch {
+    // The closed checkout check reports the invalid root.
+  }
+  const checks = await inspectRequiredPaths({
+    checkoutPath,
+    home,
+    formalAeApp,
+    components,
+    environment,
+    dependencies: merged,
+  });
+  const blockers = checks.filter((check) => check.ok === false);
+  return Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    ok: blockers.length === 0,
+    checkoutPath,
+    interpreterPath: checks.find((check) => check.id === 'core-interpreter').path,
+    formalAeApp: checks.find((check) => check.id === 'formal-ae-app').path,
+    formalAeExecutable: checks.find((check) => check.id === 'formal-ae-executable').path,
+    checks: Object.freeze(checks),
+    blockers: Object.freeze(blockers),
+  });
+}
+
+export async function launchDevelopmentAe(report, {
+  processInspector,
+  spawn,
+  environment = process.env,
+  now = () => new Date(),
+}) {
+  if (!report?.ok || report.profile !== 'development') {
+    throw developmentError(
+      'DEV_DOCTOR_BLOCKED',
+      'development environment must pass doctor before launch',
+    );
+  }
+  if (await processInspector.afterEffectsRunning()) {
+    throw developmentError(
+      'DEV_AE_ALREADY_RUNNING',
+      'formal After Effects is already running',
+    );
+  }
+  const child = spawn(report.formalAeExecutable, [], {
+    cwd: path.dirname(report.formalAeExecutable),
+    detached: true,
+    stdio: 'ignore',
+    shell: false,
+    env: { ...environment, AE_MCP_DEV_RUNTIME: report.checkoutPath },
+  });
+  child.unref();
+  return Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    pid: child.pid,
+    formalAeExecutable: report.formalAeExecutable,
+    checkoutPath: report.checkoutPath,
+    launchedAt: now().toISOString(),
+  });
+}
+
+export async function executeDevelopmentPlan(plan, {
+  execFile = createDefaultMacosDependencies().execFile,
+  environment = process.env,
+} = {}) {
+  if (DAILY_ACTIONS.includes(plan.action)
+      && (plan.dependencyBootstrapInvocations !== 0
+        || plan.steps.some((step) => step.kind === 'dependency-install'))) {
+    throw developmentError(
+      'DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN',
+      `${plan.action} may not install dependencies`,
+    );
+  }
+  if (DAILY_ACTIONS.includes(plan.action)
+      && (plan.releasePackagingInvocations !== 0
+        || plan.steps.some((step) => step.kind === 'release-package'))) {
+    throw developmentError(
+      'DEV_RELEASE_PACKAGING_FORBIDDEN',
+      `${plan.action} may not create release packages`,
+    );
+  }
+
+  const stepReceipts = [];
+  for (const step of plan.steps) {
+    try {
+      await execFile(step.executable, step.args, {
+        cwd: step.cwd,
+        env: environment,
+        shell: false,
+        encoding: 'utf8',
+      });
+      stepReceipts.push(Object.freeze({
+        id: step.id,
+        component: step.component,
+        kind: step.kind,
+        exitCode: 0,
+      }));
+    } catch (error) {
+      throw developmentError(
+        'DEV_STEP_FAILED',
+        `development step ${step.id} failed`,
+        {
+          stepId: step.id,
+          privateReceipt: {
+            executable: step.executable,
+            args: [...step.args],
+            cwd: step.cwd,
+            cause: String(error?.message || error),
+          },
+        },
+      );
+    }
+  }
+  return Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    action: plan.action,
+    components: [...plan.components],
+    steps: Object.freeze(stepReceipts),
+    actions: Object.freeze([...(plan.actions || [])]),
+    dependencyBootstrapInvocations: plan.dependencyBootstrapInvocations,
+    releasePackagingInvocations: plan.releasePackagingInvocations,
+  });
+}

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -12,8 +12,10 @@ const execFileAsync = promisify(childProcess.execFile);
 const CORE_IMPORT_PROBE = [
   'import pathlib,sys',
   'sys.path.insert(0,sys.argv[1])',
-  'import ae_mcp',
+  'sys.path.insert(0,sys.argv[2])',
+  'import ae_mcp,ae_mcp_bridge',
   'print(pathlib.Path(ae_mcp.__file__).resolve())',
+  'print(pathlib.Path(ae_mcp_bridge.__file__).resolve())',
 ].join(';');
 
 function frozenCheck(id, ok, pathValue, code, details = {}) {
@@ -132,6 +134,7 @@ async function inspectRequiredPaths({
   ));
 
   const coreRoot = path.join(checkoutPath, 'packages', 'core');
+  const bridgeRoot = path.join(checkoutPath, 'packages', 'bridge');
   const coreEntrypoint = path.join(coreRoot, 'ae_mcp', '__main__.py');
   await inspectPath(checks, dependencies, {
     id: 'core-entrypoint',
@@ -152,7 +155,7 @@ async function inspectRequiredPaths({
     try {
       const result = await dependencies.execFile(
         interpreterPath,
-        ['-B', '-I', '-c', CORE_IMPORT_PROBE, coreRoot],
+        ['-B', '-I', '-c', CORE_IMPORT_PROBE, coreRoot, bridgeRoot],
         {
           cwd: checkoutPath,
           env: environment,
@@ -160,15 +163,20 @@ async function inspectRequiredPaths({
           encoding: 'utf8',
         },
       );
-      const importedPath = String(result.stdout || '').trim();
-      const canonicalImported = await dependencies.realpath(importedPath);
-      if (!inside(canonicalImported, coreRoot)) throw new Error('import escaped checkout');
+      const importedPaths = String(result.stdout || '').trim().split(/\r?\n/);
+      if (importedPaths.length !== 2) throw new Error('import probe was incomplete');
+      const canonicalImported = await dependencies.realpath(importedPaths[0]);
+      const canonicalBridge = await dependencies.realpath(importedPaths[1]);
+      if (!inside(canonicalImported, coreRoot)
+          || !inside(canonicalBridge, bridgeRoot)) {
+        throw new Error('import escaped checkout');
+      }
       checks.push(frozenCheck(
         'core-import',
         true,
         canonicalImported,
         undefined,
-        { interpreterPath },
+        { interpreterPath, bridgePath: canonicalBridge },
       ));
     } catch {
       checks.push(frozenCheck(

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -294,10 +294,28 @@ async function inspectRequiredPaths({
 
 export function createDefaultMacosDependencies() {
   const execFile = (file, args, options = {}) => execFileAsync(file, args, options);
+  const runInteractive = (file, args, options = {}) => new Promise(
+    (resolve, reject) => {
+      const child = childProcess.spawn(file, args, {
+        ...options,
+        stdio: 'inherit',
+      });
+      child.once('error', reject);
+      child.once('exit', (code, signal) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+        const detail = signal ? `signal ${signal}` : `exit ${code}`;
+        reject(new Error(`interactive process failed with ${detail}`));
+      });
+    },
+  );
   return Object.freeze({
     fs: fs.promises,
     realpath: fs.promises.realpath.bind(fs.promises),
     execFile,
+    runInteractive,
     spawn: childProcess.spawn,
     processInspector: Object.freeze({
       async afterEffectsRunning() {
@@ -399,6 +417,7 @@ export async function launchDevelopmentAe(report, {
 
 export async function executeDevelopmentPlan(plan, {
   execFile = createDefaultMacosDependencies().execFile,
+  runInteractive = createDefaultMacosDependencies().runInteractive,
   environment = process.env,
 } = {}) {
   if (DAILY_ACTIONS.includes(plan.action)
@@ -421,7 +440,10 @@ export async function executeDevelopmentPlan(plan, {
   const stepReceipts = [];
   for (const step of plan.steps) {
     try {
-      await execFile(step.executable, step.args, {
+      const executeStep = step.kind === 'public-smoke'
+        ? runInteractive
+        : execFile;
+      await executeStep(step.executable, step.args, {
         cwd: step.cwd,
         env: environment,
         shell: false,

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -56,6 +56,7 @@ async function inspectPath(checks, dependencies, {
   directory = false,
   executable = false,
   allowSymlink = false,
+  preservePath = false,
   absent = false,
 }) {
   if (absent) {
@@ -77,8 +78,15 @@ async function inspectPath(checks, dependencies, {
       target,
       { directory, executable, allowSymlink },
     );
-    checks.push(frozenCheck(id, true, resolved));
-    return resolved;
+    const reported = preservePath ? target : resolved;
+    checks.push(frozenCheck(
+      id,
+      true,
+      reported,
+      undefined,
+      preservePath ? { resolvedPath: resolved } : {},
+    ));
+    return reported;
   } catch {
     checks.push(frozenCheck(id, false, target, code));
     return target;
@@ -137,6 +145,7 @@ async function inspectRequiredPaths({
     code: 'DEV_CORE_INTERPRETER_MISSING',
     executable: true,
     allowSymlink: true,
+    preservePath: true,
   });
   const interpreterCheck = checks.at(-1);
   if (interpreterCheck.ok) {

--- a/scripts/dev/profile-contract.mjs
+++ b/scripts/dev/profile-contract.mjs
@@ -1,0 +1,258 @@
+import path from 'node:path';
+
+export const COMPONENTS = Object.freeze(['core', 'cep', 'native']);
+export const DAILY_ACTIONS = Object.freeze(['doctor', 'launch-ae', 'sync', 'smoke']);
+
+const ACTIONS = new Set(['bootstrap', ...DAILY_ACTIONS]);
+const PATH_OPTIONS = new Map([
+  ['--repo-root', 'repoRoot'],
+  ['--home', 'home'],
+  ['--formal-ae-app', 'formalAeApp'],
+  ['--sdk-archive', 'sdkArchive'],
+  ['--sdk-root', 'sdkRoot'],
+  ['--fixture-path', 'fixturePath'],
+  ['--recovery-archive-root', 'recoveryRoot'],
+  ['--evidence-dir', 'evidenceDir'],
+]);
+const PATH_MEMBERS = new Set(PATH_OPTIONS.values());
+const STRING_OPTIONS = new Map([
+  ['--scenario', 'scenario'],
+  ['--plugin-url', 'pluginUrl'],
+]);
+
+export function developmentError(code, message, details = {}) {
+  return Object.assign(new Error(message), { code, ...details });
+}
+
+function invalid(message) {
+  throw developmentError('DEV_ARGUMENT_INVALID', message);
+}
+
+function requireAbsolute(value, name) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    invalid(`${name} must be absolute`);
+  }
+  return path.normalize(value);
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    invalid(`${name} must be a nonempty string`);
+  }
+  return value;
+}
+
+function normalizedComponents(values, action) {
+  if (values.length === 0) {
+    if (action === 'doctor' || action === 'launch-ae') return ['core'];
+    invalid(`${action} requires --component`);
+  }
+  if (new Set(values).size !== values.length) invalid('--component values must be unique');
+  if (values.includes('all')) {
+    if (values.length !== 1) invalid('all cannot be combined with another component');
+    return [...COMPONENTS];
+  }
+  if (values.some((value) => !COMPONENTS.includes(value))) {
+    invalid('--component must be core, cep, native, or all');
+  }
+  return [...values];
+}
+
+export function parseDevelopmentCommand(argv, defaults) {
+  if (!Array.isArray(argv) || !ACTIONS.has(argv[0])) invalid('unknown development action');
+  const action = argv[0];
+  const optionValues = new Map();
+  const components = [];
+
+  for (let index = 1; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (typeof name !== 'string' || !name.startsWith('--') || value === undefined) {
+      invalid('options require name/value pairs');
+    }
+    if (name === '--component') {
+      components.push(requiredString(value, name));
+      continue;
+    }
+    const member = PATH_OPTIONS.get(name) ?? STRING_OPTIONS.get(name);
+    if (!member) invalid(`unsupported option ${name}`);
+    if (optionValues.has(member)) invalid(`${name} may be supplied only once`);
+    optionValues.set(member, value);
+  }
+
+  const result = {
+    action,
+    components: Object.freeze(normalizedComponents(components, action)),
+    repoRoot: requireAbsolute(optionValues.get('repoRoot') ?? defaults?.repoRoot, '--repo-root'),
+    home: requireAbsolute(optionValues.get('home') ?? defaults?.home, '--home'),
+    formalAeApp: requireAbsolute(
+      optionValues.get('formalAeApp') ?? defaults?.formalAeApp,
+      '--formal-ae-app',
+    ),
+  };
+  for (const [member, value] of optionValues) {
+    if (member in result) continue;
+    result[member] = PATH_MEMBERS.has(member)
+      ? requireAbsolute(value, member)
+      : requiredString(value, member);
+  }
+  if (action === 'smoke') {
+    for (const member of ['scenario', 'fixturePath', 'recoveryRoot', 'evidenceDir']) {
+      if (!(member in result)) invalid(`smoke requires ${member}`);
+    }
+  }
+  return Object.freeze(result);
+}
+
+function processStep(id, component, kind, executable, args, cwd) {
+  return Object.freeze({
+    id,
+    component,
+    kind,
+    executable,
+    args: Object.freeze([...args]),
+    cwd,
+  });
+}
+
+export function assertDailyPlanSafe(plan) {
+  if (!DAILY_ACTIONS.includes(plan.action)) return plan;
+  const forbidden = plan.steps.find(
+    (step) => step.kind === 'dependency-install' || step.kind === 'release-package',
+  );
+  if (forbidden) {
+    throw developmentError(
+      'DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN',
+      `${plan.action} may not execute ${forbidden.id}`,
+    );
+  }
+  return plan;
+}
+
+function cepSteps(paths, { bootstrap }) {
+  const steps = [];
+  if (bootstrap) {
+    steps.push(
+      processStep(
+        'host-npm-ci', 'cep', 'dependency-install',
+        paths.npm, ['ci'], paths.hostRoot,
+      ),
+      processStep(
+        'sidecar-npm-ci', 'cep', 'dependency-install',
+        paths.npm, ['ci'], paths.sidecarRoot,
+      ),
+      processStep(
+        'panel-npm-ci', 'cep', 'dependency-install',
+        paths.npm, ['ci'], paths.panelRoot,
+      ),
+    );
+  }
+  steps.push(
+    processStep(
+      'cep-panel-build', 'cep', 'build',
+      paths.node, ['build.mjs'], paths.panelRoot,
+    ),
+    processStep(
+      'cep-development-install', 'cep', 'development-install',
+      '/bin/bash', [paths.cepInstaller], paths.repoRoot,
+    ),
+  );
+  return steps;
+}
+
+function nativeSteps(paths) {
+  return [
+    processStep(
+      'native-build', 'native', 'build',
+      paths.node,
+      [
+        paths.nativeBuilder,
+        '--sdk-archive', paths.sdkArchive,
+        '--sdk-root', paths.sdkRoot,
+        '--output', paths.nativeOutput,
+      ],
+      paths.repoRoot,
+    ),
+    processStep(
+      'native-development-install', 'native', 'development-install',
+      paths.node,
+      [
+        paths.nativeInstaller,
+        'install', '--artifact-dir', paths.nativeOutput,
+        '--profile', 'development',
+      ],
+      paths.repoRoot,
+    ),
+  ];
+}
+
+function smokeStep(command, paths, reused) {
+  return processStep(
+    'hdev-core-native-write-undo',
+    'core',
+    'public-smoke',
+    paths.python,
+    [
+      '-B', '-I',
+      paths.developmentSmoke,
+      '--scenario', command.scenario,
+      '--selected-components', command.components.join(','),
+      '--reused-components', reused.join(','),
+      '--checkout', paths.repoRoot,
+      '--fixture-path', command.fixturePath,
+      '--recovery-archive-root', command.recoveryRoot,
+      '--evidence-dir', command.evidenceDir,
+      '--formal-ae-app', command.formalAeApp,
+      ...(command.pluginUrl ? ['--plugin-url', command.pluginUrl] : []),
+    ],
+    paths.repoRoot,
+  );
+}
+
+export function buildDevelopmentPlan(command, paths) {
+  const steps = [];
+  const actions = [];
+  const bootstrap = command.action === 'bootstrap';
+  const reused = COMPONENTS.filter((component) => !command.components.includes(component));
+
+  if (command.action === 'sync' || bootstrap) {
+    for (const component of command.components) {
+      if (component === 'core') {
+        if (bootstrap) {
+          steps.push(processStep(
+            'core-uv-sync', 'core', 'dependency-install',
+            paths.uv, ['sync', '--all-packages', '--group', 'dev'], paths.repoRoot,
+          ));
+        }
+        actions.push(Object.freeze({
+          component: 'core',
+          action: 'restart-mcp-session',
+          reason: 'live checkout requires no copy or RuntimeManager generation',
+        }));
+      } else if (component === 'cep') {
+        steps.push(...cepSteps(paths, { bootstrap }));
+      } else if (component === 'native') {
+        steps.push(...nativeSteps(paths));
+      }
+    }
+  } else if (command.action === 'smoke') {
+    steps.push(smokeStep(command, paths, reused));
+  }
+
+  const plan = Object.freeze({
+    schemaVersion: 1,
+    profile: 'development',
+    action: command.action,
+    components: Object.freeze([...command.components]),
+    reused: Object.freeze(reused),
+    steps: Object.freeze(steps),
+    actions: Object.freeze(actions),
+    dependencyBootstrapInvocations: steps.filter(
+      (step) => step.kind === 'dependency-install',
+    ).length,
+    releasePackagingInvocations: steps.filter(
+      (step) => step.kind === 'release-package',
+    ).length,
+  });
+  return assertDailyPlanSafe(plan);
+}

--- a/scripts/dev/profile-contract.mjs
+++ b/scripts/dev/profile-contract.mjs
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 export const COMPONENTS = Object.freeze(['core', 'cep', 'native']);
 export const DAILY_ACTIONS = Object.freeze(['doctor', 'launch-ae', 'sync', 'smoke']);
+export const HDEV_SCENARIO = 'core-native-write-undo@1';
 
 const ACTIONS = new Set(['bootstrap', ...DAILY_ACTIONS]);
 const PATH_OPTIONS = new Map([
@@ -99,6 +100,9 @@ export function parseDevelopmentCommand(argv, defaults) {
   if (action === 'smoke') {
     for (const member of ['scenario', 'fixturePath', 'recoveryRoot', 'evidenceDir']) {
       if (!(member in result)) invalid(`smoke requires ${member}`);
+    }
+    if (result.scenario !== HDEV_SCENARIO) {
+      invalid(`smoke scenario must be ${HDEV_SCENARIO}`);
     }
   }
   return Object.freeze(result);

--- a/scripts/dev/test/ae-mcp-dev.test.mjs
+++ b/scripts/dev/test/ae-mcp-dev.test.mjs
@@ -25,12 +25,13 @@ function harness({
   launchError = null,
 } = {}) {
   const calls = [];
+  const reports = Array.isArray(report) ? [...report] : null;
   const dependencies = {
     defaults: DEFAULTS,
     environment: { PATH: '/usr/bin:/bin' },
     async inspectDevelopmentEnvironment(options) {
       calls.push({ kind: 'doctor', options });
-      return report;
+      return reports ? reports.shift() : report;
     },
     async launchDevelopmentAe(_report, options) {
       calls.push({ kind: 'launch', options });
@@ -173,6 +174,45 @@ test('CEP sync stops when component-scoped doctor finds missing dependencies', a
     id: 'cep-panel-dependencies',
     code: 'DEV_CEP_DEPENDENCIES_MISSING',
   }]);
+});
+
+test('CEP sync may replace only a packaged install and must pass post-sync doctor', async () => {
+  const packaged = {
+    schemaVersion: 1,
+    profile: 'development',
+    ok: false,
+    checkoutPath: '/checkout',
+    interpreterPath: '/checkout/.venv/bin/python3',
+    formalAeExecutable: '/Applications/After Effects',
+    checks: [],
+    blockers: [
+      {
+        id: 'cep-development-marker',
+        ok: false,
+        code: 'DEV_CEP_MARKER_MISSING',
+        path: '/installed/.debug',
+      },
+      {
+        id: 'cep-release-manifest-absent',
+        ok: false,
+        code: 'DEV_CEP_RELEASE_MANIFEST_PRESENT',
+        path: '/installed/bundle-manifest.json',
+      },
+    ],
+  };
+  const development = {
+    ...packaged,
+    ok: true,
+    blockers: [],
+  };
+  const h = harness({ report: [packaged, development] });
+  const result = await main(['sync', '--component', 'cep'], h);
+
+  assert.equal(result.exitCode, 0, JSON.stringify(result.output));
+  assert.equal(h.calls.filter((call) => call.kind === 'doctor').length, 2);
+  assert.equal(h.calls.filter((call) => call.kind === 'execute').length, 1);
+  assert.equal(result.output.result.dependencyBootstrapInvocations, 0);
+  assert.equal(result.output.result.releasePackagingInvocations, 0);
 });
 
 test('every daily plan preserves zero dependency and release invocations', async () => {

--- a/scripts/dev/test/ae-mcp-dev.test.mjs
+++ b/scripts/dev/test/ae-mcp-dev.test.mjs
@@ -1,0 +1,214 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { developmentError } from '../profile-contract.mjs';
+import { main } from '../ae-mcp-dev.mjs';
+
+const DEFAULTS = Object.freeze({
+  repoRoot: '/checkout',
+  home: '/Users/developer',
+  formalAeApp: '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+});
+
+function harness({
+  report = {
+    schemaVersion: 1,
+    profile: 'development',
+    ok: true,
+    checkoutPath: '/checkout',
+    interpreterPath: '/checkout/.venv/bin/python3',
+    formalAeApp: DEFAULTS.formalAeApp,
+    formalAeExecutable: `${DEFAULTS.formalAeApp}/Contents/MacOS/After Effects`,
+    checks: [],
+    blockers: [],
+  },
+  launchError = null,
+} = {}) {
+  const calls = [];
+  const dependencies = {
+    defaults: DEFAULTS,
+    environment: { PATH: '/usr/bin:/bin' },
+    async inspectDevelopmentEnvironment(options) {
+      calls.push({ kind: 'doctor', options });
+      return report;
+    },
+    async launchDevelopmentAe(_report, options) {
+      calls.push({ kind: 'launch', options });
+      if (launchError) throw launchError;
+      return {
+        schemaVersion: 1,
+        profile: 'development',
+        pid: 1234,
+        formalAeExecutable: report.formalAeExecutable,
+        checkoutPath: report.checkoutPath,
+        launchedAt: '2026-07-28T00:00:00.000Z',
+      };
+    },
+    async executeDevelopmentPlan(plan) {
+      calls.push({ kind: 'execute', plan });
+      return {
+        schemaVersion: 1,
+        profile: 'development',
+        action: plan.action,
+        components: [...plan.components],
+        steps: plan.steps.map((step) => ({
+          id: step.id,
+          component: step.component,
+          kind: step.kind,
+          exitCode: 0,
+        })),
+        actions: [...plan.actions],
+        dependencyBootstrapInvocations: plan.dependencyBootstrapInvocations,
+        releasePackagingInvocations: plan.releasePackagingInvocations,
+      };
+    },
+    async mkdtemp(prefix) {
+      calls.push({ kind: 'mkdtemp', prefix });
+      return '/private/tmp/ae-mcp-native-dev-fixture';
+    },
+    calls,
+  };
+  return dependencies;
+}
+
+test('CLI doctor returns a development profile report', async () => {
+  const h = harness();
+  const result = await main(['doctor'], h);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output.ok, true);
+  assert.equal(result.output.result.profile, 'development');
+  assert.equal(h.calls[0].kind, 'doctor');
+  assert.deepEqual(h.calls[0].options.components, ['core']);
+});
+
+test('CLI validates arguments before doctor or process execution', async () => {
+  const h = harness();
+  const result = await main(['unknown'], h);
+
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.output.error.code, 'DEV_ARGUMENT_INVALID');
+  assert.deepEqual(h.calls, []);
+});
+
+test('CLI returns a closed doctor blocker without exposing private paths in text', async () => {
+  const h = harness({
+    report: {
+      schemaVersion: 1,
+      profile: 'development',
+      ok: false,
+      checkoutPath: '/private/checkout',
+      checks: [],
+      blockers: [{
+        id: 'core-interpreter',
+        ok: false,
+        code: 'DEV_CORE_INTERPRETER_MISSING',
+        path: '/private/checkout/.venv/bin/python3',
+      }],
+    },
+  });
+  const result = await main(['sync', '--component', 'core'], h);
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.output.error.code, 'DEV_DOCTOR_BLOCKED');
+  assert.equal(JSON.stringify(result.output.error).includes('/private/checkout'), false);
+  assert.deepEqual(result.output.error.recovery, [{
+    id: 'core-interpreter',
+    code: 'DEV_CORE_INTERPRETER_MISSING',
+  }]);
+  assert.equal(h.calls.some((call) => call.kind === 'execute'), false);
+});
+
+test('CLI reports an already-running AE without spawning another host', async () => {
+  const h = harness({
+    launchError: developmentError(
+      'DEV_AE_ALREADY_RUNNING',
+      'formal After Effects is already running',
+    ),
+  });
+  const result = await main(['launch-ae'], h);
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.output.error.code, 'DEV_AE_ALREADY_RUNNING');
+});
+
+test('Core-only sync has zero process steps and ignores CEP source dependency state', async () => {
+  const h = harness();
+  const result = await main(['sync', '--component', 'core'], h);
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.output.result, {
+    selected: ['core'],
+    reused: ['cep', 'native'],
+    restart: ['mcp-session'],
+    steps: [],
+    dependencyBootstrapInvocations: 0,
+    releasePackagingInvocations: 0,
+  });
+  const doctor = h.calls.find((call) => call.kind === 'doctor');
+  assert.deepEqual(doctor.options.components, ['core']);
+});
+
+test('CEP sync stops when component-scoped doctor finds missing dependencies', async () => {
+  const h = harness({
+    report: {
+      schemaVersion: 1,
+      profile: 'development',
+      ok: false,
+      checkoutPath: '/checkout',
+      checks: [],
+      blockers: [{
+        id: 'cep-panel-dependencies',
+        ok: false,
+        code: 'DEV_CEP_DEPENDENCIES_MISSING',
+        path: '/checkout/plugin/panel/node_modules',
+      }],
+    },
+  });
+  const result = await main(['sync', '--component', 'cep'], h);
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.output.error.code, 'DEV_DOCTOR_BLOCKED');
+  assert.deepEqual(result.output.error.recovery, [{
+    id: 'cep-panel-dependencies',
+    code: 'DEV_CEP_DEPENDENCIES_MISSING',
+  }]);
+});
+
+test('every daily plan preserves zero dependency and release invocations', async () => {
+  const cases = [
+    ['doctor'],
+    ['launch-ae'],
+    ['sync', '--component', 'core'],
+    [
+      'smoke',
+      '--component', 'core',
+      '--scenario', 'core-native-write-undo@1',
+      '--fixture-path', '/fixtures/active/dev.aep',
+      '--recovery-archive-root', '/fixtures/recovery',
+      '--evidence-dir', '/evidence/hdev',
+    ],
+  ];
+  for (const argv of cases) {
+    const h = harness();
+    const result = await main(argv, h);
+    assert.equal(result.exitCode, 0, JSON.stringify(result.output));
+    assert.equal(
+      result.output.result.dependencyBootstrapInvocations ?? 0,
+      0,
+    );
+    assert.equal(result.output.result.releasePackagingInvocations ?? 0, 0);
+  }
+});
+
+test('only literal bootstrap can produce dependency-install steps', async () => {
+  const h = harness();
+  const result = await main(['bootstrap', '--component', 'core'], h);
+
+  assert.equal(result.exitCode, 0);
+  const execution = h.calls.find((call) => call.kind === 'execute');
+  assert.equal(execution.plan.action, 'bootstrap');
+  assert.deepEqual(execution.plan.steps.map((step) => step.kind), [
+    'dependency-install',
+  ]);
+});

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -35,12 +35,14 @@ async function fixture(t) {
     'print("fixture")\n',
   );
   await writeFile(repoRoot, 'packages/core/ae_mcp/__init__.py', '');
-  const interpreter = await writeFile(
+  const interpreterTarget = await writeFile(
     repoRoot,
-    '.venv/bin/python3',
+    '.venv/bin/python3.13',
     '#!/bin/sh\nexit 0\n',
     0o755,
   );
+  const interpreter = path.join(repoRoot, '.venv', 'bin', 'python3');
+  await fs.promises.symlink(path.basename(interpreterTarget), interpreter);
   await writeFile(cepRoot, '.debug', '<ExtensionList />\n');
   await writeFile(
     formalAeApp,
@@ -66,7 +68,7 @@ async function fixture(t) {
       };
       return { stdout: `${values[key]}\n`, stderr: '' };
     }
-    if (file.endsWith('/.venv/bin/python3')) {
+    if (file.includes('/.venv/bin/python3')) {
       return {
         stdout: `${await fs.promises.realpath(
           path.join(repoRoot, 'packages/core/ae_mcp/__init__.py'),
@@ -130,7 +132,7 @@ test('doctor returns the closed read-only development report', async (t) => {
   assert.equal(report.checks.every((check) => check.ok), true);
   assert.deepEqual(report.blockers, []);
   assert.equal(
-    h.calls.some((call) => call.file.endsWith('/.venv/bin/python3')
+    h.calls.some((call) => call.file.includes('/.venv/bin/python3')
       && call.args.slice(0, 3).join(' ') === '-B -I -c'
       && call.args[3].includes('sys.path.insert(0,sys.argv[1])')
       && call.args.at(-1) === path.join(report.checkoutPath, 'packages', 'core')),

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -112,8 +112,18 @@ test('doctor returns the closed read-only development report', async (t) => {
   assert.equal(report.schemaVersion, 1);
   assert.equal(report.profile, 'development');
   assert.equal(report.ok, true, JSON.stringify(report, null, 2));
-  assert.equal(report.checkoutPath, await fs.promises.realpath(h.repoRoot));
-  assert.equal(report.interpreterPath, await fs.promises.realpath(h.interpreter));
+  const canonicalRepo = await fs.promises.realpath(h.repoRoot);
+  const venvEntrypoint = path.join(canonicalRepo, '.venv/bin/python3');
+  assert.equal(report.checkoutPath, canonicalRepo);
+  assert.equal(report.interpreterPath, venvEntrypoint);
+  assert.equal(
+    report.checks.find((check) => check.id === 'core-interpreter').resolvedPath,
+    await fs.promises.realpath(h.interpreter),
+  );
+  assert.equal(
+    h.calls.some((call) => call.file === venvEntrypoint),
+    true,
+  );
   assert.equal(report.formalAeApp, await fs.promises.realpath(h.formalAeApp));
   assert.equal(
     report.formalAeExecutable,

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -289,6 +289,43 @@ test('plan execution uses execFile and reports bounded invocation counts', async
   });
 });
 
+test('public smoke inherits the current terminal instead of buffering checkpoints', async () => {
+  const calls = [];
+  const plan = {
+    action: 'smoke',
+    components: ['core', 'cep'],
+    steps: [{
+      id: 'hdev-core-native-write-undo',
+      component: 'core',
+      kind: 'public-smoke',
+      executable: '/checkout/.venv/bin/python3',
+      args: ['-B', '-I', '/checkout/scripts/hardware/development_smoke.py'],
+      cwd: '/checkout',
+    }],
+    actions: [],
+    dependencyBootstrapInvocations: 0,
+    releasePackagingInvocations: 0,
+  };
+
+  await executeDevelopmentPlan(plan, {
+    execFile: async () => {
+      throw new Error('interactive smoke must not use buffered execFile');
+    },
+    runInteractive: async (file, args, options) => {
+      calls.push({ file, args, options });
+    },
+    environment: { HOME: '/private/home' },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].file, '/checkout/.venv/bin/python3');
+  assert.deepEqual(calls[0].args, [
+    '-B', '-I', '/checkout/scripts/hardware/development_smoke.py',
+  ]);
+  assert.equal(calls[0].options.cwd, '/checkout');
+  assert.equal(calls[0].options.shell, false);
+});
+
 test('daily execution refuses dependency installation even for a forged plan', async () => {
   await assert.rejects(
     executeDevelopmentPlan({

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -35,6 +35,7 @@ async function fixture(t) {
     'print("fixture")\n',
   );
   await writeFile(repoRoot, 'packages/core/ae_mcp/__init__.py', '');
+  await writeFile(repoRoot, 'packages/bridge/ae_mcp_bridge/__init__.py', '');
   const interpreterTarget = await writeFile(
     repoRoot,
     '.venv/bin/python3.13',
@@ -70,9 +71,14 @@ async function fixture(t) {
     }
     if (file.includes('/.venv/bin/python3')) {
       return {
-        stdout: `${await fs.promises.realpath(
-          path.join(repoRoot, 'packages/core/ae_mcp/__init__.py'),
-        )}\n`,
+        stdout: [
+          await fs.promises.realpath(
+            path.join(repoRoot, 'packages/core/ae_mcp/__init__.py'),
+          ),
+          await fs.promises.realpath(
+            path.join(repoRoot, 'packages/bridge/ae_mcp_bridge/__init__.py'),
+          ),
+        ].join('\n'),
         stderr: '',
       };
     }
@@ -145,8 +151,14 @@ test('doctor returns the closed read-only development report', async (t) => {
     h.calls.some((call) => call.file.includes('/.venv/bin/python3')
       && call.args.slice(0, 3).join(' ') === '-B -I -c'
       && call.args[3].includes('sys.path.insert(0,sys.argv[1])')
-      && call.args.at(-1) === path.join(report.checkoutPath, 'packages', 'core')),
+      && call.args[3].includes('sys.path.insert(0,sys.argv[2])')
+      && call.args.at(-2) === path.join(report.checkoutPath, 'packages', 'core')
+      && call.args.at(-1) === path.join(report.checkoutPath, 'packages', 'bridge')),
     true,
+  );
+  assert.equal(
+    report.checks.find((check) => check.id === 'core-import').bridgePath,
+    path.join(report.checkoutPath, 'packages/bridge/ae_mcp_bridge/__init__.py'),
   );
 });
 

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -1,0 +1,313 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  executeDevelopmentPlan,
+  inspectDevelopmentEnvironment,
+  launchDevelopmentAe,
+} from '../macos-development.mjs';
+
+async function writeFile(root, relative, contents = '', mode = 0o644) {
+  const target = path.join(root, ...relative.split('/'));
+  await fs.promises.mkdir(path.dirname(target), { recursive: true });
+  await fs.promises.writeFile(target, contents, { mode });
+  await fs.promises.chmod(target, mode);
+  return target;
+}
+
+async function fixture(t) {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ae-mcp-dev-doctor-'));
+  t.after(() => fs.promises.rm(root, { recursive: true, force: true }));
+  const repoRoot = path.join(root, 'repo');
+  const home = path.join(root, 'home');
+  const formalAeApp = path.join(root, 'Adobe After Effects 2026.app');
+  const cepRoot = path.join(
+    home,
+    'Library/Application Support/Adobe/CEP/extensions/com.aemcp.panel',
+  );
+  await writeFile(repoRoot, 'pyproject.toml', '[tool.uv.workspace]\n');
+  await writeFile(
+    repoRoot,
+    'packages/core/ae_mcp/__main__.py',
+    'print("fixture")\n',
+  );
+  await writeFile(repoRoot, 'packages/core/ae_mcp/__init__.py', '');
+  const interpreter = await writeFile(
+    repoRoot,
+    '.venv/bin/python3',
+    '#!/bin/sh\nexit 0\n',
+    0o755,
+  );
+  await writeFile(cepRoot, '.debug', '<ExtensionList />\n');
+  await writeFile(
+    formalAeApp,
+    'Contents/Info.plist',
+    '<plist><dict></dict></plist>\n',
+  );
+  const formalAeExecutable = await writeFile(
+    formalAeApp,
+    'Contents/MacOS/After Effects',
+    '#!/bin/sh\nexit 0\n',
+    0o755,
+  );
+
+  const calls = [];
+  const execFile = async (file, args, options) => {
+    calls.push({ file, args, options });
+    if (file === '/usr/bin/plutil') {
+      const key = args[1];
+      const values = {
+        CFBundleExecutable: 'After Effects',
+        CFBundleShortVersionString: '26.3.0',
+        CFBundleVersion: '26.3.0.87',
+      };
+      return { stdout: `${values[key]}\n`, stderr: '' };
+    }
+    if (file.endsWith('/.venv/bin/python3')) {
+      return {
+        stdout: `${await fs.promises.realpath(
+          path.join(repoRoot, 'packages/core/ae_mcp/__init__.py'),
+        )}\n`,
+        stderr: '',
+      };
+    }
+    return { stdout: '', stderr: '' };
+  };
+  return {
+    root,
+    repoRoot,
+    home,
+    formalAeApp,
+    formalAeExecutable,
+    interpreter,
+    calls,
+    dependencies: {
+      execFile,
+      spawn() {
+        throw new Error('spawn not expected');
+      },
+      processInspector: {
+        async afterEffectsRunning() {
+          return false;
+        },
+      },
+    },
+  };
+}
+
+test('doctor returns the closed read-only development report', async (t) => {
+  const h = await fixture(t);
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    dependencies: h.dependencies,
+  });
+
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.profile, 'development');
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.checkoutPath, await fs.promises.realpath(h.repoRoot));
+  assert.equal(report.interpreterPath, await fs.promises.realpath(h.interpreter));
+  assert.equal(report.formalAeApp, await fs.promises.realpath(h.formalAeApp));
+  assert.equal(
+    report.formalAeExecutable,
+    await fs.promises.realpath(h.formalAeExecutable),
+  );
+  assert.deepEqual(report.checks.map((check) => check.id), [
+    'checkout',
+    'core-entrypoint',
+    'core-interpreter',
+    'core-import',
+    'cep-development-marker',
+    'cep-release-manifest-absent',
+    'formal-ae-app',
+    'formal-ae-executable',
+  ]);
+  assert.equal(report.checks.every((check) => check.ok), true);
+  assert.deepEqual(report.blockers, []);
+  assert.equal(
+    h.calls.some((call) => call.file.endsWith('/.venv/bin/python3')
+      && call.args.slice(0, 3).join(' ') === '-B -I -c'
+      && call.args[3].includes('sys.path.insert(0,sys.argv[1])')
+      && call.args.at(-1) === path.join(report.checkoutPath, 'packages', 'core')),
+    true,
+  );
+});
+
+test('doctor reports a missing Core interpreter without writing', async (t) => {
+  const h = await fixture(t);
+  await fs.promises.unlink(h.interpreter);
+  const writes = [];
+  const readOnlyFs = new Proxy(fs.promises, {
+    get(target, property) {
+      if (['mkdir', 'writeFile', 'rename', 'unlink', 'rm'].includes(property)) {
+        return async (...args) => {
+          writes.push({ property, args });
+          throw new Error('doctor attempted a write');
+        };
+      }
+      const value = Reflect.get(target, property);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    dependencies: { ...h.dependencies, fs: readOnlyFs },
+  });
+
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.blockers.map((item) => item.code), [
+    'DEV_CORE_INTERPRETER_MISSING',
+  ]);
+  assert.equal(writes.length, 0);
+});
+
+test('doctor checks CEP source dependencies only when CEP is selected', async (t) => {
+  const h = await fixture(t);
+  const core = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    components: ['core'],
+    dependencies: h.dependencies,
+  });
+  const cep = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    components: ['cep'],
+    dependencies: h.dependencies,
+  });
+
+  assert.equal(core.blockers.some((item) => item.code === 'DEV_CEP_DEPENDENCIES_MISSING'), false);
+  assert.equal(cep.blockers.filter(
+    (item) => item.code === 'DEV_CEP_DEPENDENCIES_MISSING',
+  ).length, 3);
+});
+
+test('launch refuses a running AE and otherwise spawns only the exact formal executable', async (t) => {
+  const h = await fixture(t);
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    dependencies: h.dependencies,
+  });
+  let spawned = null;
+  const spawn = (file, args, options) => {
+    spawned = { file, args, options, unrefCalls: 0 };
+    return {
+      pid: 4242,
+      unref() {
+        spawned.unrefCalls += 1;
+      },
+    };
+  };
+
+  await assert.rejects(
+    launchDevelopmentAe(report, {
+      processInspector: { async afterEffectsRunning() { return true; } },
+      spawn,
+      environment: {},
+    }),
+    (error) => error.code === 'DEV_AE_ALREADY_RUNNING',
+  );
+  assert.equal(spawned, null);
+
+  const receipt = await launchDevelopmentAe(report, {
+    processInspector: { async afterEffectsRunning() { return false; } },
+    spawn,
+    environment: { SENTINEL: 'kept' },
+    now: () => new Date('2026-07-28T00:00:00.000Z'),
+  });
+  assert.equal(spawned.file, report.formalAeExecutable);
+  assert.deepEqual(spawned.args, []);
+  assert.equal(spawned.options.cwd, path.dirname(report.formalAeExecutable));
+  assert.equal(spawned.options.detached, true);
+  assert.equal(spawned.options.stdio, 'ignore');
+  assert.equal(spawned.options.shell, false);
+  assert.equal(spawned.options.env.SENTINEL, 'kept');
+  assert.equal(spawned.options.env.AE_MCP_DEV_RUNTIME, report.checkoutPath);
+  assert.equal(spawned.unrefCalls, 1);
+  assert.deepEqual(receipt, {
+    schemaVersion: 1,
+    profile: 'development',
+    pid: 4242,
+    formalAeExecutable: report.formalAeExecutable,
+    checkoutPath: report.checkoutPath,
+    launchedAt: '2026-07-28T00:00:00.000Z',
+  });
+});
+
+test('plan execution uses execFile and reports bounded invocation counts', async () => {
+  const calls = [];
+  const plan = {
+    action: 'sync',
+    components: ['cep'],
+    steps: [{
+      id: 'cep-build',
+      component: 'cep',
+      kind: 'build',
+      executable: '/node',
+      args: ['build.mjs'],
+      cwd: '/checkout/plugin/panel',
+    }],
+    actions: [],
+    dependencyBootstrapInvocations: 0,
+    releasePackagingInvocations: 0,
+  };
+  const receipt = await executeDevelopmentPlan(plan, {
+    execFile: async (file, args, options) => {
+      calls.push({ file, args, options });
+      return { stdout: 'ok', stderr: '' };
+    },
+    environment: { HOME: '/private/home' },
+  });
+
+  assert.equal(calls[0].file, '/node');
+  assert.deepEqual(calls[0].args, ['build.mjs']);
+  assert.equal(calls[0].options.cwd, '/checkout/plugin/panel');
+  assert.equal(calls[0].options.shell, false);
+  assert.deepEqual(receipt, {
+    schemaVersion: 1,
+    profile: 'development',
+    action: 'sync',
+    components: ['cep'],
+    steps: [{ id: 'cep-build', component: 'cep', kind: 'build', exitCode: 0 }],
+    actions: [],
+    dependencyBootstrapInvocations: 0,
+    releasePackagingInvocations: 0,
+  });
+});
+
+test('daily execution refuses dependency installation even for a forged plan', async () => {
+  await assert.rejects(
+    executeDevelopmentPlan({
+      action: 'sync',
+      components: ['cep'],
+      steps: [{
+        id: 'forbidden',
+        component: 'cep',
+        kind: 'dependency-install',
+        executable: '/npm',
+        args: ['ci'],
+        cwd: '/checkout',
+      }],
+      actions: [],
+      dependencyBootstrapInvocations: 1,
+      releasePackagingInvocations: 0,
+    }, {
+      execFile: async () => {
+        throw new Error('must not execute');
+      },
+    }),
+    (error) => error.code === 'DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN',
+  );
+});

--- a/scripts/dev/test/profile-contract.test.mjs
+++ b/scripts/dev/test/profile-contract.test.mjs
@@ -1,0 +1,173 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  assertDailyPlanSafe,
+  buildDevelopmentPlan,
+  parseDevelopmentCommand,
+} from '../profile-contract.mjs';
+
+const DEFAULTS = Object.freeze({
+  repoRoot: '/repo',
+  home: '/Users/developer',
+  formalAeApp: '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+});
+
+const PATHS = Object.freeze({
+  repoRoot: '/repo',
+  uv: '/usr/local/bin/uv',
+  npm: '/usr/local/bin/npm',
+  node: '/runtime/node',
+  python: '/repo/.venv/bin/python3',
+  hostRoot: '/repo/plugin/host',
+  sidecarRoot: '/repo/plugin/sidecar',
+  panelRoot: '/repo/plugin/panel',
+  cepInstaller: '/repo/scripts/install-plugin-dev-macos.sh',
+  nativeBuilder: '/repo/native/ae-plugin/build-macos.mjs',
+  nativeInstaller: '/repo/native/ae-plugin/install-dev-macos.mjs',
+  sdkArchive: '/inputs/AfterEffectsSDK.zip',
+  sdkRoot: '/inputs/AfterEffectsSDK',
+  nativeOutput: '/private/tmp/ae-mcp-native-dev-test/artifact',
+  developmentSmoke: '/repo/scripts/hardware/development_smoke.py',
+});
+
+test('parseDevelopmentCommand normalizes one explicit sync component', () => {
+  const parsed = parseDevelopmentCommand(
+    ['sync', '--component', 'cep'],
+    DEFAULTS,
+  );
+
+  assert.deepEqual(parsed, {
+    action: 'sync',
+    components: ['cep'],
+    repoRoot: '/repo',
+    home: '/Users/developer',
+    formalAeApp: '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+  });
+});
+
+test('parseDevelopmentCommand expands all and preserves ordered smoke components', () => {
+  assert.deepEqual(
+    parseDevelopmentCommand(
+      ['bootstrap', '--component', 'all'],
+      DEFAULTS,
+    ).components,
+    ['core', 'cep', 'native'],
+  );
+  const smoke = parseDevelopmentCommand([
+    'smoke',
+    '--component', 'core',
+    '--component', 'cep',
+    '--scenario', 'core-native-write-undo@1',
+    '--fixture-path', '/fixtures/hdev.aep',
+    '--recovery-archive-root', '/fixtures/recovery',
+    '--evidence-dir', '/evidence/hdev',
+  ], DEFAULTS);
+  assert.deepEqual(smoke.components, ['core', 'cep']);
+  assert.equal(smoke.scenario, 'core-native-write-undo@1');
+  assert.equal(smoke.fixturePath, '/fixtures/hdev.aep');
+  assert.equal(smoke.recoveryRoot, '/fixtures/recovery');
+  assert.equal(smoke.evidenceDir, '/evidence/hdev');
+});
+
+test('parseDevelopmentCommand rejects unsafe or ambiguous arguments', () => {
+  for (const argv of [
+    ['sync', '--component', 'unknown'],
+    ['sync', '--component', 'core', '--component', 'core'],
+    ['sync', '--component', 'all', '--component', 'core'],
+    ['sync', '--repo-root', 'relative', '--component', 'core'],
+    ['smoke', '--component', 'core'],
+    ['unknown', '--component', 'core'],
+  ]) {
+    assert.throws(
+      () => parseDevelopmentCommand(argv, DEFAULTS),
+      (error) => error?.code === 'DEV_ARGUMENT_INVALID',
+      argv.join(' '),
+    );
+  }
+});
+
+test('buildDevelopmentPlan syncs only the selected CEP component without bootstrap', () => {
+  const command = parseDevelopmentCommand(['sync', '--component', 'cep'], DEFAULTS);
+  const plan = buildDevelopmentPlan(command, PATHS);
+
+  assert.equal(plan.action, 'sync');
+  assert.deepEqual(plan.components, ['cep']);
+  assert.deepEqual(plan.reused, ['core', 'native']);
+  assert.deepEqual(plan.steps.map((step) => step.id), [
+    'cep-panel-build',
+    'cep-development-install',
+  ]);
+  assert.equal(plan.dependencyBootstrapInvocations, 0);
+  assert.equal(plan.releasePackagingInvocations, 0);
+});
+
+test('buildDevelopmentPlan keeps Core live and makes bootstrap explicit', () => {
+  const core = buildDevelopmentPlan(
+    parseDevelopmentCommand(['sync', '--component', 'core'], DEFAULTS),
+    PATHS,
+  );
+  assert.deepEqual(core.steps, []);
+  assert.deepEqual(core.actions, [{
+    component: 'core',
+    action: 'restart-mcp-session',
+    reason: 'live checkout requires no copy or RuntimeManager generation',
+  }]);
+
+  const bootstrap = buildDevelopmentPlan(
+    parseDevelopmentCommand(['bootstrap', '--component', 'all'], DEFAULTS),
+    PATHS,
+  );
+  assert.equal(bootstrap.dependencyBootstrapInvocations, 4);
+  assert.equal(bootstrap.releasePackagingInvocations, 0);
+  assert.deepEqual(
+    bootstrap.steps.filter((step) => step.kind === 'dependency-install')
+      .map((step) => step.id),
+    ['core-uv-sync', 'host-npm-ci', 'sidecar-npm-ci', 'panel-npm-ci'],
+  );
+});
+
+test('buildDevelopmentPlan passes closed component disposition to HDEV', () => {
+  const command = parseDevelopmentCommand([
+    'smoke',
+    '--component', 'core',
+    '--component', 'cep',
+    '--scenario', 'core-native-write-undo@1',
+    '--fixture-path', '/fixtures/hdev.aep',
+    '--recovery-archive-root', '/fixtures/recovery',
+    '--evidence-dir', '/evidence/hdev',
+  ], DEFAULTS);
+  const plan = buildDevelopmentPlan(command, PATHS);
+
+  assert.deepEqual(plan.components, ['core', 'cep']);
+  assert.deepEqual(plan.reused, ['native']);
+  assert.deepEqual(plan.steps.map((step) => step.id), [
+    'hdev-core-native-write-undo',
+  ]);
+  assert.deepEqual(plan.steps[0].args.slice(0, 10), [
+    '-B', '-I',
+    '/repo/scripts/hardware/development_smoke.py',
+    '--scenario', 'core-native-write-undo@1',
+    '--selected-components', 'core,cep',
+    '--reused-components', 'native',
+    '--checkout',
+  ]);
+  assert.equal(plan.dependencyBootstrapInvocations, 0);
+});
+
+test('assertDailyPlanSafe rejects an implicit dependency install', () => {
+  assert.throws(
+    () => assertDailyPlanSafe({
+      action: 'sync',
+      steps: [{
+        id: 'forbidden-npm-ci',
+        component: 'cep',
+        kind: 'dependency-install',
+        executable: '/usr/local/bin/npm',
+        args: ['ci'],
+        cwd: '/repo/plugin/panel',
+      }],
+    }),
+    (error) => error?.code === 'DEV_IMPLICIT_BOOTSTRAP_FORBIDDEN',
+  );
+});

--- a/scripts/dev/test/profile-contract.test.mjs
+++ b/scripts/dev/test/profile-contract.test.mjs
@@ -77,6 +77,14 @@ test('parseDevelopmentCommand rejects unsafe or ambiguous arguments', () => {
     ['sync', '--component', 'all', '--component', 'core'],
     ['sync', '--repo-root', 'relative', '--component', 'core'],
     ['smoke', '--component', 'core'],
+    [
+      'smoke',
+      '--component', 'core',
+      '--scenario', 'unbounded',
+      '--fixture-path', '/fixtures/hdev.aep',
+      '--recovery-archive-root', '/fixtures/recovery',
+      '--evidence-dir', '/evidence/hdev',
+    ],
     ['unknown', '--component', 'core'],
   ]) {
     assert.throws(
@@ -153,6 +161,11 @@ test('buildDevelopmentPlan passes closed component disposition to HDEV', () => {
     '--checkout',
   ]);
   assert.equal(plan.dependencyBootstrapInvocations, 0);
+  assert.equal(plan.steps[0].args.at(-2), '--formal-ae-app');
+  assert.equal(
+    plan.steps[0].args.at(-1),
+    '/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app',
+  );
 });
 
 test('assertDailyPlanSafe rejects an implicit dependency install', () => {

--- a/scripts/generate_capability_package_index.py
+++ b/scripts/generate_capability_package_index.py
@@ -183,58 +183,84 @@ def _has_ancestor(
     )
 
 
-def _tool_registry(tables: Sequence[Table]) -> tuple[Table, list[dict[str, Any]]]:
-    registries = [
+def _tool_registry(tables: Sequence[Table]) -> tuple[dict[str, Table], list[dict[str, Any]]]:
+    canonical = [
         table
         for table in tables
         if any(_normalized(cell) == "public mcp tool" for cell in table.header)
     ]
-    if len(registries) != 1:
+    if len(canonical) > 1:
         raise ParseFailure(
-            f"expected one 'Public MCP tool' registry table, found {len(registries)}"
+            f"expected at most one 'Public MCP tool' registry table, found {len(canonical)}"
         )
-    table = registries[0]
-    tool_column = next(
-        index
-        for index, cell in enumerate(table.header)
-        if _normalized(cell) == "public mcp tool"
-    )
+    registries = canonical or [
+        table
+        for table in tables
+        if {_normalized(cell) for cell in table.header} >= {"tool", "r w"}
+    ]
+    if not registries:
+        raise ParseFailure(
+            "expected one 'Public MCP tool' registry table or split 'Tool | R/W' tables"
+        )
+
     tools: list[dict[str, Any]] = []
-    for line, cells in table.rows:
-        matches = PUBLIC_TOOL.findall(_plain(cells[tool_column]))
-        if len(matches) != 1:
-            raise ParseFailure(f"public-tool row at line {line} does not name exactly one tool")
-        name = matches[0]
-        capabilities = [
-            match
-            for cell in cells
-            for match in CAPABILITY_ID.findall(_plain(cell))
-        ]
-        kinds = [
-            _normalized(cell)
-            for cell in cells
-            if _normalized(cell) in {"read", "write"}
-        ]
-        if kinds:
-            kind = kinds[0]
-        elif name.startswith(("ae_get", "ae_list", "ae_read", "ae_inspect")):
-            kind = "read"
-        elif name.startswith(("ae_add", "ae_create", "ae_delete", "ae_set", "ae_apply")):
-            kind = "write"
-        else:
-            raise ParseFailure(f"cannot determine read/write kind for {name} at line {line}")
-        tools.append(
-            {
-                "name": name,
-                "kind": kind,
-                "nativeCapability": capabilities[0] if capabilities else None,
-                "registryLine": line,
-            }
+    registry_by_tool: dict[str, Table] = {}
+    for table in registries:
+        normalized_header = [_normalized(cell) for cell in table.header]
+        tool_column = normalized_header.index(
+            "public mcp tool" if canonical else "tool"
         )
+        kind_column = normalized_header.index("r w") if not canonical else None
+        for line, cells in table.rows:
+            matches = PUBLIC_TOOL.findall(_plain(cells[tool_column]))
+            if len(matches) != 1:
+                raise ParseFailure(
+                    f"public-tool row at line {line} does not name exactly one tool"
+                )
+            name = matches[0]
+            capabilities = [
+                match
+                for cell in cells
+                for match in CAPABILITY_ID.findall(_plain(cell))
+            ]
+            if kind_column is not None:
+                kind_value = _normalized(cells[kind_column])
+                if kind_value not in {"r", "w"}:
+                    raise ParseFailure(
+                        f"public-tool row at line {line} has an invalid R/W value"
+                    )
+                kind = "read" if kind_value == "r" else "write"
+            else:
+                kinds = [
+                    _normalized(cell)
+                    for cell in cells
+                    if _normalized(cell) in {"read", "write"}
+                ]
+                if kinds:
+                    kind = kinds[0]
+                elif name.startswith(("ae_get", "ae_list", "ae_read", "ae_inspect")):
+                    kind = "read"
+                elif name.startswith(
+                    ("ae_add", "ae_create", "ae_delete", "ae_set", "ae_apply")
+                ):
+                    kind = "write"
+                else:
+                    raise ParseFailure(
+                        f"cannot determine read/write kind for {name} at line {line}"
+                    )
+            tools.append(
+                {
+                    "name": name,
+                    "kind": kind,
+                    "nativeCapability": capabilities[0] if capabilities else None,
+                    "registryLine": line,
+                }
+            )
+            registry_by_tool[name] = table
     names = [tool["name"] for tool in tools]
     if not names or len(names) != len(set(names)):
         raise ParseFailure("public-tool registry is empty or contains duplicate tool names")
-    return table, tools
+    return registry_by_tool, tools
 
 
 def _json_property_range(lines: Sequence[str], fence: FenceRange, tool: str) -> tuple[int, int] | None:
@@ -516,7 +542,7 @@ def build_index(text: str, source_name: str) -> dict[str, Any]:
     headings = _headings(lines)
     fences = _fences(lines)
     tables = _tables(lines)
-    registry, tools = _tool_registry(tables)
+    registries, tools = _tool_registry(tables)
     execution = _execution_path(lines, headings, fences)
 
     indexed_tools = []
@@ -524,7 +550,9 @@ def build_index(text: str, source_name: str) -> dict[str, Any]:
         indexed_tools.append(
             {
                 **tool,
-                "schema": _schema_contract(lines, headings, fences, registry, tool["name"]),
+                "schema": _schema_contract(
+                    lines, headings, fences, registries[tool["name"]], tool["name"]
+                ),
                 "executionPath": execution,
                 "undoModel": _undo_model(lines, headings, tables, tool),
                 "acceptance": _acceptance_disposition(headings, tables, tool),

--- a/scripts/hardware/README.md
+++ b/scripts/hardware/README.md
@@ -159,6 +159,41 @@ Three edges are easy to misread:
   the summary rather than infer candidate status from an event row
   (`capability_package_runtime.py:324-380`).
 
+## Ordinary development HDEV
+
+`development_smoke.py` is the permanently non-candidate real-AE proof for
+ordinary AE-changing PRs. Scenario `core-native-write-undo@1` performs exactly
+seven public MCP calls: readiness, composition creation, complete settings
+before/after one background write, post-Undo locator reacquisition, and
+complete restored settings. It never runs T5/T6, never uses the stable
+RuntimeManager launcher, and every event and summary records
+`validationProfile=development`, `candidateRun=false`, and
+`candidateEvidence=false`.
+
+Run it through the component-selective CLI after read-only doctor and exact
+formal-AE launch, or directly:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python3 -B -I \
+  scripts/hardware/development_smoke.py \
+  --scenario core-native-write-undo@1 \
+  --selected-components core \
+  --reused-components cep,native \
+  --checkout "$PWD" \
+  --fixture-path "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/active/hdev-core-native.aep" \
+  --recovery-archive-root "$HOME/Library/Application Support/AfterEffectsMCP/fixtures/recovery" \
+  --evidence-dir "$HOME/Library/Application Support/AfterEffectsMCP/evidence/hdev-core-native" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+The first checkpoint saves one empty `ephemeral-validation` project. The
+driver never creates a Save As copy. After one explicit real Undo and
+independent public readback, the final checkpoint closes formal AE; only then
+does the driver archive the exact fixture. Stop immediately on an incompatible
+wire/capability/RPC digest, strict product-version mismatch, failed native load,
+`POSSIBLY_SIDE_EFFECTING_FAILURE`, corrupted fixture baseline, or AE crash.
+Never retry an uncertain write.
+
 ## Native editing milestone #167
 
 `issue167_native_media_acceptance.py` drives the frozen 22-tool Effect Stack,

--- a/scripts/hardware/development_smoke.py
+++ b/scripts/hardware/development_smoke.py
@@ -22,6 +22,10 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Any, Protocol
 
+HARDWARE_ROOT = Path(__file__).resolve().parent
+if os.fspath(HARDWARE_ROOT) not in sys.path:
+    sys.path.insert(0, os.fspath(HARDWARE_ROOT))
+
 from development_smoke_spec import (
     BASELINE_COLOR,
     CALL_HARD_LIMIT,

--- a/scripts/hardware/development_smoke.py
+++ b/scripts/hardware/development_smoke.py
@@ -40,13 +40,16 @@ FIXTURE_NAME = "HDEV Core Native Fixture"
 CORE_BOOTSTRAP = (
     "import runpy,sys;"
     "sys.path.insert(0,sys.argv[1]);"
+    "sys.path.insert(0,sys.argv[2]);"
     'runpy.run_module("ae_mcp",run_name="__main__")'
 )
 CORE_IMPORT_PROBE = (
     "import pathlib,sys;"
     "sys.path.insert(0,sys.argv[1]);"
-    "import ae_mcp;"
-    "print(pathlib.Path(ae_mcp.__file__).resolve())"
+    "sys.path.insert(0,sys.argv[2]);"
+    "import ae_mcp,ae_mcp_bridge;"
+    "print(pathlib.Path(ae_mcp.__file__).resolve());"
+    "print(pathlib.Path(ae_mcp_bridge.__file__).resolve())"
 )
 
 
@@ -708,15 +711,20 @@ class _LiveSession:
         return bool(result.isError), payload
 
 
-def _verify_checkout_core(checkout: Path) -> tuple[Path, Path]:
+def _verify_checkout_core(checkout: Path) -> tuple[Path, Path, Path]:
     require(checkout.is_dir() and not checkout.is_symlink(), "checkout is invalid")
     canonical = checkout.resolve(strict=True)
     interpreter = canonical / ".venv/bin/python3"
     core_root = canonical / "packages/core"
+    bridge_root = canonical / "packages/bridge"
     require(interpreter.exists() and os.access(interpreter, os.X_OK), "interpreter missing")
     require(
         (core_root / "ae_mcp/__main__.py").is_file(),
         "checkout Core entrypoint missing",
+    )
+    require(
+        (bridge_root / "ae_mcp_bridge/__init__.py").is_file(),
+        "checkout bridge entrypoint missing",
     )
     import subprocess
 
@@ -728,6 +736,7 @@ def _verify_checkout_core(checkout: Path) -> tuple[Path, Path]:
             "-c",
             CORE_IMPORT_PROBE,
             os.fspath(core_root),
+            os.fspath(bridge_root),
         ],
         cwd=canonical,
         env={
@@ -742,12 +751,19 @@ def _verify_checkout_core(checkout: Path) -> tuple[Path, Path]:
         capture_output=True,
         text=True,
     )
-    imported = Path(result.stdout.strip()).resolve(strict=True)
+    imported_lines = result.stdout.strip().splitlines()
+    require(len(imported_lines) == 2, "isolated Core import probe was incomplete")
+    imported = Path(imported_lines[0]).resolve(strict=True)
+    imported_bridge = Path(imported_lines[1]).resolve(strict=True)
     require(
         imported.is_relative_to(core_root),
         "isolated Core import did not resolve beneath checkout",
     )
-    return interpreter, core_root
+    require(
+        imported_bridge.is_relative_to(bridge_root),
+        "isolated bridge import did not resolve beneath checkout",
+    )
+    return interpreter, core_root, bridge_root
 
 
 @contextlib.asynccontextmanager
@@ -758,7 +774,7 @@ async def live_session(config: DevelopmentSmokeConfig) -> AsyncIterator[PublicSe
         from mcp.types import Implementation
     except ImportError as error:  # pragma: no cover - hardware environment only
         raise DevelopmentSmokeFailure("HDEV requires the bootstrapped mcp SDK") from error
-    interpreter, core_root = _verify_checkout_core(config.checkout)
+    interpreter, core_root, bridge_root = _verify_checkout_core(config.checkout)
     environment = {
         "AE_MCP_BACKEND": "ae-mcp",
         "AE_MCP_PLUGIN_URL": config.plugin_url,
@@ -771,7 +787,10 @@ async def live_session(config: DevelopmentSmokeConfig) -> AsyncIterator[PublicSe
     }
     params = StdioServerParameters(
         command=os.fspath(interpreter),
-        args=["-B", "-I", "-c", CORE_BOOTSTRAP, os.fspath(core_root)],
+        args=[
+            "-B", "-I", "-c", CORE_BOOTSTRAP,
+            os.fspath(core_root), os.fspath(bridge_root),
+        ],
         cwd=os.fspath(config.checkout),
         env=environment,
     )

--- a/scripts/hardware/development_smoke.py
+++ b/scripts/hardware/development_smoke.py
@@ -747,7 +747,7 @@ def _verify_checkout_core(checkout: Path) -> tuple[Path, Path]:
         imported.is_relative_to(core_root),
         "isolated Core import did not resolve beneath checkout",
     )
-    return interpreter.resolve(strict=True), core_root
+    return interpreter, core_root
 
 
 @contextlib.asynccontextmanager

--- a/scripts/hardware/development_smoke.py
+++ b/scripts/hardware/development_smoke.py
@@ -1,0 +1,885 @@
+#!/usr/bin/env python3
+"""Run one bounded, permanently non-candidate real-AE development smoke."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import dataclasses
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import sys
+import time
+from collections import Counter
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from datetime import timedelta
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Protocol
+
+from development_smoke_spec import (
+    BASELINE_COLOR,
+    CALL_HARD_LIMIT,
+    CALLS,
+    CHANGED_COLOR,
+    SCENARIO_ID,
+)
+
+COMPONENTS = frozenset({"core", "cep", "native"})
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+FIXTURE_NAME = "HDEV Core Native Fixture"
+CORE_BOOTSTRAP = (
+    "import runpy,sys;"
+    "sys.path.insert(0,sys.argv[1]);"
+    'runpy.run_module("ae_mcp",run_name="__main__")'
+)
+CORE_IMPORT_PROBE = (
+    "import pathlib,sys;"
+    "sys.path.insert(0,sys.argv[1]);"
+    "import ae_mcp;"
+    "print(pathlib.Path(ae_mcp.__file__).resolve())"
+)
+
+
+class DevelopmentSmokeFailure(RuntimeError):
+    """The bounded HDEV contract was not satisfied."""
+
+
+class PossiblySideEffectingStop(DevelopmentSmokeFailure):
+    """A write may have completed and must not be retried."""
+
+
+def require(condition: Any, message: str) -> None:
+    if not condition:
+        raise DevelopmentSmokeFailure(message)
+
+
+def mapping(value: Any, message: str) -> dict[str, Any]:
+    require(isinstance(value, Mapping), message)
+    return dict(value)
+
+
+def error_code(payload: Mapping[str, Any]) -> str | None:
+    error = payload.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    code = error.get("code")
+    return code if isinstance(code, str) else None
+
+
+@dataclasses.dataclass(frozen=True)
+class DevelopmentSmokeConfig:
+    scenario: str
+    selected_components: tuple[str, ...]
+    reused_components: tuple[str, ...]
+    checkout: Path
+    fixture_path: Path
+    recovery_root: Path
+    evidence_dir: Path
+    formal_ae_app: Path
+    plugin_url: str
+
+    def __post_init__(self) -> None:
+        require(self.scenario == SCENARIO_ID, "unsupported HDEV scenario")
+        selected = set(self.selected_components)
+        reused = set(self.reused_components)
+        require(
+            len(selected) == len(self.selected_components)
+            and len(reused) == len(self.reused_components),
+            "component disposition contains duplicates",
+        )
+        require(
+            selected <= COMPONENTS and reused <= COMPONENTS,
+            "component disposition contains an unknown component",
+        )
+        require(not selected.intersection(reused), "component disposition overlaps")
+        require(selected.union(reused) == COMPONENTS, "component disposition is incomplete")
+        require(bool(selected), "at least one selected component is required")
+        for member in (
+            self.checkout,
+            self.fixture_path,
+            self.recovery_root,
+            self.evidence_dir,
+            self.formal_ae_app,
+        ):
+            require(member.is_absolute(), "HDEV paths must be absolute")
+        require(self.fixture_path.suffix.lower() == ".aep", "fixture must end in .aep")
+        require(
+            self.plugin_url.startswith("http://127.0.0.1:"),
+            "HDEV plugin URL must be loopback",
+        )
+
+    @property
+    def component_disposition(self) -> dict[str, list[str]]:
+        return {
+            "selected": list(self.selected_components),
+            "reused": list(self.reused_components),
+        }
+
+
+class PublicSession(Protocol):
+    tool_names: frozenset[str]
+
+    async def call(
+        self, tool: str, arguments: Mapping[str, Any]
+    ) -> tuple[bool, dict[str, Any]]: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class DevelopmentSmokeResult:
+    exit_code: int
+    summary: dict[str, Any]
+
+
+class DevelopmentEvidence:
+    """Private HDEV evidence whose candidate fields cannot be promoted."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.root, stat.S_IRWXU)
+        self.run_id = f"hdev-{int(time.time())}-{secrets.token_hex(4)}"
+        self.events_path = root / f"{self.run_id}.ndjson"
+        self.summary_path = root / f"{self.run_id}.summary.json"
+        self._events = 0
+
+    def record(self, event: str, payload: Mapping[str, Any]) -> None:
+        entry = {
+            "schemaVersion": 1,
+            "validationProfile": "development",
+            "candidateRun": False,
+            "candidateEvidence": False,
+            "runId": self.run_id,
+            "sequence": self._events + 1,
+            "event": event,
+            "recordedAtUnixMs": int(time.time() * 1000),
+            "payload": dict(payload),
+        }
+        descriptor = os.open(
+            self.events_path,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o600,
+        )
+        with os.fdopen(descriptor, "a", encoding="utf-8") as stream:
+            stream.write(json.dumps(entry, ensure_ascii=False, separators=(",", ":")))
+            stream.write("\n")
+        os.chmod(self.events_path, stat.S_IRUSR | stat.S_IWUSR)
+        self._events += 1
+
+    def finish(
+        self,
+        *,
+        passed: bool,
+        public_calls: Mapping[str, Any],
+        component_disposition: Mapping[str, Any],
+        aep_lifecycle: Mapping[str, Any],
+        details: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        summary = {
+            "schemaVersion": 1,
+            "validationProfile": "development",
+            "candidateRun": False,
+            "candidateEvidence": False,
+            "runId": self.run_id,
+            "passed": passed,
+            "publicCalls": dict(public_calls),
+            "componentDisposition": dict(component_disposition),
+            "aepLifecycle": dict(aep_lifecycle),
+            **dict(details or {}),
+        }
+        descriptor = os.open(
+            self.summary_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(summary, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+        os.chmod(self.summary_path, stat.S_IRUSR | stat.S_IWUSR)
+        return summary
+
+
+class DevelopmentCallLedger:
+    def __init__(self) -> None:
+        self.total = 0
+        self.by_tool: Counter[str] = Counter()
+        self.by_phase: Counter[str] = Counter()
+
+    def reserve(self, tool: str, phase: str) -> int:
+        if self.total >= CALL_HARD_LIMIT:
+            raise DevelopmentSmokeFailure(
+                f"public MCP call budget exhausted before {tool}: "
+                f"{self.total}/{CALL_HARD_LIMIT}"
+            )
+        self.total += 1
+        self.by_tool[tool] += 1
+        self.by_phase[phase] += 1
+        return self.total
+
+    def public_dict(self) -> dict[str, Any]:
+        return {
+            "target": CALL_HARD_LIMIT,
+            "hardLimit": CALL_HARD_LIMIT,
+            "total": self.total,
+            "byTool": dict(sorted(self.by_tool.items())),
+            "byPhase": dict(sorted(self.by_phase.items())),
+        }
+
+
+def _time(value: Any) -> Fraction:
+    exact = mapping(value, "exact time is invalid")
+    require(
+        set(exact) == {"value", "scale", "secondsRational"}
+        and type(exact.get("value")) is int
+        and type(exact.get("scale")) is int
+        and exact["scale"] > 0,
+        "exact time is not closed",
+    )
+    result = Fraction(exact["value"], exact["scale"])
+    require(exact["secondsRational"] == str(result), "exact time rational drifted")
+    return result
+
+
+def _ratio(value: Any) -> Fraction:
+    exact = mapping(value, "exact ratio is invalid")
+    require(
+        set(exact) == {"numerator", "denominator", "rational"}
+        and type(exact.get("numerator")) is int
+        and type(exact.get("denominator")) is int
+        and exact["denominator"] > 0,
+        "exact ratio is not closed",
+    )
+    result = Fraction(exact["numerator"], exact["denominator"])
+    require(exact["rational"] == str(result), "exact ratio rational drifted")
+    return result
+
+
+def _snapshot(value: Any) -> dict[str, Any]:
+    state = mapping(value, "composition settings snapshot is invalid")
+    state.pop("compositionLocator", None)
+    require(set(state) == {
+        "name", "width", "height", "duration", "frameDuration", "frameRate",
+        "pixelAspectRatio", "backgroundColor", "workArea",
+        "displayStartTime", "layerCount",
+    }, "composition settings snapshot is not closed")
+    color = mapping(state["backgroundColor"], "background color is invalid")
+    work = mapping(state["workArea"], "work area is invalid")
+    require(
+        set(color) == {"red", "green", "blue", "alpha"},
+        "background color is not closed",
+    )
+    require(set(work) == {"start", "duration"}, "work area is not closed")
+    snapshot = {
+        "name": state["name"],
+        "width": state["width"],
+        "height": state["height"],
+        "duration": _time(state["duration"]),
+        "frameDuration": _time(state["frameDuration"]),
+        "frameRate": _ratio(state["frameRate"]),
+        "pixelAspectRatio": _ratio(state["pixelAspectRatio"]),
+        "backgroundColor": dict(color),
+        "workArea": {
+            "start": _time(work["start"]),
+            "duration": _time(work["duration"]),
+        },
+        "displayStartTime": _time(state["displayStartTime"]),
+        "layerCount": state["layerCount"],
+    }
+    require(
+        snapshot["frameDuration"] * snapshot["frameRate"] == 1,
+        "frame duration and frame rate disagree",
+    )
+    return snapshot
+
+
+EXPECTED_BASELINE = {
+    "name": FIXTURE_NAME,
+    "width": 640,
+    "height": 360,
+    "duration": Fraction(5),
+    "frameDuration": Fraction(1, 24),
+    "frameRate": Fraction(24),
+    "pixelAspectRatio": Fraction(1),
+    "backgroundColor": BASELINE_COLOR,
+    "workArea": {"start": Fraction(0), "duration": Fraction(5)},
+    "displayStartTime": Fraction(0),
+    "layerCount": 0,
+}
+
+
+class DevelopmentSmokeRunner:
+    def __init__(
+        self,
+        config: DevelopmentSmokeConfig,
+        *,
+        checkpoint: Callable[[str, Mapping[str, Any]], Awaitable[None]],
+        after_effects_running: Callable[[], Awaitable[bool]],
+        evidence: DevelopmentEvidence | None = None,
+    ) -> None:
+        self.config = config
+        self.checkpoint = checkpoint
+        self.after_effects_running = after_effects_running
+        self.evidence = evidence or DevelopmentEvidence(config.evidence_dir)
+        self.ledger = DevelopmentCallLedger()
+        self.host_instance_id: str | None = None
+        self.session_id: str | None = None
+        self.lifecycle = {
+            "created": 0,
+            "canonicalRetained": 0,
+            "evidenceSnapshotsRetained": 0,
+            "archived": 0,
+            "unclassified": 0,
+            "saveAsCopies": 0,
+        }
+
+    def _validate_native(self, payload: Mapping[str, Any], *, write: bool) -> None:
+        implementation = mapping(payload.get("implementation"), "implementation missing")
+        provenance = mapping(payload.get("provenance"), "provenance missing")
+        audit = mapping(payload.get("audit"), "audit missing")
+        evidence = mapping(payload.get("evidence"), "evidence missing")
+        postcondition = mapping(evidence.get("postcondition"), "postcondition missing")
+        require(
+            implementation.get("engine") == "native-aegp"
+            and provenance.get("engine") == "native-aegp"
+            and evidence.get("engine") == "native-aegp",
+            "native AEGP provenance drifted",
+        )
+        contract_digest = implementation.get("contractDigest")
+        require(
+            isinstance(contract_digest, str)
+            and SHA256.fullmatch(contract_digest) is not None
+            and audit.get("contractDigest") == contract_digest,
+            "capability contract digest drifted",
+        )
+        require(
+            implementation.get("capabilityId") == audit.get("capabilityId")
+            == evidence.get("capabilityId")
+            and implementation.get("capabilityVersion") == 1
+            and audit.get("capabilityVersion") == evidence.get("capabilityVersion") == 1,
+            "capability identity drifted",
+        )
+        host = provenance.get("hostInstanceId")
+        session = provenance.get("sessionId")
+        require(
+            isinstance(host, str) and host == evidence.get("hostInstanceId")
+            and isinstance(session, str) and session == evidence.get("sessionId"),
+            "formal host/session evidence drifted",
+        )
+        if self.host_instance_id is None:
+            self.host_instance_id = host
+            self.session_id = session
+        require(
+            host == self.host_instance_id and session == self.session_id,
+            "formal host/session changed during HDEV",
+        )
+        require(
+            isinstance(provenance.get("capabilitiesDigest"), str)
+            and SHA256.fullmatch(provenance["capabilitiesDigest"]) is not None,
+            "capabilities digest missing",
+        )
+        require(
+            isinstance(audit.get("requestId"), str)
+            and audit["requestId"] == evidence.get("requestId")
+            and postcondition.get("verified") is True
+            and postcondition.get("algorithm") == "sha256-rfc8785-jcs-v1"
+            and postcondition.get("digest") == audit.get("postconditionDigest"),
+            "audit/postcondition evidence drifted",
+        )
+        if write:
+            value = mapping(payload.get("value"), "write value missing")
+            undo = mapping(evidence.get("undo"), "write Undo evidence missing")
+            require(value.get("changed") is True, "write did not report changed=true")
+            require(
+                set(undo) >= {"available", "verified"}
+                and type(undo["available"]) is bool
+                and type(undo["verified"]) is bool
+                and audit.get("undoAvailable") is undo["available"]
+                and audit.get("undoVerified") is undo["verified"],
+                "write Undo availability/verification drifted",
+            )
+
+    async def public_call(
+        self,
+        session: PublicSession,
+        phase: str,
+        tool: str,
+        arguments: Mapping[str, Any],
+        *,
+        write: bool = False,
+    ) -> dict[str, Any]:
+        sequence = self.ledger.reserve(tool, phase)
+        self.evidence.record("public-tool-request", {
+            "call": sequence,
+            "phase": phase,
+            "tool": tool,
+            "arguments": dict(arguments),
+        })
+        is_error, payload = await session.call(tool, dict(arguments))
+        self.evidence.record("public-tool-response", {
+            "call": sequence,
+            "phase": phase,
+            "tool": tool,
+            "isError": is_error,
+            "payload": payload,
+        })
+        code = error_code(payload)
+        if code == "POSSIBLY_SIDE_EFFECTING_FAILURE":
+            raise PossiblySideEffectingStop(
+                f"{tool} may have changed AE; inspect state and audit before any retry"
+            )
+        require(not is_error and code is None and payload.get("ok") is True, f"{tool} failed")
+        self._validate_native(payload, write=write)
+        return dict(payload)
+
+    @staticmethod
+    def _composition_locator(value: Any) -> dict[str, Any]:
+        locator = mapping(value, "composition locator missing")
+        require(
+            set(locator) == {
+                "kind", "hostInstanceId", "sessionId", "projectId",
+                "generation", "objectId",
+            } and locator.get("kind") == "composition",
+            "composition locator is not closed",
+        )
+        return locator
+
+    async def _archive_fixture(self) -> Path:
+        require(
+            not await self.after_effects_running(),
+            "formal After Effects still owns the HDEV fixture",
+        )
+        require(self.config.fixture_path.is_file(), "HDEV fixture is missing before archive")
+        self.config.recovery_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.config.recovery_root, stat.S_IRWXU)
+        destination = self.config.recovery_root / (
+            f"{self.config.fixture_path.stem}-{int(time.time())}-"
+            f"{secrets.token_hex(3)}.aep"
+        )
+        require(not destination.exists(), "HDEV recovery destination already exists")
+        shutil.move(os.fspath(self.config.fixture_path), os.fspath(destination))
+        self.lifecycle["archived"] = 1
+        return destination
+
+    async def run(self, session: PublicSession) -> dict[str, Any]:
+        required_tools = {tool for _, tool in CALLS}
+        require(required_tools <= session.tool_names, "HDEV public tool set is incomplete")
+
+        await self.checkpoint("save-empty-project", {
+            "instruction": (
+                "In formal After Effects, create one empty project and save it once "
+                "at fixturePath. Do not use Save As again."
+            ),
+            "fixturePath": os.fspath(self.config.fixture_path),
+            "activeFixtureCount": 1,
+            "saveAsCopies": 0,
+            "validationProfile": "development",
+            "candidateRun": False,
+            "candidateEvidence": False,
+        })
+        require(self.config.fixture_path.is_file(), "saved HDEV fixture is missing")
+        self.lifecycle["created"] = 1
+        readiness = await self.public_call(
+            session, "readiness", "ae_projectSummary", {}
+        )
+        readiness_value = mapping(readiness.get("value"), "readiness value missing")
+        require(
+            readiness_value.get("projectOpen") is True
+            and readiness_value.get("itemCount") == 0,
+            "saved HDEV project is not empty and ready",
+        )
+
+        created = await self.public_call(
+            session,
+            "composition-create",
+            "ae_createComposition",
+            {
+                "name": FIXTURE_NAME,
+                "width": 640,
+                "height": 360,
+                "duration": {"value": 5, "scale": 1},
+                "frame_rate": {"numerator": 24, "denominator": 1},
+                "pixel_aspect_ratio": {"numerator": 1, "denominator": 1},
+                "idempotency_key": "hdev-core-native-composition-0001",
+            },
+            write=True,
+        )
+        locator = self._composition_locator(
+            mapping(created.get("value"), "composition create value missing")
+            .get("compositionLocator")
+        )
+        baseline_payload = await self.public_call(
+            session,
+            "baseline-settings",
+            "ae_getCompositionSettings",
+            {"composition_locator": locator},
+        )
+        baseline_value = mapping(baseline_payload.get("value"), "baseline value missing")
+        baseline = _snapshot(baseline_value)
+        require(baseline == EXPECTED_BASELINE, "new composition baseline drifted")
+        locator = self._composition_locator(baseline_value.get("compositionLocator"))
+
+        changed_payload = await self.public_call(
+            session,
+            "background-set",
+            "ae_setCompositionBackgroundColor",
+            {
+                "composition_locator": locator,
+                "background_color": CHANGED_COLOR,
+                "idempotency_key": "hdev-core-native-background-0001",
+            },
+            write=True,
+        )
+        changed_value = mapping(changed_payload.get("value"), "background write value missing")
+        before = _snapshot(changed_value.get("before"))
+        after = _snapshot(changed_value.get("after"))
+        require(before == baseline, "write before snapshot drifted")
+        require(before["backgroundColor"] == BASELINE_COLOR, "write before colour drifted")
+        require(after == {**baseline, "backgroundColor": CHANGED_COLOR}, "write after drifted")
+        require(after["backgroundColor"] == CHANGED_COLOR, "write after colour drifted")
+        locator = self._composition_locator(changed_value.get("compositionLocator"))
+
+        changed_read_payload = await self.public_call(
+            session,
+            "changed-settings",
+            "ae_getCompositionSettings",
+            {"composition_locator": locator},
+        )
+        require(
+            _snapshot(changed_read_payload.get("value")) == after,
+            "independent changed settings readback drifted",
+        )
+        undo = mapping(
+            mapping(changed_payload.get("evidence"), "write evidence missing").get("undo"),
+            "write Undo evidence missing",
+        )
+        require(
+            undo.get("available") is True and undo.get("verified") is False,
+            "background write is not one available, unexecuted Undo",
+        )
+        await self.checkpoint("undo-background-change", {
+            "instruction": (
+                "Refresh Edit, execute exactly one real Undo for the background "
+                "change, refresh Edit again, and do not retry the write."
+            ),
+            "fixturePath": os.fspath(self.config.fixture_path),
+            "activeFixtureCount": 1,
+            "saveAsCopies": 0,
+        })
+
+        reacquired_payload = await self.public_call(
+            session,
+            "undo-reacquire",
+            "ae_listProjectItems",
+            {"offset": 0, "limit": 50},
+        )
+        items = mapping(reacquired_payload.get("value"), "project items value missing").get(
+            "items"
+        )
+        require(isinstance(items, list), "project items are invalid")
+        matches = [
+            mapping(item, "project item invalid")
+            for item in items
+            if isinstance(item, Mapping)
+            and item.get("name") == FIXTURE_NAME
+            and item.get("type") == "composition"
+        ]
+        require(len(matches) == 1, "HDEV composition was not uniquely reacquired")
+        locator = self._composition_locator(matches[0].get("locator"))
+        restored_payload = await self.public_call(
+            session,
+            "undo-settings",
+            "ae_getCompositionSettings",
+            {"composition_locator": locator},
+        )
+        restored = _snapshot(restored_payload.get("value"))
+        require(restored == baseline, "real Undo did not restore the complete baseline")
+        require(
+            restored["backgroundColor"] == BASELINE_COLOR,
+            "real Undo did not restore background colour",
+        )
+        require(self.ledger.total == CALL_HARD_LIMIT, "HDEV call count drifted")
+
+        await self.checkpoint("close-formal-ae", {
+            "instruction": (
+                "Save the existing project without Save As, close formal After "
+                "Effects, and wait until no After Effects / AfterFX process remains."
+            ),
+            "fixturePath": os.fspath(self.config.fixture_path),
+            "activeFixtureCount": 1,
+            "saveAsCopies": 0,
+        })
+        archived = await self._archive_fixture()
+        self.evidence.record("fixture-archived", {
+            "lifecycle": "ephemeral-validation",
+            "archived": True,
+            "archiveName": archived.name,
+            "saveAsCopies": 0,
+        })
+        return {
+            "scenario": self.config.scenario,
+            "hostInstanceId": self.host_instance_id,
+            "sessionId": self.session_id,
+            "realUndo": {
+                "executed": 1,
+                "verified": True,
+                "tool": "ae_setCompositionBackgroundColor",
+            },
+        }
+
+
+async def run_development_smoke(
+    config: DevelopmentSmokeConfig,
+    *,
+    session: PublicSession,
+    checkpoint: Callable[[str, Mapping[str, Any]], Awaitable[None]],
+    after_effects_running: Callable[[], Awaitable[bool]],
+) -> DevelopmentSmokeResult:
+    evidence = DevelopmentEvidence(config.evidence_dir)
+    runner = DevelopmentSmokeRunner(
+        config,
+        checkpoint=checkpoint,
+        after_effects_running=after_effects_running,
+        evidence=evidence,
+    )
+    passed = False
+    exit_code = 2
+    details: dict[str, Any] = {}
+    try:
+        details = await runner.run(session)
+        passed = True
+        exit_code = 0
+    except PossiblySideEffectingStop as error:
+        details = {
+            "stopReason": "possibly-side-effecting",
+            "message": str(error),
+        }
+        exit_code = 3
+    except DevelopmentSmokeFailure as error:
+        details = {"failure": str(error)}
+        exit_code = 2
+    if not passed and runner.lifecycle["created"] == 1:
+        runner.lifecycle["unclassified"] = 1
+    summary = evidence.finish(
+        passed=passed,
+        public_calls=runner.ledger.public_dict(),
+        component_disposition=config.component_disposition,
+        aep_lifecycle=runner.lifecycle,
+        details=details,
+    )
+    return DevelopmentSmokeResult(exit_code=exit_code, summary=summary)
+
+
+async def completed_checkpoint() -> None:
+    return None
+
+
+async def completed_process_check(value: bool) -> bool:
+    return value
+
+
+class _LiveSession:
+    def __init__(self, session: Any, tool_names: Sequence[str]) -> None:
+        self._session = session
+        self.tool_names = frozenset(tool_names)
+
+    async def call(
+        self, tool: str, arguments: Mapping[str, Any]
+    ) -> tuple[bool, dict[str, Any]]:
+        result = await self._session.call_tool(tool, dict(arguments))
+        texts = [
+            item.text for item in result.content
+            if getattr(item, "type", None) == "text"
+        ]
+        require(len(texts) == 1, f"{tool} did not return exactly one JSON text block")
+        try:
+            payload = json.loads(texts[0])
+        except (TypeError, ValueError) as error:
+            raise DevelopmentSmokeFailure(f"{tool} returned non-JSON text") from error
+        require(isinstance(payload, dict), f"{tool} JSON payload is not an object")
+        return bool(result.isError), payload
+
+
+def _verify_checkout_core(checkout: Path) -> tuple[Path, Path]:
+    require(checkout.is_dir() and not checkout.is_symlink(), "checkout is invalid")
+    canonical = checkout.resolve(strict=True)
+    interpreter = canonical / ".venv/bin/python3"
+    core_root = canonical / "packages/core"
+    require(interpreter.exists() and os.access(interpreter, os.X_OK), "interpreter missing")
+    require(
+        (core_root / "ae_mcp/__main__.py").is_file(),
+        "checkout Core entrypoint missing",
+    )
+    import subprocess
+
+    result = subprocess.run(
+        [
+            os.fspath(interpreter),
+            "-B",
+            "-I",
+            "-c",
+            CORE_IMPORT_PROBE,
+            os.fspath(core_root),
+        ],
+        cwd=canonical,
+        env={
+            "HOME": os.fspath(Path.home()),
+            "LANG": os.environ.get("LANG", "en_US.UTF-8"),
+            "PATH": "/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "TMPDIR": os.environ.get("TMPDIR", "/private/tmp"),
+        },
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    imported = Path(result.stdout.strip()).resolve(strict=True)
+    require(
+        imported.is_relative_to(core_root),
+        "isolated Core import did not resolve beneath checkout",
+    )
+    return interpreter.resolve(strict=True), core_root
+
+
+@contextlib.asynccontextmanager
+async def live_session(config: DevelopmentSmokeConfig) -> AsyncIterator[PublicSession]:
+    try:
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+        from mcp.types import Implementation
+    except ImportError as error:  # pragma: no cover - hardware environment only
+        raise DevelopmentSmokeFailure("HDEV requires the bootstrapped mcp SDK") from error
+    interpreter, core_root = _verify_checkout_core(config.checkout)
+    environment = {
+        "AE_MCP_BACKEND": "ae-mcp",
+        "AE_MCP_PLUGIN_URL": config.plugin_url,
+        "HOME": os.fspath(Path.home()),
+        "LANG": os.environ.get("LANG", "en_US.UTF-8"),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+        "TMPDIR": os.environ.get("TMPDIR", "/private/tmp"),
+    }
+    params = StdioServerParameters(
+        command=os.fspath(interpreter),
+        args=["-B", "-I", "-c", CORE_BOOTSTRAP, os.fspath(core_root)],
+        cwd=os.fspath(config.checkout),
+        env=environment,
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(
+            read,
+            write,
+            read_timeout_seconds=timedelta(seconds=75),
+            client_info=Implementation(name="ae-mcp-hdev", version="1"),
+        ) as session:
+            await session.initialize()
+            listed = await session.list_tools()
+            yield _LiveSession(session, [tool.name for tool in listed.tools])
+
+
+async def stdin_checkpoint(kind: str, details: Mapping[str, Any]) -> None:
+    checkpoint_id = f"{kind}-{secrets.token_hex(6)}"
+    print(json.dumps({
+        "event": "CHECKPOINT_REQUIRED",
+        "checkpointId": checkpoint_id,
+        "kind": kind,
+        "details": dict(details),
+        "validationProfile": "development",
+        "candidateRun": False,
+        "candidateEvidence": False,
+    }, ensure_ascii=False, separators=(",", ":")), flush=True)
+    line = await asyncio.to_thread(sys.stdin.readline)
+    require(bool(line), f"checkpoint {checkpoint_id} reached EOF")
+    try:
+        acknowledgement = json.loads(line)
+    except ValueError as error:
+        raise DevelopmentSmokeFailure("checkpoint acknowledgement is invalid") from error
+    require(
+        isinstance(acknowledgement, Mapping)
+        and acknowledgement.get("checkpointId") == checkpoint_id
+        and acknowledgement.get("status") == "completed",
+        f"checkpoint {checkpoint_id} was not completed",
+    )
+
+
+async def formal_ae_running() -> bool:
+    process = await asyncio.create_subprocess_exec(
+        "/usr/bin/pgrep",
+        "-f",
+        "Adobe After Effects|AfterFX",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    status = await process.wait()
+    if status not in {0, 1}:
+        raise DevelopmentSmokeFailure("could not inspect formal AE process state")
+    return status == 0
+
+
+def _components(value: str) -> tuple[str, ...]:
+    members = tuple(item for item in value.split(",") if item)
+    require(bool(members), "component list must not be empty")
+    return members
+
+
+def parse_args(argv: Sequence[str] | None = None) -> DevelopmentSmokeConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--selected-components", required=True)
+    parser.add_argument("--reused-components", required=True)
+    parser.add_argument("--checkout", type=Path, required=True)
+    parser.add_argument("--fixture-path", type=Path, required=True)
+    parser.add_argument("--recovery-archive-root", type=Path, required=True)
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    parser.add_argument("--formal-ae-app", type=Path, required=True)
+    parser.add_argument(
+        "--plugin-url",
+        default=os.environ.get("AE_MCP_PLUGIN_URL", "http://127.0.0.1:11488"),
+    )
+    arguments = parser.parse_args(argv)
+    return DevelopmentSmokeConfig(
+        scenario=arguments.scenario,
+        selected_components=_components(arguments.selected_components),
+        reused_components=_components(arguments.reused_components),
+        checkout=arguments.checkout,
+        fixture_path=arguments.fixture_path,
+        recovery_root=arguments.recovery_archive_root,
+        evidence_dir=arguments.evidence_dir,
+        formal_ae_app=arguments.formal_ae_app,
+        plugin_url=arguments.plugin_url,
+    )
+
+
+async def _run_cli(config: DevelopmentSmokeConfig) -> int:
+    async with live_session(config) as session:
+        result = await run_development_smoke(
+            config,
+            session=session,
+            checkpoint=stdin_checkpoint,
+            after_effects_running=formal_ae_running,
+        )
+    print(json.dumps({
+        "event": "PASS" if result.exit_code == 0 else "FAIL",
+        "validationProfile": "development",
+        "candidateRun": False,
+        "candidateEvidence": False,
+        "publicCalls": result.summary["publicCalls"]["total"],
+        "summaryPath": os.fspath(
+            next(config.evidence_dir.glob(f"{result.summary['runId']}.summary.json"))
+        ),
+    }, separators=(",", ":")), flush=True)
+    return result.exit_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return asyncio.run(_run_cli(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hardware/development_smoke_spec.py
+++ b/scripts/hardware/development_smoke_spec.py
@@ -1,0 +1,25 @@
+"""Frozen executable contract for the bounded development real-AE smoke."""
+
+from __future__ import annotations
+
+SCENARIO_ID = "core-native-write-undo@1"
+CALL_HARD_LIMIT = 7
+CALLS = (
+    ("readiness", "ae_projectSummary"),
+    ("composition-create", "ae_createComposition"),
+    ("baseline-settings", "ae_getCompositionSettings"),
+    ("background-set", "ae_setCompositionBackgroundColor"),
+    ("changed-settings", "ae_getCompositionSettings"),
+    ("undo-reacquire", "ae_listProjectItems"),
+    ("undo-settings", "ae_getCompositionSettings"),
+)
+
+# AEGP_CreateComp exposes no background-colour input. Its deterministic new-comp
+# background is opaque black; the first typed settings read is the independent
+# proof before the bounded setter changes it.
+BASELINE_COLOR = {"red": 0, "green": 0, "blue": 0, "alpha": 255}
+CHANGED_COLOR = {"red": 64, "green": 96, "blue": 128, "alpha": 255}
+
+assert len(CALLS) == CALL_HARD_LIMIT
+assert len({key for key, _ in CALLS}) == CALL_HARD_LIMIT
+assert len({tool for _, tool in CALLS}) == 5

--- a/scripts/package/test/capability-package-index.test.mjs
+++ b/scripts/package/test/capability-package-index.test.mjs
@@ -53,6 +53,38 @@ test('indexes every tracked capability brief deterministically', () => {
   assert.equal(fs.statSync(indexPath).mtimeMs, firstMtime);
 });
 
+test('indexes a split public-tool registry without admitting unrelated tool tables', () => {
+  const result = runGenerator([
+    path.join(repositoryRoot, 'docs/capability-packages/text-shape-marker.md'),
+    '--stdout',
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+
+  const parsed = JSON.parse(result.stdout);
+  assert.deepEqual(
+    parsed.tools.map((entry) => entry.name),
+    [
+      'ae_listInstalledFonts',
+      'ae_createTextLayer',
+      'ae_getTextDocument',
+      'ae_setTextContent',
+      'ae_setTextCharacterStyle',
+      'ae_setTextParagraphStyle',
+      'ae_createShapeLayer',
+      'ae_listShapeGroups',
+      'ae_createShapeGroup',
+      'ae_setShapePath',
+      'ae_setShapeFillStyle',
+      'ae_setShapeStrokeStyle',
+      'ae_reorderShapeGroup',
+      'ae_listMarkers',
+      'ae_createMarker',
+      'ae_setMarker',
+      'ae_deleteMarker',
+    ],
+  );
+});
+
 test('fails closed and writes no index when required brief structure is absent', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-bad-brief-'));
   const brief = path.join(root, 'bad.md');


### PR DESCRIPTION
## Why

Every development deploy ran the full release installation: verify the bundle and runtime manifests, verify every runtime file and the stable launcher, copy ~491 MB into a fresh generation, take the RuntimeManager exclusive lock, publish `current`.

That ceremony serves an installed user who has no Python. It is correct for release. During development it is pure cost, and it has already produced two real incidents — the ~85 GB of duplicated managed runtimes reclaimed on 2026-07-26 (#179) and the RuntimeManager lock that blocked a candidate deployment (#161).

`plugin/panel/src/cep/runtimeManager.js` is 1496 lines and had no environment override at all.

## What changed

`AE_MCP_DEV_RUNTIME` names an absolute source checkout. On a development build the panel launches that checkout's interpreter directly with `-B -I -m ae_mcp` and performs **no** manifest verification, **no** generation creation, **no** pointer mutation and **no** lock acquisition.

With the variable unset the packaged path is byte-for-byte the path it was.

## Guards

| | |
|---|---|
| Packaged release | refuses with `RUNTIME_DEVELOPMENT_RUNTIME_RELEASE_REFUSED` |
| Absent / unusable checkout | fails closed with `RUNTIME_DEVELOPMENT_RUNTIME_INVALID`, no production fallback |
| Diagnostics | `DEVELOPMENT CHECKOUT` + canonical checkout path + invoked and resolved interpreter |

The release refusal reuses the panel's existing development/release boundary (`.debug` present, `bundle-manifest.json` absent) rather than introducing a second mechanism. The compile-time switch referenced in `docs/THREAT_MODEL.md:41` no longer exists on `main` — it went with the local pairing removal.

**Mutation-proved:** disabling the release refusal makes its test fail (`Missing expected rejection`); restoring it passes.

## Scope

This does not touch production install, verify, repair, rollback or uninstall logic, the native plugin, or Windows behaviour. It adds no dependency and no network path.

## Verification

`pytest 1188 passed, 4 skipped` · `plugin/panel 994/0` · `plugin/host 156/0` · `protocol 45/0` · `scripts/package 409/0` · `scripts/release 123/0` · governance passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)