### PR TITLE
feat(panel): expose local attachments to selected chat backends

### DIFF
--- a/docs/platform/PLATFORM_HELPER_SECURITY.md
+++ b/docs/platform/PLATFORM_HELPER_SECURITY.md
@@ -88,4 +88,9 @@ and environment values are excluded from evidence.
 
 Runtime provider credentials remain behind the helper's OS credential-store interface. Phase 0
 signing evidence proves code identity and packaging order only; it does not grant credential-store
-access and never contains provider configuration.
+access and never contains provider configuration. The ad-hoc development Helper uses the current
+user's file-based macOS Keychain because Data Protection Keychain writes require a signed
+application identifier; it never falls back to a plaintext provider file. Release signing renders
+the application identifier from the protected Team ID, embeds it in the standalone Helper and XPC
+bundle, and verifies those entitlements before promotion. A signed Helper whose Team ID and
+application identifier do not match fails closed instead of using the development Keychain profile.

--- a/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
+++ b/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
@@ -4,7 +4,7 @@
 
 **Goal:** Register the verified bundled macOS Platform Helper and reach it from hardened Adobe CEP through a bounded same-binary stdio broker, so Provider credentials work in real After Effects without any plaintext fallback.
 
-**Architecture:** The CommonJS registration module validates the fixed seven-file macOS payload, materializes a private per-user launchd plist, reuses only an already-loaded service whose program path matches the verified Helper, and bootstraps the service when absent. Real AE proved that Adobe's hardened CEP process cannot load a non-Adobe-Team N-API addon. The macOS host therefore spawns the exact verified Helper executable in a bounded `--client-stdio` mode; that child owns the existing XPC connection. Service authorization accepts the broker only with its fixed native identity, direct trusted CEP parent, stable Adobe ancestry, current UID/audit session, and supported AE version. Windows keeps the addon path.
+**Architecture:** The CommonJS registration module validates the fixed seven-file macOS payload, materializes a private per-user launchd plist, reuses only an already-loaded service whose program path matches the verified Helper, and bootstraps the service when absent. Real AE proved that Adobe's hardened CEP process cannot load a non-Adobe-Team N-API addon. The macOS host therefore spawns the exact verified Helper executable in a bounded `--client-stdio` mode; that child owns the existing XPC connection. Service authorization accepts the broker only with its fixed native identity, direct trusted CEP renderer parent followed by the signed CEP process, stable Adobe ancestry, current UID/audit session, and supported AE version. Windows keeps the addon path.
 
 **Tech Stack:** Node.js CommonJS host modules, `node:test`, macOS `launchctl`, Swift stdio/XPC broker, Security.framework caller inspection, existing CEP development sync and non-candidate HDEV tooling.
 
@@ -44,7 +44,8 @@ transport placement while retaining the completed registration work.
   `--client-stdio` argument and private pipes.
 - [ ] Add failing lifecycle tests for bounded stdout frames, EOF, spawn failure,
   unexpected exit, and concurrent requests.
-- [ ] Add failing Swift tests for broker identity + direct CEP + AE ancestry,
+- [ ] Add failing Swift tests for broker identity + direct CEP renderer +
+  required CEP + AE ancestry,
   including independent mutations of every retained authorization boundary.
 
 ### Task 5: Implement the same-binary stdio broker
@@ -56,6 +57,14 @@ transport placement while retaining the completed registration work.
   and rejection-only backend behavior.
 - [ ] Change only macOS host transport to spawn the broker; retain the Windows
   N-API addon behavior unchanged.
+
+Real CEP process inspection refined the broker branch: Node executes in
+Adobe's signed `CEPHtmlEngine Helper (Renderer)`, so that renderer—not the
+top-level `CEPHtmlEngine`—is the broker's direct parent. Authorization pins the
+exact renderer identifier, then independently requires its signed
+`CEPHtmlEngine` parent and the supported AE ancestor; it does not accept an
+arbitrary Adobe-signed parent.
+
 - [ ] Prove the new guards by mutation, then run focused Node, Swift, protocol,
   static-boundary, panel, package, and governance checks.
 

--- a/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
+++ b/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
@@ -2,21 +2,71 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Register the verified bundled macOS Platform Helper before the panel opens its XPC connection, so Provider credentials work in real After Effects without any plaintext fallback.
+**Goal:** Register the verified bundled macOS Platform Helper and reach it from hardened Adobe CEP through a bounded same-binary stdio broker, so Provider credentials work in real After Effects without any plaintext fallback.
 
-**Architecture:** Add one focused CommonJS registration module beside the existing host transport. It validates the fixed seven-file macOS payload, materializes a private per-user launchd plist, reuses only an already-loaded service whose program path matches the verified Helper, and bootstraps the service when absent. The existing transport invokes that module before loading the native XPC connection; all Provider, protocol, caller-authorization, and Windows behavior remains unchanged.
+**Architecture:** The CommonJS registration module validates the fixed seven-file macOS payload, materializes a private per-user launchd plist, reuses only an already-loaded service whose program path matches the verified Helper, and bootstraps the service when absent. Real AE proved that Adobe's hardened CEP process cannot load a non-Adobe-Team N-API addon. The macOS host therefore spawns the exact verified Helper executable in a bounded `--client-stdio` mode; that child owns the existing XPC connection. Service authorization accepts the broker only with its fixed native identity, direct trusted CEP parent, stable Adobe ancestry, current UID/audit session, and supported AE version. Windows keeps the addon path.
 
-**Tech Stack:** Node.js CommonJS host modules, `node:test`, macOS `launchctl`, native N-API/XPC transport, existing CEP development sync and non-candidate HDEV tooling.
+**Tech Stack:** Node.js CommonJS host modules, `node:test`, macOS `launchctl`, Swift stdio/XPC broker, Security.framework caller inspection, existing CEP development sync and non-candidate HDEV tooling.
 
 ## Global Constraints
 
-- Do not change Provider routing, accepted credentials, plaintext fallback policy, Helper methods, protocol schemas, caller authorization, or release signing requirements.
+- Do not change Provider routing, accepted credentials, plaintext fallback policy, Helper methods, protocol schemas, or release signing requirements.
+- Caller authorization may add only the broker route described above; direct Adobe CEP authorization and every existing rejected-peer boundary remain covered.
 - Do not read, print, log, or persist plaintext Provider credentials outside the existing Helper request boundary.
 - Do not use a shell for registration; invoke only the fixed `/bin/launchctl` executable with an argv array.
 - Do not boot out, kill, or restart an already-loaded matching Helper during routine panel startup.
-- Windows keeps its existing verified-helper spawn path.
+- Windows keeps its existing verified-helper addon/spawn path.
 - Reuse installed dependencies; do not run `npm ci`, `uv sync`, portable-runtime generation, ZXP packaging, T5, or T6.
 - Real-machine verification is non-candidate HDEV and must run through the installed panel inside real After Effects.
+
+## Real-host correction checkpoint
+
+Tasks 1-3 below were completed and committed as `50378cb` and `c9614ad`.
+Focused tests, mutation proof, host/panel/package/governance checks, CEP-only
+sync, and an AE restart all passed their applicable boundaries. Real CEP then
+reported:
+
+```text
+ERR_DLOPEN_FAILED: mapping process and mapped file have different Team IDs
+```
+
+The installed CEP executable is Adobe Team `JQ525L2MZD`, hardened, and has no
+disable-library-validation entitlement. The development addon is ad-hoc signed;
+a release addon would use the product Team ID, which is still not Adobe's.
+Accordingly, the original “load addon inside CEP after registration” step is
+not a viable macOS product path. The following tasks supersede only that
+transport placement while retaining the completed registration work.
+
+### Task 4: Specify the out-of-process macOS transport
+
+- [ ] Add failing host tests proving macOS never loads the N-API addon, waits
+  for registration, and spawns only the verified Helper path with the literal
+  `--client-stdio` argument and private pipes.
+- [ ] Add failing lifecycle tests for bounded stdout frames, EOF, spawn failure,
+  unexpected exit, and concurrent requests.
+- [ ] Add failing Swift tests for broker identity + direct CEP + AE ancestry,
+  including independent mutations of every retained authorization boundary.
+
+### Task 5: Implement the same-binary stdio broker
+
+- [ ] Add Swift `--client-stdio` mode that reads one bounded JSON frame per line,
+  forwards it through the existing XPC protocol, writes one bounded response per
+  line, and exits on EOF.
+- [ ] Add the broker authorization branch while preserving the direct CEP branch
+  and rejection-only backend behavior.
+- [ ] Change only macOS host transport to spawn the broker; retain the Windows
+  N-API addon behavior unchanged.
+- [ ] Prove the new guards by mutation, then run focused Node, Swift, protocol,
+  static-boundary, panel, package, and governance checks.
+
+### Task 6: Real-AE development verification
+
+- [ ] Rebuild only the changed Helper/CEP components and perform development
+  sync without dependency bootstrap or release packaging.
+- [ ] Restart formal AE, obtain Helper capabilities from the Adobe CEP process,
+  and verify the service caller evidence is authorized.
+- [ ] Run only the pending non-candidate Claude Provider multimodal HDEV; do not
+  run packaged T5/T6.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
+++ b/docs/superpowers/plans/2026-07-28-macos-platform-helper-registration.md
@@ -1,0 +1,504 @@
+# macOS Platform Helper Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Register the verified bundled macOS Platform Helper before the panel opens its XPC connection, so Provider credentials work in real After Effects without any plaintext fallback.
+
+**Architecture:** Add one focused CommonJS registration module beside the existing host transport. It validates the fixed seven-file macOS payload, materializes a private per-user launchd plist, reuses only an already-loaded service whose program path matches the verified Helper, and bootstraps the service when absent. The existing transport invokes that module before loading the native XPC connection; all Provider, protocol, caller-authorization, and Windows behavior remains unchanged.
+
+**Tech Stack:** Node.js CommonJS host modules, `node:test`, macOS `launchctl`, native N-API/XPC transport, existing CEP development sync and non-candidate HDEV tooling.
+
+## Global Constraints
+
+- Do not change Provider routing, accepted credentials, plaintext fallback policy, Helper methods, protocol schemas, caller authorization, or release signing requirements.
+- Do not read, print, log, or persist plaintext Provider credentials outside the existing Helper request boundary.
+- Do not use a shell for registration; invoke only the fixed `/bin/launchctl` executable with an argv array.
+- Do not boot out, kill, or restart an already-loaded matching Helper during routine panel startup.
+- Windows keeps its existing verified-helper spawn path.
+- Reuse installed dependencies; do not run `npm ci`, `uv sync`, portable-runtime generation, ZXP packaging, T5, or T6.
+- Real-machine verification is non-candidate HDEV and must run through the installed panel inside real After Effects.
+
+---
+
+## File Structure
+
+- Create `plugin/host/platform-helper-registration.js`: macOS manifest verification, private plist materialization, launchd inspection, and bootstrap.
+- Create `plugin/host/platform-helper-registration.test.js`: direct property tests for payload, state-directory, argv, reuse, and failure classification.
+- Modify `plugin/host/platform-helper-transport.js`: call the registrar before opening macOS native XPC and preserve its bounded lifecycle errors.
+- Modify `plugin/host/platform-helper-transport.test.js`: integration ordering, single-flight registration, mutation guard, Windows non-regression, and process-boundary allowlist.
+- Modify `plugin/client/dist/app.js`: generated panel bundle produced by the existing build.
+
+### Task 1: Verified macOS registration boundary
+
+**Files:**
+- Create: `plugin/host/platform-helper-registration.js`
+- Create: `plugin/host/platform-helper-registration.test.js`
+
+**Interfaces:**
+- Consumes: an absolute addon path ending in `lib/ae-mcp-platform-helper-transport.node`; injected `fsImpl`, `createHash`, `execFile`, `homedir`, `getuid`, and `processId` for deterministic tests.
+- Produces:
+
+```js
+prepareMacosHelperRegistration(options) -> Object.freeze({
+    helperPath: string,
+    ensureRegistered: async function () -> undefined,
+})
+```
+
+- Throws only bounded errors with `{code, retryable}`:
+  - malformed/tampered payload or mismatched loaded program:
+    `PLATFORM_HELPER_REPAIR_REQUIRED`, `retryable:false`;
+  - launchctl execution/bootstrap failure:
+    `HELPER_START_FAILED`, `retryable:true`.
+
+- [ ] **Step 1: Write fixture helpers and the failing happy-path test**
+
+Create a seven-file fixture whose manifest matches:
+
+```js
+const MACOS_FILES = [
+    ['bin/ae-mcp-platform-helper', 'macho-arm64'],
+    ['bin/ae-mcp', 'script'],
+    ['lib/ae-mcp-platform-helper-transport.node', 'macho-arm64'],
+    ['xpc/com.junkdoge.ae-mcp.platform-helper.xpc/Contents/MacOS/ae-mcp-platform-helper', 'macho-arm64'],
+    ['xpc/com.junkdoge.ae-mcp.platform-helper.xpc/Contents/Info.plist', 'data'],
+    ['metadata/PlatformHelper.entitlements', 'data'],
+    ['launchd/com.junkdoge.ae-mcp.platform-helper.plist', 'data'],
+];
+```
+
+The launchd mock must observe exactly:
+
+```js
+[
+    ['/bin/launchctl', ['print', 'gui/501/com.junkdoge.ae-mcp.platform-helper']],
+    ['/bin/launchctl', ['bootstrap', 'gui/501', generatedPlist]],
+    ['/bin/launchctl', ['print', 'gui/501/com.junkdoge.ae-mcp.platform-helper']],
+]
+```
+
+The first `print` rejects as absent; the second returns the literal
+`program = ` prefix followed by the fixture's verified absolute Helper path.
+
+```text
+program = /fixture/platform/macos-arm64/bin/ae-mcp-platform-helper
+```
+
+Assert that the generated plist:
+
+```js
+assert.equal(plist.includes('__AE_MCP_HELPER_EXECUTABLE__'), false);
+assert.equal(plist.includes(verifiedHelperPath), true);
+assert.equal((fs.statSync(stateRoot).mode & 0o077), 0);
+assert.equal((fs.statSync(generatedPlist).mode & 0o177), 0);
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-registration.test.js
+```
+
+Expected: FAIL because `./platform-helper-registration` does not exist.
+
+- [ ] **Step 3: Implement strict payload verification**
+
+In `platform-helper-registration.js`, define the exact file/architecture records,
+resolve every manifest path beneath the helper root, reject symlinks and
+non-regular files, and compare every file to its manifest SHA-256. Validate:
+
+```js
+manifest.schemaVersion === 1
+manifest.platform === 'macos-arm64'
+manifest.helperId === 'com.junkdoge.ae-mcp.platform-helper'
+manifest.entrypoints.helper === 'bin/ae-mcp-platform-helper'
+manifest.entrypoints.launcher === 'bin/ae-mcp'
+```
+
+Reject missing, extra, duplicate, reordered, or architecture-mismatched file
+records before any launchctl invocation.
+
+- [ ] **Step 4: Implement private plist materialization**
+
+Use:
+
+```js
+const stateRoot = path.join(
+    homedir(),
+    'Library',
+    'Application Support',
+    'AfterEffectsMCP',
+    'platform-helper-v1',
+);
+```
+
+Create/chmod the directory to `0700`, reject a symbolic/non-directory state
+root, XML-escape the verified helper path, replace exactly one template token,
+write a unique `0600` temporary file with `flag:'wx'`, and atomically rename it
+to `com.junkdoge.ae-mcp.platform-helper.plist`.
+
+- [ ] **Step 5: Implement registration and exact service reuse**
+
+Wrap callback-style `execFile` in a Promise with:
+
+```js
+execFile('/bin/launchctl', args, {
+    encoding: 'utf8',
+    timeout: 5000,
+    windowsHide: true,
+    maxBuffer: 65536,
+}, callback);
+```
+
+Algorithm:
+
+```js
+const domain = 'gui/' + getuid();
+const service = domain + '/com.junkdoge.ae-mcp.platform-helper';
+const current = await launchctl(['print', service], { allowMissing: true });
+if (current.found) {
+    requireExactProgram(current.stdout, helperPath);
+    return;
+}
+const plistPath = materializePrivatePlist();
+await launchctl(['bootstrap', domain, plistPath]);
+const registered = await launchctl(['print', service]);
+requireExactProgram(registered.stdout, helperPath);
+```
+
+`requireExactProgram` accepts only a trimmed launchctl line equal to
+`program = ${helperPath}`. It must not use substring matching.
+
+- [ ] **Step 6: Add failing security and lifecycle tests**
+
+Add independent tests that assert:
+
+1. changing one payload byte prevents all launchctl calls;
+2. an extra manifest file prevents all launchctl calls;
+3. a symbolic state root prevents all launchctl calls;
+4. an already-loaded exact program performs one `print`, no `bootstrap`, no
+   `bootout`;
+5. an already-loaded different program fails
+   `PLATFORM_HELPER_REPAIR_REQUIRED`;
+6. failed `bootstrap` returns `HELPER_START_FAILED` without leaking stderr or
+   local paths in the public message;
+7. concurrent `ensureRegistered()` calls share one registration Promise.
+
+- [ ] **Step 7: Run the tests and verify GREEN**
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-registration.test.js
+```
+
+Expected: all registration tests pass with no warnings.
+
+- [ ] **Step 8: Commit the registration unit**
+
+```bash
+git add plugin/host/platform-helper-registration.js plugin/host/platform-helper-registration.test.js
+git commit -m "fix(panel): register verified macOS platform helper"
+```
+
+### Task 2: Bind registration to the macOS transport
+
+**Files:**
+- Modify: `plugin/host/platform-helper-transport.js`
+- Modify: `plugin/host/platform-helper-transport.test.js`
+
+**Interfaces:**
+- Consumes:
+
+```js
+prepareMacosHelperRegistration({ addonPath, ...injectedDependencies })
+```
+
+- Adds one test injection point:
+
+```js
+options.prepareMacosHelperRegistration
+```
+
+- The injected function returns the exact `{helperPath, ensureRegistered}`
+  object defined in Task 1.
+
+- [ ] **Step 1: Write the failing registration-before-XPC test**
+
+Add a macOS test that records:
+
+```js
+events.push('register:start');
+events.push('register:done');
+events.push('addon:createTransport');
+events.push('native:request');
+```
+
+Resolve registration asynchronously and assert the native addon is not opened
+until it resolves. After `transport.request('xpc')`, assert:
+
+```js
+assert.deepEqual(events, [
+    'register:start',
+    'register:done',
+    'addon:createTransport',
+    'native:request',
+]);
+```
+
+- [ ] **Step 2: Run the transport test and verify RED**
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-transport.test.js
+```
+
+Expected: FAIL because macOS currently opens the addon transport without
+registration.
+
+- [ ] **Step 3: Implement the minimal transport integration**
+
+Load `prepareMacosHelperRegistration` from the new module. Construct it before
+loading the addon so a malformed payload blocks native code. Add:
+
+```js
+async function connectMacos() {
+    await macosRegistration.ensureRegistered();
+    return openNativeTransport();
+}
+```
+
+Use `connectMacos()` only for `macos-arm64`; keep `connectWindows()` byte-for-byte
+equivalent in behavior. Preserve registrar error codes through the transport
+and existing sanitized client boundary.
+
+- [ ] **Step 4: Update the host process-boundary invariant**
+
+The current static test permits process launch only in
+`platform-helper-transport.js`. Change it to permit process APIs only in:
+
+```js
+new Set([
+    'platform-helper-transport.js',
+    'platform-helper-registration.js',
+])
+```
+
+Add source assertions that the registration module contains `/bin/launchctl`,
+uses `execFile`, and contains none of:
+
+```text
+shell:true
+exec(
+spawn(
+bootout
+kill
+stdio:'inherit'
+```
+
+- [ ] **Step 5: Add failure and single-flight integration tests**
+
+Assert:
+
+- concurrent macOS requests invoke `ensureRegistered()` once;
+- registrar `HELPER_START_FAILED` remains retryable and does not open native
+  transport;
+- registrar `PLATFORM_HELPER_REPAIR_REQUIRED` remains non-retryable and does
+  not open native transport;
+- Windows does not construct or invoke the macOS registrar.
+
+- [ ] **Step 6: Run focused host tests and verify GREEN**
+
+Run:
+
+```bash
+node --test \
+  plugin/host/platform-helper-registration.test.js \
+  plugin/host/platform-helper-transport.test.js \
+  plugin/host/platform-helper-client.test.js
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Prove the ordering guard by mutation**
+
+Temporarily remove only:
+
+```js
+await macosRegistration.ensureRegistered();
+```
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-transport.test.js
+```
+
+Expected: the registration-before-XPC test fails because
+`addon:createTransport` appears before registration. Restore the line and rerun
+the same command; expected PASS. Record both outcomes in the completion
+evidence.
+
+- [ ] **Step 8: Commit the transport integration**
+
+```bash
+git add plugin/host/platform-helper-transport.js plugin/host/platform-helper-transport.test.js
+git commit -m "fix(panel): start macOS helper before XPC"
+```
+
+### Task 3: Rebuild and run affected automated tiers
+
+**Files:**
+- Modify generated file: `plugin/client/dist/app.js`
+
+**Interfaces:**
+- Consumes the host registration and transport behavior from Tasks 1-2.
+- Produces an installed CEP candidate containing the updated host files and
+  rebuilt panel bundle; no Core/native/runtime artifact changes.
+
+- [ ] **Step 1: Run all host and panel tests**
+
+Run:
+
+```bash
+npm --prefix plugin/host test
+npm --prefix plugin/panel test
+```
+
+Expected: all tests pass. The known unrelated receipt-reuse flake may be
+reported once but must not hide a deterministic failure in the changed tests.
+
+- [ ] **Step 2: Rebuild the panel bundle**
+
+Run:
+
+```bash
+npm --prefix plugin/panel run build
+```
+
+Expected: exit 0 and only the generated `plugin/client/dist/app.js` changes in
+addition to intended source/tests/docs.
+
+- [ ] **Step 3: Run package and governance checks affected by host/process rules**
+
+Run these affected package, platform, and governance checks without dependency
+installation:
+
+```bash
+node --test \
+  scripts/package/test/dev-install-contract.test.mjs \
+  scripts/package/test/no-platform-leaks.test.mjs \
+  scripts/package/test/repository-governance.test.mjs \
+  native/platform-helper/macos/Tests/platform-helper-static.test.mjs
+node scripts/check-repository-governance.mjs
+```
+
+Expected: all selected checks pass.
+
+- [ ] **Step 4: Audit the diff and commit generated output**
+
+Confirm:
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+No Core, native Helper, protocol schema, Provider routing, or dependency lock
+file may change.
+
+Commit:
+
+```bash
+git add plugin/client/dist/app.js
+git commit -m "chore(panel): rebuild helper registration bundle"
+```
+
+### Task 4: Component-selective real-AE verification
+
+**Files:**
+- No tracked source edits expected.
+- Evidence remains in the existing ignored HDEV evidence root and is
+  permanently non-candidate.
+
+**Interfaces:**
+- Consumes the existing `scripts/dev/ae-mcp-dev.mjs` component-selective
+  workflow and installed Helper payload.
+- Produces read-only Helper capability evidence and the pending Claude Provider
+  multimodal HDEV result.
+
+- [ ] **Step 1: Record the pre-sync development state**
+
+Record branch/HEAD, clean status, current CEP install receipt/path, current
+Helper manifest metadata, and active AE PID. Do not hash the Core/native runtime
+tree and do not inspect Provider secret values.
+
+- [ ] **Step 2: Close the formal After Effects process and sync only CEP**
+
+Use the already-authorized normal GUI quit path, verify all After Effects and
+AfterFX processes exited, then run:
+
+```bash
+node scripts/dev/ae-mcp-dev.mjs sync \
+  --component cep \
+  --repo-root "$(pwd -P)" \
+  --home "$HOME" \
+  --formal-ae-app "/Applications/Adobe After Effects 2026/Adobe After Effects 2026.app"
+```
+
+Expected receipt:
+
+```text
+selected=["cep"]
+dependencyBootstrapInvocations=0
+releasePackagingInvocations=0
+```
+
+- [ ] **Step 3: Launch formal AE and verify Helper registration**
+
+Launch through the existing development command, open the panel, and verify:
+
+```bash
+launchctl print gui/$(id -u)/com.junkdoge.ae-mcp.platform-helper
+```
+
+The service program must equal the verified installed Helper path. From the
+CEP-in-process host, call only `capabilities()` and verify protocol version 1,
+platform `macos-arm64`, Helper version `0.9.2`, `authenticatedCaller:true`, and
+the exact method set. Do not use an external Node process as authorization
+evidence because it is intentionally not an Adobe CEP caller.
+
+- [ ] **Step 4: Run the pending Claude Provider HDEV**
+
+Use the existing panel acceptance bridge and five-file multimodal fixture from
+the current branch. Verify the Claude custom Provider route reaches Claude Code
+through the loopback Provider facade, attachments are exposed as scoped file
+paths, public AE MCP calls remain observable, and no plaintext credential is
+written to panel storage or evidence.
+
+This run is explicitly:
+
+```text
+profile=development
+candidateEvidence=false
+T5=false
+T6=false
+```
+
+- [ ] **Step 5: Verify recovery and final state**
+
+Close the acceptance route cleanly, confirm no unreconciled write or secret
+migration remains, preserve only redacted non-candidate evidence, and report:
+
+- original native error and confirmed root cause;
+- source commits;
+- focused/full automated test counts;
+- mutation RED and restored GREEN;
+- CEP-only sync with zero dependency/bootstrap/release-package invocations;
+- launchd service identity and CEP-authenticated capabilities;
+- Claude Provider HDEV disposition;
+- remaining release/Windows risks without claiming packaged acceptance.

--- a/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
+++ b/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
@@ -211,7 +211,7 @@ Add `turn-accepted` to `BACKEND_EVENTS`. Add these exact dispositions:
 subscription: { attachmentTransport: 'agent-sdk' }
 'claude-api': { attachmentTransport: 'agent-sdk' }
 byok: { attachmentTransport: 'reject' }
-codex: { attachmentTransport: 'native' }
+codex: { attachmentTransport: 'native+manifest' }
 opencode: { attachmentTransport: 'native' }
 zcode: { attachmentTransport: 'manifest' }
 ```
@@ -828,28 +828,35 @@ git commit -m "feat(panel): retain attachment turns until accepted"
 - Consumes: normalized `TurnInput`, `withAttachmentManifest`, and
   `attachmentFileUrl`
 - Produces: one `turn-accepted` event per accepted turn
-- Codex transport: app-server local input items
+- Codex transport: manifest for every file plus native image/audio input items
 - OpenCode transport: `FilePartInput`
 - ZCode transport: delimited attachment manifest
 - BYOK transport: pre-dispatch structured rejection
 
-- [ ] **Step 1: Write failing Codex native-input tests**
+- [ ] **Step 1: Write failing Codex hybrid-input tests**
 
 Assert the `turn/start` body contains:
 
 ```js
 [
-  { type: 'text', text: 'inspect' },
+  {
+    type: 'text',
+    text: 'inspect\n\n<ae_mcp_attachments version="1">\n'
+      + '{"files":[/* every attachment in order */]}\n'
+      + '</ae_mcp_attachments>',
+  },
   { type: 'localImage', path: '/tmp/frame.png' },
   { type: 'localAudio', path: '/tmp/audio.wav' },
-  { type: 'mention', name: 'clip.mov', path: '/tmp/clip.mov' },
 ]
 ```
 
 Use advisory `mediaType` only to select the app-server's image/audio native
-shape; every other file uses the generic `mention`. Assert `turn/started`
-emits `{type:'turn-accepted', turnId, transport:'codex-app-server'}` exactly
-once before normal streaming.
+shape. The app-server's `mention` item is for `app://` and `plugin://`
+references, not arbitrary local files, so every attachment also appears in
+the manifest and no filesystem path is serialized as a `mention`. Assert
+`turn/started` emits
+`{type:'turn-accepted', turnId, transport:'codex-app-server'}` exactly once
+before normal streaming.
 
 - [ ] **Step 2: Write failing OpenCode file-part tests**
 
@@ -914,9 +921,10 @@ Expected: FAIL on string-only serialization and the missing acceptance event.
 - [ ] **Step 6: Implement Codex mapping**
 
 Store `activeTurnId` and the full normalized turn. Replace `turnParams(text)`
-with `turnParams(turn, textWithPreamble)`. Build the text item only when text is
-non-empty, append every file item in order, and keep the preamble confined to
-the text item.
+with `turnParams(turn, textWithPreamble)`. Build one text item containing the
+user text plus an attachment manifest whenever attachments are present, append
+native image/audio items in attachment order, and keep the preamble confined
+to the text item.
 
 Never place a local path in emitted events or transcript messages.
 
@@ -1218,7 +1226,7 @@ Expected: all commands pass and `plugin/client/dist/app.js` plus
 
 - [ ] **Step 4: Perform an explicit production-code mutation proof**
 
-Temporarily remove `attachmentTransport: 'native'` from the Codex registry row
+Temporarily remove `attachmentTransport: 'native+manifest'` from the Codex registry row
 using `apply_patch`. Run:
 
 ```bash

--- a/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
+++ b/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
@@ -2,16 +2,18 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add FilePond-backed local file attachments to the real AE chat Composer and expose every attachment through Codex, Claude Agent SDK, OpenCode, and ZCode without panel-side content parsing.
+**Goal:** Add FilePond-backed local file attachments to the real AE chat Composer and expose every attachment through the built-in Codex and Claude Code choices without panel-side content parsing.
 
-**Architecture:** The Panel owns one normalized `TurnInput` contract and one session-scoped attachment store. FilePond owns picker/drop/paste presentation, while a thin draft reducer and store create stable local references. Backend adapters map those references to native local-file items where available or to a delimited, non-visible attachment manifest; the legacy direct-HTTP `byok` fallback rejects attachment turns before dispatch because it cannot read local files.
+**Architecture:** The Panel owns one normalized `TurnInput` contract and one session-scoped attachment store. FilePond owns picker/drop/paste presentation, while a thin draft reducer and store create stable local references. Backend adapters map those references to native local-file items where available or to a delimited, non-visible attachment manifest. Claude subscription and custom Provider channels both use the Agent SDK sidecar; custom Providers are exposed through a panel-owned loopback route. The internal legacy direct-HTTP `byok` backend remains only for state compatibility and is never a live fallback.
 
 **Tech Stack:** React 18.3.1, FilePond 4.32.12, react-filepond 7.1.3, filepond-plugin-image-preview 4.6.12, CEP Node filesystem APIs, Node test runner, Codex app-server JSON-RPC, Claude Agent SDK sidecar, OpenCode HTTP/SSE, ZCode app-server RPC.
 
 ## Global Constraints
 
-- Supported attachment backends are Codex, Claude Agent SDK, OpenCode, and ZCode.
-- The internal legacy `byok` HTTP fallback remains text-only and must reject attachment turns before dispatch with `ATTACHMENT_SIDECAR_REQUIRED`.
+- Built-in attachment choices and real-host HDEV targets are Codex and Claude Code.
+- Claude custom Providers use the Claude Agent SDK loopback route; absence of a usable Node/sidecar runtime fails closed with no direct-HTTP fallback.
+- Internal OpenCode and ZCode adapters remain contract-tested but are not exposed or exercised in this slice.
+- The internal legacy `byok` HTTP backend remains text-only and must reject attachment turns before dispatch with `ATTACHMENT_SIDECAR_REQUIRED`.
 - Do not add a file-extension or MIME allowlist.
 - Do not parse, extract, OCR, transcribe, index, convert, transcode, thumbnail video, or sample video frames.
 - Do not add a provider upload manager or a new public AE MCP tool.
@@ -1236,7 +1238,7 @@ Verify:
 
 - no parser, converter, upload endpoint, video slicer, or MIME allowlist was
   introduced;
-- only the legacy `byok` fallback rejects attachments;
+- only the internal legacy `byok` backend rejects attachments;
 - every supported backend carries all attachment refs in order;
 - absolute paths occur only inside scoped store/transport code and tests;
 - no native, Core, public MCP, protocol, release, #67, or #69 files changed;
@@ -1269,7 +1271,7 @@ Create, outside tracked source and outside Adobe scan roots:
 Record lifecycle `ephemeral-validation`, the file count, and a cleanup
 condition. Do not retain file contents in the PR or checkpoint.
 
-- [ ] **Step 8: Run focused real AE/CEP validation through all four backends**
+- [ ] **Step 8: Run focused real AE/CEP validation through both built-in backends**
 
 In the actual AE panel:
 
@@ -1277,8 +1279,8 @@ In the actual AE panel:
 2. remove and re-add one item;
 3. send an attachment-only turn;
 4. send a text-plus-attachment turn;
-5. verify each supported backend receives all filenames in order:
-   Codex, Claude Agent SDK, OpenCode, and ZCode;
+5. verify each built-in backend receives all filenames in order:
+   Codex and Claude Agent SDK;
 6. record native versus manifest transport for each;
 7. on one native multimodal backend, ask it to use the image or video through
    its own capability;
@@ -1319,7 +1321,7 @@ Create `docs/checkpoints/2026-07-28-multimodal-file-input-hdev.md` containing:
   fixture contents.
 
 Update the design status to “Implemented; non-candidate HDEV verified” only if
-all four supported backend checks passed.
+both built-in backend checks passed.
 
 - [ ] **Step 11: Run final verification**
 
@@ -1355,7 +1357,8 @@ Review specifically:
 - no cleanup path can escape the managed root;
 - no absolute path reaches logs or transcript;
 - every backend emits one correctly correlated acceptance event;
-- legacy BYOK fails before dispatch;
+- internal legacy BYOK fails before dispatch and is not a live Provider
+  fallback;
 - FilePond introduces no format allowlist or upload endpoint;
 - existing Composer resize and keyboard behavior remains intact.
 

--- a/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
+++ b/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
@@ -1,0 +1,1360 @@
+# Multimodal File Input Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add FilePond-backed local file attachments to the real AE chat Composer and expose every attachment through Codex, Claude Agent SDK, OpenCode, and ZCode without panel-side content parsing.
+
+**Architecture:** The Panel owns one normalized `TurnInput` contract and one session-scoped attachment store. FilePond owns picker/drop/paste presentation, while a thin draft reducer and store create stable local references. Backend adapters map those references to native local-file items where available or to a delimited, non-visible attachment manifest; the legacy direct-HTTP `byok` fallback rejects attachment turns before dispatch because it cannot read local files.
+
+**Tech Stack:** React 18.3.1, FilePond 4.32.12, react-filepond 7.1.3, filepond-plugin-image-preview 4.6.12, CEP Node filesystem APIs, Node test runner, Codex app-server JSON-RPC, Claude Agent SDK sidecar, OpenCode HTTP/SSE, ZCode app-server RPC.
+
+## Global Constraints
+
+- Supported attachment backends are Codex, Claude Agent SDK, OpenCode, and ZCode.
+- The internal legacy `byok` HTTP fallback remains text-only and must reject attachment turns before dispatch with `ATTACHMENT_SIDECAR_REQUIRED`.
+- Do not add a file-extension or MIME allowlist.
+- Do not parse, extract, OCR, transcribe, index, convert, transcode, thumbnail video, or sample video frames.
+- Do not add a provider upload manager or a new public AE MCP tool.
+- Accept at most 32 attachments per turn.
+- Stable path-backed files are references and have no Panel-level byte cap.
+- Pathless clipboard blobs are capped at 256 MiB each and 512 MiB per turn.
+- Never log file contents, absolute paths, generated manifests, credentials, or signed URLs.
+- Delete only application-created temporary files; never modify or delete a user original.
+- Preserve existing Enter, Shift+Enter, Shift+ArrowUp/Down, pointer resize, chips, send/stop, streaming, and approval behavior.
+- Reuse the current development dependencies and installed AE environment where unchanged.
+- Run ordinary focused development validation only. Do not run packaged T5 or T6.
+- Do not touch the dirty root checkout or its existing #67/#69 and release changes.
+
+---
+
+## File Structure
+
+### New files
+
+- `plugin/shared/chat-attachments.mjs`
+  - Normalizes `TurnInput` and `AttachmentRef`.
+  - Builds redacted display metadata, native file URLs, and the delimited model-facing manifest.
+  - Defines the fixed attachment and clipboard resource constants.
+  - Is imported by both the Panel bundle and Claude sidecar so manifest syntax
+    cannot drift across processes.
+- `plugin/panel/src/lib/attachmentDraft.js`
+  - Pure reducer for pending, staging, ready, failed, sending, accepted, and rejected draft states.
+- `plugin/panel/src/cep/attachmentStore.js`
+  - Validates stable source paths.
+  - Atomically stages pathless Blob data in bounded chunks.
+  - Tracks temporary ownership and performs contained cleanup.
+- `plugin/panel/src/components/chat/AttachmentPond.jsx`
+  - Registers FilePond's image preview plugin.
+  - Renders picker/drop/paste, progress, generic cards, image previews, errors, and remove actions.
+- `plugin/panel/test/attachments.test.js`
+  - Common contract, manifest, URL, display-redaction, limits, and registry-invariant tests.
+- `plugin/panel/test/attachmentDraft.test.js`
+  - Pure draft state and send/accept/reject tests.
+- `plugin/panel/test/attachmentStore.test.js`
+  - Real temporary-directory staging and cleanup tests.
+- `plugin/panel/test/composerAttachmentsWiring.test.js`
+  - Source-level React wiring and keyboard-regression guard.
+
+### Modified files
+
+- `plugin/panel/package.json`
+- `plugin/panel/package-lock.json`
+- `plugin/panel/src/main.jsx`
+- `plugin/panel/src/styles/index.css`
+- `plugin/panel/src/components/chat/Composer.jsx`
+- `plugin/panel/src/components/chat/ChatBubble.jsx`
+- `plugin/panel/src/screens/ChatScreen.jsx`
+- `plugin/panel/src/app/App.jsx`
+- `plugin/panel/src/lib/chatEntries.js`
+- `plugin/panel/src/lib/agentLoop.js`
+- `plugin/panel/src/cep/backends/contract.js`
+- `plugin/panel/src/cep/backends/index.js`
+- `plugin/panel/src/cep/codexBackend.js`
+- `plugin/panel/src/cep/claudeAgentBackend.js`
+- `plugin/panel/src/cep/openCodeBackend.js`
+- `plugin/panel/src/cep/zcodeBackend.js`
+- `plugin/sidecar/lib.mjs`
+- `plugin/panel/test/backends-contract.test.js`
+- `plugin/panel/test/chatEntries.test.js`
+- `plugin/panel/test/agentLoop.test.js`
+- `plugin/panel/test/codexBackend.test.js`
+- `plugin/panel/test/claudeAgentBackend.test.js`
+- `plugin/panel/test/openCodeBackend.test.js`
+- `plugin/panel/test/zcodeBackend.test.js`
+- `plugin/sidecar/test/sidecar.test.js`
+- `docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md`
+
+---
+
+### Task 1: Freeze the shared turn and backend attachment contracts
+
+**Files:**
+- Create: `plugin/shared/chat-attachments.mjs`
+- Modify: `plugin/panel/src/cep/backends/contract.js`
+- Modify: `plugin/panel/src/cep/backends/index.js`
+- Create: `plugin/panel/test/attachments.test.js`
+- Modify: `plugin/panel/test/backends-contract.test.js`
+
+**Interfaces:**
+- Produces: `normalizeTurnInput(input) -> TurnInput`
+- Produces: `displayAttachments(attachments) -> DisplayAttachment[]`
+- Produces: `attachmentManifest(attachments) -> string`
+- Produces: `withAttachmentManifest(text, attachments) -> string`
+- Produces: `attachmentFileUrl(path, platformId) -> string`
+- Produces: `assertAttachmentBackendRegistry(registry) -> true`
+- Produces event: `{type: "turn-accepted", turnId: string, transport: string}`
+- Extends pre-acceptance errors with:
+  `turnId: string` and `dispatchState: "not-started" | "uncertain"`
+- Produces registry field: `attachmentTransport: "agent-sdk" | "native" | "manifest" | "reject"`
+
+- [ ] **Step 1: Write failing common-contract tests**
+
+Add exact tests covering legacy string normalization, attachment-only turns,
+order preservation, display redaction, manifest generation, Windows/macOS file
+URLs, and invalid shapes:
+
+```js
+test('normalizeTurnInput preserves an attachment-only turn', () => {
+  const turn = normalizeTurnInput({
+    turnId: 'turn-1',
+    text: '',
+    attachments: [{
+      id: 'att-1',
+      name: 'clip.bin',
+      localPath: '/tmp/private/clip.bin',
+      size: 3,
+      mediaType: 'application/octet-stream',
+      temporary: true,
+    }],
+  });
+  assert.equal(turn.turnId, 'turn-1');
+  assert.equal(turn.text, '');
+  assert.equal(turn.attachments[0].localPath, '/tmp/private/clip.bin');
+});
+
+test('display metadata never contains a local path', () => {
+  const value = displayAttachments([fixtureAttachment()]);
+  assert.deepEqual(value, [{
+    id: 'att-1',
+    name: 'clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+  }]);
+  assert.equal(JSON.stringify(value).includes('/tmp/private'), false);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify the contract does not exist**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachments.test.js test/backends-contract.test.js
+```
+
+Expected: FAIL because `chat-attachments.mjs`, `turn-accepted`, and
+`attachmentTransport` do not exist.
+
+- [ ] **Step 3: Implement the normalized contract and manifest helpers**
+
+Use the following public shapes:
+
+```js
+export const MAX_ATTACHMENTS_PER_TURN = 32;
+export const MAX_CLIPBOARD_ITEM_BYTES = 256 * 1024 * 1024;
+export const MAX_CLIPBOARD_TURN_BYTES = 512 * 1024 * 1024;
+export const ATTACHMENT_MANIFEST_OPEN = '<ae_mcp_attachments version="1">';
+export const ATTACHMENT_MANIFEST_CLOSE = '</ae_mcp_attachments>';
+
+export function normalizeTurnInput(input) {
+  const source = typeof input === 'string'
+    ? { turnId: '', text: input, attachments: [] }
+    : input;
+  // Return a fresh frozen-compatible object after exact primitive checks.
+}
+
+export function displayAttachments(attachments) {
+  return attachments.map(({ id, name, size, mediaType }) => ({
+    id, name, size, ...(mediaType ? { mediaType } : {}),
+  }));
+}
+
+export function attachmentManifest(attachments) {
+  const files = attachments.map(({ id, name, localPath, size, mediaType }) => ({
+    id, name, path: localPath, size, mediaType: mediaType || 'application/octet-stream',
+  }));
+  return ATTACHMENT_MANIFEST_OPEN + '\n'
+    + JSON.stringify({ files }) + '\n'
+    + ATTACHMENT_MANIFEST_CLOSE;
+}
+
+export function withAttachmentManifest(text, attachments) {
+  const body = String(text || '');
+  if (!attachments.length) return body;
+  return body
+    ? body + '\n\n' + attachmentManifest(attachments)
+    : attachmentManifest(attachments);
+}
+```
+
+`attachmentFileUrl` must percent-encode path components and produce
+`file:///C:/...` on `windows-x64` and `file:///...` on `macos-arm64`.
+
+- [ ] **Step 4: Add the acceptance event and registry dispositions**
+
+Add `turn-accepted` to `BACKEND_EVENTS`. Add these exact dispositions:
+
+```js
+subscription: { attachmentTransport: 'agent-sdk' }
+'claude-api': { attachmentTransport: 'agent-sdk' }
+byok: { attachmentTransport: 'reject' }
+codex: { attachmentTransport: 'native' }
+opencode: { attachmentTransport: 'native' }
+zcode: { attachmentTransport: 'manifest' }
+```
+
+`assertAttachmentBackendRegistry` must enumerate the supplied registry,
+require one known disposition on every row, allow `reject` only for `byok`,
+and require every other row to have a non-reject transport.
+
+Document the dispatch rule in `backends/contract.js`:
+
+- an error before any model-turn request is sent uses
+  `dispatchState: "not-started"`;
+- a transport failure after the request is sent but before `turn-accepted`
+  uses `dispatchState: "uncertain"`;
+- no adapter retries an uncertain turn automatically.
+
+- [ ] **Step 5: Prove the registry guard with an in-test mutation**
+
+Add:
+
+```js
+test('attachment registry rejects a missing supported-backend mapping', () => {
+  const mutated = {
+    ...BACKENDS,
+    codex: { ...BACKENDS.codex, attachmentTransport: undefined },
+  };
+  assert.throws(
+    () => assertAttachmentBackendRegistry(mutated),
+    /codex.*attachment transport/i,
+  );
+});
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachments.test.js test/backends-contract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the shared contract**
+
+```bash
+git add plugin/shared/chat-attachments.mjs plugin/panel/src/cep/backends/contract.js plugin/panel/src/cep/backends/index.js plugin/panel/test/attachments.test.js plugin/panel/test/backends-contract.test.js
+git commit -m "feat(panel): define attachment turn contract"
+```
+
+---
+
+### Task 2: Build the bounded session attachment store
+
+**Files:**
+- Create: `plugin/panel/src/cep/attachmentStore.js`
+- Create: `plugin/panel/test/attachmentStore.test.js`
+
+**Interfaces:**
+- Consumes: constants and normalized attachment shape from
+  `plugin/shared/chat-attachments.mjs`
+- Produces: `createAttachmentStore(options) -> AttachmentStore`
+- Produces: `store.prepare(file, {sessionId, pondId}) -> Promise<AttachmentRef>`
+- Produces: `store.release(attachmentId) -> void`
+- Produces: `store.releaseSession(sessionId) -> void`
+- Produces: `store.dispose() -> void`
+
+- [ ] **Step 1: Write failing filesystem lifecycle tests**
+
+Use `mkdtempSync` and real Node `fs` for a disposable root. Cover:
+
+```js
+test('path-backed originals remain user-owned and are never deleted', async (t) => {
+  const original = join(root, 'original.mov');
+  writeFileSync(original, Buffer.from('video'));
+  const store = makeStore(root);
+  const ref = await store.prepare(
+    { name: 'original.mov', size: 5, type: 'video/quicktime', path: original },
+    { sessionId: 's1', pondId: 'p1' },
+  );
+  assert.equal(ref.temporary, false);
+  store.release(ref.id);
+  assert.equal(readFileSync(original, 'utf8'), 'video');
+});
+
+test('pathless blob is staged atomically and removed with its session', async () => {
+  const store = makeStore(root);
+  const blob = new Blob([Buffer.from('abc')], { type: 'application/octet-stream' });
+  Object.defineProperty(blob, 'name', { value: 'clip.bin' });
+  const ref = await store.prepare(blob, { sessionId: 's1', pondId: 'p1' });
+  assert.equal(ref.temporary, true);
+  assert.equal(readFileSync(ref.localPath, 'utf8'), 'abc');
+  store.releaseSession('s1');
+  assert.equal(existsSync(ref.localPath), false);
+});
+```
+
+Also test the 32-item limit, both clipboard byte limits, separator stripping,
+partial-write cleanup, idempotent release, and refusal to delete outside the
+managed root.
+
+- [ ] **Step 2: Run the store test and verify it fails**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachmentStore.test.js
+```
+
+Expected: FAIL because `createAttachmentStore` does not exist.
+
+- [ ] **Step 3: Implement stable-path preparation**
+
+Use this constructor:
+
+```js
+export function createAttachmentStore({
+  platform,
+  randomUUID,
+  readBlobChunk = browserBlobChunk,
+  chunkBytes = 1024 * 1024,
+  now = Date.now,
+}) {
+  const root = platform.paths.join([
+    platform.paths.tempRoot,
+    'ae-mcp-panel-attachments',
+  ]);
+  // Track {ref, sessionId} by attachment id.
+}
+```
+
+For `file.path`:
+
+1. normalize it with `platform.paths.resolve([file.path])`;
+2. require an absolute path;
+3. require `statSync(path).isFile()`;
+4. require `accessSync(path, fs.constants.R_OK)`;
+5. return `temporary: false` without copying.
+
+Use `platform.paths.basename` for the display name so a browser-supplied name
+cannot create nested paths.
+
+- [ ] **Step 4: Implement bounded pathless-Blob staging**
+
+Create `<root>/<sessionId>/` with owner-only permissions where supported. Write
+to `<id>.part`, call `fsyncSync`, close it, then rename to
+`<id>-<safe-basename>`.
+
+Read the Blob in `chunkBytes` slices. The browser default uses `FileReader` for
+each slice; tests inject a reader based on `slice.arrayBuffer()`.
+
+On any failure:
+
+- close the descriptor if open;
+- unlink only the contained `.part` path;
+- remove the in-memory record;
+- throw an error with a stable code such as
+  `ATTACHMENT_STAGING_FAILED`, `ATTACHMENT_ITEM_TOO_LARGE`, or
+  `ATTACHMENT_TURN_TOO_LARGE`.
+
+- [ ] **Step 5: Implement contained cleanup**
+
+Before any unlink:
+
+```js
+if (!ref.temporary || !platform.paths.contains(root, ref.localPath)) return;
+```
+
+`release`, `releaseSession`, and `dispose` are idempotent. Cleanup removes empty
+session directories but never recursively targets `tempRoot` or `configRoot`.
+
+- [ ] **Step 6: Run focused store and path tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachmentStore.test.js test/platform-paths.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the attachment store**
+
+```bash
+git add plugin/panel/src/cep/attachmentStore.js plugin/panel/test/attachmentStore.test.js
+git commit -m "feat(panel): stage session attachments safely"
+```
+
+---
+
+### Task 3: Add the FilePond Composer surface and pure draft state
+
+**Files:**
+- Modify: `plugin/panel/package.json`
+- Modify: `plugin/panel/package-lock.json`
+- Modify: `plugin/panel/src/main.jsx`
+- Modify: `plugin/panel/src/styles/index.css`
+- Create: `plugin/panel/src/lib/attachmentDraft.js`
+- Create: `plugin/panel/src/components/chat/AttachmentPond.jsx`
+- Modify: `plugin/panel/src/components/chat/Composer.jsx`
+- Create: `plugin/panel/test/attachmentDraft.test.js`
+- Create: `plugin/panel/test/composerAttachmentsWiring.test.js`
+- Modify: `plugin/panel/test/composerResizeWiring.test.js`
+
+**Interfaces:**
+- Consumes: `AttachmentStore.prepare/release`
+- Produces: `createAttachmentDraftState()`
+- Produces: `reduceAttachmentDraft(state, action)`
+- Produces component: `AttachmentPond`
+- Extends `Composer` props with `attachmentDraft`, `onAddFile`,
+  `onRemoveAttachment`, `onRetryAttachment`, and `attachmentLabels`
+
+- [ ] **Step 1: Add exact open-source dependencies**
+
+From `plugin/panel` run:
+
+```bash
+npm install --save-exact filepond@4.32.12 react-filepond@7.1.3 filepond-plugin-image-preview@4.6.12
+```
+
+Do not add FilePond type-validation, file-size-validation, PDF-preview, video
+preview, transform, encode, or upload plugins.
+
+- [ ] **Step 2: Write failing pure draft tests**
+
+Cover add/staging/ready/error/remove, attachment-only send eligibility,
+pre-dispatch preservation, accepted clear, and rejected retention:
+
+```js
+test('accepted clears only the matching frozen turn', () => {
+  let state = createAttachmentDraftState();
+  state = reduceAttachmentDraft(state, { type: 'text', value: 'inspect' });
+  state = reduceAttachmentDraft(state, { type: 'ready', pondId: 'p1', ref: fixtureRef() });
+  state = reduceAttachmentDraft(state, { type: 'sending', turnId: 'turn-1' });
+  assert.equal(reduceAttachmentDraft(state, { type: 'accepted', turnId: 'other' }), state);
+  const cleared = reduceAttachmentDraft(state, { type: 'accepted', turnId: 'turn-1' });
+  assert.equal(cleared.text, '');
+  assert.deepEqual(cleared.items, []);
+});
+
+test('pre-dispatch rejection preserves text and files', () => {
+  const sending = readySendingState('turn-1');
+  const rejected = reduceAttachmentDraft(sending, {
+    type: 'rejected',
+    turnId: 'turn-1',
+    error: 'backend unavailable',
+  });
+  assert.equal(rejected.text, sending.text);
+  assert.deepEqual(rejected.items, sending.items);
+  assert.equal(rejected.pendingTurnId, null);
+});
+```
+
+- [ ] **Step 3: Run the draft test and verify it fails**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachmentDraft.test.js
+```
+
+Expected: FAIL because the reducer does not exist.
+
+- [ ] **Step 4: Implement the pure reducer**
+
+Use item states:
+
+```js
+{
+  pondId,
+  file,
+  status: 'staging' | 'ready' | 'error',
+  ref: null | AttachmentRef,
+  error: null | {code, message},
+}
+```
+
+The state also contains:
+
+```js
+{
+  text: '',
+  items: [],
+  pendingTurnId: null,
+  pendingSnapshot: null,
+}
+```
+
+Export selectors `readyAttachments(state)`, `draftCanSend(state)`, and
+`draftIsBusy(state)`.
+
+- [ ] **Step 5: Create the FilePond wrapper**
+
+Register `FilePondPluginImagePreview` once at module scope. Configure:
+
+```jsx
+<FilePond
+  files={pondFiles}
+  allowMultiple
+  allowPaste
+  allowBrowse={!disabled}
+  allowDrop={!disabled}
+  allowReorder={false}
+  instantUpload={false}
+  maxFiles={MAX_ATTACHMENTS_PER_TURN}
+  credits={false}
+  onaddfile={handleAdd}
+  onremovefile={handleRemove}
+/>
+```
+
+Do not configure `acceptedFileTypes`, a FilePond `server`, any other MIME or
+extension filter, or an upload endpoint. Use
+FilePond only for local item interaction. Render application status text beside
+each item so staging and errors remain understandable even if FilePond's
+internal status wording differs. A staging error exposes explicit retry and
+remove actions; retry reuses the original FilePond `File` and creates a fresh
+store operation.
+
+- [ ] **Step 6: Wire attachments into Composer without changing keyboard behavior**
+
+Import FilePond CSS and image-preview CSS from `main.jsx`, before the local
+stylesheet:
+
+```js
+import 'filepond/dist/filepond.min.css';
+import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
+import './styles/index.css';
+```
+
+Render `AttachmentPond` inside the resizable input well above the textarea.
+Compute:
+
+```js
+const canSend = !disabled
+  && !streaming
+  && !attachmentsBusy
+  && (value.trim().length > 0 || readyAttachmentCount > 0);
+```
+
+Keep the existing `handleKey` condition for Enter and Shift+Enter. Keep the
+resize handle and option row outside FilePond's event handling.
+
+Give `AttachmentPond` a ref exposing `addFiles(files)`. Add `dragenter`,
+`dragover`, and `drop` handlers to the Composer input well, call
+`preventDefault` only when the transfer contains files, and forward the
+complete dropped file list to FilePond. This makes the whole Composer the drop
+target without implementing a second file list. Non-file text drops keep their
+existing browser behavior.
+
+- [ ] **Step 7: Add CSS scoped under `.ae-attachment-pond`**
+
+Override FilePond only within the Composer:
+
+- compact single-column item height;
+- image thumbnail where available;
+- generic icon/name/size for other files;
+- visible remove button and focus ring;
+- no media, PDF, or video preview;
+- no clipping of Composer chip drop-ups;
+- internal scroll once attachments consume the allowed Composer space.
+
+- [ ] **Step 8: Add wiring regressions**
+
+The source-level test must assert:
+
+- FilePond is configured with `allowPaste`, `allowMultiple`, and no accepted
+  type list;
+- a file drop anywhere on the Composer delegates to FilePond exactly once;
+- a staging error exposes retry and remove without discarding other items;
+- attachment-only state participates in `canSend`;
+- `Shift+Enter` remains excluded from send;
+- `ComposerResizeHandle` and its Shift+Arrow logic remain present;
+- no `FileReader` or content parser exists in the React component.
+
+- [ ] **Step 9: Run focused UI-state and resize tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachmentDraft.test.js test/composerAttachmentsWiring.test.js test/composerResize.test.js test/composerResizeWiring.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the Composer surface**
+
+```bash
+git add plugin/panel/package.json plugin/panel/package-lock.json plugin/panel/src/main.jsx plugin/panel/src/styles/index.css plugin/panel/src/lib/attachmentDraft.js plugin/panel/src/components/chat/AttachmentPond.jsx plugin/panel/src/components/chat/Composer.jsx plugin/panel/test/attachmentDraft.test.js plugin/panel/test/composerAttachmentsWiring.test.js plugin/panel/test/composerResizeWiring.test.js
+git commit -m "feat(panel): add FilePond attachment composer"
+```
+
+---
+
+### Task 4: Integrate drafts, acceptance, transcript metadata, and cleanup
+
+**Files:**
+- Modify: `plugin/panel/src/screens/ChatScreen.jsx`
+- Modify: `plugin/panel/src/app/App.jsx`
+- Modify: `plugin/panel/src/lib/chatEntries.js`
+- Modify: `plugin/panel/src/components/chat/ChatBubble.jsx`
+- Modify: `plugin/panel/test/chatEntries.test.js`
+- Modify: `plugin/panel/test/composerAttachmentsWiring.test.js`
+
+**Interfaces:**
+- Consumes: `AttachmentStore`, draft reducer, `TurnInput`, and
+  `turn-accepted`
+- Produces: `onSend(turnInput)`
+- Produces: `userTurnEntry(turnInput) -> redacted transcript entry`
+- Produces prop: `createTurnId() -> string`
+- Produces transcript entry:
+  `{type: "user-text", text, attachments: DisplayAttachment[]}`
+
+- [ ] **Step 1: Write failing send-lifecycle tests**
+
+Add reducer and source-wiring tests proving:
+
+```js
+test('turn-accepted appends only redacted display metadata', () => {
+  const entry = userTurnEntry({
+    turnId: 'turn-1',
+    text: '',
+    attachments: [fixtureAttachment()],
+  });
+  assert.equal(entry.type, 'user-text');
+  assert.deepEqual(entry.attachments, [{
+    id: 'att-1',
+    name: 'clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+  }]);
+  assert.equal(JSON.stringify(entry).includes('/tmp/private'), false);
+});
+```
+
+The wiring test must require a pending `turnId`, delayed draft clearing, and
+temporary cleanup on terminal events.
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/chatEntries.test.js test/composerAttachmentsWiring.test.js
+```
+
+Expected: FAIL because App and ChatScreen still pass strings and clear
+immediately.
+
+- [ ] **Step 3: Make ChatScreen a controlled attachment draft consumer**
+
+Replace the local text-only send path with:
+
+```js
+const send = () => {
+  if (!draftCanSend(attachmentDraft) || composerDisabled || streaming) return;
+  const turnId = createTurnId();
+  const turn = {
+    turnId,
+    text: attachmentDraft.text.trim(),
+    attachments: readyAttachments(attachmentDraft),
+  };
+  dispatchAttachmentDraft({ type: 'sending', turnId, turn });
+  onSend?.(turn);
+};
+```
+
+Do not clear on click. Clear only when `acceptedTurnId` matches. On a matching
+`rejectedTurn`, retain text and attachments and expose the error beside the
+Composer.
+
+App passes `createTurnId={() => cepRequire('crypto').randomUUID()}`. Do not
+derive the turn id from `Date.now()` or an attachment filename.
+
+- [ ] **Step 4: Own store and draft lifecycle in App**
+
+Create one store from the existing `platform`:
+
+```js
+const attachmentStore = React.useMemo(() => createAttachmentStore({
+  platform,
+  randomUUID: () => cepRequire('crypto').randomUUID(),
+}), [platform]);
+```
+
+Keep draft state above the conditionally rendered Chat tab so switching tabs
+does not lose it. Use a session token such as `chat-${chatSessionEpoch}`.
+
+The add/remove callbacks are:
+
+```js
+async function addAttachment({ pondId, file }) {
+  dispatchAttachmentDraft({ type: 'staging', pondId, file });
+  try {
+    const ref = await attachmentStore.prepare(file, { sessionId, pondId });
+    dispatchAttachmentDraft({ type: 'ready', pondId, ref });
+  } catch (error) {
+    dispatchAttachmentDraft({
+      type: 'error',
+      pondId,
+      error: { code: error.code || 'ATTACHMENT_STAGING_FAILED', message: error.message },
+    });
+  }
+}
+```
+
+Remove releases a ready ref before deleting the reducer item. Retry calls
+`addAttachment` again with the retained original `File`.
+
+On a new session or backend reset:
+
+1. stop/reset the backend as today;
+2. release the previous session's temporary attachments;
+3. create a new session token;
+4. reset the draft and transcript.
+
+Dispose the store during App unmount.
+
+- [ ] **Step 5: Correlate accepted and rejected turns**
+
+Keep `pendingTurnRef` with one immutable normalized turn. `sendChat(turn)` must:
+
+1. reject a second send while one turn is pending;
+2. store the snapshot;
+3. call `activeBackend.sendUser(turn)`;
+4. avoid appending transcript content before acceptance.
+
+On matching `turn-accepted`:
+
+- append one `user-text` entry created by
+  `userTurnEntry(pendingTurnRef.current)`, with display attachments;
+- set the accepted turn id for ChatScreen;
+- mark streaming true;
+- retain temporary refs until the terminal event.
+
+On an `error` before acceptance:
+
+- when `dispatchState === "not-started"`, set the rejected turn for ChatScreen,
+  do not append the user entry, leave the draft and temporary refs intact, and
+  permit an explicit retry;
+- when `dispatchState === "uncertain"`, retain the frozen snapshot, leave the
+  draft and temporary refs intact, disable resubmission, and require backend
+  reset/new-session reconciliation.
+
+Every pre-acceptance backend error must carry the matching `turnId`. Ignore
+stale errors from an older turn rather than applying them to the current draft.
+
+On `turn-end` or a post-acceptance `error`:
+
+- release the dispatched temporary refs;
+- clear the pending snapshot;
+- preserve the existing streaming/thinking terminal behavior.
+
+- [ ] **Step 6: Render transcript attachment metadata**
+
+Extend user `ChatBubble` content with compact attachment rows containing only
+name and formatted size. Do not render `localPath`, `temporary`, manifest
+content, or transport details.
+
+Export `userTurnEntry` from `chatEntries.js`:
+
+```js
+export function userTurnEntry(turn) {
+  return {
+    id: `user-${turn.turnId}`,
+    type: 'user-text',
+    text: turn.text,
+    attachments: displayAttachments(turn.attachments),
+  };
+}
+```
+
+- [ ] **Step 7: Run focused lifecycle tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/attachmentDraft.test.js test/chatEntries.test.js test/composerAttachmentsWiring.test.js test/backendLifecycle.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit lifecycle integration**
+
+```bash
+git add plugin/panel/src/screens/ChatScreen.jsx plugin/panel/src/app/App.jsx plugin/panel/src/lib/chatEntries.js plugin/panel/src/components/chat/ChatBubble.jsx plugin/panel/test/chatEntries.test.js plugin/panel/test/composerAttachmentsWiring.test.js
+git commit -m "feat(panel): retain attachment turns until accepted"
+```
+
+---
+
+### Task 5: Map Codex, OpenCode, ZCode, and legacy BYOK
+
+**Files:**
+- Modify: `plugin/panel/src/cep/codexBackend.js`
+- Modify: `plugin/panel/src/cep/openCodeBackend.js`
+- Modify: `plugin/panel/src/cep/zcodeBackend.js`
+- Modify: `plugin/panel/src/lib/agentLoop.js`
+- Modify: `plugin/panel/test/codexBackend.test.js`
+- Modify: `plugin/panel/test/openCodeBackend.test.js`
+- Modify: `plugin/panel/test/zcodeBackend.test.js`
+- Modify: `plugin/panel/test/agentLoop.test.js`
+
+**Interfaces:**
+- Consumes: normalized `TurnInput`, `withAttachmentManifest`, and
+  `attachmentFileUrl`
+- Produces: one `turn-accepted` event per accepted turn
+- Codex transport: app-server local input items
+- OpenCode transport: `FilePartInput`
+- ZCode transport: delimited attachment manifest
+- BYOK transport: pre-dispatch structured rejection
+
+- [ ] **Step 1: Write failing Codex native-input tests**
+
+Assert the `turn/start` body contains:
+
+```js
+[
+  { type: 'text', text: 'inspect' },
+  { type: 'localImage', path: '/tmp/frame.png' },
+  { type: 'localAudio', path: '/tmp/audio.wav' },
+  { type: 'mention', name: 'clip.mov', path: '/tmp/clip.mov' },
+]
+```
+
+Use advisory `mediaType` only to select the app-server's image/audio native
+shape; every other file uses the generic `mention`. Assert `turn/started`
+emits `{type:'turn-accepted', turnId, transport:'codex-app-server'}` exactly
+once before normal streaming.
+
+- [ ] **Step 2: Write failing OpenCode file-part tests**
+
+The message body must contain:
+
+```js
+{
+  parts: [
+    { type: 'text', text: 'inspect' },
+    {
+      type: 'file',
+      mime: 'application/pdf',
+      filename: 'notes.pdf',
+      url: 'file:///tmp/notes.pdf',
+    },
+  ],
+}
+```
+
+This matches OpenCode's official `FilePartInput` fields. Emit
+`turn-accepted` only after the message POST succeeds.
+
+- [ ] **Step 3: Write failing ZCode manifest tests**
+
+Assert `session/send.params.content` contains the original text followed by
+one manifest with every attachment in order. Assert the user transcript remains
+the original text. Resolve `session/send` with `{accepted:true}` and require:
+
+```js
+{ type: 'turn-accepted', turnId: 'turn-1', transport: 'zcode-manifest' }
+```
+
+- [ ] **Step 4: Write failing BYOK rejection tests**
+
+Assert that a text-only turn still behaves exactly as before. For any non-empty
+attachment list, assert:
+
+```js
+{
+  type: 'error',
+  kind: 'attachment',
+  code: 'ATTACHMENT_SIDECAR_REQUIRED',
+  message: 'Restore the Claude Agent SDK sidecar to send local files.',
+  turnId: 'turn-1',
+}
+```
+
+The Anthropic HTTP function must not be called and no user history entry may be
+added. The error uses `dispatchState: 'not-started'`.
+
+- [ ] **Step 5: Run adapter tests and verify they fail**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/codexBackend.test.js test/openCodeBackend.test.js test/zcodeBackend.test.js test/agentLoop.test.js
+```
+
+Expected: FAIL on string-only serialization and the missing acceptance event.
+
+- [ ] **Step 6: Implement Codex mapping**
+
+Store `activeTurnId` and the full normalized turn. Replace `turnParams(text)`
+with `turnParams(turn, textWithPreamble)`. Build the text item only when text is
+non-empty, append every file item in order, and keep the preamble confined to
+the text item.
+
+Never place a local path in emitted events or transcript messages.
+
+Track whether `rpc.request('turn/start', ...)` has been issued. Initialization,
+profile, and thread failures before that call are `not-started`; a rejection or
+disconnect after the call but before `turn/started` is `uncertain`. Both error
+forms retain the matching `turnId`.
+
+- [ ] **Step 7: Implement OpenCode mapping**
+
+Use the official file part shape:
+
+```js
+function openCodeParts(turn, platformId) {
+  return [
+    ...(turn.text ? [{ type: 'text', text: turn.text }] : []),
+    ...turn.attachments.map((file) => ({
+      type: 'file',
+      mime: file.mediaType || 'application/octet-stream',
+      filename: file.name,
+      url: attachmentFileUrl(file.localPath, platformId),
+    })),
+  ];
+}
+```
+
+Emit acceptance after the HTTP request resolves successfully, before waiting
+for the SSE terminal state. A fetch failure after the POST begins and before
+its response is `uncertain`; failures while starting the local server/session
+before the POST are `not-started`. Both error forms retain the matching
+`turnId`.
+
+- [ ] **Step 8: Implement ZCode mapping**
+
+Build `turnText` from the unchanged user text plus
+`withAttachmentManifest`. Preserve the existing first-turn server-instruction
+preamble outside the generated attachment envelope.
+
+Await or chain the `session/send` acceptance promise so rejection remains
+classified correctly and success emits `turn-accepted` with the matching id.
+Session creation/subscription failures are `not-started`; a `session/send`
+failure before its acceptance response is `uncertain`. Both error forms retain
+the matching `turnId`.
+
+- [ ] **Step 9: Implement legacy BYOK rejection**
+
+Normalize the turn before mutating `messages` or emitting `turn-start`. If it
+contains attachments, emit the structured error and return without calling
+the provider or changing history.
+
+For text-only input, preserve current string compatibility and event order.
+
+- [ ] **Step 10: Run focused adapter tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/codexBackend.test.js test/openCodeBackend.test.js test/zcodeBackend.test.js test/agentLoop.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit the non-Claude adapter mappings**
+
+```bash
+git add plugin/panel/src/cep/codexBackend.js plugin/panel/src/cep/openCodeBackend.js plugin/panel/src/cep/zcodeBackend.js plugin/panel/src/lib/agentLoop.js plugin/panel/test/codexBackend.test.js plugin/panel/test/openCodeBackend.test.js plugin/panel/test/zcodeBackend.test.js plugin/panel/test/agentLoop.test.js
+git commit -m "feat(panel): expose files to chat backends"
+```
+
+---
+
+### Task 6: Give Claude Agent SDK scoped access to selected files
+
+**Files:**
+- Modify: `plugin/panel/src/cep/claudeAgentBackend.js`
+- Modify: `plugin/sidecar/lib.mjs`
+- Modify: `plugin/panel/test/claudeAgentBackend.test.js`
+- Modify: `plugin/sidecar/test/sidecar.test.js`
+
+**Interfaces:**
+- Consumes: normalized `TurnInput` from the Panel
+- Panel-to-sidecar message:
+  `{t:"user", turnId, text, attachments, permissionMode, model, effort?, thinking?}`
+- Produces: scoped Claude `Read` permission for exact selected real paths
+- Produces: `{type:"turn-accepted", turnId, transport:"claude-agent-sdk"}`
+
+- [ ] **Step 1: Write failing Panel-to-sidecar tests**
+
+Assert the sidecar stdin message contains all attachment references and no
+extra content transformation:
+
+```js
+{
+  t: 'user',
+  turnId: 'turn-1',
+  text: 'inspect',
+  attachments: [{
+    id: 'att-1',
+    name: 'notes.pdf',
+    localPath: '/tmp/notes.pdf',
+    size: 12,
+    mediaType: 'application/pdf',
+    temporary: false,
+  }],
+  permissionMode: 'manual',
+  model: 'claude-test',
+}
+```
+
+The Panel backend must not emit the attachment paths in any event or stderr
+summary.
+
+- [ ] **Step 2: Write failing sidecar permission tests**
+
+Inject filesystem/path dependencies so the tests are platform-neutral. Cover:
+
+```js
+test('Read is allowed only for an exact selected attachment path', async () => {
+  const query = captureQuery();
+  const sidecar = makeSidecar({ queryFn: query.fn, realpath: (p) => p });
+  sidecar.handleLine(JSON.stringify(userWithAttachment('/tmp/notes.pdf')));
+  await query.started;
+  assert.deepEqual(
+    await query.options.canUseTool('Read', { file_path: '/tmp/notes.pdf' }),
+    { behavior: 'allow', updatedInput: { file_path: '/tmp/notes.pdf' } },
+  );
+  assert.equal(
+    (await query.options.canUseTool('Read', { file_path: '/tmp/other.pdf' })).behavior,
+    'deny',
+  );
+});
+```
+
+Also deny a directory, traversal alias, symlink resolving outside the selected
+real path, missing `file_path`, `Write`, `Edit`, `Bash`, and every other
+non-`mcp__ae__` tool.
+
+- [ ] **Step 3: Run Claude tests and verify they fail**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/claudeAgentBackend.test.js
+cd ../sidecar
+node --test test/sidecar.test.js
+```
+
+Expected: FAIL because the sidecar only accepts text and denies `Read`.
+
+- [ ] **Step 4: Forward the normalized turn to the sidecar**
+
+`claudeAgentBackend.sendUser` must:
+
+1. normalize before starting;
+2. retain `turnId`;
+3. write the exact attachments array only after the ready handshake;
+4. keep transcript storage limited to user text and display metadata;
+5. add current attachment paths to redaction values for all errors and stderr
+   summaries during the turn.
+
+- [ ] **Step 5: Normalize and canonicalize selected paths in the sidecar**
+
+At turn start:
+
+- require each attachment path to be absolute;
+- call injected/default `realpathSync`;
+- require `statSync(realPath).isFile()`;
+- store the exact real paths in the turn;
+- build the model prompt with `withAttachmentManifest`;
+- never emit the prompt or manifest.
+
+If any path cannot be canonicalized, emit a pre-dispatch attachment error with
+the `turnId`, `dispatchState: 'not-started'`, and do not invoke `queryFn`.
+
+- [ ] **Step 6: Add the exact-path Read allowance**
+
+For turns with attachments:
+
+- include `Read` in `queryOptions.allowedTools`;
+- include `Read` in the `ae` agent tool list;
+- keep `Read` absent on text-only turns;
+- in `canUseTool`, canonicalize `input.file_path`;
+- allow only an exact member of the current turn's selected-real-path set;
+- deny directories and every non-member without opening an approval card.
+
+All existing AE MCP approval behavior remains unchanged.
+
+Extend the Claude agent prompt with one narrow rule: `Read` may be used only
+for exact paths listed in the current `<ae_mcp_attachments>` manifest. Do not
+generalize the prompt to arbitrary filesystem exploration.
+
+- [ ] **Step 7: Emit acceptance and redact path-bearing errors**
+
+Emit `turn-accepted` immediately before `queryFn` begins consuming the accepted
+turn. Include only `turnId` and `transport`.
+
+Replace every selected real path in sidecar error text with
+`[attachment-path]` before emitting the error.
+
+- [ ] **Step 8: Run Panel and sidecar focused tests**
+
+Run:
+
+```bash
+cd plugin/panel
+node --test test/claudeAgentBackend.test.js
+cd ../sidecar
+node --test test/sidecar.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Claude scoped attachment access**
+
+```bash
+git add plugin/panel/src/cep/claudeAgentBackend.js plugin/sidecar/lib.mjs plugin/panel/test/claudeAgentBackend.test.js plugin/sidecar/test/sidecar.test.js
+git commit -m "feat(sidecar): expose selected attachments to Claude"
+```
+
+---
+
+### Task 7: Close cross-layer tests, prove the guard, build, and run real-host HDEV
+
+**Files:**
+- Modify: `plugin/panel/test/backends-contract.test.js`
+- Modify: `plugin/panel/test/noSensitiveDefaults.test.js`
+- Modify: `docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md`
+- Create after validation: `docs/checkpoints/2026-07-28-multimodal-file-input-hdev.md`
+
+**Interfaces:**
+- Consumes all preceding tasks
+- Produces mutation evidence, automated regression evidence, built CEP assets,
+  and non-candidate real-host development evidence
+
+- [ ] **Step 1: Add the dynamic cross-backend invariant**
+
+Enumerate `BACKENDS` rather than hardcoding only the four implementation files:
+
+```js
+test('every registered backend has a truthful attachment disposition', () => {
+  assert.equal(assertAttachmentBackendRegistry(BACKENDS), true);
+});
+```
+
+Add a source registry used by tests to associate the supported rows with their
+factories:
+
+```js
+{
+  subscription: createClaudeAgentBackend,
+  'claude-api': createClaudeAgentBackend,
+  byok: createAgentLoop,
+  codex: createCodexBackend,
+  opencode: createOpenCodeBackend,
+  zcode: createZcodeBackend,
+}
+```
+
+For every non-reject row, require a shared fixture to reach one
+`turn-accepted` event with the original turn id. For `byok`, require the exact
+pre-dispatch rejection.
+
+- [ ] **Step 2: Add sensitive-data regressions**
+
+Use a sentinel absolute path such as
+`/private/attachment-secret/customer.mov`. Assert it is absent from:
+
+- transcript entries;
+- `reduceEvent` output;
+- Panel diagnostic/log helpers;
+- sidecar stderr tail;
+- structured error events;
+- exported log text.
+
+The path may appear only in captured transport requests inside adapter unit
+tests.
+
+- [ ] **Step 3: Run the full lower test tiers**
+
+Reuse dependency caches; do not reinstall the native runtime.
+
+Run:
+
+```bash
+cd plugin/panel
+npm test
+npm run build
+cd ../sidecar
+npm test
+cd ../..
+node --test scripts/package/test/*.test.mjs
+node scripts/check-repository-governance.mjs
+```
+
+Expected: all commands pass and `plugin/client/dist/app.js` plus
+`plugin/client/dist/app.css` build successfully.
+
+- [ ] **Step 4: Perform an explicit production-code mutation proof**
+
+Temporarily remove `attachmentTransport: 'native'` from the Codex registry row
+using `apply_patch`. Run:
+
+```bash
+cd plugin/panel
+node --test test/backends-contract.test.js
+```
+
+Expected: FAIL naming Codex's missing attachment transport while unrelated
+contract tests remain green.
+
+Restore the exact line with `apply_patch`, rerun the same command, and require
+PASS. Do not commit the mutation.
+
+- [ ] **Step 5: Review the complete diff before AE**
+
+Verify:
+
+- no parser, converter, upload endpoint, video slicer, or MIME allowlist was
+  introduced;
+- only the legacy `byok` fallback rejects attachments;
+- every supported backend carries all attachment refs in order;
+- absolute paths occur only inside scoped store/transport code and tests;
+- no native, Core, public MCP, protocol, release, #67, or #69 files changed;
+- the root checkout remains untouched.
+
+- [ ] **Step 6: Sync only changed Panel and sidecar development components**
+
+Use the repository's current HDEV component-sync command from
+`scripts/hardware/README.md`. Reuse unchanged Core, native plug-in, helper, Node,
+and provider installations. Record:
+
+- branch and commit;
+- changed component receipts;
+- panel/sidecar version and modification times;
+- `candidateEvidence=false`;
+- `validationClass=HDEV`.
+
+Do not perform a clean environment install, release audit, T5, or T6.
+
+- [ ] **Step 7: Prepare one disposable attachment fixture set**
+
+Create, outside tracked source and outside Adobe scan roots:
+
+- `note.txt`;
+- `image.png`;
+- `document.pdf`;
+- a short `video.mp4`;
+- `unknown.payload`.
+
+Record lifecycle `ephemeral-validation`, the file count, and a cleanup
+condition. Do not retain file contents in the PR or checkpoint.
+
+- [ ] **Step 8: Run focused real AE/CEP validation through all four backends**
+
+In the actual AE panel:
+
+1. add files using picker, drag/drop, and paste across the fixture set;
+2. remove and re-add one item;
+3. send an attachment-only turn;
+4. send a text-plus-attachment turn;
+5. verify each supported backend receives all filenames in order:
+   Codex, Claude Agent SDK, OpenCode, and ZCode;
+6. record native versus manifest transport for each;
+7. on one native multimodal backend, ask it to use the image or video through
+   its own capability;
+8. switch away from and back to Chat before one send and confirm the draft is
+   retained;
+9. force one pre-dispatch failure and confirm the complete draft remains;
+10. simulate or capture one request-sent/pre-acceptance transport interruption,
+    confirm the turn becomes uncertain, and confirm the UI offers no blind
+    resend;
+11. confirm no absolute attachment path appears in exported Panel logs.
+
+This is non-candidate development evidence. It is not packaged-release
+acceptance.
+
+- [ ] **Step 9: Verify cleanup**
+
+Remove the draft and end the test sessions. Confirm:
+
+- all application-created temporary files are gone;
+- original fixture files remain byte-for-byte unchanged;
+- no attachment file exists in tracked source;
+- `.aep` counts are unchanged because this feature does not create a project.
+
+- [ ] **Step 10: Write the redacted HDEV checkpoint**
+
+Create `docs/checkpoints/2026-07-28-multimodal-file-input-hdev.md` containing:
+
+- tested commit;
+- `candidateEvidence=false`;
+- `validationClass=HDEV`;
+- automated test/build totals;
+- per-backend attachment count and transport kind;
+- pre-dispatch draft-retention result;
+- log-redaction result;
+- temporary/original cleanup counts;
+- explicit statement that T5/T6 were not run;
+- no credentials, absolute local paths, prompts containing private data, or
+  fixture contents.
+
+Update the design status to “Implemented; non-candidate HDEV verified” only if
+all four supported backend checks passed.
+
+- [ ] **Step 11: Run final verification**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+cd plugin/panel
+npm test
+npm run build
+cd ../sidecar
+npm test
+cd ../..
+node scripts/check-repository-governance.mjs
+```
+
+Expected: clean diff check, only intentional tracked changes, all tests/build
+green, governance green.
+
+- [ ] **Step 12: Commit validation evidence**
+
+```bash
+git add plugin/panel/test/backends-contract.test.js plugin/panel/test/noSensitiveDefaults.test.js docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md docs/checkpoints/2026-07-28-multimodal-file-input-hdev.md
+git commit -m "test(panel): verify multimodal attachment delivery"
+```
+
+- [ ] **Step 13: Request concentrated review**
+
+Review specifically:
+
+- exact selected-path authorization in Claude;
+- no cleanup path can escape the managed root;
+- no absolute path reaches logs or transcript;
+- every backend emits one correctly correlated acceptance event;
+- legacy BYOK fails before dispatch;
+- FilePond introduces no format allowlist or upload endpoint;
+- existing Composer resize and keyboard behavior remains intact.
+
+Do not merge until the review has no unresolved blocker and CI is green.

--- a/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
+++ b/docs/superpowers/plans/2026-07-28-multimodal-file-input.md
@@ -410,6 +410,8 @@ git commit -m "feat(panel): stage session attachments safely"
 - Modify: `plugin/panel/package-lock.json`
 - Modify: `plugin/panel/src/main.jsx`
 - Modify: `plugin/panel/src/styles/index.css`
+- Modify (generated): `plugin/client/dist/app.js`
+- Modify (generated): `plugin/client/dist/app.css`
 - Create: `plugin/panel/src/lib/attachmentDraft.js`
 - Create: `plugin/panel/src/components/chat/AttachmentPond.jsx`
 - Modify: `plugin/panel/src/components/chat/Composer.jsx`
@@ -603,7 +605,7 @@ Expected: PASS.
 - [ ] **Step 10: Commit the Composer surface**
 
 ```bash
-git add plugin/panel/package.json plugin/panel/package-lock.json plugin/panel/src/main.jsx plugin/panel/src/styles/index.css plugin/panel/src/lib/attachmentDraft.js plugin/panel/src/components/chat/AttachmentPond.jsx plugin/panel/src/components/chat/Composer.jsx plugin/panel/test/attachmentDraft.test.js plugin/panel/test/composerAttachmentsWiring.test.js plugin/panel/test/composerResizeWiring.test.js
+git add plugin/panel/package.json plugin/panel/package-lock.json plugin/panel/src/main.jsx plugin/panel/src/styles/index.css plugin/panel/src/lib/attachmentDraft.js plugin/panel/src/components/chat/AttachmentPond.jsx plugin/panel/src/components/chat/Composer.jsx plugin/panel/test/attachmentDraft.test.js plugin/panel/test/composerAttachmentsWiring.test.js plugin/panel/test/composerResizeWiring.test.js plugin/client/dist/app.js plugin/client/dist/app.css
 git commit -m "feat(panel): add FilePond attachment composer"
 ```
 

--- a/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
+++ b/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
@@ -1,0 +1,98 @@
+# macOS Platform Helper Registration Design
+
+## Problem
+
+The panel ships a valid macOS arm64 Platform Helper payload and a native XPC
+transport, but no production or development startup path registers the bundled
+Mach service with the current user's launchd domain. The addon can therefore
+load successfully while its first request fails with the native error
+`Couldn’t communicate with a helper application.` The panel then maps that
+transport failure to a generic Provider initialization repair message.
+
+This is a missing lifecycle step, not a Provider credential, protocol-version,
+or caller-authorization failure.
+
+## Scope
+
+Add the missing macOS registration lifecycle to the panel-owned Platform Helper
+transport. The fix applies to both development and packaged panel installations.
+It does not change Provider routing, accepted credentials, plaintext fallback
+policy, Helper methods, protocol schemas, caller authorization, or release
+signing requirements.
+
+Windows keeps its existing verified-helper spawn path.
+
+## Design
+
+### Verified payload boundary
+
+Before invoking launchd, the host verifies the macOS helper root derived from
+the loaded addon:
+
+- `helper-manifest.json` is a regular, non-symbolic file with schema version 1,
+  platform `macos-arm64`, and the expected Helper identifier;
+- the manifest declares the exact reviewed seven-file macOS payload;
+- every declared path resolves beneath the helper root and names a regular,
+  non-symbolic file;
+- each file matches its manifest SHA-256;
+- the helper and launcher entrypoints match their reviewed relative paths.
+
+This is the existing signed/helper security boundary, not a repository-source
+identity check. Development may use its current locally built and explicitly
+installed payload; release signing and audit gates remain unchanged.
+
+### Per-user launchd registration
+
+The host renders the bundled launchd template into a private state directory
+outside Adobe's extension scan root. It substitutes only the verified absolute
+Helper executable path, writes the result atomically with restrictive
+permissions, and never accepts caller-provided plist content or executable
+paths.
+
+The transport invokes the fixed `/bin/launchctl` executable for the current
+`gui/<uid>` domain. It first attempts to bootstrap the reviewed registration.
+An already-loaded service is reused. Other launchctl failures become the
+sanitized, retryable `HELPER_START_FAILED` lifecycle error.
+
+The registration step completes before the native addon opens its XPC
+connection. The existing client then performs the unchanged capabilities,
+protocol-version, method-set, Helper-version, and authenticated Adobe CEP caller
+checks.
+
+The panel does not boot out or restart an already-loaded Helper during routine
+startup. This avoids disrupting another live After Effects panel. Updating a
+loaded Helper remains an explicit install/restart operation.
+
+### Failure and recovery behavior
+
+No failure enables a plaintext Provider credential path. Missing or malformed
+payloads fail closed with `PLATFORM_HELPER_REPAIR_REQUIRED`. Registration
+execution failures use `HELPER_START_FAILED`. XPC transport failures continue to
+use `HELPER_UNAVAILABLE`; authorization and protocol errors retain their current
+codes.
+
+The user-facing repair message remains bounded and does not expose helper
+paths, launchctl output, credentials, or native error details.
+
+## Verification
+
+Tests are written before production changes and must demonstrate:
+
+1. macOS transport cannot issue a native request until registration succeeds;
+2. the exact reviewed manifest and payload are required before launchctl runs;
+3. launchctl receives a fixed executable, current-user domain, and private
+   generated plist;
+4. an already-loaded service is reusable without bootout or process kill;
+5. registration failure preserves the sanitized lifecycle code;
+6. Windows startup behavior and all existing authorization/protocol guards
+   remain unchanged.
+
+Mutation proof removes the registration step and confirms the new transport
+test fails, then restores it and confirms the test passes.
+
+After focused host and panel tests, rebuild and component-sync only the changed
+CEP panel. Real-machine verification uses the existing After Effects
+installation and performs a read-only Helper `capabilities` call followed by
+the pending non-candidate Claude Provider HDEV. It does not run packaged T5/T6,
+install dependencies, or read/log plaintext credentials.
+

--- a/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
+++ b/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
@@ -32,9 +32,10 @@ credential path is introduced.
 
 The service authorizes either the legacy direct Adobe CEP peer or the broker
 peer. A broker is accepted only when its native signature is valid for the
-fixed Helper signing identifier, it is arm64, its direct parent is the same
-trusted Adobe CEP identity, and the stable ancestry reaches a supported trusted
-AE process. The XPC connection receives the matching broker code-signing
+fixed Helper signing identifier, it is arm64, its direct parent is Adobe's
+signed `CEPHtmlEngine Helper (Renderer)`, that renderer's direct parent is the
+signed `CEPHtmlEngine`, and the stable ancestry then reaches a supported
+trusted AE process. The XPC connection receives the matching broker code-signing
 requirement before activation. This preserves the existing same-user,
 audit-session, process-generation, Adobe ancestry, and rejected-peer
 `backendAccessCount=0` boundaries.
@@ -111,7 +112,7 @@ Tests are written before production changes and must demonstrate:
 6. macOS CEP transport never attempts to load the N-API addon;
 7. the broker accepts bounded frames, proxies XPC responses, and exits on EOF;
 8. broker authorization requires the fixed broker identity, direct trusted CEP
-   parent, and supported trusted AE ancestry;
+   renderer, its trusted CEP parent, and supported trusted AE ancestry;
 9. Windows startup behavior and all existing protocol/release guards remain
    unchanged.
 

--- a/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
+++ b/docs/superpowers/specs/2026-07-28-macos-platform-helper-registration-design.md
@@ -3,22 +3,45 @@
 ## Problem
 
 The panel ships a valid macOS arm64 Platform Helper payload and a native XPC
-transport, but no production or development startup path registers the bundled
-Mach service with the current user's launchd domain. The addon can therefore
-load successfully while its first request fails with the native error
-`Couldn’t communicate with a helper application.` The panel then maps that
-transport failure to a generic Provider initialization repair message.
+transport, but the original implementation had two independent real-host
+blockers:
 
-This is a missing lifecycle step, not a Provider credential, protocol-version,
-or caller-authorization failure.
+1. no production or development startup path registered the bundled Mach
+   service with the current user's launchd domain; and
+2. Adobe's hardened `CEPHtmlEngine` does not carry
+   `com.apple.security.cs.disable-library-validation`, so macOS rejects a
+   non-Adobe-Team N-API addon before registration or XPC can begin.
+
+The second fact was measured in real AE 26.3 after the registration unit was
+installed: CEP Node 17.7.2 returned `ERR_DLOPEN_FAILED` because the Adobe process
+and mapped addon have different Team IDs. Signing the addon with the product's
+Developer ID does not solve that boundary; only Adobe could produce a library
+that satisfies the host's same-Team requirement.
+
+This is a transport-process placement defect, not a Provider credential,
+protocol-version, or Keychain failure.
 
 ## Scope
 
-Add the missing macOS registration lifecycle to the panel-owned Platform Helper
-transport. The fix applies to both development and packaged panel installations.
-It does not change Provider routing, accepted credentials, plaintext fallback
-policy, Helper methods, protocol schemas, caller authorization, or release
-signing requirements.
+Add the missing macOS registration lifecycle and move the macOS XPC client out
+of the hardened Adobe process. The already-manifested Helper executable gains a
+bounded `--client-stdio` mode: CEP spawns that exact verified binary, exchanges
+one-line protocol frames over private inherited pipes, and the child opens the
+existing Mach-service XPC connection. No TCP/UDP listener or plaintext
+credential path is introduced.
+
+The service authorizes either the legacy direct Adobe CEP peer or the broker
+peer. A broker is accepted only when its native signature is valid for the
+fixed Helper signing identifier, it is arm64, its direct parent is the same
+trusted Adobe CEP identity, and the stable ancestry reaches a supported trusted
+AE process. The XPC connection receives the matching broker code-signing
+requirement before activation. This preserves the existing same-user,
+audit-session, process-generation, Adobe ancestry, and rejected-peer
+`backendAccessCount=0` boundaries.
+
+The fix applies to both development and packaged panel installations. It does
+not change Provider routing, accepted credentials, plaintext fallback policy,
+Helper methods, protocol schemas, or release signing requirements.
 
 Windows keeps its existing verified-helper spawn path.
 
@@ -54,10 +77,10 @@ The transport invokes the fixed `/bin/launchctl` executable for the current
 An already-loaded service is reused. Other launchctl failures become the
 sanitized, retryable `HELPER_START_FAILED` lifecycle error.
 
-The registration step completes before the native addon opens its XPC
-connection. The existing client then performs the unchanged capabilities,
-protocol-version, method-set, Helper-version, and authenticated Adobe CEP caller
-checks.
+The registration step completes before CEP spawns the stdio broker. The broker
+opens XPC only after launchd registration is confirmed. The existing client then
+performs the unchanged capabilities, protocol-version, method-set, Helper
+version, and authenticated caller checks.
 
 The panel does not boot out or restart an already-loaded Helper during routine
 startup. This avoids disrupting another live After Effects panel. Updating a
@@ -66,10 +89,10 @@ loaded Helper remains an explicit install/restart operation.
 ### Failure and recovery behavior
 
 No failure enables a plaintext Provider credential path. Missing or malformed
-payloads fail closed with `PLATFORM_HELPER_REPAIR_REQUIRED`. Registration
-execution failures use `HELPER_START_FAILED`. XPC transport failures continue to
-use `HELPER_UNAVAILABLE`; authorization and protocol errors retain their current
-codes.
+payloads fail closed with `PLATFORM_HELPER_REPAIR_REQUIRED`. Registration or
+broker-spawn failures use `HELPER_START_FAILED`. XPC transport failures continue
+to use `HELPER_UNAVAILABLE`; authorization and protocol errors retain their
+current codes. Stderr is bounded and never copied into a public error.
 
 The user-facing repair message remains bounded and does not expose helper
 paths, launchctl output, credentials, or native error details.
@@ -78,14 +101,19 @@ paths, launchctl output, credentials, or native error details.
 
 Tests are written before production changes and must demonstrate:
 
-1. macOS transport cannot issue a native request until registration succeeds;
+1. macOS transport cannot spawn its broker or issue a request until registration
+   succeeds;
 2. the exact reviewed manifest and payload are required before launchctl runs;
 3. launchctl receives a fixed executable, current-user domain, and private
    generated plist;
 4. an already-loaded service is reusable without bootout or process kill;
 5. registration failure preserves the sanitized lifecycle code;
-6. Windows startup behavior and all existing authorization/protocol guards
-   remain unchanged.
+6. macOS CEP transport never attempts to load the N-API addon;
+7. the broker accepts bounded frames, proxies XPC responses, and exits on EOF;
+8. broker authorization requires the fixed broker identity, direct trusted CEP
+   parent, and supported trusted AE ancestry;
+9. Windows startup behavior and all existing protocol/release guards remain
+   unchanged.
 
 Mutation proof removes the registration step and confirms the new transport
 test fails, then restores it and confirms the test passes.
@@ -95,4 +123,3 @@ CEP panel. Real-machine verification uses the existing After Effects
 installation and performs a read-only Helper `capabilities` call followed by
 the pending non-candidate Claude Provider HDEV. It does not run packaged T5/T6,
 install dependencies, or read/log plaintext credentials.
-

--- a/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
+++ b/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
@@ -22,6 +22,16 @@ The Composer remains backend-neutral. A missing attachment mapping is an
 adapter defect to repair, not a reason to permanently disable attachments for
 one backend.
 
+The four supported attachment backends are Codex, Claude through the Agent SDK
+sidecar, OpenCode, and ZCode. The registry also contains an internal legacy
+`byok` HTTP fallback used only when the Claude sidecar cannot run. That direct
+HTTP loop has neither local filesystem access nor a portable provider upload
+contract, so it cannot truthfully expose arbitrary local files. In that
+degraded state the Composer remains visible, but an attachment turn fails
+before dispatch with guidance to restore the Claude sidecar. It never drops
+the files, sends a path the remote model cannot read, or claims attachment
+support.
+
 ## Current behavior
 
 The Composer accepts only text. `ChatScreen` owns one text draft and calls the
@@ -55,6 +65,8 @@ never creates or forwards attachments.
 - Native attachment or file-resource transport where a backend provides it.
 - An application-generated attachment manifest where a backend has no generic
   file item, so the agent still receives readable file references.
+- A scoped local-file read allowance for the Claude Agent SDK that can open
+  only paths present in the current user-selected attachment set.
 - Session-scoped attachment drafts and deterministic cleanup of
   application-created temporary files.
 - Explicit pre-dispatch, accepted, and uncertain-dispatch behavior.
@@ -72,6 +84,8 @@ never creates or forwards attachments.
   tables.
 - A cloud upload manager, durable media library, or provider-specific file
   store.
+- Portable arbitrary-file support for the internal legacy `byok` direct-HTTP
+  fallback. It remains text-only and fails attachment turns before dispatch.
 - Directory attachment in this slice.
 - Downloading a remote URL supplied as an attachment.
 - Changing the public AE MCP surface, AEGP behavior, project state, or Undo.
@@ -199,8 +213,10 @@ This fallback is still file exposure, not content processing. It must not:
 - claim native multimodal delivery when only a readable path was supplied;
 - log the generated manifest.
 
-Codex, Claude, OpenCode, and ZCode must all implement either native transport
-or manifest transport. The Composer never branches on backend identity.
+Codex, Claude Agent SDK, OpenCode, and ZCode must all implement either native
+transport or manifest transport. The Composer never branches on backend
+identity. The application backend boundary, rather than the Composer,
+classifies the internal `byok` fallback as unavailable for attachment turns.
 
 ## Composer interaction
 
@@ -339,9 +355,12 @@ Assert for every adapter that:
 - redacted diagnostics contain no contents or absolute paths.
 
 Add a dynamic invariant that enumerates the registered chat backends and
-requires every one to implement the attachment mapping contract. Prove the
-guard by mutation: remove one backend's mapping, observe the test fail, restore
-it, and observe the test pass.
+requires every one to declare either an implemented attachment mapping or the
+explicit legacy-HTTP pre-dispatch rejection. The four supported attachment
+backends must use a real mapping; only the internal `byok` fallback may use the
+rejection disposition. Prove the guard by mutation: remove one supported
+backend's mapping, observe the test fail, restore it, and observe the test
+pass.
 
 ### Real-host development validation
 

--- a/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
+++ b/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
@@ -220,6 +220,13 @@ registry coverage cannot drift. The Composer never branches on backend
 identity. The application backend boundary, rather than the Composer,
 classifies the internal `byok` backend as unavailable for attachment turns.
 
+Codex uses a hybrid mapping. Its app-server protocol has native local-image
+and local-audio input items, but no generic local-file item. The protocol's
+`mention` input is reserved for `app://` and `plugin://` references and must
+not be used for arbitrary filesystem paths. The adapter therefore includes
+every selected file in the manifest and additionally sends images and audio
+through their native input items.
+
 ## Composer interaction
 
 The existing Composer gains an attachment button and an attachment area above

--- a/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
+++ b/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
@@ -9,8 +9,8 @@
 ## Outcome
 
 Let a user attach local files to a chat turn from the After Effects CEP panel
-and expose those files to the selected model through every existing chat
-backend: Codex, Claude, OpenCode, and ZCode.
+and expose those files to the selected model through both user-visible chat
+backends: Codex and Claude Code.
 
 The panel does not decide how a model should understand a file. It does not
 extract document text, parse PDFs, convert Office files, transcode media,
@@ -22,15 +22,16 @@ The Composer remains backend-neutral. A missing attachment mapping is an
 adapter defect to repair, not a reason to permanently disable attachments for
 one backend.
 
-The four supported attachment backends are Codex, Claude through the Agent SDK
-sidecar, OpenCode, and ZCode. The registry also contains an internal legacy
-`byok` HTTP fallback used only when the Claude sidecar cannot run. That direct
-HTTP loop has neither local filesystem access nor a portable provider upload
-contract, so it cannot truthfully expose arbitrary local files. In that
-degraded state the Composer remains visible, but an attachment turn fails
-before dispatch with guidance to restore the Claude sidecar. It never drops
-the files, sends a path the remote model cannot read, or claims attachment
-support.
+The two user-visible attachment backends are Codex and Claude through the Agent
+SDK sidecar. A Claude custom Provider uses the same Agent SDK backend through a
+panel-owned loopback universal-Provider route; the sidecar receives only a
+local route token and never the upstream credential. The registry retains an
+internal legacy `byok` direct-HTTP backend for state compatibility, but live
+selection never falls back to it. If the Agent SDK runtime cannot run, the
+Claude channel fails closed instead of silently changing transport.
+
+OpenCode and ZCode adapters remain internal implementation compatibility, not
+built-in product choices and not real-host acceptance targets for this slice.
 
 ## Current behavior
 
@@ -38,12 +39,11 @@ The Composer accepts only text. `ChatScreen` owns one text draft and calls the
 application with a string. The application appends that text to the transcript
 and calls `activeBackend.sendUser(text)`.
 
-All four backends therefore expose text-only submission contracts:
+The current user-visible backends therefore expose text-only submission
+contracts:
 
 - Codex sends one `text` item to `turn/start`.
 - Claude sends a string through the sidecar to the Agent SDK.
-- OpenCode sends one text part to the session message endpoint.
-- ZCode sends string content to `session/send`.
 
 The provider codec already understands some image content blocks, and model
 probing preserves provider input modalities, but the panel submission path
@@ -60,8 +60,8 @@ never creates or forwards attachments.
 - Image thumbnails using FilePond's existing image preview support.
 - Generic name-and-size cards for all other files.
 - Text-plus-file and attachment-only turns.
-- One backend-neutral turn contract consumed by Codex, Claude, OpenCode, and
-  ZCode.
+- One backend-neutral turn contract consumed by Codex and Claude, while the
+  internal OpenCode and ZCode adapters remain contract-compatible.
 - Native attachment or file-resource transport where a backend provides it.
 - An application-generated attachment manifest where a backend has no generic
   file item, so the agent still receives readable file references.
@@ -85,7 +85,8 @@ never creates or forwards attachments.
 - A cloud upload manager, durable media library, or provider-specific file
   store.
 - Portable arbitrary-file support for the internal legacy `byok` direct-HTTP
-  fallback. It remains text-only and fails attachment turns before dispatch.
+  backend. It remains text-only, unreachable from live Provider selection, and
+  fails attachment turns before dispatch if restored from legacy state.
 - Directory attachment in this slice.
 - Downloading a remote URL supplied as an attachment.
 - Changing the public AE MCP surface, AEGP behavior, project state, or Undo.
@@ -213,10 +214,11 @@ This fallback is still file exposure, not content processing. It must not:
 - claim native multimodal delivery when only a readable path was supplied;
 - log the generated manifest.
 
-Codex, Claude Agent SDK, OpenCode, and ZCode must all implement either native
-transport or manifest transport. The Composer never branches on backend
+Codex and Claude Agent SDK must implement either native transport or manifest
+transport. Internal OpenCode and ZCode adapters keep the same contract so
+registry coverage cannot drift. The Composer never branches on backend
 identity. The application backend boundary, rather than the Composer,
-classifies the internal `byok` fallback as unavailable for attachment turns.
+classifies the internal `byok` backend as unavailable for attachment turns.
 
 ## Composer interaction
 
@@ -344,8 +346,7 @@ Focused Panel tests prove:
 
 ### Cross-backend contract tests
 
-Run the same `TurnInput` vector through Codex, Claude, OpenCode, and ZCode.
-Assert for every adapter that:
+Run the same `TurnInput` vector through every registered adapter. Assert that:
 
 - all attachments are present in order;
 - names, sizes, and readable references survive serialization;
@@ -356,11 +357,11 @@ Assert for every adapter that:
 
 Add a dynamic invariant that enumerates the registered chat backends and
 requires every one to declare either an implemented attachment mapping or the
-explicit legacy-HTTP pre-dispatch rejection. The four supported attachment
-backends must use a real mapping; only the internal `byok` fallback may use the
-rejection disposition. Prove the guard by mutation: remove one supported
-backend's mapping, observe the test fail, restore it, and observe the test
-pass.
+explicit legacy-HTTP pre-dispatch rejection. Codex, Claude Agent SDK, and the
+retained internal adapters must use a real mapping; only internal `byok` may
+use the rejection disposition. Prove the guard by mutation: remove one
+supported backend's mapping, observe the test fail, restore it, and observe the
+test pass.
 
 ### Real-host development validation
 
@@ -376,7 +377,7 @@ Use one application-owned temporary fixture set containing:
 - a short video;
 - a file with an unknown extension.
 
-For each of Codex, Claude, OpenCode, and ZCode:
+For Codex and Claude Code:
 
 1. attach the same fixture set from the real Composer;
 2. send the smallest prompt that asks the model to list the files it can see;
@@ -408,8 +409,8 @@ This slice is complete when:
   cleanup behave as specified;
 - the mutation-proven cross-backend invariant passes;
 - focused Panel tests and required repository checks pass;
-- the real AE panel verifies file exposure through all four configured
-  backends using reused development dependencies;
+- the real AE panel verifies file exposure through both user-visible backends
+  using reused development dependencies;
 - the resulting PR documents any backend that used a native attachment versus
   a manifest, without claiming that transport alone proves model
   understanding.

--- a/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
+++ b/docs/superpowers/specs/2026-07-28-multimodal-file-input-design.md
@@ -1,0 +1,396 @@
+# Multimodal File Input Design
+
+**Date:** 2026-07-28
+
+**Issue:** #113 (file input slice)
+
+**Status:** User-approved design
+
+## Outcome
+
+Let a user attach local files to a chat turn from the After Effects CEP panel
+and expose those files to the selected model through every existing chat
+backend: Codex, Claude, OpenCode, and ZCode.
+
+The panel does not decide how a model should understand a file. It does not
+extract document text, parse PDFs, convert Office files, transcode media,
+sample video frames, or maintain a model-format routing table. It supplies a
+stable file reference and lets the backend and model use their native
+multimodal or agentic file capabilities.
+
+The Composer remains backend-neutral. A missing attachment mapping is an
+adapter defect to repair, not a reason to permanently disable attachments for
+one backend.
+
+## Current behavior
+
+The Composer accepts only text. `ChatScreen` owns one text draft and calls the
+application with a string. The application appends that text to the transcript
+and calls `activeBackend.sendUser(text)`.
+
+All four backends therefore expose text-only submission contracts:
+
+- Codex sends one `text` item to `turn/start`.
+- Claude sends a string through the sidecar to the Agent SDK.
+- OpenCode sends one text part to the session message endpoint.
+- ZCode sends string content to `session/send`.
+
+The provider codec already understands some image content blocks, and model
+probing preserves provider input modalities, but the panel submission path
+never creates or forwards attachments.
+
+## Scope
+
+### Included
+
+- A FilePond-powered attachment surface in the existing Composer.
+- File selection, multi-select, drag-and-drop, clipboard file paste, compact
+  preview, progress, and per-item removal.
+- Arbitrary regular files without an extension or MIME allowlist.
+- Image thumbnails using FilePond's existing image preview support.
+- Generic name-and-size cards for all other files.
+- Text-plus-file and attachment-only turns.
+- One backend-neutral turn contract consumed by Codex, Claude, OpenCode, and
+  ZCode.
+- Native attachment or file-resource transport where a backend provides it.
+- An application-generated attachment manifest where a backend has no generic
+  file item, so the agent still receives readable file references.
+- Session-scoped attachment drafts and deterministic cleanup of
+  application-created temporary files.
+- Explicit pre-dispatch, accepted, and uncertain-dispatch behavior.
+- Automated cross-backend contract tests and focused real-host development
+  validation.
+
+### Explicit non-goals
+
+- Parsing, summarizing, indexing, embedding, OCR, transcription, or other
+  interpretation inside the panel.
+- Extracting text from PDF, Office, spreadsheet, archive, text, or code files.
+- Generating video thumbnails, sampling video frames, transcoding video or
+  audio, or deciding when a model should use native vision.
+- A file-extension or MIME allowlist that duplicates model/provider support
+  tables.
+- A cloud upload manager, durable media library, or provider-specific file
+  store.
+- Directory attachment in this slice.
+- Downloading a remote URL supplied as an attachment.
+- Changing the public AE MCP surface, AEGP behavior, project state, or Undo.
+- Packaged-release T5/T6 evidence. This standalone panel feature uses the
+  ordinary development validation path.
+
+## Open-source boundary
+
+Use FilePond and its React adapter rather than implementing picker, drag/drop,
+paste, item state, progress, and removal behavior from scratch.
+
+The initial dependency set is:
+
+- `filepond`
+- `react-filepond`
+- `filepond-plugin-image-preview`
+
+Type validation is not enabled as an acceptance gate. FilePond is the
+interaction and pending-file state layer, not the authority for what a model
+can consume. The dependency versions are pinned by the Panel lockfile and their
+licenses are recorded through the repository's existing dependency process.
+
+Application-owned code is deliberately thin:
+
+1. translate a FilePond item into an application attachment reference;
+2. keep the reference stable until the turn finishes;
+3. map the common turn into each backend's transport;
+4. redact logs and clean temporary files.
+
+It does not duplicate FilePond's upload-widget behavior or introduce a custom
+content-processing framework.
+
+## Common turn contract
+
+Replace the text-only backend boundary with a structured turn:
+
+```ts
+type TurnInput = {
+  text: string;
+  attachments: AttachmentRef[];
+};
+
+type AttachmentRef = {
+  id: string;
+  name: string;
+  localPath: string;
+  size: number;
+  mediaType?: string;
+  temporary: boolean;
+};
+```
+
+`mediaType` is advisory metadata. It may help a backend select its native
+transport shape, but it does not permit or reject the file.
+
+The contract invariants are:
+
+- attachment order is preserved;
+- `name` is the user-visible filename;
+- `localPath` is readable for the lifetime of the dispatched turn;
+- the ordinary transcript stores display metadata, not the absolute path;
+- logs never include file contents or absolute paths;
+- text may be empty only when at least one attachment exists;
+- every active backend accepts the same `TurnInput` shape.
+
+## File exposure and staging
+
+Prefer a stable original local path when the CEP host exposes one and the
+selected backend process can read it. Do not copy a large video merely to
+produce a second path. If a path is valid in CEP but inaccessible to the
+backend's sandbox or session, expose it through the same managed staging root
+used for pathless input.
+
+Some inputs, especially clipboard blobs, have no durable source path. Those
+items are streamed to an application-managed, session-scoped attachment
+directory. The application returns a stable `AttachmentRef` only after the
+temporary file is fully written.
+
+The staging layer:
+
+- stores no parsed or derived representation;
+- uses an opaque attachment ID rather than the original path as its UI key;
+- writes atomically so a backend never observes a partial file;
+- distinguishes user-owned originals from application-owned temporary copies;
+- deletes only files marked `temporary`;
+- retains a dispatched temporary file until the backend turn reaches a
+  terminal state or the session is explicitly discarded.
+
+Removing an attachment, discarding a draft, or closing its session cleans the
+associated temporary copy. It never deletes, moves, renames, or modifies a
+user-owned original.
+
+## Backend mapping
+
+`backend.sendUser(turnInput)` becomes the common submission boundary. Each
+adapter receives the complete attachment list.
+
+### Native transport
+
+When the installed backend protocol provides a structured local attachment,
+file part, image/audio item, mounted file, or equivalent resource reference,
+the adapter maps `AttachmentRef` into that native shape.
+
+The adapter may use advisory media metadata required by that protocol, but it
+does not parse or transform the file.
+
+### Manifest transport
+
+When a protocol version has no generic local-file field, the adapter adds a
+machine-generated attachment manifest to the model-facing request. The
+manifest is separate from the user-visible transcript text and includes the
+stable readable path and display metadata required for the agent to open the
+file with its tools.
+
+For a protocol that exposes only one string content field, “separate” is a
+logical application boundary: the adapter encodes a delimited manifest beside
+the user text in the model-facing request, while the draft and transcript keep
+only the original user text. The generated envelope is adapter-owned and is
+never echoed into the visible message or logs.
+
+This fallback is still file exposure, not content processing. It must not:
+
+- replace the user's visible message with a filename;
+- silently omit an attachment;
+- claim native multimodal delivery when only a readable path was supplied;
+- log the generated manifest.
+
+Codex, Claude, OpenCode, and ZCode must all implement either native transport
+or manifest transport. The Composer never branches on backend identity.
+
+## Composer interaction
+
+The existing Composer gains an attachment button and an attachment area above
+the text editor.
+
+- The button opens a multi-file picker.
+- The complete Composer accepts dropped files.
+- Pasting files while the editor is focused adds them without replacing text.
+- Images use FilePond's thumbnail support.
+- Other files show a generic icon, filename, size, state, and remove action.
+- The send button is enabled when non-whitespace text or at least one ready
+  attachment exists.
+- Attachments that are still staging show progress; the turn cannot be sent
+  until every included item is ready.
+- A failed item is marked in place and can be removed or retried without
+  deleting successful items.
+
+The attachment surface does not change existing Composer resize behavior:
+
+- Enter sends.
+- Shift+Enter inserts a newline.
+- Shift+ArrowUp and Shift+ArrowDown resize only when the resize handle's focus
+  carrier owns the keyboard event.
+- Pointer resizing, compact-panel clamping, option chips, send/stop, and
+  streaming behavior remain intact.
+
+## Draft and send lifecycle
+
+Text and pending attachments belong to the same per-session draft. Switching
+sessions preserves each session's draft independently.
+
+On send:
+
+1. verify that every attachment is ready and readable;
+2. freeze one immutable `TurnInput` snapshot;
+3. submit that snapshot to the selected backend;
+4. clear the Composer only after the backend emits its existing or newly
+   normalized “turn accepted” event.
+
+Turn acceptance is distinct from assistant completion. The backend boundary
+must expose acceptance as soon as the remote/local session has created the
+turn, while token streaming and terminal completion continue through their
+existing event path. A backend that returns only at terminal completion needs
+its adapter contract normalized; the Composer must not stay populated for the
+entire assistant response.
+
+If submission fails before dispatch, the complete text and attachment draft is
+retained.
+
+If the connection fails after dispatch and acceptance is uncertain, the panel
+does not automatically resubmit. It preserves enough state to reconcile the
+backend session and avoids creating a duplicate model turn.
+
+Once accepted, the user message in the transcript displays attachment names
+and sizes but not absolute paths. Temporary attachments remain available until
+the backend turn is terminal, then become eligible for cleanup.
+
+## Resource protection
+
+Resource controls protect the panel rather than define model capabilities:
+
+- at most 32 attachments per turn;
+- stable path-backed files are passed by reference and are not loaded into
+  panel memory or rejected by an application-level file-size allowlist;
+- a pathless clipboard blob is limited to 256 MiB per item and 512 MiB per
+  turn because it must be materialized by the application;
+- non-image files and large media do not receive generated previews;
+- backend or provider size failures are reported as their actual errors rather
+  than copied into a Composer support table.
+
+These limits are named configuration constants and produce actionable UI
+errors.
+
+## Error handling and observability
+
+The panel distinguishes these outcomes:
+
+- **staging failure:** the file never became a valid attachment; keep the rest
+  of the draft;
+- **pre-dispatch failure:** the backend did not accept the turn; retain the
+  complete draft;
+- **accepted:** the backend owns the turn; clear the Composer and show the
+  attachment metadata in the transcript;
+- **uncertain dispatch:** do not retry automatically; reconcile session state;
+- **backend rejection:** show the backend's real error without silently
+  converting or dropping files.
+
+The UI says that files were attached or delivered, never that the model read,
+understood, or correctly interpreted them.
+
+Diagnostics may record:
+
+- attachment IDs;
+- attachment count;
+- byte sizes;
+- temporary/original ownership;
+- staging and dispatch dispositions;
+- backend and transport kind.
+
+Diagnostics must not record:
+
+- file contents;
+- absolute local paths;
+- generated attachment manifests;
+- provider credentials or signed upload URLs.
+
+## Validation strategy
+
+### UI and lifecycle tests
+
+Focused Panel tests prove:
+
+1. picker, drag/drop, and clipboard input produce the same attachment model;
+2. image and unknown-extension files are both accepted;
+3. image preview and generic file cards render correctly;
+4. removal cleans only application-owned temporary files;
+5. attachment-only turns can be sent;
+6. text and attachments remain paired when switching sessions;
+7. staging and pre-dispatch failures preserve the draft;
+8. accepted turns clear the draft exactly once;
+9. uncertain dispatch does not trigger automatic resubmission;
+10. existing Enter, Shift+Enter, resize, chip, send, stop, and streaming
+    behavior remains unchanged.
+
+### Cross-backend contract tests
+
+Run the same `TurnInput` vector through Codex, Claude, OpenCode, and ZCode.
+Assert for every adapter that:
+
+- all attachments are present in order;
+- names, sizes, and readable references survive serialization;
+- the adapter selects an implemented native or manifest transport;
+- attachment metadata reaches the backend request without changing the
+  user-visible text;
+- redacted diagnostics contain no contents or absolute paths.
+
+Add a dynamic invariant that enumerates the registered chat backends and
+requires every one to implement the attachment mapping contract. Prove the
+guard by mutation: remove one backend's mapping, observe the test fail, restore
+it, and observe the test pass.
+
+### Real-host development validation
+
+Reuse the installed development dependencies and the current real AE/CEP
+environment. Do not rebuild or reinstall unchanged components, and do not run
+packaged-release T5/T6.
+
+Use one application-owned temporary fixture set containing:
+
+- a text file;
+- an image;
+- a PDF;
+- a short video;
+- a file with an unknown extension.
+
+For each of Codex, Claude, OpenCode, and ZCode:
+
+1. attach the same fixture set from the real Composer;
+2. send the smallest prompt that asks the model to list the files it can see;
+3. verify the backend accepted every attachment and the model-facing request
+   contains every reference;
+4. record whether delivery used a native attachment or the agent-readable
+   manifest;
+5. do not require the model to parse every file as proof of transport.
+
+On at least one configured backend with native multimodal support, ask the
+model to use an image or video through its own supported mechanism. This proves
+the panel did not prevent native multimodal behavior without making the panel
+responsible for interpreting the media.
+
+Finally remove the drafts and close the test sessions. Verify that
+application-created temporary files are gone and the fixture originals remain
+unchanged.
+
+## Done criteria
+
+This slice is complete when:
+
+- the Composer exposes FilePond-backed file selection, drop, paste, preview,
+  removal, and attachment-only send;
+- every registered backend accepts the same structured turn and exposes all
+  files to the model;
+- no application format allowlist, parser, converter, or video slicer exists;
+- draft retention, uncertain dispatch, redacted diagnostics, and temporary
+  cleanup behave as specified;
+- the mutation-proven cross-backend invariant passes;
+- focused Panel tests and required repository checks pass;
+- the real AE panel verifies file exposure through all four configured
+  backends using reused development dependencies;
+- the resulting PR documents any backend that used a native attachment versus
+  a manifest, without claiming that transport alone proves model
+  understanding.

--- a/native/platform-helper/macos/Sources/PlatformHelperService/Authorization.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/Authorization.swift
@@ -11,6 +11,7 @@ enum NativeArchitecture: String, Equatable {
 enum MacCallerPolicy {
     static let afterEffectsBundleIdentifier = "com.adobe.AfterEffects.application"
     static let cepSigningIdentifier = "com.adobe.cep.CEPHtmlEngine"
+    static let brokerSigningIdentifier = "ae-mcp-platform-helper"
     static let adobeTeamIdentifier = "JQ525L2MZD"
     static let supportedAfterEffectsMajors = [25, 26]
     static let requiredArchitecture = NativeArchitecture.arm64
@@ -21,6 +22,9 @@ enum MacCallerPolicy {
 
     static let directConnectionRequirement =
         #"anchor apple generic and certificate leaf[subject.OU] = "JQ525L2MZD" and identifier "com.adobe.cep.CEPHtmlEngine""#
+
+    static let brokerConnectionRequirement =
+        #"identifier "ae-mcp-platform-helper""#
 }
 
 struct SignedProcessIdentity: Equatable {
@@ -31,6 +35,27 @@ struct SignedProcessIdentity: Equatable {
     let bundleVersionMajor: Int?
     let architecture: NativeArchitecture
     let signatureValid: Bool
+    let brokerSignatureValid: Bool
+
+    init(
+        processIdentifier: pid_t,
+        parentProcessIdentifier: pid_t,
+        signingIdentifier: String,
+        teamIdentifier: String,
+        bundleVersionMajor: Int?,
+        architecture: NativeArchitecture,
+        signatureValid: Bool,
+        brokerSignatureValid: Bool = false
+    ) {
+        self.processIdentifier = processIdentifier
+        self.parentProcessIdentifier = parentProcessIdentifier
+        self.signingIdentifier = signingIdentifier
+        self.teamIdentifier = teamIdentifier
+        self.bundleVersionMajor = bundleVersionMajor
+        self.architecture = architecture
+        self.signatureValid = signatureValid
+        self.brokerSignatureValid = brokerSignatureValid
+    }
 }
 
 struct CallerEvidence: Equatable {
@@ -77,19 +102,33 @@ struct MacCallerAuthorizer: CallerAuthorizing {
               evidence.effectiveUserIdentifier == connection.effectiveUserIdentifier,
               evidence.auditSessionIdentifier == connection.auditSessionIdentifier,
               evidence.generationBefore == connection.processGeneration,
-              evidence.generationAfter == connection.processGeneration,
-              trustedAdobeProcess(evidence.caller),
-              evidence.caller.signingIdentifier == MacCallerPolicy.cepSigningIdentifier
+              evidence.generationAfter == connection.processGeneration
         else {
             throw HelperFailure.unauthorized
         }
 
-        guard let aeIndex = evidence.ancestry.firstIndex(where: {
+        let adobeAncestry: ArraySlice<SignedProcessIdentity>
+        let connectionRequirement: String
+        if trustedAdobeProcess(evidence.caller),
+           evidence.caller.signingIdentifier == MacCallerPolicy.cepSigningIdentifier {
+            adobeAncestry = evidence.ancestry[...]
+            connectionRequirement = MacCallerPolicy.directConnectionRequirement
+        } else if trustedBrokerProcess(evidence.caller),
+                  let directParent = evidence.ancestry.first,
+                  trustedAdobeProcess(directParent),
+                  directParent.signingIdentifier == MacCallerPolicy.cepSigningIdentifier {
+            adobeAncestry = evidence.ancestry.dropFirst()
+            connectionRequirement = MacCallerPolicy.brokerConnectionRequirement
+        } else {
+            throw HelperFailure.unauthorized
+        }
+
+        guard let aeIndex = adobeAncestry.firstIndex(where: {
             $0.signingIdentifier == MacCallerPolicy.afterEffectsBundleIdentifier
         }) else {
             throw HelperFailure.unauthorized
         }
-        let pathToAfterEffects = evidence.ancestry[...aeIndex]
+        let pathToAfterEffects = adobeAncestry[...aeIndex]
         guard pathToAfterEffects.allSatisfy(trustedAdobeProcess),
               let major = pathToAfterEffects.last?.bundleVersionMajor,
               MacCallerPolicy.supportedAfterEffectsMajors.contains(major)
@@ -98,13 +137,20 @@ struct MacCallerAuthorizer: CallerAuthorizing {
         }
         return AuthorizedCaller(
             processIdentifier: connection.processIdentifier,
-            afterEffectsMajor: major
+            afterEffectsMajor: major,
+            connectionRequirement: connectionRequirement
         )
     }
 
     private func trustedAdobeProcess(_ process: SignedProcessIdentity) -> Bool {
         process.signatureValid
             && process.teamIdentifier == MacCallerPolicy.adobeTeamIdentifier
+            && process.architecture == MacCallerPolicy.requiredArchitecture
+    }
+
+    private func trustedBrokerProcess(_ process: SignedProcessIdentity) -> Bool {
+        process.brokerSignatureValid
+            && process.signingIdentifier == MacCallerPolicy.brokerSigningIdentifier
             && process.architecture == MacCallerPolicy.requiredArchitecture
     }
 }
@@ -231,6 +277,20 @@ struct SecurityFrameworkSignedProcessInspector: SignedProcessInspecting {
             requirement
         ) == errSecSuccess
 
+        var brokerRequirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            MacCallerPolicy.brokerConnectionRequirement as CFString,
+            SecCSFlags(rawValue: 0),
+            &brokerRequirement
+        ) == errSecSuccess, let brokerRequirement else {
+            throw HelperFailure.unauthorized
+        }
+        let brokerSignatureValid = SecCodeCheckValidity(
+            dynamicCode,
+            SecCSFlags(rawValue: 1 << 4),
+            brokerRequirement
+        ) == errSecSuccess
+
         var staticCode: SecStaticCode?
         guard SecCodeCopyStaticCode(
             dynamicCode,
@@ -246,11 +306,12 @@ struct SecurityFrameworkSignedProcessInspector: SignedProcessInspecting {
             &signingInformation
         ) == errSecSuccess,
               let information = signingInformation as? [String: Any],
-              let signingIdentifier = information[kSecCodeInfoIdentifier as String] as? String,
-              let teamIdentifier = information[kSecCodeInfoTeamIdentifier as String] as? String
+              let signingIdentifier = information[kSecCodeInfoIdentifier as String] as? String
         else {
             throw HelperFailure.unauthorized
         }
+        let teamIdentifier =
+            information[kSecCodeInfoTeamIdentifier as String] as? String ?? ""
         let plist = information[kSecCodeInfoPList as String] as? [String: Any]
         return SignedProcessIdentity(
             processIdentifier: snapshot.processIdentifier,
@@ -259,7 +320,8 @@ struct SecurityFrameworkSignedProcessInspector: SignedProcessInspecting {
             teamIdentifier: teamIdentifier,
             bundleVersionMajor: bundleVersionMajor(plist),
             architecture: snapshot.architecture,
-            signatureValid: signatureValid
+            signatureValid: signatureValid,
+            brokerSignatureValid: brokerSignatureValid
         )
     }
 

--- a/native/platform-helper/macos/Sources/PlatformHelperService/Authorization.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/Authorization.swift
@@ -11,6 +11,7 @@ enum NativeArchitecture: String, Equatable {
 enum MacCallerPolicy {
     static let afterEffectsBundleIdentifier = "com.adobe.AfterEffects.application"
     static let cepSigningIdentifier = "com.adobe.cep.CEPHtmlEngine"
+    static let cepRendererSigningIdentifier = "com.adobe.cep.CEPHtmlEngine Helper (Renderer)"
     static let brokerSigningIdentifier = "ae-mcp-platform-helper"
     static let adobeTeamIdentifier = "JQ525L2MZD"
     static let supportedAfterEffectsMajors = [25, 26]
@@ -116,7 +117,10 @@ struct MacCallerAuthorizer: CallerAuthorizing {
         } else if trustedBrokerProcess(evidence.caller),
                   let directParent = evidence.ancestry.first,
                   trustedAdobeProcess(directParent),
-                  directParent.signingIdentifier == MacCallerPolicy.cepSigningIdentifier {
+                  directParent.signingIdentifier == MacCallerPolicy.cepRendererSigningIdentifier,
+                  let cepParent = evidence.ancestry.dropFirst().first,
+                  trustedAdobeProcess(cepParent),
+                  cepParent.signingIdentifier == MacCallerPolicy.cepSigningIdentifier {
             adobeAncestry = evidence.ancestry.dropFirst()
             connectionRequirement = MacCallerPolicy.brokerConnectionRequirement
         } else {

--- a/native/platform-helper/macos/Sources/PlatformHelperService/KeychainSecretStore.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/KeychainSecretStore.swift
@@ -57,6 +57,47 @@ protocol KeychainBackend {
     func delete(service: String, account: String) throws
 }
 
+enum KeychainStorageMode: Equatable {
+    case fileBased
+    case dataProtection
+}
+
+struct KeychainProcessIdentity: Equatable {
+    let teamIdentifier: String
+    let applicationIdentifier: String?
+}
+
+func keychainStorageMode(for identity: KeychainProcessIdentity) throws -> KeychainStorageMode {
+    if identity.teamIdentifier.isEmpty {
+        guard identity.applicationIdentifier == nil else {
+            throw HelperFailure.secretStoreUnavailable
+        }
+        return .fileBased
+    }
+    let expected = "\(identity.teamIdentifier).com.junkdoge.ae-mcp.platform-helper"
+    guard identity.applicationIdentifier == expected else {
+        throw HelperFailure.secretStoreUnavailable
+    }
+    return .dataProtection
+}
+
+func keychainBaseQuery(
+    service: String,
+    account: String,
+    mode: KeychainStorageMode
+) -> [String: Any] {
+    var query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: account,
+    ]
+    if mode == .dataProtection {
+        query[kSecUseDataProtectionKeychain as String] = true
+        query[kSecAttrSynchronizable as String] = false
+    }
+    return query
+}
+
 private struct CredentialBlob: Codable, Equatable {
     let schemaVersion: Int
     let revision: Int
@@ -294,9 +335,17 @@ final class InMemoryKeychainBackend: KeychainBackend {
 }
 
 final class SecurityKeychainBackend: KeychainBackend {
+    private let storageMode: Result<KeychainStorageMode, Error>
+
+    init(identity: KeychainProcessIdentity? = nil) {
+        storageMode = Result {
+            try keychainStorageMode(for: identity ?? Self.currentProcessIdentity())
+        }
+    }
+
     func read(service: String, account: String) throws -> Data? {
         var item: CFTypeRef?
-        var query = baseQuery(service: service, account: account)
+        var query = try baseQuery(service: service, account: account)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         let status = SecItemCopyMatching(query as CFDictionary, &item)
@@ -308,9 +357,12 @@ final class SecurityKeychainBackend: KeychainBackend {
     }
 
     func add(service: String, account: String, data: Data) throws {
-        var query = baseQuery(service: service, account: account)
+        let mode = try storageMode.get()
+        var query = keychainBaseQuery(service: service, account: account, mode: mode)
         query[kSecValueData as String] = data
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        if mode == .dataProtection {
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        }
         guard SecItemAdd(query as CFDictionary, nil) == errSecSuccess else {
             throw HelperFailure.secretStoreUnavailable
         }
@@ -318,27 +370,62 @@ final class SecurityKeychainBackend: KeychainBackend {
 
     func update(service: String, account: String, data: Data) throws {
         let status = SecItemUpdate(
-            baseQuery(service: service, account: account) as CFDictionary,
+            try baseQuery(service: service, account: account) as CFDictionary,
             [kSecValueData as String: data] as CFDictionary
         )
         guard status == errSecSuccess else { throw HelperFailure.secretStoreUnavailable }
     }
 
     func delete(service: String, account: String) throws {
-        let status = SecItemDelete(baseQuery(service: service, account: account) as CFDictionary)
+        let status = SecItemDelete(try baseQuery(service: service, account: account) as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw HelperFailure.secretStoreUnavailable
         }
     }
 
-    private func baseQuery(service: String, account: String) -> [String: Any] {
-        [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecUseDataProtectionKeychain as String: true,
-            kSecAttrSynchronizable as String: false,
-        ]
+    private func baseQuery(service: String, account: String) throws -> [String: Any] {
+        keychainBaseQuery(
+            service: service,
+            account: account,
+            mode: try storageMode.get()
+        )
+    }
+
+    private static func currentProcessIdentity() throws -> KeychainProcessIdentity {
+        var code: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(rawValue: 0), &code) == errSecSuccess,
+              let code
+        else {
+            throw HelperFailure.secretStoreUnavailable
+        }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(
+            code,
+            SecCSFlags(rawValue: 0),
+            &staticCode
+        ) == errSecSuccess,
+              let staticCode
+        else {
+            throw HelperFailure.secretStoreUnavailable
+        }
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: 1 << 1),
+            &information
+        ) == errSecSuccess,
+              let values = information as? [String: Any]
+        else {
+            throw HelperFailure.secretStoreUnavailable
+        }
+        let teamIdentifier = values[kSecCodeInfoTeamIdentifier as String] as? String ?? ""
+        let entitlements = values[kSecCodeInfoEntitlementsDict as String] as? [String: Any]
+        let applicationIdentifier =
+            entitlements?["com.apple.application-identifier"] as? String
+        return KeychainProcessIdentity(
+            teamIdentifier: teamIdentifier,
+            applicationIdentifier: applicationIdentifier
+        )
     }
 }
 

--- a/native/platform-helper/macos/Sources/PlatformHelperService/ProtocolDispatcher.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/ProtocolDispatcher.swift
@@ -28,6 +28,17 @@ struct ConnectionIdentity: Equatable {
 struct AuthorizedCaller: Equatable {
     let processIdentifier: pid_t
     let afterEffectsMajor: Int
+    let connectionRequirement: String
+
+    init(
+        processIdentifier: pid_t,
+        afterEffectsMajor: Int,
+        connectionRequirement: String = MacCallerPolicy.directConnectionRequirement
+    ) {
+        self.processIdentifier = processIdentifier
+        self.afterEffectsMajor = afterEffectsMajor
+        self.connectionRequirement = connectionRequirement
+    }
 }
 
 protocol CallerAuthorizing {

--- a/native/platform-helper/macos/Sources/PlatformHelperService/ServiceRegistration.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/ServiceRegistration.swift
@@ -115,7 +115,7 @@ final class PlatformHelperListenerDelegate: NSObject, NSXPCListenerDelegate {
 
             // This public macOS 13+ API gives the authorized branch an OS-enforced
             // direct-peer requirement in addition to the generation/ancestry checks.
-            connection.setCodeSigningRequirement(MacCallerPolicy.directConnectionRequirement)
+            connection.setCodeSigningRequirement(caller.connectionRequirement)
             exportedObject = AuthorizedPlatformHelperExport(
                 identity: identity,
                 caller: caller,

--- a/native/platform-helper/macos/Sources/PlatformHelperService/StdioBroker.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/StdioBroker.swift
@@ -1,0 +1,133 @@
+import Dispatch
+import Foundation
+
+private enum StdioBrokerFailure: Error {
+    case invalidFrame
+    case xpcFailure
+}
+
+final class StdioFrameBroker {
+    typealias Request = (Data) throws -> Data
+
+    private let maxMessageBytes: Int
+    private let request: Request
+    private var buffered = Data()
+
+    init(
+        maxMessageBytes: Int = platformHelperMaximumMessageBytes,
+        request: @escaping Request
+    ) {
+        self.maxMessageBytes = maxMessageBytes
+        self.request = request
+    }
+
+    func accept(_ chunk: Data) throws -> Data {
+        guard !chunk.isEmpty else { return Data() }
+        buffered.append(chunk)
+        var output = Data()
+        while let newline = buffered.firstIndex(of: 0x0a) {
+            var frame = buffered[..<newline]
+            buffered.removeSubrange(...newline)
+            if frame.last == 0x0d { frame = frame.dropLast() }
+            guard !frame.isEmpty, frame.count <= maxMessageBytes else {
+                throw StdioBrokerFailure.invalidFrame
+            }
+            let response = try request(Data(frame))
+            guard !response.isEmpty,
+                  response.count <= maxMessageBytes,
+                  !response.contains(0x0a),
+                  !response.contains(0x0d)
+            else {
+                throw StdioBrokerFailure.invalidFrame
+            }
+            output.append(response)
+            output.append(0x0a)
+        }
+        guard buffered.count <= maxMessageBytes else {
+            throw StdioBrokerFailure.invalidFrame
+        }
+        return output
+    }
+
+    func finish() throws {
+        guard buffered.isEmpty else { throw StdioBrokerFailure.invalidFrame }
+    }
+}
+
+private final class StdioXPCClient {
+    private let connection: NSXPCConnection
+
+    init() {
+        connection = NSXPCConnection(
+            machServiceName: PlatformHelperServiceMain.machServiceName,
+            options: []
+        )
+        connection.remoteObjectInterface =
+            NSXPCInterface(with: PlatformHelperXPCProtocol.self)
+        connection.resume()
+    }
+
+    deinit {
+        connection.invalidate()
+    }
+
+    func request(_ bytes: Data) throws -> Data {
+        let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var response: Data?
+        var failed = false
+
+        let proxy = connection.remoteObjectProxyWithErrorHandler { _ in
+            lock.lock()
+            failed = true
+            lock.unlock()
+            semaphore.signal()
+        }
+        guard let service = proxy as? PlatformHelperXPCProtocol else {
+            throw StdioBrokerFailure.xpcFailure
+        }
+        service.requestJSON(bytes as NSData) { reply, error in
+            lock.lock()
+            if let reply, error == nil {
+                response = reply as Data
+            } else {
+                failed = true
+            }
+            lock.unlock()
+            semaphore.signal()
+        }
+        guard semaphore.wait(timeout: .now() + .seconds(10)) == .success else {
+            connection.invalidate()
+            throw StdioBrokerFailure.xpcFailure
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        guard !failed, let response else { throw StdioBrokerFailure.xpcFailure }
+        return response
+    }
+}
+
+enum PlatformHelperStdioBroker {
+    static func run(
+        input: FileHandle = .standardInput,
+        output: FileHandle = .standardOutput
+    ) -> Int32 {
+        let client = StdioXPCClient()
+        let broker = StdioFrameBroker(request: client.request)
+        do {
+            while true {
+                let chunk = input.availableData
+                if chunk.isEmpty {
+                    try broker.finish()
+                    return 0
+                }
+                let responses = try broker.accept(chunk)
+                if !responses.isEmpty {
+                    try output.write(contentsOf: responses)
+                }
+            }
+        } catch {
+            return 70
+        }
+    }
+}

--- a/native/platform-helper/macos/Sources/PlatformHelperService/main.swift
+++ b/native/platform-helper/macos/Sources/PlatformHelperService/main.swift
@@ -1,1 +1,8 @@
+import Darwin
+
+if CommandLine.arguments.count == 2,
+   CommandLine.arguments[1] == "--client-stdio" {
+    exit(PlatformHelperStdioBroker.run())
+}
+guard CommandLine.arguments.count == 1 else { exit(64) }
 PlatformHelperServiceMain.run()

--- a/native/platform-helper/macos/Tests/PlatformHelperTests/AuthorizationTests.swift
+++ b/native/platform-helper/macos/Tests/PlatformHelperTests/AuthorizationTests.swift
@@ -20,7 +20,7 @@ import Testing
     }
 
     @Test
-    func testAcceptsOnlySignedBrokerWithDirectTrustedCepAndSupportedAfterEffectsAncestry() throws {
+    func testAcceptsSignedBrokerSpawnedByTrustedCepRendererUnderCepAndSupportedAfterEffects() throws {
         let inspector = FixedCallerInspector(evidence: .validBroker)
         let authorizer = MacCallerAuthorizer(
             inspector: inspector,
@@ -42,6 +42,10 @@ import Testing
             .validBroker.replacing(callerBrokerSignatureValid: false),
             .validBroker.replacing(callerArchitecture: .x86_64),
             .validBroker.replacing(ancestry: Array(CallerEvidence.validBroker.ancestry.dropFirst())),
+            .validBroker.replacing(ancestry: [
+                CallerEvidence.validBroker.ancestry[0],
+                CallerEvidence.validBroker.ancestry[2],
+            ]),
             .validBroker.replacing(firstAncestorSigningIdentifier: "com.example.fake-cep"),
             .validBroker.replacing(firstAncestorTeamIdentifier: "ATTACKER01"),
             .validBroker.replacing(firstAncestorSignatureValid: false),
@@ -116,6 +120,10 @@ import Testing
     func testPolicyConstantsMatchProductionIdentifiersAndVersions() {
         XCTAssertEqual(MacCallerPolicy.afterEffectsBundleIdentifier, "com.adobe.AfterEffects.application")
         XCTAssertEqual(MacCallerPolicy.cepSigningIdentifier, "com.adobe.cep.CEPHtmlEngine")
+        XCTAssertEqual(
+            MacCallerPolicy.cepRendererSigningIdentifier,
+            "com.adobe.cep.CEPHtmlEngine Helper (Renderer)"
+        )
         XCTAssertEqual(MacCallerPolicy.adobeTeamIdentifier, "JQ525L2MZD")
         XCTAssertEqual(MacCallerPolicy.supportedAfterEffectsMajors, [25, 26])
         XCTAssertEqual(MacCallerPolicy.requiredArchitecture, .arm64)
@@ -323,7 +331,7 @@ private extension CallerEvidence {
             SignedProcessIdentity(
                 processIdentifier: 1002,
                 parentProcessIdentifier: 1001,
-                signingIdentifier: "com.adobe.cep.CEPHtmlEngine",
+                signingIdentifier: "com.adobe.cep.CEPHtmlEngine Helper (Renderer)",
                 teamIdentifier: "JQ525L2MZD",
                 bundleVersionMajor: nil,
                 architecture: .arm64,
@@ -331,6 +339,15 @@ private extension CallerEvidence {
             ),
             SignedProcessIdentity(
                 processIdentifier: 1001,
+                parentProcessIdentifier: 1000,
+                signingIdentifier: "com.adobe.cep.CEPHtmlEngine",
+                teamIdentifier: "JQ525L2MZD",
+                bundleVersionMajor: nil,
+                architecture: .arm64,
+                signatureValid: true
+            ),
+            SignedProcessIdentity(
+                processIdentifier: 1000,
                 parentProcessIdentifier: 1,
                 signingIdentifier: "com.adobe.AfterEffects.application",
                 teamIdentifier: "JQ525L2MZD",

--- a/native/platform-helper/macos/Tests/PlatformHelperTests/AuthorizationTests.swift
+++ b/native/platform-helper/macos/Tests/PlatformHelperTests/AuthorizationTests.swift
@@ -20,6 +20,47 @@ import Testing
     }
 
     @Test
+    func testAcceptsOnlySignedBrokerWithDirectTrustedCepAndSupportedAfterEffectsAncestry() throws {
+        let inspector = FixedCallerInspector(evidence: .validBroker)
+        let authorizer = MacCallerAuthorizer(
+            inspector: inspector,
+            currentUserIdentifier: 501
+        )
+
+        let caller = try authorizer.authorize(connection: .brokerFixture)
+
+        XCTAssertEqual(caller.processIdentifier, 1003)
+        XCTAssertEqual(caller.afterEffectsMajor, 26)
+        XCTAssertEqual(caller.connectionRequirement, MacCallerPolicy.brokerConnectionRequirement)
+        XCTAssertEqual(inspector.accessCount, 1)
+    }
+
+    @Test
+    func testRejectsBrokerWhenAnyBrokerCepOrAeBoundaryChanges() throws {
+        let invalid: [CallerEvidence] = [
+            .validBroker.replacing(callerSigningIdentifier: "com.example.attacker"),
+            .validBroker.replacing(callerBrokerSignatureValid: false),
+            .validBroker.replacing(callerArchitecture: .x86_64),
+            .validBroker.replacing(ancestry: Array(CallerEvidence.validBroker.ancestry.dropFirst())),
+            .validBroker.replacing(firstAncestorSigningIdentifier: "com.example.fake-cep"),
+            .validBroker.replacing(firstAncestorTeamIdentifier: "ATTACKER01"),
+            .validBroker.replacing(firstAncestorSignatureValid: false),
+            .validBroker.replacing(firstAncestorArchitecture: .x86_64),
+            .validBroker.replacing(afterEffectsMajor: 27),
+        ]
+
+        for evidence in invalid {
+            let authorizer = MacCallerAuthorizer(
+                inspector: FixedCallerInspector(evidence: evidence),
+                currentUserIdentifier: 501
+            )
+            XCTAssertThrowsError(try authorizer.authorize(connection: .brokerFixture)) { error in
+                XCTAssertEqual((error as? HelperFailure)?.code, "HELPER_UNAUTHORIZED")
+            }
+        }
+    }
+
+    @Test
     func testRejectsEveryIdentityBoundaryIndependently() throws {
         let invalid: [CallerEvidence] = [
             .valid.replacing(processIdentifier: 1003),
@@ -262,6 +303,44 @@ private extension CallerEvidence {
         ]
     )
 
+    static let validBroker = CallerEvidence(
+        processIdentifier: 1003,
+        effectiveUserIdentifier: 501,
+        auditSessionIdentifier: 77,
+        generationBefore: ProcessGeneration(seconds: 101, microseconds: 1),
+        generationAfter: ProcessGeneration(seconds: 101, microseconds: 1),
+        caller: SignedProcessIdentity(
+            processIdentifier: 1003,
+            parentProcessIdentifier: 1002,
+            signingIdentifier: "ae-mcp-platform-helper",
+            teamIdentifier: "",
+            bundleVersionMajor: nil,
+            architecture: .arm64,
+            signatureValid: false,
+            brokerSignatureValid: true
+        ),
+        ancestry: [
+            SignedProcessIdentity(
+                processIdentifier: 1002,
+                parentProcessIdentifier: 1001,
+                signingIdentifier: "com.adobe.cep.CEPHtmlEngine",
+                teamIdentifier: "JQ525L2MZD",
+                bundleVersionMajor: nil,
+                architecture: .arm64,
+                signatureValid: true
+            ),
+            SignedProcessIdentity(
+                processIdentifier: 1001,
+                parentProcessIdentifier: 1,
+                signingIdentifier: "com.adobe.AfterEffects.application",
+                teamIdentifier: "JQ525L2MZD",
+                bundleVersionMajor: 26,
+                architecture: .arm64,
+                signatureValid: true
+            ),
+        ]
+    )
+
     func replacing(
         processIdentifier: pid_t? = nil,
         effectiveUserIdentifier: uid_t? = nil,
@@ -272,8 +351,13 @@ private extension CallerEvidence {
         callerBundleVersionMajor: Int? = nil,
         callerTeamIdentifier: String? = nil,
         callerSignatureValid: Bool? = nil,
+        callerBrokerSignatureValid: Bool? = nil,
         callerArchitecture: NativeArchitecture? = nil,
         ancestry: [SignedProcessIdentity]? = nil,
+        firstAncestorSigningIdentifier: String? = nil,
+        firstAncestorTeamIdentifier: String? = nil,
+        firstAncestorSignatureValid: Bool? = nil,
+        firstAncestorArchitecture: NativeArchitecture? = nil,
         afterEffectsBundleIdentifier: String? = nil,
         afterEffectsTeamIdentifier: String? = nil,
         afterEffectsSignatureValid: Bool? = nil,
@@ -288,19 +372,36 @@ private extension CallerEvidence {
             teamIdentifier: callerTeamIdentifier ?? nextCaller.teamIdentifier,
             bundleVersionMajor: callerBundleVersionMajor ?? nextCaller.bundleVersionMajor,
             architecture: callerArchitecture ?? nextCaller.architecture,
-            signatureValid: callerSignatureValid ?? nextCaller.signatureValid
+            signatureValid: callerSignatureValid ?? nextCaller.signatureValid,
+            brokerSignatureValid: callerBrokerSignatureValid ?? nextCaller.brokerSignatureValid
         )
         var nextAncestry = ancestry ?? self.ancestry
         if !nextAncestry.isEmpty {
-            let ae = nextAncestry[0]
+            let first = nextAncestry[0]
             nextAncestry[0] = SignedProcessIdentity(
+                processIdentifier: first.processIdentifier,
+                parentProcessIdentifier: first.parentProcessIdentifier,
+                signingIdentifier: firstAncestorSigningIdentifier ?? first.signingIdentifier,
+                teamIdentifier: firstAncestorTeamIdentifier ?? first.teamIdentifier,
+                bundleVersionMajor: first.bundleVersionMajor,
+                architecture: firstAncestorArchitecture ?? first.architecture,
+                signatureValid: firstAncestorSignatureValid ?? first.signatureValid,
+                brokerSignatureValid: first.brokerSignatureValid
+            )
+        }
+        if let aeIndex = nextAncestry.firstIndex(where: {
+            $0.signingIdentifier == MacCallerPolicy.afterEffectsBundleIdentifier
+        }) {
+            let ae = nextAncestry[aeIndex]
+            nextAncestry[aeIndex] = SignedProcessIdentity(
                 processIdentifier: ae.processIdentifier,
                 parentProcessIdentifier: ae.parentProcessIdentifier,
                 signingIdentifier: afterEffectsBundleIdentifier ?? ae.signingIdentifier,
                 teamIdentifier: afterEffectsTeamIdentifier ?? ae.teamIdentifier,
                 bundleVersionMajor: afterEffectsMajor ?? ae.bundleVersionMajor,
                 architecture: afterEffectsArchitecture ?? ae.architecture,
-                signatureValid: afterEffectsSignatureValid ?? ae.signatureValid
+                signatureValid: afterEffectsSignatureValid ?? ae.signatureValid,
+                brokerSignatureValid: ae.brokerSignatureValid
             )
         }
         return CallerEvidence(
@@ -321,5 +422,12 @@ private extension ConnectionIdentity {
         effectiveUserIdentifier: 501,
         auditSessionIdentifier: 77,
         processGeneration: ProcessGeneration(seconds: 100, microseconds: 1)
+    )
+
+    static let brokerFixture = ConnectionIdentity(
+        processIdentifier: 1003,
+        effectiveUserIdentifier: 501,
+        auditSessionIdentifier: 77,
+        processGeneration: ProcessGeneration(seconds: 101, microseconds: 1)
     )
 }

--- a/native/platform-helper/macos/Tests/PlatformHelperTests/KeychainSecretStoreTests.swift
+++ b/native/platform-helper/macos/Tests/PlatformHelperTests/KeychainSecretStoreTests.swift
@@ -1,11 +1,72 @@
 @preconcurrency import Dispatch
 import Foundation
+import Security
 import Testing
 
 @testable import PlatformHelperService
 
 @Suite struct KeychainSecretStoreTests {
     private let rawReference = "aemcp-secret://provider/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/api/v1"
+
+    @Test
+    func testDevelopmentAndReleaseSigningIdentitiesSelectDifferentKeychainProfiles() throws {
+        XCTAssertEqual(
+            try keychainStorageMode(for: KeychainProcessIdentity(
+                teamIdentifier: "",
+                applicationIdentifier: nil
+            )),
+            .fileBased
+        )
+        XCTAssertEqual(
+            try keychainStorageMode(for: KeychainProcessIdentity(
+                teamIdentifier: "ABCDE12345",
+                applicationIdentifier: "ABCDE12345.com.junkdoge.ae-mcp.platform-helper"
+            )),
+            .dataProtection
+        )
+
+        for identity in [
+            KeychainProcessIdentity(
+                teamIdentifier: "ABCDE12345",
+                applicationIdentifier: nil
+            ),
+            KeychainProcessIdentity(
+                teamIdentifier: "ABCDE12345",
+                applicationIdentifier: "WRONG12345.com.junkdoge.ae-mcp.platform-helper"
+            ),
+        ] {
+            XCTAssertThrowsError(try keychainStorageMode(for: identity)) { error in
+                XCTAssertEqual((error as? HelperFailure)?.code, "SECRET_STORE_UNAVAILABLE")
+            }
+        }
+    }
+
+    @Test
+    func testDevelopmentKeychainQueryOmitsDataProtectionOnlyAttributes() {
+        let fileBased = keychainBaseQuery(
+            service: "com.junkdoge.ae-mcp",
+            account: "provider:test",
+            mode: .fileBased
+        )
+        XCTAssertEqual(
+            Set(fileBased.keys),
+            [kSecClass as String, kSecAttrService as String, kSecAttrAccount as String]
+        )
+
+        let dataProtection = keychainBaseQuery(
+            service: "com.junkdoge.ae-mcp",
+            account: "provider:test",
+            mode: .dataProtection
+        )
+        XCTAssertEqual(
+            dataProtection[kSecUseDataProtectionKeychain as String] as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            dataProtection[kSecAttrSynchronizable as String] as? Bool,
+            false
+        )
+    }
 
     @Test
     func testSecretReferenceUsesStrictGrammarAndOpaqueAccountDerivation() throws {

--- a/native/platform-helper/macos/Tests/PlatformHelperTests/StdioBrokerTests.swift
+++ b/native/platform-helper/macos/Tests/PlatformHelperTests/StdioBrokerTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import PlatformHelperService
+
+@Suite struct StdioBrokerTests {
+    @Test
+    func testFramesPartialAndConcurrentInputIntoOrderedXpcRequests() throws {
+        var requests: [String] = []
+        let broker = StdioFrameBroker { request in
+            let text = String(decoding: request, as: UTF8.self)
+            requests.append(text)
+            return Data(("reply-" + text).utf8)
+        }
+
+        XCTAssertEqual(try broker.accept(Data("one\npar".utf8)), Data("reply-one\n".utf8))
+        XCTAssertEqual(
+            try broker.accept(Data("tial\ntwo\n".utf8)),
+            Data("reply-partial\nreply-two\n".utf8)
+        )
+        try broker.finish()
+        XCTAssertEqual(requests, ["one", "partial", "two"])
+    }
+
+    @Test
+    func testRejectsEmptyOversizedAndIncompleteFrames() throws {
+        let broker = StdioFrameBroker(maxMessageBytes: 4) { request in request }
+
+        XCTAssertThrowsError(try broker.accept(Data("\n".utf8)))
+        XCTAssertThrowsError(try broker.accept(Data("12345".utf8)))
+
+        let incomplete = StdioFrameBroker(maxMessageBytes: 4) { request in request }
+        _ = try incomplete.accept(Data("123".utf8))
+        XCTAssertThrowsError(try incomplete.finish())
+    }
+
+    @Test
+    func testRejectsOversizedXpcResponse() throws {
+        let broker = StdioFrameBroker(maxMessageBytes: 4) { _ in Data("12345".utf8) }
+
+        XCTAssertThrowsError(try broker.accept(Data("one\n".utf8)))
+    }
+}

--- a/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
+++ b/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
@@ -84,6 +84,10 @@ test('mac identity policy locks public connection, signer, version, and Keychain
   ]);
   assert.equal(
     policy.macos.caller.brokerDirectParentSigningIdentifier,
+    'com.adobe.cep.CEPHtmlEngine Helper (Renderer)',
+  );
+  assert.equal(
+    policy.macos.caller.brokerRequiredAncestorSigningIdentifier,
     'com.adobe.cep.CEPHtmlEngine',
   );
   assert.equal(policy.macos.authorization.publicConnectionIdentityOnly, true);

--- a/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
+++ b/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
@@ -80,7 +80,12 @@ test('mac identity policy locks public connection, signer, version, and Keychain
   assert.deepEqual(policy.macos.caller.afterEffectsMajors, [25, 26]);
   assert.deepEqual(policy.macos.caller.directSigningIdentifiers, [
     'com.adobe.cep.CEPHtmlEngine',
+    'ae-mcp-platform-helper',
   ]);
+  assert.equal(
+    policy.macos.caller.brokerDirectParentSigningIdentifier,
+    'com.adobe.cep.CEPHtmlEngine',
+  );
   assert.equal(policy.macos.authorization.publicConnectionIdentityOnly, true);
   assert.equal(policy.macos.authorization.processGenerationDoubleRead, true);
   assert.equal(policy.macos.authorization.positiveAuditSessionBinding, true);

--- a/native/platform-helper/macos/Tests/platform-helper-static.test.mjs
+++ b/native/platform-helper/macos/Tests/platform-helper-static.test.mjs
@@ -33,7 +33,7 @@ test('rejected XPC peers cannot instantiate or reach production backends', () =>
   assert.doesNotMatch(rejection, /KeychainSecretStore|ScreenCapture|ProtocolRequestValidator/);
 });
 
-test('stdio broker keeps XPC out of CEP and retains direct CEP plus AE ancestry checks', () => {
+test('stdio broker keeps XPC out of CEP and pins renderer, CEP, and AE ancestry', () => {
   const authorization = source('Authorization.swift');
   const broker = source('StdioBroker.swift');
   const main = source('main.swift');
@@ -42,7 +42,8 @@ test('stdio broker keeps XPC out of CEP and retains direct CEP plus AE ancestry 
   assert.match(broker, /NSXPCConnection/);
   assert.match(broker, /platformHelperMaximumMessageBytes/);
   assert.match(authorization, /brokerSigningIdentifier\s*=\s*"ae-mcp-platform-helper"/);
-  assert.match(authorization, /directParent\.signingIdentifier\s*==\s*MacCallerPolicy\.cepSigningIdentifier/);
+  assert.match(authorization, /directParent\.signingIdentifier\s*==\s*MacCallerPolicy\.cepRendererSigningIdentifier/);
+  assert.match(authorization, /cepParent\.signingIdentifier\s*==\s*MacCallerPolicy\.cepSigningIdentifier/);
   assert.match(authorization, /adobeAncestry\.firstIndex/);
   assert.match(authorization, /connectionRequirement:\s*connectionRequirement/);
 });

--- a/native/platform-helper/macos/Tests/platform-helper-static.test.mjs
+++ b/native/platform-helper/macos/Tests/platform-helper-static.test.mjs
@@ -33,6 +33,20 @@ test('rejected XPC peers cannot instantiate or reach production backends', () =>
   assert.doesNotMatch(rejection, /KeychainSecretStore|ScreenCapture|ProtocolRequestValidator/);
 });
 
+test('stdio broker keeps XPC out of CEP and retains direct CEP plus AE ancestry checks', () => {
+  const authorization = source('Authorization.swift');
+  const broker = source('StdioBroker.swift');
+  const main = source('main.swift');
+
+  assert.match(main, /--client-stdio/);
+  assert.match(broker, /NSXPCConnection/);
+  assert.match(broker, /platformHelperMaximumMessageBytes/);
+  assert.match(authorization, /brokerSigningIdentifier\s*=\s*"ae-mcp-platform-helper"/);
+  assert.match(authorization, /directParent\.signingIdentifier\s*==\s*MacCallerPolicy\.cepSigningIdentifier/);
+  assert.match(authorization, /adobeAncestry\.firstIndex/);
+  assert.match(authorization, /connectionRequirement:\s*connectionRequirement/);
+});
+
 test('authorized connections share one lazily-created serial credential store', () => {
   const service = source('ServiceRegistration.swift');
   assert.match(service, /final class AuthorizedBackendRegistry/);

--- a/packaging/helper-identity-policy.json
+++ b/packaging/helper-identity-policy.json
@@ -31,7 +31,8 @@
         "com.adobe.cep.CEPHtmlEngine",
         "ae-mcp-platform-helper"
       ],
-      "brokerDirectParentSigningIdentifier": "com.adobe.cep.CEPHtmlEngine"
+      "brokerDirectParentSigningIdentifier": "com.adobe.cep.CEPHtmlEngine Helper (Renderer)",
+      "brokerRequiredAncestorSigningIdentifier": "com.adobe.cep.CEPHtmlEngine"
     }
   },
   "windows": {

--- a/packaging/helper-identity-policy.json
+++ b/packaging/helper-identity-policy.json
@@ -28,8 +28,10 @@
         26
       ],
       "directSigningIdentifiers": [
-        "com.adobe.cep.CEPHtmlEngine"
-      ]
+        "com.adobe.cep.CEPHtmlEngine",
+        "ae-mcp-platform-helper"
+      ],
+      "brokerDirectParentSigningIdentifier": "com.adobe.cep.CEPHtmlEngine"
     }
   },
   "windows": {

--- a/plugin/client/dist/app.css
+++ b/plugin/client/dist/app.css
@@ -1,3 +1,988 @@
+/* node_modules/filepond/dist/filepond.min.css */
+.filepond--assistant {
+  position: absolute;
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.filepond--browser.filepond--browser {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  left: 1em;
+  top: 1.75em;
+  width: calc(100% - 2em);
+  opacity: 0;
+  font-size: 0;
+}
+.filepond--data {
+  position: absolute;
+  width: 0;
+  height: 0;
+  padding: 0;
+  margin: 0;
+  border: none;
+  visibility: hidden;
+  pointer-events: none;
+  contain: strict;
+}
+.filepond--drip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+  opacity: .1;
+  pointer-events: none;
+  border-radius: .5em;
+  background: rgba(0, 0, 0, .01);
+}
+.filepond--drip-blob {
+  -webkit-transform-origin: center center;
+  transform-origin: center center;
+  width: 8em;
+  height: 8em;
+  margin-left: -4em;
+  margin-top: -4em;
+  background: #292625;
+  border-radius: 50%;
+}
+.filepond--drip-blob,
+.filepond--drop-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  will-change: transform, opacity;
+}
+.filepond--drop-label {
+  right: 0;
+  margin: 0;
+  color: #4f4f4f;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.filepond--drop-label.filepond--drop-label label {
+  display: block;
+  margin: 0;
+  padding: .5em;
+}
+.filepond--drop-label label {
+  cursor: default;
+  font-size: .875em;
+  font-weight: 400;
+  text-align: center;
+  line-height: 1.5;
+}
+.filepond--label-action {
+  text-decoration: underline;
+  -webkit-text-decoration-skip: ink;
+  text-decoration-skip-ink: auto;
+  -webkit-text-decoration-color: #a7a4a4;
+  text-decoration-color: #a7a4a4;
+  cursor: pointer;
+}
+.filepond--root[data-disabled] .filepond--drop-label label {
+  opacity: .5;
+}
+.filepond--file-action-button.filepond--file-action-button {
+  font-size: 1em;
+  width: 1.625em;
+  height: 1.625em;
+  font-family: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  will-change: transform, opacity;
+}
+.filepond--file-action-button.filepond--file-action-button span {
+  position: absolute;
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.filepond--file-action-button.filepond--file-action-button svg {
+  width: 100%;
+  height: 100%;
+}
+.filepond--file-action-button.filepond--file-action-button:after {
+  position: absolute;
+  left: -.75em;
+  right: -.75em;
+  top: -.75em;
+  bottom: -.75em;
+  content: "";
+}
+.filepond--file-action-button {
+  cursor: auto;
+  color: #fff;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, .5);
+  background-image: none;
+  box-shadow: 0 0 0 0 hsla(0, 0%, 100%, 0);
+  transition: box-shadow .25s ease-in;
+}
+.filepond--file-action-button:focus,
+.filepond--file-action-button:hover {
+  box-shadow: 0 0 0 .125em hsla(0, 0%, 100%, .9);
+}
+.filepond--file-action-button[disabled] {
+  color: hsla(0, 0%, 100%, .5);
+  background-color: rgba(0, 0, 0, .25);
+}
+.filepond--file-action-button[hidden] {
+  display: none;
+}
+.filepond--action-edit-item.filepond--action-edit-item {
+  width: 2em;
+  height: 2em;
+  padding: .1875em;
+}
+.filepond--action-edit-item.filepond--action-edit-item[data-align*=center] {
+  margin-left: -.1875em;
+}
+.filepond--action-edit-item.filepond--action-edit-item[data-align*=bottom] {
+  margin-bottom: -.1875em;
+}
+.filepond--action-edit-item-alt {
+  border: none;
+  line-height: inherit;
+  background: transparent;
+  font-family: inherit;
+  color: inherit;
+  outline: none;
+  padding: 0;
+  margin: 0 0 0 .25em;
+  pointer-events: all;
+  position: absolute;
+}
+.filepond--action-edit-item-alt svg {
+  width: 1.3125em;
+  height: 1.3125em;
+}
+.filepond--action-edit-item-alt span {
+  font-size: 0;
+  opacity: 0;
+}
+.filepond--file-info {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 1;
+  margin: 0 .5em 0 0;
+  min-width: 0;
+  will-change: transform, opacity;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.filepond--file-info * {
+  margin: 0;
+}
+.filepond--file-info .filepond--file-info-main {
+  font-size: .75em;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
+}
+.filepond--file-info .filepond--file-info-sub {
+  font-size: .625em;
+  opacity: .5;
+  transition: opacity .25s ease-in-out;
+  white-space: nowrap;
+}
+.filepond--file-info .filepond--file-info-sub:empty {
+  display: none;
+}
+.filepond--file-status {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-grow: 0;
+  flex-shrink: 0;
+  margin: 0;
+  min-width: 2.25em;
+  text-align: right;
+  will-change: transform, opacity;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.filepond--file-status * {
+  margin: 0;
+  white-space: nowrap;
+}
+.filepond--file-status .filepond--file-status-main {
+  font-size: .75em;
+  line-height: 1.2;
+}
+.filepond--file-status .filepond--file-status-sub {
+  font-size: .625em;
+  opacity: .5;
+  transition: opacity .25s ease-in-out;
+}
+.filepond--file-wrapper.filepond--file-wrapper {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+  height: 100%;
+}
+.filepond--file-wrapper.filepond--file-wrapper > legend {
+  position: absolute;
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.filepond--file {
+  position: static;
+  display: flex;
+  height: 100%;
+  align-items: flex-start;
+  padding: .5625em;
+  color: #fff;
+  border-radius: .5em;
+}
+.filepond--file .filepond--file-status {
+  margin-left: auto;
+  margin-right: 2.25em;
+}
+.filepond--file .filepond--processing-complete-indicator {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 3;
+}
+.filepond--file .filepond--file-action-button,
+.filepond--file .filepond--processing-complete-indicator,
+.filepond--file .filepond--progress-indicator {
+  position: absolute;
+}
+.filepond--file [data-align*=left] {
+  left: .5625em;
+}
+.filepond--file [data-align*=right] {
+  right: .5625em;
+}
+.filepond--file [data-align*=center] {
+  left: calc(50% - .8125em);
+}
+.filepond--file [data-align*=bottom] {
+  bottom: 1.125em;
+}
+.filepond--file [data-align=center] {
+  top: calc(50% - .8125em);
+}
+.filepond--file .filepond--progress-indicator {
+  margin-top: .1875em;
+}
+.filepond--file .filepond--progress-indicator[data-align*=right] {
+  margin-right: .1875em;
+}
+.filepond--file .filepond--progress-indicator[data-align*=left] {
+  margin-left: .1875em;
+}
+[data-filepond-item-state*=error] .filepond--file-info,
+[data-filepond-item-state*=invalid] .filepond--file-info,
+[data-filepond-item-state=cancelled] .filepond--file-info {
+  margin-right: 2.25em;
+}
+[data-filepond-item-state~=processing] .filepond--file-status-sub {
+  opacity: 0;
+}
+[data-filepond-item-state~=processing] .filepond--action-abort-item-processing ~ .filepond--file-status .filepond--file-status-sub {
+  opacity: .5;
+}
+[data-filepond-item-state=processing-error] .filepond--file-status-sub {
+  opacity: 0;
+}
+[data-filepond-item-state=processing-error] .filepond--action-retry-item-processing ~ .filepond--file-status .filepond--file-status-sub {
+  opacity: .5;
+}
+[data-filepond-item-state=processing-complete] .filepond--action-revert-item-processing svg {
+  -webkit-animation: fall .5s linear .125s both;
+  animation: fall .5s linear .125s both;
+}
+[data-filepond-item-state=processing-complete] .filepond--file-status-sub {
+  opacity: .5;
+}
+[data-filepond-item-state=processing-complete] .filepond--file-info-sub,
+[data-filepond-item-state=processing-complete] .filepond--processing-complete-indicator:not([style*=hidden]) ~ .filepond--file-status .filepond--file-status-sub {
+  opacity: 0;
+}
+[data-filepond-item-state=processing-complete] .filepond--action-revert-item-processing ~ .filepond--file-info .filepond--file-info-sub {
+  opacity: .5;
+}
+[data-filepond-item-state*=error] .filepond--file-wrapper,
+[data-filepond-item-state*=error] .filepond--panel,
+[data-filepond-item-state*=invalid] .filepond--file-wrapper,
+[data-filepond-item-state*=invalid] .filepond--panel {
+  -webkit-animation: shake .65s linear both;
+  animation: shake .65s linear both;
+}
+[data-filepond-item-state*=busy] .filepond--progress-indicator svg {
+  -webkit-animation: spin 1s linear infinite;
+  animation: spin 1s linear infinite;
+}
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+@-webkit-keyframes shake {
+  10%, 90% {
+    -webkit-transform: translateX(-.0625em);
+    transform: translateX(-.0625em);
+  }
+  20%, 80% {
+    -webkit-transform: translateX(.125em);
+    transform: translateX(.125em);
+  }
+  30%, 50%, 70% {
+    -webkit-transform: translateX(-.25em);
+    transform: translateX(-.25em);
+  }
+  40%, 60% {
+    -webkit-transform: translateX(.25em);
+    transform: translateX(.25em);
+  }
+}
+@keyframes shake {
+  10%, 90% {
+    -webkit-transform: translateX(-.0625em);
+    transform: translateX(-.0625em);
+  }
+  20%, 80% {
+    -webkit-transform: translateX(.125em);
+    transform: translateX(.125em);
+  }
+  30%, 50%, 70% {
+    -webkit-transform: translateX(-.25em);
+    transform: translateX(-.25em);
+  }
+  40%, 60% {
+    -webkit-transform: translateX(.25em);
+    transform: translateX(.25em);
+  }
+}
+@-webkit-keyframes fall {
+  0% {
+    opacity: 0;
+    -webkit-transform: scale(.5);
+    transform: scale(.5);
+    -webkit-animation-timing-function: ease-out;
+    animation-timing-function: ease-out;
+  }
+  70% {
+    opacity: 1;
+    -webkit-transform: scale(1.1);
+    transform: scale(1.1);
+    -webkit-animation-timing-function: ease-in-out;
+    animation-timing-function: ease-in-out;
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-animation-timing-function: ease-out;
+    animation-timing-function: ease-out;
+  }
+}
+@keyframes fall {
+  0% {
+    opacity: 0;
+    -webkit-transform: scale(.5);
+    transform: scale(.5);
+    -webkit-animation-timing-function: ease-out;
+    animation-timing-function: ease-out;
+  }
+  70% {
+    opacity: 1;
+    -webkit-transform: scale(1.1);
+    transform: scale(1.1);
+    -webkit-animation-timing-function: ease-in-out;
+    animation-timing-function: ease-in-out;
+  }
+  to {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    -webkit-animation-timing-function: ease-out;
+    animation-timing-function: ease-out;
+  }
+}
+.filepond--hopper[data-hopper-state=drag-over] > * {
+  pointer-events: none;
+}
+.filepond--hopper[data-hopper-state=drag-over]:after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+}
+.filepond--progress-indicator {
+  z-index: 103;
+}
+.filepond--file-action-button {
+  z-index: 102;
+}
+.filepond--file-status {
+  z-index: 101;
+}
+.filepond--file-info {
+  z-index: 100;
+}
+.filepond--item {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  padding: 0;
+  margin: .25em;
+  will-change: transform, opacity;
+  touch-action: auto;
+}
+.filepond--item > .filepond--panel {
+  z-index: -1;
+}
+.filepond--item > .filepond--panel .filepond--panel-bottom {
+  box-shadow: 0 .0625em .125em -.0625em rgba(0, 0, 0, .25);
+}
+.filepond--item > .filepond--file-wrapper,
+.filepond--item > .filepond--panel {
+  transition: opacity .15s ease-out;
+}
+.filepond--item[data-drag-state] {
+  cursor: -webkit-grab;
+  cursor: grab;
+}
+.filepond--item[data-drag-state] > .filepond--panel {
+  transition: box-shadow .125s ease-in-out;
+  box-shadow: 0 0 0 transparent;
+}
+.filepond--item[data-drag-state=drag] {
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+.filepond--item[data-drag-state=drag] > .filepond--panel {
+  box-shadow: 0 .125em .3125em rgba(0, 0, 0, .325);
+}
+.filepond--item[data-drag-state]:not([data-drag-state=idle]) {
+  z-index: 2;
+}
+.filepond--item-panel {
+  background-color: #64605e;
+}
+[data-filepond-item-state=processing-complete] .filepond--item-panel {
+  background-color: #369763;
+}
+[data-filepond-item-state*=error] .filepond--item-panel,
+[data-filepond-item-state*=invalid] .filepond--item-panel {
+  background-color: #c44e47;
+}
+.filepond--item-panel {
+  border-radius: .5em;
+  transition: background-color .25s;
+}
+.filepond--list-scroller {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  will-change: transform;
+}
+.filepond--list-scroller[data-state=overflow] .filepond--list {
+  bottom: 0;
+  right: 0;
+}
+.filepond--list-scroller[data-state=overflow] {
+  overflow-y: scroll;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  -webkit-mask:
+    linear-gradient(
+      180deg,
+      #000 calc(100% - .5em),
+      transparent);
+  mask:
+    linear-gradient(
+      180deg,
+      #000 calc(100% - .5em),
+      transparent);
+}
+.filepond--list-scroller::-webkit-scrollbar {
+  background: transparent;
+}
+.filepond--list-scroller::-webkit-scrollbar:vertical {
+  width: 1em;
+}
+.filepond--list-scroller::-webkit-scrollbar:horizontal {
+  height: 0;
+}
+.filepond--list-scroller::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, .3);
+  border-radius: 99999px;
+  border: .3125em solid transparent;
+  background-clip: content-box;
+}
+.filepond--list.filepond--list {
+  position: absolute;
+  top: 0;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  will-change: transform;
+}
+.filepond--list {
+  left: .75em;
+  right: .75em;
+}
+.filepond--root[data-style-panel-layout~=integrated] {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  margin: 0;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--panel-root,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--panel-root {
+  border-radius: 0;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--panel-root > *,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--panel-root > * {
+  display: none;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--drop-label,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--drop-label {
+  bottom: 0;
+  height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 7;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--item-panel,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--item-panel {
+  display: none;
+}
+.filepond--root[data-style-panel-layout~=compact] .filepond--list-scroller,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--list-scroller {
+  overflow: hidden;
+  height: 100%;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.filepond--root[data-style-panel-layout~=compact] .filepond--list,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--list {
+  left: 0;
+  right: 0;
+  height: 100%;
+}
+.filepond--root[data-style-panel-layout~=compact] .filepond--item,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--item {
+  margin: 0;
+}
+.filepond--root[data-style-panel-layout~=compact] .filepond--file-wrapper,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--file-wrapper {
+  height: 100%;
+}
+.filepond--root[data-style-panel-layout~=compact] .filepond--drop-label,
+.filepond--root[data-style-panel-layout~=integrated] .filepond--drop-label {
+  z-index: 7;
+}
+.filepond--root[data-style-panel-layout~=circle] {
+  border-radius: 99999rem;
+  overflow: hidden;
+}
+.filepond--root[data-style-panel-layout~=circle] > .filepond--panel {
+  border-radius: inherit;
+}
+.filepond--root[data-style-panel-layout~=circle] > .filepond--panel > * {
+  display: none;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--file-info,
+.filepond--root[data-style-panel-layout~=circle] .filepond--file-status {
+  display: none;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--action-edit-item {
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+@media not all and (min-resolution:0.001dpcm) {
+  @supports (-webkit-appearance:none) and (stroke-color:transparent) {
+    .filepond--root[data-style-panel-layout~=circle] {
+      will-change: transform;
+    }
+  }
+}
+.filepond--panel-root {
+  border-radius: .5em;
+  background-color: #f1f0ef;
+}
+.filepond--panel {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  margin: 0;
+  height: 100% !important;
+  pointer-events: none;
+}
+.filepond-panel:not([data-scalable=false]) {
+  height: auto !important;
+}
+.filepond--panel[data-scalable=false] > div {
+  display: none;
+}
+.filepond--panel[data-scalable=true] {
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  background-color: transparent !important;
+  border: none !important;
+}
+.filepond--panel-bottom,
+.filepond--panel-center,
+.filepond--panel-top {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  margin: 0;
+  padding: 0;
+}
+.filepond--panel-bottom,
+.filepond--panel-top {
+  height: .5em;
+}
+.filepond--panel-top {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-bottom: none !important;
+}
+.filepond--panel-top:after {
+  content: "";
+  position: absolute;
+  height: 2px;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  background-color: inherit;
+}
+.filepond--panel-bottom,
+.filepond--panel-center {
+  will-change: transform;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+  -webkit-transform: translate3d(0, .5em, 0);
+  transform: translate3d(0, .5em, 0);
+}
+.filepond--panel-bottom {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  border-top: none !important;
+}
+.filepond--panel-bottom:before {
+  content: "";
+  position: absolute;
+  height: 2px;
+  left: 0;
+  right: 0;
+  top: -1px;
+  background-color: inherit;
+}
+.filepond--panel-center {
+  height: 100px !important;
+  border-top: none !important;
+  border-bottom: none !important;
+  border-radius: 0 !important;
+}
+.filepond--panel-center:not([style]) {
+  visibility: hidden;
+}
+.filepond--progress-indicator {
+  position: static;
+  width: 1.25em;
+  height: 1.25em;
+  color: #fff;
+  margin: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+.filepond--progress-indicator svg {
+  width: 100%;
+  height: 100%;
+  vertical-align: top;
+  transform-box: fill-box;
+}
+.filepond--progress-indicator path {
+  fill: none;
+  stroke: currentColor;
+}
+.filepond--list-scroller {
+  z-index: 6;
+}
+.filepond--drop-label {
+  z-index: 5;
+}
+.filepond--drip {
+  z-index: 3;
+}
+.filepond--root > .filepond--panel {
+  z-index: 2;
+}
+.filepond--browser {
+  z-index: 1;
+}
+.filepond--root {
+  box-sizing: border-box;
+  position: relative;
+  margin-bottom: 1em;
+  font-size: 1rem;
+  line-height: normal;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+  font-weight: 450;
+  text-align: left;
+  text-rendering: optimizeLegibility;
+  direction: ltr;
+  contain: layout style size;
+}
+.filepond--root * {
+  box-sizing: inherit;
+  line-height: inherit;
+}
+.filepond--root :not(text) {
+  font-size: inherit;
+}
+.filepond--root[data-disabled] {
+  pointer-events: none;
+}
+.filepond--root[data-disabled] .filepond--list-scroller {
+  pointer-events: all;
+}
+.filepond--root[data-disabled] .filepond--list {
+  pointer-events: none;
+}
+.filepond--root .filepond--drop-label {
+  min-height: 4.75em;
+}
+.filepond--root .filepond--list-scroller {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+.filepond--root .filepond--credits {
+  position: absolute;
+  right: 0;
+  opacity: .4;
+  line-height: .85;
+  font-size: 11px;
+  color: inherit;
+  text-decoration: none;
+  z-index: 3;
+  bottom: -14px;
+}
+.filepond--root .filepond--credits[style] {
+  top: 0;
+  bottom: auto;
+  margin-top: 14px;
+}
+
+/* node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css */
+.filepond--image-preview-markup {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+.filepond--image-preview-wrapper {
+  z-index: 2;
+}
+.filepond--image-preview-overlay {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  min-height: 5rem;
+  max-height: 7rem;
+  margin: 0;
+  opacity: 0;
+  z-index: 2;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.filepond--image-preview-overlay svg {
+  width: 100%;
+  height: auto;
+  color: inherit;
+  max-height: inherit;
+}
+.filepond--image-preview-overlay-idle {
+  mix-blend-mode: multiply;
+  color: rgba(40, 40, 40, 0.85);
+}
+.filepond--image-preview-overlay-success {
+  mix-blend-mode: normal;
+  color: rgba(54, 151, 99, 1);
+}
+.filepond--image-preview-overlay-failure {
+  mix-blend-mode: normal;
+  color: rgba(196, 78, 71, 1);
+}
+@supports (-webkit-marquee-repetition: infinite) and ((-o-object-fit: fill) or (object-fit: fill)) {
+  .filepond--image-preview-overlay-idle {
+    mix-blend-mode: normal;
+  }
+}
+.filepond--image-preview-wrapper {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  height: 100%;
+  margin: 0;
+  border-radius: 0.45em;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.01);
+}
+.filepond--image-preview {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+  background: #222;
+  will-change: transform, opacity;
+}
+.filepond--image-clip {
+  position: relative;
+  overflow: hidden;
+  margin: 0 auto;
+}
+.filepond--image-clip[data-transparency-indicator=grid] img,
+.filepond--image-clip[data-transparency-indicator=grid] canvas {
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg' fill='%23eee'%3E%3Cpath d='M0 0 H50 V50 H0'/%3E%3Cpath d='M50 50 H100 V100 H50'/%3E%3C/svg%3E");
+  background-size: 1.25em 1.25em;
+}
+.filepond--image-bitmap,
+.filepond--image-vector {
+  position: absolute;
+  left: 0;
+  top: 0;
+  will-change: transform;
+}
+.filepond--root[data-style-panel-layout~=integrated] .filepond--image-preview-wrapper {
+  border-radius: 0;
+}
+.filepond--root[data-style-panel-layout~=integrated] .filepond--image-preview {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--image-preview-wrapper {
+  border-radius: 99999rem;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--image-preview-overlay {
+  top: auto;
+  bottom: 0;
+  -webkit-transform: scaleY(-1);
+  transform: scaleY(-1);
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--file .filepond--file-action-button[data-align*=bottom]:not([data-align*=center]) {
+  margin-bottom: 0.325em;
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--file [data-align*=left] {
+  left: calc(50% - 3em);
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--file [data-align*=right] {
+  right: calc(50% - 3em);
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--progress-indicator[data-align*=bottom][data-align*=left],
+.filepond--root[data-style-panel-layout~=circle] .filepond--progress-indicator[data-align*=bottom][data-align*=right] {
+  margin-bottom: calc(0.325em + 0.1875em);
+}
+.filepond--root[data-style-panel-layout~=circle] .filepond--progress-indicator[data-align*=bottom][data-align*=center] {
+  margin-top: 0;
+  margin-bottom: 0.1875em;
+  margin-left: 0.1875em;
+}
+
 /* src/styles/tokens/colors.css */
 :root {
   --gray-0: #161616;
@@ -224,6 +1209,86 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
+}
+.ae-attachment-pond {
+  flex: none;
+  min-width: 0;
+  max-height: min(42%, 168px);
+  overflow-y: auto;
+}
+.ae-attachment-pond .filepond--root {
+  min-height: 30px;
+  margin: 0;
+  font: var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui);
+}
+.ae-attachment-pond .filepond--drop-label {
+  min-height: 30px;
+  color: var(--text-tertiary);
+}
+.ae-attachment-pond .filepond--panel-root {
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+}
+.ae-attachment-pond .filepond--list-scroller {
+  margin: 0;
+}
+.ae-attachment-pond .filepond--item {
+  margin: 2px 0;
+}
+.ae-attachment-pond .filepond--file {
+  min-height: 32px;
+  padding: 4px 8px;
+  color: var(--text-primary);
+  background: var(--bg-raised);
+}
+.ae-attachment-pond .filepond--image-preview {
+  background: var(--bg-well);
+}
+.ae-attachment-pond button:focus-visible {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+.ae-attachment-status-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 3px;
+}
+.ae-attachment-status {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px 4px;
+  color: var(--text-secondary);
+  font: var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui);
+}
+.ae-attachment-status--error {
+  color: var(--error);
+}
+.ae-attachment-status__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-attachment-status__size,
+.ae-attachment-status__state {
+  flex: none;
+  color: var(--text-tertiary);
+}
+.ae-attachment-status__state {
+  margin-left: auto;
+}
+.ae-attachment-status button {
+  flex: none;
+  padding: 1px 4px;
+  color: inherit;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
 }
 .tools-screen {
   position: relative;
@@ -604,3 +1669,19 @@ body {
     transition: none;
   }
 }
+/*! Bundled license information:
+
+filepond/dist/filepond.min.css:
+  (*!
+   * FilePond 4.32.12
+   * Licensed under MIT, https://opensource.org/licenses/MIT/
+   * Please visit https://pqina.nl/filepond/ for details.
+   *)
+
+filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css:
+  (*!
+   * FilePondPluginImagePreview 4.6.12
+   * Licensed under MIT, https://opensource.org/licenses/MIT/
+   * Please visit https://pqina.nl/filepond/ for details.
+   *)
+*/

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -23504,6 +23504,8 @@
   var MAX_ATTACHMENTS_PER_TURN = 32;
   var MAX_CLIPBOARD_ITEM_BYTES = 256 * 1024 * 1024;
   var MAX_CLIPBOARD_TURN_BYTES = 512 * 1024 * 1024;
+  var ATTACHMENT_MANIFEST_OPEN = '<ae_mcp_attachments version="1">';
+  var ATTACHMENT_MANIFEST_CLOSE = "</ae_mcp_attachments>";
   function requireString(value, field, { allowEmpty = false } = {}) {
     if (typeof value !== "string" || !allowEmpty && !value) {
       throw new TypeError(field + " must be " + (allowEmpty ? "a string" : "a non-empty string"));
@@ -23562,6 +23564,47 @@
         ...mediaType ? { mediaType } : {}
       });
     });
+  }
+  function attachmentManifest(attachments) {
+    const files = attachments.map((value) => {
+      const { id, name, localPath, size, mediaType } = normalizeAttachment(value);
+      return {
+        id,
+        name,
+        path: localPath,
+        size,
+        mediaType: mediaType || "application/octet-stream"
+      };
+    });
+    return ATTACHMENT_MANIFEST_OPEN + "\n" + JSON.stringify({ files }) + "\n" + ATTACHMENT_MANIFEST_CLOSE;
+  }
+  function withAttachmentManifest(text, attachments) {
+    const body = String(text || "");
+    if (!attachments.length) return body;
+    const manifest = attachmentManifest(attachments);
+    return body ? body + "\n\n" + manifest : manifest;
+  }
+  function encodePathSegments(value) {
+    return value.split("/").map((part) => encodeURIComponent(part)).join("/");
+  }
+  function attachmentFileUrl(localPath, platformId) {
+    requireString(localPath, "attachment path");
+    if (platformId === "macos-arm64") {
+      if (!localPath.startsWith("/")) throw new TypeError("macOS attachment path must be absolute");
+      return "file://" + encodePathSegments(localPath);
+    }
+    if (platformId === "windows-x64") {
+      const normalized = localPath.replace(/\\/g, "/");
+      if (normalized.startsWith("//")) {
+        return "file://" + encodePathSegments(normalized.slice(2));
+      }
+      if (!/^[A-Za-z]:\//.test(normalized)) {
+        throw new TypeError("Windows attachment path must be absolute");
+      }
+      const drive = normalized.slice(0, 2);
+      return "file:///" + drive + encodePathSegments(normalized.slice(2));
+    }
+    throw new TypeError("unsupported attachment platform: " + platformId);
   }
 
   // src/components/chat/AttachmentPond.jsx
@@ -28358,15 +28401,41 @@
       }
       return await executeTool(toolUse);
     }
-    async function sendUser(text) {
+    async function sendUser(input) {
       if (activeRun) return activeRun;
-      const userMessage = { role: "user", content: String(text || "") };
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "TURN_INPUT_INVALID",
+          message: error.message,
+          ...turnId ? { turnId, dispatchState: "not-started" } : {}
+        });
+        return;
+      }
+      if (turn.attachments.length) {
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "ATTACHMENT_SIDECAR_REQUIRED",
+          message: "Restore the Claude Agent SDK sidecar to send local files.",
+          turnId: turn.turnId,
+          dispatchState: "not-started"
+        });
+        return;
+      }
+      const userMessage = { role: "user", content: turn.text };
       messages.push(userMessage);
       emit({ type: "turn-start" });
       const controller = new AbortController();
       activeController = controller;
       activeRun = (async () => {
         let activeSensitiveValues = [];
+        let turnAccepted = false;
         try {
           const tools = await mcp.listTools();
           const toolByName = new Map((tools || []).map((tool) => [tool.name, tool]));
@@ -28385,12 +28454,16 @@
             activeSensitiveValues = sensitiveValues(requestProfile);
             const deltaRedactor = createDeltaRedactor(
               activeSensitiveValues,
-              (text2) => {
-                if (text2) emit({ type: "text-delta", text: text2 });
+              (text) => {
+                if (text) emit({ type: "text-delta", text });
               }
             );
             let result;
             try {
+              if (turn.turnId && !turnAccepted) {
+                turnAccepted = true;
+                emit({ type: "turn-accepted", turnId: turn.turnId, transport: "legacy-byok" });
+              }
               result = await anthropic({
                 requestProfile,
                 model: getModel && getModel() || DEFAULT_MODEL,
@@ -28426,7 +28499,15 @@
         } catch (e) {
           const kind = normalizeErrorKind(e);
           repairDanglingToolUses();
-          emit({ type: "error", kind, message: safeErrorMessage(e, activeSensitiveValues) });
+          emit({
+            type: "error",
+            kind,
+            message: safeErrorMessage(e, activeSensitiveValues),
+            ...!turnAccepted && turn.turnId ? {
+              turnId: turn.turnId,
+              dispatchState: "not-started"
+            } : {}
+          });
         } finally {
           activeSensitiveValues = [];
           activeController = null;
@@ -28939,6 +29020,9 @@
     let activeRun = null;
     let activeResolve = null;
     let activeAssistantText = "";
+    let activeTurn = null;
+    let activeTurnAccepted = false;
+    let sendDispatched = false;
     let environmentSecretValues = [];
     let runtimeSecretValues = [];
     let activeSecretValues = [];
@@ -29025,13 +29109,28 @@
       if (!activeResolve) {
         activeRun = null;
         activeAssistantText = "";
+        activeTurn = null;
+        activeTurnAccepted = false;
+        sendDispatched = false;
         return;
       }
       const resolve = activeResolve;
       activeResolve = null;
       activeRun = null;
       activeAssistantText = "";
+      activeTurn = null;
+      activeTurnAccepted = false;
+      sendDispatched = false;
       resolve();
+    }
+    function activeTurnFailureFields() {
+      if (!(activeTurn == null ? void 0 : activeTurn.turnId)) return {};
+      return {
+        turnId: activeTurn.turnId,
+        ...!activeTurnAccepted ? {
+          dispatchState: sendDispatched ? "uncertain" : "not-started"
+        } : {}
+      };
     }
     function drainApprovals() {
       for (const [toolUseId, approval] of Array.from(pendingApprovals.entries())) {
@@ -29227,7 +29326,7 @@
       if (type === "turn.failed") {
         const payload = params.payload || {};
         const message2 = zcodePlanRuntimeFailureHint(zcodeErrorMessage(payload.error || payload.message, "ZCode turn failed", lang), activeRuntimeModel);
-        emit({ type: "error", kind: zcodeErrorKind(message2), message: message2 });
+        emit({ type: "error", kind: zcodeErrorKind(message2), message: message2, ...activeTurnFailureFields() });
         finishActive();
         return;
       }
@@ -29284,7 +29383,12 @@
         return;
       }
       if (activeRun) {
-        emit({ type: "error", kind: "mcp", message: "ZCode app-server exited: " + detail });
+        emit({
+          type: "error",
+          kind: "mcp",
+          message: "ZCode app-server exited: " + detail,
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
       scheduleSecretCleanup();
@@ -29301,7 +29405,7 @@
       subscribed = false;
       activeRuntimeModel = null;
       if (activeRun) {
-        emit({ type: "error", kind: "mcp", message: err.message });
+        emit({ type: "error", kind: "mcp", message: err.message, ...activeTurnFailureFields() });
         finishActive();
       }
       scheduleSecretCleanup();
@@ -29433,29 +29537,62 @@
         sessionPromise = null;
       }
     }
-    async function sendUser(text) {
+    async function sendUser(input) {
       if (activeRun) return activeRun;
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "TURN_INPUT_INVALID",
+          message: error.message,
+          ...turnId ? { turnId, dispatchState: "not-started" } : {}
+        });
+        return;
+      }
       activeAssistantText = "";
+      activeTurn = turn;
+      activeTurnAccepted = false;
+      sendDispatched = false;
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
       });
       try {
         await ensureSession();
-        const userText = String(text || "");
+        const userText = turn.text;
         transcript.push({ role: "user", text: userText });
-        let turnText = userText;
+        let turnText = withAttachmentManifest(userText, turn.attachments);
         if (transcript.filter((m) => m.role === "user").length === 1) {
           const instr = (getServerInstructions() || "").trim();
           if (instr) turnText = instr + "\n\n---\n\n" + userText;
         }
-        rpc.request("session/send", { sessionId, content: turnText }, 18e4).catch((e) => {
+        sendDispatched = true;
+        rpc.request("session/send", { sessionId, content: turnText }, 18e4).then(() => {
+          if (activeTurn === turn && turn.turnId) {
+            activeTurnAccepted = true;
+            emit({ type: "turn-accepted", turnId: turn.turnId, transport: "zcode-manifest" });
+          }
+        }).catch((e) => {
           const message = zcodeErrorMessage(e, "Failed to start ZCode turn.", lang);
-          emit({ type: "error", kind: zcodeErrorKind(message), message });
+          emit({
+            type: "error",
+            kind: zcodeErrorKind(message),
+            message,
+            ...activeTurnFailureFields()
+          });
           finishActive();
         });
       } catch (e) {
         const message = zcodeErrorMessage(e, "Failed to start ZCode turn.", lang);
-        emit({ type: "error", kind: zcodeErrorKind(message), message });
+        emit({
+          type: "error",
+          kind: zcodeErrorKind(message),
+          message,
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
       return activeRun;
@@ -29519,7 +29656,7 @@
       }
       drainApprovals();
       if (activeRun) {
-        emit({ type: "error", kind: "aborted", message: "Turn aborted." });
+        emit({ type: "error", kind: "aborted", message: "Turn aborted.", ...activeTurnFailureFields() });
         finishActive();
       }
     }
@@ -29541,6 +29678,9 @@
       sessionModelRef = null;
       subscribed = false;
       activeRuntimeModel = null;
+      activeTurn = null;
+      activeTurnAccepted = false;
+      sendDispatched = false;
       transcript = [];
       pendingApprovals.clear();
       pendingElicitations.clear();
@@ -39959,6 +40099,9 @@ data: ${JSON.stringify(payload)}
     let turnFailureInFlight = false;
     let providerRecoverySequence = 0;
     let providerRefreshPending = false;
+    let activeTurn = null;
+    let activeTurnAccepted = false;
+    let activeTurnDispatched = false;
     let activeUserText = "";
     let activeUserRecorded = false;
     const pendingApprovals = /* @__PURE__ */ new Map();
@@ -40010,12 +40153,24 @@ data: ${JSON.stringify(payload)}
     function currentEnv() {
       return adapter.completeSpawnEnv(env || {});
     }
+    function activeTurnFailureFields() {
+      if (!(activeTurn == null ? void 0 : activeTurn.turnId)) return {};
+      return {
+        turnId: activeTurn.turnId,
+        ...!activeTurnAccepted ? {
+          dispatchState: activeTurnDispatched ? "uncertain" : "not-started"
+        } : {}
+      };
+    }
     function finishActive() {
       const resolve = activeResolve;
       const refreshProvider = providerRefreshPending;
       activeResolve = null;
       activeRun = null;
       activeAssistantText = "";
+      activeTurn = null;
+      activeTurnAccepted = false;
+      activeTurnDispatched = false;
       activeUserText = "";
       activeUserRecorded = false;
       providerRecoveryAttempted = false;
@@ -40065,6 +40220,10 @@ data: ${JSON.stringify(payload)}
       if (message.method === "turn/started") {
         currentTurnId = params.turn && params.turn.id || params.turnId || null;
         resetProviderDeltaRedactor();
+        if (activeTurn && activeTurn.turnId && !activeTurnAccepted) {
+          activeTurnAccepted = true;
+          emit({ type: "turn-accepted", turnId: activeTurn.turnId, transport: "codex-app-server" });
+        }
         emit({ type: "turn-start" });
         return;
       }
@@ -40232,7 +40391,12 @@ data: ${JSON.stringify(payload)}
         return;
       }
       if (activeRun) {
-        emit({ type: "error", kind: "mcp", message: "codex app-server exited: " + detail });
+        emit({
+          type: "error",
+          kind: "mcp",
+          message: "codex app-server exited: " + detail,
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
       clearProviderSensitiveValues();
@@ -40249,7 +40413,7 @@ data: ${JSON.stringify(payload)}
       preambleSent = false;
       closeProviderRoute();
       if (activeRun) {
-        emit({ type: "error", kind: "mcp", message: err.message });
+        emit({ type: "error", kind: "mcp", message: err.message, ...activeTurnFailureFields() });
         finishActive();
       }
       clearProviderSensitiveValues();
@@ -40563,10 +40727,24 @@ data: ${JSON.stringify(payload)}
       threadId = threadIdFromResult(result);
       return threadId;
     }
-    function turnParams(text) {
+    function turnInput(turn, text) {
+      const input = [];
+      if (text) input.push({ type: "text", text });
+      for (const attachment of turn.attachments) {
+        if (attachment.mediaType.startsWith("image/")) {
+          input.push({ type: "localImage", path: attachment.localPath });
+        } else if (attachment.mediaType.startsWith("audio/")) {
+          input.push({ type: "localAudio", path: attachment.localPath });
+        } else {
+          input.push({ type: "mention", name: attachment.name, path: attachment.localPath });
+        }
+      }
+      return input;
+    }
+    function turnParams(turn, text) {
       const params = {
         threadId,
-        input: [{ type: "text", text }],
+        input: turnInput(turn, text),
         model: getModel(),
         effort: getEffort ? getEffort() : void 0,
         approvalPolicy: APPROVAL_POLICY,
@@ -40589,7 +40767,8 @@ data: ${JSON.stringify(payload)}
         if (instructions) turnText = instructions + "\n\n---\n\n" + activeUserText;
         preambleSent = true;
       }
-      rpc.request("turn/start", turnParams(turnText), 18e4).catch((error) => {
+      activeTurnDispatched = true;
+      rpc.request("turn/start", turnParams(activeTurn, turnText), 18e4).catch((error) => {
         void handleTurnFailure(error);
       });
     }
@@ -40640,7 +40819,7 @@ data: ${JSON.stringify(payload)}
           message: redactValue((error == null ? void 0 : error.message) || "Failed to start Codex turn.", providerSensitiveValues)
         };
         try {
-          if (await attemptProviderRecovery(error)) return;
+          if (!activeTurnDispatched && await attemptProviderRecovery(error)) return;
         } catch (recoveryError) {
           failure2 = {
             kind: recoveryError == null ? void 0 : recoveryError.kind,
@@ -40655,17 +40834,35 @@ data: ${JSON.stringify(payload)}
           type: "error",
           kind: (failure2 == null ? void 0 : failure2.kind) || (providerHttpFailure || /model/i.test(message) ? "model" : "mcp"),
           ...(failure2 == null ? void 0 : failure2.code) ? { code: failure2.code } : {},
-          message
+          message,
+          ...activeTurnFailureFields()
         });
         finishActive();
       } finally {
         turnFailureInFlight = false;
       }
     }
-    async function sendUser(text) {
+    async function sendUser(input) {
       if (activeRun) return activeRun;
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "TURN_INPUT_INVALID",
+          message: error.message,
+          ...turnId ? { turnId, dispatchState: "not-started" } : {}
+        });
+        return;
+      }
       activeAssistantText = "";
-      activeUserText = String(text || "");
+      activeTurn = turn;
+      activeTurnAccepted = false;
+      activeTurnDispatched = false;
+      activeUserText = turn.text;
       activeUserRecorded = false;
       providerRecoveryAttempted = false;
       providerRecoveryInFlight = false;
@@ -40711,7 +40908,7 @@ data: ${JSON.stringify(payload)}
       drainApprovals();
       providerDeltaRedactor.discard();
       if (activeRun) {
-        emit({ type: "error", kind: "aborted", message: "Turn aborted." });
+        emit({ type: "error", kind: "aborted", message: "Turn aborted.", ...activeTurnFailureFields() });
         finishActive();
       }
     }
@@ -40976,6 +41173,9 @@ data: ${JSON.stringify(payload)}
     let activeRun = null;
     let activeResolve = null;
     let activeAssistantText = "";
+    let activeTurn = null;
+    let activeTurnAccepted = false;
+    let messageDispatched = false;
     let turnStarted = false;
     let toolMeta = { annotations: {} };
     const pendingApprovals = /* @__PURE__ */ new Map();
@@ -40995,6 +41195,9 @@ data: ${JSON.stringify(payload)}
       if (!activeResolve) {
         activeRun = null;
         activeAssistantText = "";
+        activeTurn = null;
+        activeTurnAccepted = false;
+        messageDispatched = false;
         turnStarted = false;
         startedTools.clear();
         return;
@@ -41003,6 +41206,9 @@ data: ${JSON.stringify(payload)}
       activeResolve = null;
       activeRun = null;
       activeAssistantText = "";
+      activeTurn = null;
+      activeTurnAccepted = false;
+      messageDispatched = false;
       turnStarted = false;
       startedTools.clear();
       resolve();
@@ -41014,6 +41220,15 @@ data: ${JSON.stringify(payload)}
         throw new Error("OpenCode HTTP " + (response ? response.status : "error") + (text ? ": " + text : ""));
       }
       return response;
+    }
+    function activeTurnFailureFields() {
+      if (!(activeTurn == null ? void 0 : activeTurn.turnId)) return {};
+      return {
+        turnId: activeTurn.turnId,
+        ...!activeTurnAccepted ? {
+          dispatchState: messageDispatched ? "uncertain" : "not-started"
+        } : {}
+      };
     }
     async function requestJson(path, options = {}) {
       const response = await request(path, options);
@@ -41073,7 +41288,12 @@ data: ${JSON.stringify(payload)}
       if (wasStopping) return;
       if (activeRun) {
         const detail = stderrTail ? String(code) + (signal ? " " + signal : "") + " " + stderrTail : String(code) + (signal ? " " + signal : "");
-        emit({ type: "error", kind: "mcp", message: "opencode serve exited: " + detail });
+        emit({
+          type: "error",
+          kind: "mcp",
+          message: "opencode serve exited: " + detail,
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
     }
@@ -41085,7 +41305,12 @@ data: ${JSON.stringify(payload)}
       sseClosed = true;
       sseStarted = false;
       if (activeRun) {
-        emit({ type: "error", kind: "mcp", message: error && error.message ? error.message : "opencode serve error" });
+        emit({
+          type: "error",
+          kind: "mcp",
+          message: error && error.message ? error.message : "opencode serve error",
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
     }
@@ -41150,7 +41375,12 @@ data: ${JSON.stringify(payload)}
       const parser = createSseParser(({ data: data2 }) => handleOpenCodeEvent(data2));
       request("/event").then((response) => readSseBody(response.body, parser)).catch((e) => {
         if (!sseClosed && activeRun) {
-          emit({ type: "error", kind: "mcp", message: e && e.message ? e.message : "OpenCode event stream failed." });
+          emit({
+            type: "error",
+            kind: "mcp",
+            message: e && e.message ? e.message : "OpenCode event stream failed.",
+            ...activeTurnFailureFields()
+          });
           finishActive();
         }
       });
@@ -41278,7 +41508,12 @@ data: ${JSON.stringify(payload)}
       }
       if (type === "session.error") {
         const error = p.error || p;
-        emit({ type: "error", kind: error.kind || "mcp", message: error.message || String(error || "OpenCode session error") });
+        emit({
+          type: "error",
+          kind: error.kind || "mcp",
+          message: error.message || String(error || "OpenCode session error"),
+          ...activeTurnFailureFields()
+        });
         finishActive();
         return;
       }
@@ -41295,21 +41530,59 @@ data: ${JSON.stringify(payload)}
       }
       return Promise.allSettled(replies);
     }
-    async function sendUser(text) {
+    function openCodeParts(turn) {
+      return [
+        ...turn.text ? [{ type: "text", text: turn.text }] : [],
+        ...turn.attachments.map((file) => ({
+          type: "file",
+          mime: file.mediaType || "application/octet-stream",
+          filename: file.name,
+          url: attachmentFileUrl(file.localPath, adapter.id)
+        }))
+      ];
+    }
+    async function sendUser(input) {
       if (activeRun) return activeRun;
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "TURN_INPUT_INVALID",
+          message: error.message,
+          ...turnId ? { turnId, dispatchState: "not-started" } : {}
+        });
+        return;
+      }
       activeAssistantText = "";
+      activeTurn = turn;
+      activeTurnAccepted = false;
+      messageDispatched = false;
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
       });
       try {
         const id = await ensureSession();
-        const userText = String(text || "");
+        const userText = turn.text;
         transcript.push({ role: "user", text: userText });
+        messageDispatched = true;
         await postJson("/session/" + encodeURIComponent(id) + "/message", {
-          parts: [{ type: "text", text: userText }]
+          parts: openCodeParts(turn)
         });
+        if (turn.turnId) {
+          activeTurnAccepted = true;
+          emit({ type: "turn-accepted", turnId: turn.turnId, transport: "opencode-file-part" });
+        }
       } catch (e) {
-        emit({ type: "error", kind: "mcp", message: e && e.message ? e.message : "Failed to start OpenCode turn." });
+        emit({
+          type: "error",
+          kind: "mcp",
+          message: e && e.message ? e.message : "Failed to start OpenCode turn.",
+          ...activeTurnFailureFields()
+        });
         finishActive();
       }
       return activeRun;
@@ -41331,7 +41604,7 @@ data: ${JSON.stringify(payload)}
       }
       await drainApprovals();
       if (activeRun) {
-        emit({ type: "error", kind: "aborted", message: "Turn aborted." });
+        emit({ type: "error", kind: "aborted", message: "Turn aborted.", ...activeTurnFailureFields() });
         finishActive();
       }
     }
@@ -41346,6 +41619,9 @@ data: ${JSON.stringify(payload)}
       activeResolve = null;
       activeRun = null;
       activeAssistantText = "";
+      activeTurn = null;
+      activeTurnAccepted = false;
+      messageDispatched = false;
       turnStarted = false;
       startedTools.clear();
       transcript.length = 0;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -48766,6 +48766,21 @@ data: ${JSON.stringify(payload)}
   function redactSecrets(text, exactSecrets = []) {
     return redactCredentialText(text, exactSecrets);
   }
+  function attachmentPathSecrets({ draft, pendingTurn } = {}) {
+    var _a;
+    const paths = [];
+    for (const item of (draft == null ? void 0 : draft.items) || []) {
+      if (typeof ((_a = item == null ? void 0 : item.ref) == null ? void 0 : _a.localPath) === "string" && item.ref.localPath) {
+        paths.push(item.ref.localPath);
+      }
+    }
+    for (const attachment of (pendingTurn == null ? void 0 : pendingTurn.attachments) || []) {
+      if (typeof (attachment == null ? void 0 : attachment.localPath) === "string" && attachment.localPath) {
+        paths.push(attachment.localPath);
+      }
+    }
+    return [...new Set(paths)];
+  }
   function buildLogExport({ panelLogs = [], hostInfo = {}, sidecarTail = "", version = "", now = /* @__PURE__ */ new Date(), exactSecrets = [] } = {}) {
     const lines = [];
     lines.push("# ae-mcp panel log export");
@@ -50258,6 +50273,11 @@ ${baseUrl}`),
       try {
         const exactSecrets = providerSecretService.getRedactionValues();
         if (zcodeStoredKeyRef.current) exactSecrets.push(zcodeStoredKeyRef.current);
+        const attachmentSecrets = attachmentPathSecrets({
+          draft: attachmentDraft,
+          pendingTurn: pendingTurnRef.current
+        });
+        exactSecrets.push(...attachmentSecrets);
         const text = buildLogExport({
           panelLogs: logs,
           hostInfo: { hostVersion: connInfo && connInfo.hostVersion || "-", pythonVersion: connInfo && connInfo.pythonVersion || "-" },
@@ -50271,7 +50291,7 @@ ${baseUrl}`),
       } catch (e) {
         pushLog("Log export failed: " + (e && e.message ? e.message : String(e)));
       }
-    }, [logs, connInfo, claudeBackend, providerSecretService, pushLog]);
+    }, [logs, connInfo, claudeBackend, providerSecretService, pushLog, attachmentDraft]);
     const undoToPreviousCheckpoint = import_react46.default.useCallback(async () => {
       try {
         await revertToPreviousCheckpoint(mcp);

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -38220,7 +38220,12 @@ data: ${JSON.stringify(payload)}
     const match = message.match(
       /^Unexpected value\(s\)\s+(.+?)\s+for the `anthropic-beta` header(?:\.|$)/
     );
-    if (!match) return null;
+    if (!match) {
+      if (!/\bbeta\b/i.test(message) || !/\binvalid\b/i.test(message)) return null;
+      const next2 = { ...headers };
+      delete next2["anthropic-beta"];
+      return next2;
+    }
     const token = "[A-Za-z0-9][A-Za-z0-9._:-]{0,127}";
     const listPattern = new RegExp("^`" + token + "`(?:\\s*(?:,|and)\\s*`" + token + "`)*$");
     if (!listPattern.test(match[1])) return null;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -29025,6 +29025,12 @@
     let environmentSecretValues = [];
     let runtimeSecretValues = [];
     let activeSecretValues = [];
+    let activeAttachmentPaths = [];
+    let processStderrAttachmentPaths = [];
+    let assistantDeltaRedactor = createDeltaRedactor([], () => {
+    });
+    let stderrRedactor = createDeltaRedactor([], () => {
+    });
     let secretEpoch = 0;
     let toolMeta = { allowedTools: [], annotations: {} };
     const pendingApprovals = /* @__PURE__ */ new Map();
@@ -29032,24 +29038,69 @@
     const pendingUserInputs = /* @__PURE__ */ new Map();
     const sessionAllowedTools = /* @__PURE__ */ new Set();
     const sessionAllowedPlans = /* @__PURE__ */ new Set();
+    function activeRedactionValues() {
+      return [...activeSecretValues, ...activeAttachmentPaths];
+    }
+    function stderrRedactionValues() {
+      return [...activeSecretValues, ...processStderrAttachmentPaths];
+    }
     function emit(evt) {
-      if (onEvent) onEvent(redactValue(evt, activeSecretValues));
+      if (onEvent) onEvent(redactValue(evt, activeRedactionValues()));
     }
     function safeText(value) {
-      return redactText(value, activeSecretValues);
+      return redactText(value, activeRedactionValues());
+    }
+    function resetAssistantDeltaRedactor() {
+      assistantDeltaRedactor.discard();
+      assistantDeltaRedactor = createDeltaRedactor(activeRedactionValues(), (text) => {
+        activeAssistantText += text;
+        emit({ type: "text-delta", text });
+      });
+    }
+    function resetStderrRedactor() {
+      stderrRedactor.discard();
+      stderrRedactor = createDeltaRedactor(stderrRedactionValues(), (text) => {
+        stderrTail = appendTail2(stderrTail, text);
+      });
+    }
+    function resetOutputRedactors() {
+      resetAssistantDeltaRedactor();
+      resetStderrRedactor();
+    }
+    function setActiveAttachmentPaths(values) {
+      activeAttachmentPaths = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
+      if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+      const previousProcessPathCount = processStderrAttachmentPaths.length;
+      processStderrAttachmentPaths = Array.from(/* @__PURE__ */ new Set([
+        ...processStderrAttachmentPaths,
+        ...activeAttachmentPaths
+      ])).sort((left, right) => right.length - left.length);
+      resetAssistantDeltaRedactor();
+      if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+        resetStderrRedactor();
+      }
+    }
+    function clearProcessStderrAttachmentPaths() {
+      processStderrAttachmentPaths = [];
+      resetStderrRedactor();
     }
     function refreshActiveSecretValues() {
-      activeSecretValues = Array.from(/* @__PURE__ */ new Set([
+      const nextSecretValues = Array.from(/* @__PURE__ */ new Set([
         ...environmentSecretValues,
         ...runtimeSecretValues
       ])).sort((left, right) => right.length - left.length);
+      const stderrInventoryChanged = nextSecretValues.length !== activeSecretValues.length || nextSecretValues.some((value, index) => value !== activeSecretValues[index]);
+      activeSecretValues = nextSecretValues;
       secretEpoch += 1;
+      resetAssistantDeltaRedactor();
+      if (stderrInventoryChanged) resetStderrRedactor();
     }
     function clearActiveSecretValues() {
       environmentSecretValues = [];
       runtimeSecretValues = [];
       activeSecretValues = [];
       secretEpoch += 1;
+      resetOutputRedactors();
     }
     function scheduleSecretCleanup() {
       const scheduledEpoch = secretEpoch;
@@ -29111,6 +29162,7 @@
         activeTurn = null;
         activeTurnAccepted = false;
         sendDispatched = false;
+        setActiveAttachmentPaths([]);
         return;
       }
       const resolve = activeResolve;
@@ -29120,6 +29172,7 @@
       activeTurn = null;
       activeTurnAccepted = false;
       sendDispatched = false;
+      setActiveAttachmentPaths([]);
       resolve();
     }
     function activeTurnFailureFields() {
@@ -29278,6 +29331,7 @@
       if (type === "state.updated") {
         const patch = params.patch || params.payload || {};
         if (patch.status === "idle" && activeRun) {
+          assistantDeltaRedactor.flush();
           drainApprovals();
           emit({ type: "turn-end", stopReason: "end_turn" });
           transcript.push({ role: "assistant", text: activeAssistantText });
@@ -29292,9 +29346,7 @@
       if (type === "model.streaming") {
         const payload = params.payload || {};
         if (payload.kind === "text_delta" && payload.delta) {
-          const delta = safeText(String(payload.delta));
-          activeAssistantText += delta;
-          emit({ type: "text-delta", text: delta });
+          assistantDeltaRedactor.feed(String(payload.delta));
         }
         return;
       }
@@ -29315,6 +29367,7 @@
         return;
       }
       if (type === "turn.completed") {
+        assistantDeltaRedactor.flush();
         drainApprovals();
         const payload = params.payload || {};
         emit({ type: "turn-end", stopReason: "end_turn" });
@@ -29323,6 +29376,7 @@
         return;
       }
       if (type === "turn.failed") {
+        assistantDeltaRedactor.discard();
         const payload = params.payload || {};
         const message2 = zcodePlanRuntimeFailureHint(zcodeErrorMessage(payload.error || payload.message, "ZCode turn failed", lang), activeRuntimeModel);
         emit({ type: "error", kind: zcodeErrorKind(message2), message: message2, ...activeTurnFailureFields() });
@@ -29367,6 +29421,7 @@
     }
     function handleExit(code, signal) {
       const wasStopping = stopping;
+      stderrRedactor.flush();
       const detail = stderrTail ? String(code) + (signal ? " " + signal : "") + " " + stderrTail : String(code) + (signal ? " " + signal : "");
       if (rpc) rpc.close(new Error("ZCode app-server exited: " + detail));
       proc = null;
@@ -29378,6 +29433,7 @@
       subscribed = false;
       activeRuntimeModel = null;
       if (wasStopping) {
+        clearProcessStderrAttachmentPaths();
         scheduleSecretCleanup();
         return;
       }
@@ -29390,6 +29446,7 @@
         });
         finishActive();
       }
+      clearProcessStderrAttachmentPaths();
       scheduleSecretCleanup();
     }
     function handleError(error) {
@@ -29407,6 +29464,7 @@
         emit({ type: "error", kind: "mcp", message: err.message, ...activeTurnFailureFields() });
         finishActive();
       }
+      clearProcessStderrAttachmentPaths();
       scheduleSecretCleanup();
     }
     async function startProcess() {
@@ -29441,7 +29499,7 @@
         const reader = createNdjsonReader((message) => rpc && rpc.handleMessage(message));
         if (proc.stdout && proc.stdout.on) proc.stdout.on("data", reader);
         if (proc.stderr && proc.stderr.on) proc.stderr.on("data", (chunk) => {
-          stderrTail = appendTail2(stderrTail, chunk);
+          stderrRedactor.feed(chunk);
         });
         proc.on("exit", (code, signal) => handleExit(code, signal));
         proc.on("error", (error) => handleError(error));
@@ -29556,6 +29614,7 @@
       activeTurn = turn;
       activeTurnAccepted = false;
       sendDispatched = false;
+      setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
       });
@@ -29566,7 +29625,7 @@
         let turnText = withAttachmentManifest(userText, turn.attachments);
         if (transcript.filter((m) => m.role === "user").length === 1) {
           const instr = (getServerInstructions() || "").trim();
-          if (instr) turnText = instr + "\n\n---\n\n" + userText;
+          if (instr) turnText = instr + "\n\n---\n\n" + turnText;
         }
         sendDispatched = true;
         rpc.request("session/send", { sessionId, content: turnText }, 18e4).then(() => {
@@ -29689,6 +29748,7 @@
       toolMeta = { allowedTools: [], annotations: {} };
       finishActive();
       stderrTail = "";
+      clearProcessStderrAttachmentPaths();
       clearActiveSecretValues();
       stopping = false;
     }
@@ -40194,6 +40254,8 @@ data: ${JSON.stringify(payload)}
     let lastCliInfo = null;
     let providerRoute = null;
     let providerSensitiveValues = [];
+    let activeAttachmentPaths = [];
+    let processStderrAttachmentPaths = [];
     let providerDeltaPhase = void 0;
     let providerDeltaRedactor = createDeltaRedactor([], () => {
     });
@@ -40221,25 +40283,48 @@ data: ${JSON.stringify(payload)}
       });
     }
     function emit(evt) {
-      if (onEvent) onEvent(redactValue(evt, providerSensitiveValues));
+      if (onEvent) onEvent(redactValue(evt, [...providerSensitiveValues, ...activeAttachmentPaths]));
     }
     function resetProviderDeltaRedactor() {
       providerDeltaRedactor.discard();
       providerDeltaPhase = void 0;
-      providerDeltaRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
-        activeAssistantText += text;
-        emit({ type: "text-delta", text, phase: providerDeltaPhase });
-      });
+      providerDeltaRedactor = createDeltaRedactor(
+        [...providerSensitiveValues, ...activeAttachmentPaths],
+        (text) => {
+          activeAssistantText += text;
+          emit({ type: "text-delta", text, phase: providerDeltaPhase });
+        }
+      );
     }
     function resetProviderStderrRedactor() {
       providerStderrRedactor.discard();
-      providerStderrRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
-        stderrTail = appendTail4(stderrTail, text);
-      });
+      providerStderrRedactor = createDeltaRedactor(
+        [...providerSensitiveValues, ...processStderrAttachmentPaths],
+        (text) => {
+          stderrTail = appendTail4(stderrTail, text);
+        }
+      );
     }
     function setProviderSensitiveValues(values) {
       providerSensitiveValues = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
       resetProviderDeltaRedactor();
+      resetProviderStderrRedactor();
+    }
+    function setActiveAttachmentPaths(values) {
+      activeAttachmentPaths = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
+      if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+      const previousProcessPathCount = processStderrAttachmentPaths.length;
+      processStderrAttachmentPaths = Array.from(/* @__PURE__ */ new Set([
+        ...processStderrAttachmentPaths,
+        ...activeAttachmentPaths
+      ])).sort((left, right) => right.length - left.length);
+      resetProviderDeltaRedactor();
+      if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+        resetProviderStderrRedactor();
+      }
+    }
+    function clearProcessStderrAttachmentPaths({ preserveActive = false } = {}) {
+      processStderrAttachmentPaths = preserveActive ? activeAttachmentPaths.slice() : [];
       resetProviderStderrRedactor();
     }
     function providerRedactionValues(additional = []) {
@@ -40252,9 +40337,9 @@ data: ${JSON.stringify(payload)}
       providerStderrRedactor.discard();
       providerSensitiveValues = [];
       providerDeltaPhase = void 0;
-      providerDeltaRedactor = createDeltaRedactor([], () => {
+      providerDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, () => {
       });
-      providerStderrRedactor = createDeltaRedactor([], () => {
+      providerStderrRedactor = createDeltaRedactor(processStderrAttachmentPaths, () => {
       });
     }
     function currentEnv() {
@@ -40284,6 +40369,7 @@ data: ${JSON.stringify(payload)}
       providerRecoveryInFlight = false;
       turnFailureInFlight = false;
       providerRefreshPending = false;
+      setActiveAttachmentPaths([]);
       if (resolve) resolve();
       if (refreshProvider) {
         Promise.resolve().then(() => onProviderProfileRecovered()).catch(() => {
@@ -40315,6 +40401,7 @@ data: ${JSON.stringify(payload)}
       activeAssistantText = "";
       stderrTail = "";
       clearProviderSensitiveValues();
+      clearProcessStderrAttachmentPaths({ preserveActive: true });
       if (previousProc) {
         try {
           previousProc.kill();
@@ -40495,6 +40582,7 @@ data: ${JSON.stringify(payload)}
       closeProviderRoute();
       if (wasStopping) {
         clearProviderSensitiveValues();
+        clearProcessStderrAttachmentPaths();
         return;
       }
       if (activeRun) {
@@ -40507,6 +40595,7 @@ data: ${JSON.stringify(payload)}
         finishActive();
       }
       clearProviderSensitiveValues();
+      clearProcessStderrAttachmentPaths();
     }
     function handleError(error) {
       const err = error instanceof Error ? error : new Error("codex app-server error");
@@ -40524,6 +40613,7 @@ data: ${JSON.stringify(payload)}
         finishActive();
       }
       clearProviderSensitiveValues();
+      clearProcessStderrAttachmentPaths();
     }
     function clearSpawnCredentialCopies(runtimeConfig, spawnEnvironment, extraNames = []) {
       const names = new Set(extraNames);
@@ -40922,7 +41012,10 @@ data: ${JSON.stringify(payload)}
         let failure2 = {
           kind: error == null ? void 0 : error.kind,
           code: error == null ? void 0 : error.code,
-          message: redactValue((error == null ? void 0 : error.message) || "Failed to start Codex turn.", providerSensitiveValues)
+          message: redactValue(
+            (error == null ? void 0 : error.message) || "Failed to start Codex turn.",
+            [...providerSensitiveValues, ...activeAttachmentPaths]
+          )
         };
         try {
           if (!activeTurnDispatched && await attemptProviderRecovery(error)) return;
@@ -40930,7 +41023,10 @@ data: ${JSON.stringify(payload)}
           failure2 = {
             kind: recoveryError == null ? void 0 : recoveryError.kind,
             code: recoveryError == null ? void 0 : recoveryError.code,
-            message: redactValue((recoveryError == null ? void 0 : recoveryError.message) || "Failed to start Codex turn.", providerSensitiveValues)
+            message: redactValue(
+              (recoveryError == null ? void 0 : recoveryError.message) || "Failed to start Codex turn.",
+              [...providerSensitiveValues, ...activeAttachmentPaths]
+            )
           };
         }
         providerDeltaRedactor.discard();
@@ -40968,6 +41064,7 @@ data: ${JSON.stringify(payload)}
       activeTurn = turn;
       activeTurnAccepted = false;
       activeTurnDispatched = false;
+      setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
       activeUserText = turn.text;
       activeUserRecorded = false;
       providerRecoveryAttempted = false;
@@ -41048,6 +41145,7 @@ data: ${JSON.stringify(payload)}
       finishActive();
       stderrTail = "";
       clearProviderSensitiveValues();
+      clearProcessStderrAttachmentPaths();
       stopping = false;
     }
     const PROBE_INITIALIZE_TIMEOUT_MS = 1e4;
@@ -41279,6 +41377,12 @@ data: ${JSON.stringify(payload)}
     let activeRun = null;
     let activeResolve = null;
     let activeAssistantText = "";
+    let activeAttachmentPaths = [];
+    let processStderrAttachmentPaths = [];
+    let assistantDeltaRedactor = createDeltaRedactor([], () => {
+    });
+    let stderrRedactor = createDeltaRedactor([], () => {
+    });
     let activeTurn = null;
     let activeTurnAccepted = false;
     let messageDispatched = false;
@@ -41289,7 +41393,37 @@ data: ${JSON.stringify(payload)}
     const startedTools = /* @__PURE__ */ new Set();
     const transcript = [];
     function emit(evt) {
-      if (onEvent) onEvent(evt);
+      if (onEvent) onEvent(redactValue(evt, activeAttachmentPaths));
+    }
+    function resetAssistantDeltaRedactor() {
+      assistantDeltaRedactor.discard();
+      assistantDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, (text) => {
+        activeAssistantText += text;
+        emit({ type: "text-delta", text });
+      });
+    }
+    function resetStderrRedactor() {
+      stderrRedactor.discard();
+      stderrRedactor = createDeltaRedactor(processStderrAttachmentPaths, (text) => {
+        stderrTail = appendTail5(stderrTail, text);
+      });
+    }
+    function setActiveAttachmentPaths(values) {
+      activeAttachmentPaths = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
+      if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+      const previousProcessPathCount = processStderrAttachmentPaths.length;
+      processStderrAttachmentPaths = Array.from(/* @__PURE__ */ new Set([
+        ...processStderrAttachmentPaths,
+        ...activeAttachmentPaths
+      ])).sort((left, right) => right.length - left.length);
+      resetAssistantDeltaRedactor();
+      if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+        resetStderrRedactor();
+      }
+    }
+    function clearProcessStderrAttachmentPaths() {
+      processStderrAttachmentPaths = [];
+      resetStderrRedactor();
     }
     function fetcher() {
       return fetchImpl || defaultFetch();
@@ -41306,6 +41440,7 @@ data: ${JSON.stringify(payload)}
         messageDispatched = false;
         turnStarted = false;
         startedTools.clear();
+        setActiveAttachmentPaths([]);
         return;
       }
       const resolve = activeResolve;
@@ -41317,6 +41452,7 @@ data: ${JSON.stringify(payload)}
       messageDispatched = false;
       turnStarted = false;
       startedTools.clear();
+      setActiveAttachmentPaths([]);
       resolve();
     }
     async function request(path, options = {}) {
@@ -41385,13 +41521,17 @@ data: ${JSON.stringify(payload)}
     }
     function handleExit(code, signal) {
       const wasStopping = stopping;
+      stderrRedactor.flush();
       proc = null;
       serverPromise = null;
       sessionPromise = null;
       sessionId = null;
       sseClosed = true;
       sseStarted = false;
-      if (wasStopping) return;
+      if (wasStopping) {
+        clearProcessStderrAttachmentPaths();
+        return;
+      }
       if (activeRun) {
         const detail = stderrTail ? String(code) + (signal ? " " + signal : "") + " " + stderrTail : String(code) + (signal ? " " + signal : "");
         emit({
@@ -41402,6 +41542,7 @@ data: ${JSON.stringify(payload)}
         });
         finishActive();
       }
+      clearProcessStderrAttachmentPaths();
     }
     function handleError(error) {
       proc = null;
@@ -41419,6 +41560,7 @@ data: ${JSON.stringify(payload)}
         });
         finishActive();
       }
+      clearProcessStderrAttachmentPaths();
     }
     async function startServer() {
       if (proc && baseUrl) return true;
@@ -41441,7 +41583,7 @@ data: ${JSON.stringify(payload)}
           env: spawnEnv
         });
         if (proc.stderr && proc.stderr.on) proc.stderr.on("data", (chunk) => {
-          stderrTail = appendTail5(stderrTail, chunk);
+          stderrRedactor.feed(chunk);
         });
         if (proc.on) {
           proc.on("exit", (code, signal) => handleExit(code, signal));
@@ -41586,6 +41728,7 @@ data: ${JSON.stringify(payload)}
             emit({ type: "turn-start" });
           }
         } else if (st === "idle") {
+          assistantDeltaRedactor.flush();
           drainApprovals();
           emit({ type: "turn-end", stopReason: "end_turn" });
           transcript.push({ role: "assistant", text: activeAssistantText });
@@ -41597,10 +41740,7 @@ data: ${JSON.stringify(payload)}
         if (p.field === "text") {
           emit({ type: "thinking", active: false });
           const text = p.delta;
-          if (text) {
-            activeAssistantText += String(text);
-            emit({ type: "text-delta", text: String(text) });
-          }
+          if (text) assistantDeltaRedactor.feed(String(text));
         } else if (p.field === "reasoning") {
           emit({ type: "thinking", active: true });
         }
@@ -41613,6 +41753,7 @@ data: ${JSON.stringify(payload)}
         return;
       }
       if (type === "session.error") {
+        assistantDeltaRedactor.discard();
         const error = p.error || p;
         emit({
           type: "error",
@@ -41667,6 +41808,10 @@ data: ${JSON.stringify(payload)}
       activeTurn = turn;
       activeTurnAccepted = false;
       messageDispatched = false;
+      setActiveAttachmentPaths(turn.attachments.flatMap((attachment) => [
+        attachment.localPath,
+        attachmentFileUrl(attachment.localPath, adapter.id)
+      ]));
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
       });
@@ -41734,6 +41879,8 @@ data: ${JSON.stringify(payload)}
       if (proc && proc.kill) proc.kill();
       proc = null;
       serverPromise = null;
+      stderrTail = "";
+      clearProcessStderrAttachmentPaths();
       try {
         if (configHome) {
           const fs = fsImpl || adapter.fs;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -22005,8 +22005,7 @@
       /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(Section, { id: "ai", title: t.ai, expanded: sections.ai, onToggle: onToggleSection, children: [
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.backend, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Segmented, { full: true, value: backend, onChange: onBackendChange, options: [
           { value: "subscription", label: t.backendSub },
-          { value: "codex", label: t.backendCodex },
-          { value: "zcode", label: t.backendZcode }
+          { value: "codex", label: t.backendCodex }
         ] }) }),
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
           ChannelCard,
@@ -30078,12 +30077,13 @@
       checking: probe === null,
       ok: Boolean(probe && probe.nodeOk !== false && probe.loggedIn),
       detail: probe && probe.detail || "",
-      fixHint: probe && probe.nodeOk === false ? { zh: "\u5185\u5D4C\u5BF9\u8BDD\u9700\u8981\u7CFB\u7EDF Node 18+\uFF1A\u5B89\u88C5 Node.js LTS \u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u6216\u4F7F\u7528\u4E0B\u65B9\u300CAPI \u76F4\u8FDE\u300D\u901A\u9053\uFF08\u65E0 Node \u65F6\u81EA\u52A8\u964D\u7EA7\u4E3A\u76F4\u8FDE HTTP\uFF09\u3002", en: "Embedded chat needs system Node 18+: install Node.js LTS and re-check, or use the API direct channel below (falls back to direct HTTP without Node)." } : { zh: "\u8BA2\u9605\u672A\u767B\u5F55\uFF1A\u5728\u7EC8\u7AEF\u8FD0\u884C claude /login \u5B8C\u6210\u767B\u5F55\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u6216\u6539\u7528\u4E0B\u65B9\u300CAPI \u76F4\u8FDE\u300D\u901A\u9053\u3002", en: "Not logged in: run claude /login in a terminal and re-check, or switch to the API direct channel below." }
+      fixHint: probe && probe.nodeOk === false ? { zh: "Claude Code \u5185\u5D4C\u5BF9\u8BDD\u4E0E\u81EA\u5B9A\u4E49 Provider \u90FD\u9700\u8981\u53EF\u7528\u7684 Node \u8FD0\u884C\u65F6\uFF1A\u4FEE\u590D\u8FD0\u884C\u65F6\u540E\u91CD\u65B0\u68C0\u6D4B\u3002", en: "Embedded Claude Code chat and custom Providers both require an available Node runtime. Repair the runtime, then re-check." } : { zh: "\u8BA2\u9605\u672A\u767B\u5F55\uFF1A\u5728\u7EC8\u7AEF\u8FD0\u884C claude /login \u5B8C\u6210\u767B\u5F55\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u6216\u6539\u7528\u4E0B\u65B9\u300C\u81EA\u5B9A\u4E49 Provider\u300D\u901A\u9053\u3002", en: "Not logged in: run claude /login in a terminal and re-check, or switch to the custom Provider channel below." }
     };
     const selected = apiProviderSelected === void 0 ? Boolean(apiProvider) : Boolean(apiProviderSelected);
     const resolverReady = providerCredentialResolverReady === void 0 ? providerAvailable === void 0 ? providerHasCredentialPolicy(apiProvider) : providerAvailable : providerCredentialResolverReady;
+    const runtimeReady = !(probe && probe.nodeOk === false);
     const canPreflight = Boolean(
-      !providerChecking && selected && (apiProvider == null ? void 0 : apiProvider.baseUrl) && resolverReady
+      !providerChecking && selected && (apiProvider == null ? void 0 : apiProvider.baseUrl) && resolverReady && runtimeReady
     );
     const api = {
       channel: "api",
@@ -30093,7 +30093,7 @@
       checking: Boolean(providerChecking),
       ok: canPreflight,
       detail: apiProvider && apiProvider.baseUrl ? apiProvider.baseUrl : "",
-      fixHint: apiProvider && resolverReady !== true && !providerChecking ? { zh: "\u7CFB\u7EDF\u51ED\u636E\u5E93\u4E0D\u53EF\u7528\uFF1AHelper \u4F1A\u968F AE \u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u5148\u91CD\u65B0\u6253\u5F00\u9762\u677F\u6216\u91CD\u542F AE\uFF1B\u4ECD\u5931\u8D25\u65F6\u518D\u4FEE\u590D\u5F53\u524D\u5B89\u88C5\u3002\u4E0D\u4F1A\u56DE\u9000\u8BFB\u53D6\u660E\u6587 provider \u6587\u4EF6\u3002", en: "The system credential store is unavailable. Helper starts with AE; reopen the panel or restart AE first, then repair the current install if it still fails. Plaintext provider fallback is disabled." } : { zh: "\u5728\u300CProvider \u7BA1\u7406\u300D\u65B0\u589E\u6216\u9009\u62E9\u4E00\u4E2A\u901A\u7528 Provider\uFF08Base URL + API Key\uFF09\u3002\u7CFB\u7EDF\u4F1A\u6309\u6A21\u578B\u81EA\u52A8\u9009\u62E9 Messages\u3001Responses \u6216 Chat \u8DEF\u7531\u3002", en: "Add or select a universal Provider (base URL + API key) in Provider Manager. Messages, Responses, or Chat routing is selected per model." }
+      fixHint: !runtimeReady ? { zh: "Claude \u81EA\u5B9A\u4E49 Provider \u901A\u8FC7 Agent SDK \u8FD0\u884C\uFF0C\u9700\u8981\u53EF\u7528\u7684 Node \u8FD0\u884C\u65F6\uFF1A\u4FEE\u590D\u8FD0\u884C\u65F6\u540E\u91CD\u65B0\u68C0\u6D4B\u3002", en: "Claude custom Providers run through the Agent SDK and require an available Node runtime. Repair the runtime, then re-check." } : apiProvider && resolverReady !== true && !providerChecking ? { zh: "\u7CFB\u7EDF\u51ED\u636E\u5E93\u4E0D\u53EF\u7528\uFF1AHelper \u4F1A\u968F AE \u81EA\u52A8\u542F\u52A8\uFF0C\u8BF7\u5148\u91CD\u65B0\u6253\u5F00\u9762\u677F\u6216\u91CD\u542F AE\uFF1B\u4ECD\u5931\u8D25\u65F6\u518D\u4FEE\u590D\u5F53\u524D\u5B89\u88C5\u3002\u4E0D\u4F1A\u56DE\u9000\u8BFB\u53D6\u660E\u6587 provider \u6587\u4EF6\u3002", en: "The system credential store is unavailable. Helper starts with AE; reopen the panel or restart AE first, then repair the current install if it still fails. Plaintext provider fallback is disabled." } : { zh: "\u5728\u300CProvider \u7BA1\u7406\u300D\u65B0\u589E\u6216\u9009\u62E9\u4E00\u4E2A\u901A\u7528 Provider\uFF08Base URL + API Key\uFF09\u3002\u7CFB\u7EDF\u4F1A\u6309\u6A21\u578B\u81EA\u52A8\u9009\u62E9 Messages\u3001Responses \u6216 Chat \u8DEF\u7531\u3002", en: "Add or select a universal Provider (base URL + API key) in Provider Manager. Messages, Responses, or Chat routing is selected per model." }
     };
     api.directHttp = false;
     return [sub, api];
@@ -30197,10 +30197,10 @@
         lockedChannel = "api";
         storage.setItem("ae_mcp_backend", pref);
         storage.setItem("ae_mcp_channel_lock", lockedChannel);
-      } else if (raw === "opencode") {
+      } else if (raw === "opencode" || raw === "zcode") {
         pref = "subscription";
         storage.setItem("ae_mcp_backend", pref);
-      } else if (raw === "codex" || raw === "zcode" || raw === "subscription") {
+      } else if (raw === "codex" || raw === "subscription") {
         pref = raw;
       }
     } catch (e) {
@@ -30209,7 +30209,7 @@
   }
 
   // src/lib/backendSelect.js
-  function pickBackend({ pref, channels = {}, lockedChannel = "", nodeOk = true }) {
+  function pickBackend({ pref, channels = {}, lockedChannel = "" }) {
     const group = pref === "codex" || pref === "zcode" ? pref : "claude";
     const list = channels[group] || [];
     const selectedCustom = group === "codex" ? list.find((channel) => (channel == null ? void 0 : channel.channel) === "custom" && channel.selected === true) : null;
@@ -30231,7 +30231,7 @@
     }
     if (group === "claude") {
       if (chosen.channel === "api") {
-        return { backend: "byok", reason: "ok", channel: "api", fixHint: null };
+        return { backend: "claude-api", reason: "ok", channel: "api", fixHint: null };
       }
       return { backend: "subscription", reason: "ok", channel: "subscription", fixHint: null };
     }
@@ -49611,8 +49611,7 @@ ${baseUrl}`),
       codex: codexChannels({ codexProbe, customProvider: codexCustomProvider, customProviderSelected: Boolean(codexProviderId), customProviderAvailable: providerInit.state === "ready" && Boolean(codexCustomProvider), customProviderCredentialResolverReady: codexProviderCredentialResolverReady, providerChecking: providerInit.state === "checking", cliConfig: codexCliConfig, cliCredentialAvailable: codexCliCredentialReady }),
       zcode: zcodeChannels({ zcodeProbe, configSummary: zcodeConfigSummary })
     }), [probe, claudeApiProvider, claudeProviderId, codexProbe, codexCustomProvider, codexProviderCredentialResolverReady, codexProviderId, zcodeProbe, zcodeConfigSummary, codexCliConfig, codexCliCredentialReady, providerInit.state]);
-    const nodeOk = !(probe && probe.nodeOk === false);
-    const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk });
+    const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock });
     const claudeSettingsHint = import_react46.default.useMemo(() => {
       try {
         return inspectClaudeSettingsEnv({ platform, fsImpl: platform.fs });

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -39249,16 +39249,30 @@ data: ${JSON.stringify(payload)}
     let routeClosePromise = Promise.resolve();
     let runtimeGeneration = 0;
     let providerSensitiveValues = [];
+    let activeAttachmentPaths = [];
     let providerDeltaPhase = void 0;
     let providerDeltaRedactor = createDeltaRedactor([], () => {
     });
+    let activeTurn = null;
+    let activeTurnAccepted = false;
+    let activeTurnDispatched = false;
     function emit(evt) {
-      if (onEvent) onEvent(redactValue(evt, providerSensitiveValues));
+      let event = evt;
+      if ((event == null ? void 0 : event.type) === "error" && (activeTurn == null ? void 0 : activeTurn.turnId) && !event.turnId) {
+        event = {
+          ...event,
+          turnId: activeTurn.turnId,
+          ...!activeTurnAccepted ? {
+            dispatchState: activeTurnDispatched ? "uncertain" : "not-started"
+          } : {}
+        };
+      }
+      if (onEvent) onEvent(redactValue(event, [...providerSensitiveValues, ...activeAttachmentPaths]));
     }
     function resetProviderDeltaRedactor() {
       providerDeltaRedactor.discard();
       providerDeltaPhase = void 0;
-      providerDeltaRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
+      providerDeltaRedactor = createDeltaRedactor([...providerSensitiveValues, ...activeAttachmentPaths], (text) => {
         activeAssistantText += text;
         emit({ type: "text-delta", text, ...providerDeltaPhase ? { phase: providerDeltaPhase } : {} });
       });
@@ -39267,11 +39281,18 @@ data: ${JSON.stringify(payload)}
       providerSensitiveValues = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
       resetProviderDeltaRedactor();
     }
+    function setActiveAttachmentPaths(values) {
+      activeAttachmentPaths = Array.from(new Set((values || []).filter((value) => typeof value === "string" && value))).sort((left, right) => right.length - left.length);
+      if (stderrTail) {
+        stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+      }
+      resetProviderDeltaRedactor();
+    }
     function clearProviderSensitiveValues() {
       providerDeltaRedactor.discard();
       providerSensitiveValues = [];
       providerDeltaPhase = void 0;
-      providerDeltaRedactor = createDeltaRedactor([], () => {
+      providerDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, () => {
       });
     }
     function writeMessage(message) {
@@ -39279,16 +39300,15 @@ data: ${JSON.stringify(payload)}
       proc.stdin.write(JSON.stringify(message) + "\n");
     }
     function finishActive() {
-      if (!activeResolve) {
-        activeRun = null;
-        activeAssistantText = "";
-        return;
-      }
       const resolve = activeResolve;
       activeResolve = null;
       activeRun = null;
       activeAssistantText = "";
-      resolve();
+      activeTurn = null;
+      activeTurnAccepted = false;
+      activeTurnDispatched = false;
+      setActiveAttachmentPaths([]);
+      if (resolve) resolve();
     }
     function handleSidecarMessage(message) {
       if (!message || message.t === "ready") return;
@@ -39306,6 +39326,9 @@ data: ${JSON.stringify(payload)}
         return;
       }
       providerDeltaRedactor.flush();
+      if (event.type === "turn-accepted" && activeTurn && event.turnId === activeTurn.turnId) {
+        activeTurnAccepted = true;
+      }
       emit(event);
       if (event.type === "turn-end") {
         transcript.push({ role: "assistant", text: activeAssistantText });
@@ -39646,7 +39669,8 @@ data: ${JSON.stringify(payload)}
         if (spawnedProc.stdout && spawnedProc.stdout.on) spawnedProc.stdout.on("data", reader);
         if (spawnedProc.stderr && spawnedProc.stderr.on) spawnedProc.stderr.on("data", (chunk) => {
           if (startGeneration !== runtimeGeneration || proc !== spawnedProc) return;
-          stderrTail = appendTail3(stderrTail, processChannel === "api" ? "[provider-sidecar-stderr-redacted]\n" : chunk);
+          const detail = processChannel === "api" ? "[provider-sidecar-stderr-redacted]\n" : redactValue(String(chunk), [...providerSensitiveValues, ...activeAttachmentPaths]);
+          stderrTail = appendTail3(stderrTail, detail);
         });
         spawnedProc.on("exit", (code, signal) => handleExit(spawnedProc, startGeneration, code, signal));
         spawnedProc.on("error", (error) => {
@@ -39716,9 +39740,28 @@ data: ${JSON.stringify(payload)}
         return false;
       }
     }
-    async function sendUser(text) {
+    async function sendUser(input) {
       if (activeRun) return activeRun;
+      const structuredInput = input !== null && typeof input === "object" && !Array.isArray(input);
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        emit({
+          type: "error",
+          kind: "attachment",
+          code: "TURN_INPUT_INVALID",
+          message: error.message,
+          ...turnId ? { turnId, dispatchState: "not-started" } : {}
+        });
+        return;
+      }
       activeAssistantText = "";
+      activeTurn = turn;
+      activeTurnAccepted = false;
+      activeTurnDispatched = false;
+      setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
       resetProviderDeltaRedactor();
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
@@ -39729,11 +39772,14 @@ data: ${JSON.stringify(payload)}
         if (activeRun === run) finishActive();
         return run;
       }
-      const userText = String(text || "");
+      const userText = turn.text;
       transcript.push({ role: "user", text: userText });
+      activeTurnDispatched = true;
       writeMessage({
         t: "user",
+        ...turn.turnId ? { turnId: turn.turnId } : {},
         text: userText,
+        ...structuredInput ? { attachments: turn.attachments } : {},
         permissionMode: getPermissionMode(),
         model: processModel,
         effort: getEffort ? getEffort() : void 0,

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -7279,12 +7279,11996 @@
     }
   });
 
+  // node_modules/filepond/dist/filepond.js
+  var require_filepond = __commonJS({
+    "node_modules/filepond/dist/filepond.js"(exports, module) {
+      (function(global, factory) {
+        typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = global || self, factory(global.FilePond = {}));
+      })(exports, function(exports2) {
+        "use strict";
+        var isNode = function isNode2(value) {
+          return value instanceof HTMLElement;
+        };
+        var createStore = function createStore2(initialState) {
+          var queries2 = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : [];
+          var actions2 = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : [];
+          var state2 = Object.assign({}, initialState);
+          var actionQueue = [];
+          var dispatchQueue = [];
+          var getState = function getState2() {
+            return Object.assign({}, state2);
+          };
+          var processActionQueue = function processActionQueue2() {
+            var queue = [].concat(actionQueue);
+            actionQueue.length = 0;
+            return queue;
+          };
+          var processDispatchQueue = function processDispatchQueue2() {
+            var queue = [].concat(dispatchQueue);
+            dispatchQueue.length = 0;
+            queue.forEach(function(_ref) {
+              var type = _ref.type, data3 = _ref.data;
+              dispatch2(type, data3);
+            });
+          };
+          var dispatch2 = function dispatch3(type, data3, isBlocking) {
+            if (isBlocking && !document.hidden) {
+              dispatchQueue.push({ type, data: data3 });
+              return;
+            }
+            if (actionHandlers[type]) {
+              actionHandlers[type](data3);
+            }
+            actionQueue.push({
+              type,
+              data: data3
+            });
+          };
+          var query = function query2(str) {
+            var _queryHandles;
+            for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+              args[_key - 1] = arguments[_key];
+            }
+            return queryHandles[str] ? (_queryHandles = queryHandles)[str].apply(_queryHandles, args) : null;
+          };
+          var api = {
+            getState,
+            processActionQueue,
+            processDispatchQueue,
+            dispatch: dispatch2,
+            query
+          };
+          var queryHandles = {};
+          queries2.forEach(function(query2) {
+            queryHandles = Object.assign({}, query2(state2), {}, queryHandles);
+          });
+          var actionHandlers = {};
+          actions2.forEach(function(action) {
+            actionHandlers = Object.assign({}, action(dispatch2, query, state2), {}, actionHandlers);
+          });
+          return api;
+        };
+        var defineProperty = function defineProperty2(obj, property, definition) {
+          if (typeof definition === "function") {
+            obj[property] = definition;
+            return;
+          }
+          Object.defineProperty(obj, property, Object.assign({}, definition));
+        };
+        var forin = function forin2(obj, cb) {
+          for (var key in obj) {
+            if (!obj.hasOwnProperty(key)) {
+              continue;
+            }
+            cb(key, obj[key]);
+          }
+        };
+        var createObject = function createObject2(definition) {
+          var obj = {};
+          forin(definition, function(property) {
+            defineProperty(obj, property, definition[property]);
+          });
+          return obj;
+        };
+        var attr = function attr2(node, name2) {
+          var value = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : null;
+          if (value === null) {
+            return node.getAttribute(name2) || node.hasAttribute(name2);
+          }
+          node.setAttribute(name2, value);
+        };
+        var ns = "http://www.w3.org/2000/svg";
+        var svgElements = ["svg", "path"];
+        var isSVGElement = function isSVGElement2(tag) {
+          return svgElements.includes(tag);
+        };
+        var createElement3 = function createElement4(tag, className) {
+          var attributes = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {};
+          if (typeof className === "object") {
+            attributes = className;
+            className = null;
+          }
+          var element = isSVGElement(tag) ? document.createElementNS(ns, tag) : document.createElement(tag);
+          if (className) {
+            if (isSVGElement(tag)) {
+              attr(element, "class", className);
+            } else {
+              element.className = className;
+            }
+          }
+          forin(attributes, function(name2, value) {
+            attr(element, name2, value);
+          });
+          return element;
+        };
+        var appendChild = function appendChild2(parent) {
+          return function(child, index) {
+            if (typeof index !== "undefined" && parent.children[index]) {
+              parent.insertBefore(child, parent.children[index]);
+            } else {
+              parent.appendChild(child);
+            }
+          };
+        };
+        var appendChildView = function appendChildView2(parent, childViews) {
+          return function(view, index) {
+            if (typeof index !== "undefined") {
+              childViews.splice(index, 0, view);
+            } else {
+              childViews.push(view);
+            }
+            return view;
+          };
+        };
+        var removeChildView = function removeChildView2(parent, childViews) {
+          return function(view) {
+            childViews.splice(childViews.indexOf(view), 1);
+            if (view.element.parentNode) {
+              parent.removeChild(view.element);
+            }
+            return view;
+          };
+        };
+        var IS_BROWSER = function() {
+          return typeof window !== "undefined" && typeof window.document !== "undefined";
+        }();
+        var isBrowser = function isBrowser2() {
+          return IS_BROWSER;
+        };
+        var testElement = isBrowser() ? createElement3("svg") : {};
+        var getChildCount = "children" in testElement ? function(el) {
+          return el.children.length;
+        } : function(el) {
+          return el.childNodes.length;
+        };
+        var getViewRect = function getViewRect2(elementRect, childViews, offset, scale) {
+          var left = offset[0] || elementRect.left;
+          var top = offset[1] || elementRect.top;
+          var right = left + elementRect.width;
+          var bottom = top + elementRect.height * (scale[1] || 1);
+          var rect = {
+            // the rectangle of the element itself
+            element: Object.assign({}, elementRect),
+            // the rectangle of the element expanded to contain its children, does not include any margins
+            inner: {
+              left: elementRect.left,
+              top: elementRect.top,
+              right: elementRect.right,
+              bottom: elementRect.bottom
+            },
+            // the rectangle of the element expanded to contain its children including own margin and child margins
+            // margins will be added after we've recalculated the size
+            outer: {
+              left,
+              top,
+              right,
+              bottom
+            }
+          };
+          childViews.filter(function(childView) {
+            return !childView.isRectIgnored();
+          }).map(function(childView) {
+            return childView.rect;
+          }).forEach(function(childViewRect) {
+            expandRect(rect.inner, Object.assign({}, childViewRect.inner));
+            expandRect(rect.outer, Object.assign({}, childViewRect.outer));
+          });
+          calculateRectSize(rect.inner);
+          rect.outer.bottom += rect.element.marginBottom;
+          rect.outer.right += rect.element.marginRight;
+          calculateRectSize(rect.outer);
+          return rect;
+        };
+        var expandRect = function expandRect2(parent, child) {
+          child.top += parent.top;
+          child.right += parent.left;
+          child.bottom += parent.top;
+          child.left += parent.left;
+          if (child.bottom > parent.bottom) {
+            parent.bottom = child.bottom;
+          }
+          if (child.right > parent.right) {
+            parent.right = child.right;
+          }
+        };
+        var calculateRectSize = function calculateRectSize2(rect) {
+          rect.width = rect.right - rect.left;
+          rect.height = rect.bottom - rect.top;
+        };
+        var isNumber = function isNumber2(value) {
+          return typeof value === "number";
+        };
+        var thereYet = function thereYet2(position, destination, velocity) {
+          var errorMargin = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : 1e-3;
+          return Math.abs(position - destination) < errorMargin && Math.abs(velocity) < errorMargin;
+        };
+        var spring = (
+          // default options
+          function spring2() {
+            var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, _ref$stiffness = _ref.stiffness, stiffness = _ref$stiffness === void 0 ? 0.5 : _ref$stiffness, _ref$damping = _ref.damping, damping = _ref$damping === void 0 ? 0.75 : _ref$damping, _ref$mass = _ref.mass, mass = _ref$mass === void 0 ? 10 : _ref$mass;
+            var target = null;
+            var position = null;
+            var velocity = 0;
+            var resting = false;
+            var interpolate = function interpolate2(ts, skipToEndState) {
+              if (resting) return;
+              if (!(isNumber(target) && isNumber(position))) {
+                resting = true;
+                velocity = 0;
+                return;
+              }
+              var f = -(position - target) * stiffness;
+              velocity += f / mass;
+              position += velocity;
+              velocity *= damping;
+              if (thereYet(position, target, velocity) || skipToEndState) {
+                position = target;
+                velocity = 0;
+                resting = true;
+                api.onupdate(position);
+                api.oncomplete(position);
+              } else {
+                api.onupdate(position);
+              }
+            };
+            var setTarget = function setTarget2(value) {
+              if (isNumber(value) && !isNumber(position)) {
+                position = value;
+              }
+              if (target === null) {
+                target = value;
+                position = value;
+              }
+              target = value;
+              if (position === target || typeof target === "undefined") {
+                resting = true;
+                velocity = 0;
+                api.onupdate(position);
+                api.oncomplete(position);
+                return;
+              }
+              resting = false;
+            };
+            var api = createObject({
+              interpolate,
+              target: {
+                set: setTarget,
+                get: function get() {
+                  return target;
+                }
+              },
+              resting: {
+                get: function get() {
+                  return resting;
+                }
+              },
+              onupdate: function onupdate(value) {
+              },
+              oncomplete: function oncomplete(value) {
+              }
+            });
+            return api;
+          }
+        );
+        var easeLinear = function easeLinear2(t) {
+          return t;
+        };
+        var easeInOutQuad = function easeInOutQuad2(t) {
+          return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+        };
+        var tween = (
+          // default values
+          function tween2() {
+            var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, _ref$duration = _ref.duration, duration = _ref$duration === void 0 ? 500 : _ref$duration, _ref$easing = _ref.easing, easing = _ref$easing === void 0 ? easeInOutQuad : _ref$easing, _ref$delay = _ref.delay, delay = _ref$delay === void 0 ? 0 : _ref$delay;
+            var start = null;
+            var t;
+            var p;
+            var resting = true;
+            var reverse = false;
+            var target = null;
+            var interpolate = function interpolate2(ts, skipToEndState) {
+              if (resting || target === null) return;
+              if (start === null) {
+                start = ts;
+              }
+              if (ts - start < delay) return;
+              t = ts - start - delay;
+              if (t >= duration || skipToEndState) {
+                t = 1;
+                p = reverse ? 0 : 1;
+                api.onupdate(p * target);
+                api.oncomplete(p * target);
+                resting = true;
+              } else {
+                p = t / duration;
+                api.onupdate((t >= 0 ? easing(reverse ? 1 - p : p) : 0) * target);
+              }
+            };
+            var api = createObject({
+              interpolate,
+              target: {
+                get: function get() {
+                  return reverse ? 0 : target;
+                },
+                set: function set2(value) {
+                  if (target === null) {
+                    target = value;
+                    api.onupdate(value);
+                    api.oncomplete(value);
+                    return;
+                  }
+                  if (value < target) {
+                    target = 1;
+                    reverse = true;
+                  } else {
+                    reverse = false;
+                    target = value;
+                  }
+                  resting = false;
+                  start = null;
+                }
+              },
+              resting: {
+                get: function get() {
+                  return resting;
+                }
+              },
+              onupdate: function onupdate(value) {
+              },
+              oncomplete: function oncomplete(value) {
+              }
+            });
+            return api;
+          }
+        );
+        var animator = {
+          spring,
+          tween
+        };
+        var createAnimator = function createAnimator2(definition, category, property) {
+          var def = definition[category] && typeof definition[category][property] === "object" ? definition[category][property] : definition[category] || definition;
+          var type = typeof def === "string" ? def : def.type;
+          var props = typeof def === "object" ? Object.assign({}, def) : {};
+          return animator[type] ? animator[type](props) : null;
+        };
+        var addGetSet = function addGetSet2(keys, obj, props) {
+          var overwrite = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+          obj = Array.isArray(obj) ? obj : [obj];
+          obj.forEach(function(o) {
+            keys.forEach(function(key) {
+              var name2 = key;
+              var getter = function getter2() {
+                return props[key];
+              };
+              var setter = function setter2(value) {
+                return props[key] = value;
+              };
+              if (typeof key === "object") {
+                name2 = key.key;
+                getter = key.getter || getter;
+                setter = key.setter || setter;
+              }
+              if (o[name2] && !overwrite) {
+                return;
+              }
+              o[name2] = {
+                get: getter,
+                set: setter
+              };
+            });
+          });
+        };
+        var animations = function animations2(_ref) {
+          var mixinConfig = _ref.mixinConfig, viewProps = _ref.viewProps, viewInternalAPI = _ref.viewInternalAPI, viewExternalAPI = _ref.viewExternalAPI;
+          var initialProps = Object.assign({}, viewProps);
+          var animations3 = [];
+          forin(mixinConfig, function(property, animation) {
+            var animator2 = createAnimator(animation);
+            if (!animator2) {
+              return;
+            }
+            animator2.onupdate = function(value) {
+              viewProps[property] = value;
+            };
+            animator2.target = initialProps[property];
+            var prop = {
+              key: property,
+              setter: function setter(value) {
+                if (animator2.target === value) {
+                  return;
+                }
+                animator2.target = value;
+              },
+              getter: function getter() {
+                return viewProps[property];
+              }
+            };
+            addGetSet([prop], [viewInternalAPI, viewExternalAPI], viewProps, true);
+            animations3.push(animator2);
+          });
+          return {
+            write: function write2(ts) {
+              var skipToEndState = document.hidden;
+              var resting = true;
+              animations3.forEach(function(animation) {
+                if (!animation.resting) resting = false;
+                animation.interpolate(ts, skipToEndState);
+              });
+              return resting;
+            },
+            destroy: function destroy() {
+            }
+          };
+        };
+        var addEvent = function addEvent2(element) {
+          return function(type, fn2) {
+            element.addEventListener(type, fn2);
+          };
+        };
+        var removeEvent = function removeEvent2(element) {
+          return function(type, fn2) {
+            element.removeEventListener(type, fn2);
+          };
+        };
+        var listeners = function listeners2(_ref) {
+          var mixinConfig = _ref.mixinConfig, viewProps = _ref.viewProps, viewInternalAPI = _ref.viewInternalAPI, viewExternalAPI = _ref.viewExternalAPI, viewState = _ref.viewState, view = _ref.view;
+          var events = [];
+          var add = addEvent(view.element);
+          var remove = removeEvent(view.element);
+          viewExternalAPI.on = function(type, fn2) {
+            events.push({
+              type,
+              fn: fn2
+            });
+            add(type, fn2);
+          };
+          viewExternalAPI.off = function(type, fn2) {
+            events.splice(
+              events.findIndex(function(event) {
+                return event.type === type && event.fn === fn2;
+              }),
+              1
+            );
+            remove(type, fn2);
+          };
+          return {
+            write: function write2() {
+              return true;
+            },
+            destroy: function destroy() {
+              events.forEach(function(event) {
+                remove(event.type, event.fn);
+              });
+            }
+          };
+        };
+        var apis = function apis2(_ref) {
+          var mixinConfig = _ref.mixinConfig, viewProps = _ref.viewProps, viewExternalAPI = _ref.viewExternalAPI;
+          addGetSet(mixinConfig, viewExternalAPI, viewProps);
+        };
+        var isDefined = function isDefined2(value) {
+          return value != null;
+        };
+        var defaults = {
+          opacity: 1,
+          scaleX: 1,
+          scaleY: 1,
+          translateX: 0,
+          translateY: 0,
+          rotateX: 0,
+          rotateY: 0,
+          rotateZ: 0,
+          originX: 0,
+          originY: 0
+        };
+        var styles = function styles2(_ref) {
+          var mixinConfig = _ref.mixinConfig, viewProps = _ref.viewProps, viewInternalAPI = _ref.viewInternalAPI, viewExternalAPI = _ref.viewExternalAPI, view = _ref.view;
+          var initialProps = Object.assign({}, viewProps);
+          var currentProps = {};
+          addGetSet(mixinConfig, [viewInternalAPI, viewExternalAPI], viewProps);
+          var getOffset = function getOffset2() {
+            return [viewProps["translateX"] || 0, viewProps["translateY"] || 0];
+          };
+          var getScale = function getScale2() {
+            return [viewProps["scaleX"] || 0, viewProps["scaleY"] || 0];
+          };
+          var getRect = function getRect2() {
+            return view.rect ? getViewRect(view.rect, view.childViews, getOffset(), getScale()) : null;
+          };
+          viewInternalAPI.rect = { get: getRect };
+          viewExternalAPI.rect = { get: getRect };
+          mixinConfig.forEach(function(key) {
+            viewProps[key] = typeof initialProps[key] === "undefined" ? defaults[key] : initialProps[key];
+          });
+          return {
+            write: function write2() {
+              if (!propsHaveChanged(currentProps, viewProps)) {
+                return;
+              }
+              applyStyles(view.element, viewProps);
+              Object.assign(currentProps, Object.assign({}, viewProps));
+              return true;
+            },
+            destroy: function destroy() {
+            }
+          };
+        };
+        var propsHaveChanged = function propsHaveChanged2(currentProps, newProps) {
+          if (Object.keys(currentProps).length !== Object.keys(newProps).length) {
+            return true;
+          }
+          for (var prop in newProps) {
+            if (newProps[prop] !== currentProps[prop]) {
+              return true;
+            }
+          }
+          return false;
+        };
+        var applyStyles = function applyStyles2(element, _ref2) {
+          var opacity = _ref2.opacity, perspective = _ref2.perspective, translateX = _ref2.translateX, translateY = _ref2.translateY, scaleX = _ref2.scaleX, scaleY = _ref2.scaleY, rotateX = _ref2.rotateX, rotateY = _ref2.rotateY, rotateZ = _ref2.rotateZ, originX = _ref2.originX, originY = _ref2.originY, width = _ref2.width, height = _ref2.height;
+          var transforms = "";
+          var styles2 = "";
+          if (isDefined(originX) || isDefined(originY)) {
+            styles2 += "transform-origin: " + (originX || 0) + "px " + (originY || 0) + "px;";
+          }
+          if (isDefined(perspective)) {
+            transforms += "perspective(" + perspective + "px) ";
+          }
+          if (isDefined(translateX) || isDefined(translateY)) {
+            transforms += "translate3d(" + (translateX || 0) + "px, " + (translateY || 0) + "px, 0) ";
+          }
+          if (isDefined(scaleX) || isDefined(scaleY)) {
+            transforms += "scale3d(" + (isDefined(scaleX) ? scaleX : 1) + ", " + (isDefined(scaleY) ? scaleY : 1) + ", 1) ";
+          }
+          if (isDefined(rotateZ)) {
+            transforms += "rotateZ(" + rotateZ + "rad) ";
+          }
+          if (isDefined(rotateX)) {
+            transforms += "rotateX(" + rotateX + "rad) ";
+          }
+          if (isDefined(rotateY)) {
+            transforms += "rotateY(" + rotateY + "rad) ";
+          }
+          if (transforms.length) {
+            styles2 += "transform:" + transforms + ";";
+          }
+          if (isDefined(opacity)) {
+            styles2 += "opacity:" + opacity + ";";
+            if (opacity === 0) {
+              styles2 += "visibility:hidden;";
+            }
+            if (opacity < 1) {
+              styles2 += "pointer-events:none;";
+            }
+          }
+          if (isDefined(height)) {
+            styles2 += "height:" + height + "px;";
+          }
+          if (isDefined(width)) {
+            styles2 += "width:" + width + "px;";
+          }
+          var elementCurrentStyle = element.elementCurrentStyle || "";
+          if (styles2.length !== elementCurrentStyle.length || styles2 !== elementCurrentStyle) {
+            element.style.cssText = styles2;
+            element.elementCurrentStyle = styles2;
+          }
+        };
+        var Mixins = {
+          styles,
+          listeners,
+          animations,
+          apis
+        };
+        var updateRect = function updateRect2() {
+          var rect = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+          var element = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+          var style = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {};
+          if (!element.layoutCalculated) {
+            rect.paddingTop = parseInt(style.paddingTop, 10) || 0;
+            rect.marginTop = parseInt(style.marginTop, 10) || 0;
+            rect.marginRight = parseInt(style.marginRight, 10) || 0;
+            rect.marginBottom = parseInt(style.marginBottom, 10) || 0;
+            rect.marginLeft = parseInt(style.marginLeft, 10) || 0;
+            element.layoutCalculated = true;
+          }
+          rect.left = element.offsetLeft || 0;
+          rect.top = element.offsetTop || 0;
+          rect.width = element.offsetWidth || 0;
+          rect.height = element.offsetHeight || 0;
+          rect.right = rect.left + rect.width;
+          rect.bottom = rect.top + rect.height;
+          rect.scrollTop = element.scrollTop;
+          rect.hidden = element.offsetParent === null;
+          return rect;
+        };
+        var createView = (
+          // default view definition
+          function createView2() {
+            var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, _ref$tag = _ref.tag, tag = _ref$tag === void 0 ? "div" : _ref$tag, _ref$name = _ref.name, name2 = _ref$name === void 0 ? null : _ref$name, _ref$attributes = _ref.attributes, attributes = _ref$attributes === void 0 ? {} : _ref$attributes, _ref$read = _ref.read, read = _ref$read === void 0 ? function() {
+            } : _ref$read, _ref$write = _ref.write, write2 = _ref$write === void 0 ? function() {
+            } : _ref$write, _ref$create = _ref.create, create2 = _ref$create === void 0 ? function() {
+            } : _ref$create, _ref$destroy = _ref.destroy, destroy = _ref$destroy === void 0 ? function() {
+            } : _ref$destroy, _ref$filterFrameActio = _ref.filterFrameActionsForChild, filterFrameActionsForChild = _ref$filterFrameActio === void 0 ? function(child, actions2) {
+              return actions2;
+            } : _ref$filterFrameActio, _ref$didCreateView = _ref.didCreateView, didCreateView = _ref$didCreateView === void 0 ? function() {
+            } : _ref$didCreateView, _ref$didWriteView = _ref.didWriteView, didWriteView = _ref$didWriteView === void 0 ? function() {
+            } : _ref$didWriteView, _ref$ignoreRect = _ref.ignoreRect, ignoreRect = _ref$ignoreRect === void 0 ? false : _ref$ignoreRect, _ref$ignoreRectUpdate = _ref.ignoreRectUpdate, ignoreRectUpdate = _ref$ignoreRectUpdate === void 0 ? false : _ref$ignoreRectUpdate, _ref$mixins = _ref.mixins, mixins = _ref$mixins === void 0 ? [] : _ref$mixins;
+            return function(store) {
+              var props = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+              var element = createElement3(tag, "filepond--" + name2, attributes);
+              var style = window.getComputedStyle(element, null);
+              var rect = updateRect();
+              var frameRect = null;
+              var isResting = false;
+              var childViews = [];
+              var activeMixins = [];
+              var ref = {};
+              var state2 = {};
+              var writers = [
+                write2
+                // default writer
+              ];
+              var readers = [
+                read
+                // default reader
+              ];
+              var destroyers = [
+                destroy
+                // default destroy
+              ];
+              var getElement = function getElement2() {
+                return element;
+              };
+              var getChildViews = function getChildViews2() {
+                return childViews.concat();
+              };
+              var getReference = function getReference2() {
+                return ref;
+              };
+              var createChildView = function createChildView2(store2) {
+                return function(view, props2) {
+                  return view(store2, props2);
+                };
+              };
+              var getRect = function getRect2() {
+                if (frameRect) {
+                  return frameRect;
+                }
+                frameRect = getViewRect(rect, childViews, [0, 0], [1, 1]);
+                return frameRect;
+              };
+              var getStyle = function getStyle2() {
+                return style;
+              };
+              var _read = function _read2() {
+                frameRect = null;
+                childViews.forEach(function(child) {
+                  return child._read();
+                });
+                var shouldUpdate = !(ignoreRectUpdate && rect.width && rect.height);
+                if (shouldUpdate) {
+                  updateRect(rect, element, style);
+                }
+                var api = { root: internalAPI, props, rect };
+                readers.forEach(function(reader) {
+                  return reader(api);
+                });
+              };
+              var _write = function _write2(ts, frameActions, shouldOptimize) {
+                var resting = frameActions.length === 0;
+                writers.forEach(function(writer) {
+                  var writerResting = writer({
+                    props,
+                    root: internalAPI,
+                    actions: frameActions,
+                    timestamp: ts,
+                    shouldOptimize
+                  });
+                  if (writerResting === false) {
+                    resting = false;
+                  }
+                });
+                activeMixins.forEach(function(mixin) {
+                  var mixinResting = mixin.write(ts);
+                  if (mixinResting === false) {
+                    resting = false;
+                  }
+                });
+                childViews.filter(function(child) {
+                  return !!child.element.parentNode;
+                }).forEach(function(child) {
+                  var childResting = child._write(
+                    ts,
+                    filterFrameActionsForChild(child, frameActions),
+                    shouldOptimize
+                  );
+                  if (!childResting) {
+                    resting = false;
+                  }
+                });
+                childViews.forEach(function(child, index) {
+                  if (child.element.parentNode) {
+                    return;
+                  }
+                  internalAPI.appendChild(child.element, index);
+                  child._read();
+                  child._write(
+                    ts,
+                    filterFrameActionsForChild(child, frameActions),
+                    shouldOptimize
+                  );
+                  resting = false;
+                });
+                isResting = resting;
+                didWriteView({
+                  props,
+                  root: internalAPI,
+                  actions: frameActions,
+                  timestamp: ts
+                });
+                return resting;
+              };
+              var _destroy = function _destroy2() {
+                activeMixins.forEach(function(mixin) {
+                  return mixin.destroy();
+                });
+                destroyers.forEach(function(destroyer) {
+                  destroyer({ root: internalAPI, props });
+                });
+                childViews.forEach(function(child) {
+                  return child._destroy();
+                });
+              };
+              var sharedAPIDefinition = {
+                element: {
+                  get: getElement
+                },
+                style: {
+                  get: getStyle
+                },
+                childViews: {
+                  get: getChildViews
+                }
+              };
+              var internalAPIDefinition = Object.assign({}, sharedAPIDefinition, {
+                rect: {
+                  get: getRect
+                },
+                // access to custom children references
+                ref: {
+                  get: getReference
+                },
+                // dom modifiers
+                is: function is(needle) {
+                  return name2 === needle;
+                },
+                appendChild: appendChild(element),
+                createChildView: createChildView(store),
+                linkView: function linkView(view) {
+                  childViews.push(view);
+                  return view;
+                },
+                unlinkView: function unlinkView(view) {
+                  childViews.splice(childViews.indexOf(view), 1);
+                },
+                appendChildView: appendChildView(element, childViews),
+                removeChildView: removeChildView(element, childViews),
+                registerWriter: function registerWriter(writer) {
+                  return writers.push(writer);
+                },
+                registerReader: function registerReader(reader) {
+                  return readers.push(reader);
+                },
+                registerDestroyer: function registerDestroyer(destroyer) {
+                  return destroyers.push(destroyer);
+                },
+                invalidateLayout: function invalidateLayout() {
+                  return element.layoutCalculated = false;
+                },
+                // access to data store
+                dispatch: store.dispatch,
+                query: store.query
+              });
+              var externalAPIDefinition = {
+                element: {
+                  get: getElement
+                },
+                childViews: {
+                  get: getChildViews
+                },
+                rect: {
+                  get: getRect
+                },
+                resting: {
+                  get: function get() {
+                    return isResting;
+                  }
+                },
+                isRectIgnored: function isRectIgnored() {
+                  return ignoreRect;
+                },
+                _read,
+                _write,
+                _destroy
+              };
+              var mixinAPIDefinition = Object.assign({}, sharedAPIDefinition, {
+                rect: {
+                  get: function get() {
+                    return rect;
+                  }
+                }
+              });
+              Object.keys(mixins).sort(function(a, b) {
+                if (a === "styles") {
+                  return 1;
+                } else if (b === "styles") {
+                  return -1;
+                }
+                return 0;
+              }).forEach(function(key) {
+                var mixinAPI = Mixins[key]({
+                  mixinConfig: mixins[key],
+                  viewProps: props,
+                  viewState: state2,
+                  viewInternalAPI: internalAPIDefinition,
+                  viewExternalAPI: externalAPIDefinition,
+                  view: createObject(mixinAPIDefinition)
+                });
+                if (mixinAPI) {
+                  activeMixins.push(mixinAPI);
+                }
+              });
+              var internalAPI = createObject(internalAPIDefinition);
+              create2({
+                root: internalAPI,
+                props
+              });
+              var childCount = getChildCount(element);
+              childViews.forEach(function(child, index) {
+                internalAPI.appendChild(child.element, childCount + index);
+              });
+              didCreateView(internalAPI);
+              return createObject(externalAPIDefinition);
+            };
+          }
+        );
+        var createPainter = function createPainter2(read, write2) {
+          var fps = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 60;
+          var name2 = "__framePainter";
+          if (window[name2]) {
+            window[name2].readers.push(read);
+            window[name2].writers.push(write2);
+            return;
+          }
+          window[name2] = {
+            readers: [read],
+            writers: [write2]
+          };
+          var painter = window[name2];
+          var interval = 1e3 / fps;
+          var last = null;
+          var id2 = null;
+          var requestTick = null;
+          var cancelTick = null;
+          var setTimerType = function setTimerType2() {
+            if (document.hidden) {
+              requestTick = function requestTick2() {
+                return window.setTimeout(function() {
+                  return tick(performance.now());
+                }, interval);
+              };
+              cancelTick = function cancelTick2() {
+                return window.clearTimeout(id2);
+              };
+            } else {
+              requestTick = function requestTick2() {
+                return window.requestAnimationFrame(tick);
+              };
+              cancelTick = function cancelTick2() {
+                return window.cancelAnimationFrame(id2);
+              };
+            }
+          };
+          document.addEventListener("visibilitychange", function() {
+            if (cancelTick) cancelTick();
+            setTimerType();
+            tick(performance.now());
+          });
+          var tick = function tick2(ts) {
+            id2 = requestTick(tick2);
+            if (!last) {
+              last = ts;
+            }
+            var delta = ts - last;
+            if (delta <= interval) {
+              return;
+            }
+            last = ts - delta % interval;
+            painter.readers.forEach(function(read2) {
+              return read2();
+            });
+            painter.writers.forEach(function(write3) {
+              return write3(ts);
+            });
+          };
+          setTimerType();
+          tick(performance.now());
+          return {
+            pause: function pause() {
+              cancelTick(id2);
+            }
+          };
+        };
+        var createRoute = function createRoute2(routes, fn2) {
+          return function(_ref) {
+            var root2 = _ref.root, props = _ref.props, _ref$actions = _ref.actions, actions2 = _ref$actions === void 0 ? [] : _ref$actions, timestamp2 = _ref.timestamp, shouldOptimize = _ref.shouldOptimize;
+            actions2.filter(function(action) {
+              return routes[action.type];
+            }).forEach(function(action) {
+              return routes[action.type]({
+                root: root2,
+                props,
+                action: action.data,
+                timestamp: timestamp2,
+                shouldOptimize
+              });
+            });
+            if (fn2) {
+              fn2({
+                root: root2,
+                props,
+                actions: actions2,
+                timestamp: timestamp2,
+                shouldOptimize
+              });
+            }
+          };
+        };
+        var insertBefore = function insertBefore2(newNode, referenceNode) {
+          return referenceNode.parentNode.insertBefore(newNode, referenceNode);
+        };
+        var insertAfter = function insertAfter2(newNode, referenceNode) {
+          return referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
+        };
+        var isArray = function isArray2(value) {
+          return Array.isArray(value);
+        };
+        var isEmpty = function isEmpty2(value) {
+          return value == null;
+        };
+        var trim = function trim2(str) {
+          return str.trim();
+        };
+        var toString = function toString2(value) {
+          return "" + value;
+        };
+        var toArray = function toArray2(value) {
+          var splitter = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : ",";
+          if (isEmpty(value)) {
+            return [];
+          }
+          if (isArray(value)) {
+            return value;
+          }
+          return toString(value).split(splitter).map(trim).filter(function(str) {
+            return str.length;
+          });
+        };
+        var isBoolean = function isBoolean2(value) {
+          return typeof value === "boolean";
+        };
+        var toBoolean = function toBoolean2(value) {
+          return isBoolean(value) ? value : value === "true";
+        };
+        var isString = function isString2(value) {
+          return typeof value === "string";
+        };
+        var toNumber = function toNumber2(value) {
+          return isNumber(value) ? value : isString(value) ? toString(value).replace(/[a-z]+/gi, "") : 0;
+        };
+        var toInt = function toInt2(value) {
+          return parseInt(toNumber(value), 10);
+        };
+        var toFloat = function toFloat2(value) {
+          return parseFloat(toNumber(value));
+        };
+        var isInt = function isInt2(value) {
+          return isNumber(value) && isFinite(value) && Math.floor(value) === value;
+        };
+        var toBytes = function toBytes2(value) {
+          var base = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 1e3;
+          if (isInt(value)) {
+            return value;
+          }
+          var naturalFileSize = toString(value).trim();
+          if (/MB$/i.test(naturalFileSize)) {
+            naturalFileSize = naturalFileSize.replace(/MB$i/, "").trim();
+            return toInt(naturalFileSize) * base * base;
+          }
+          if (/KB/i.test(naturalFileSize)) {
+            naturalFileSize = naturalFileSize.replace(/KB$i/, "").trim();
+            return toInt(naturalFileSize) * base;
+          }
+          return toInt(naturalFileSize);
+        };
+        var isFunction = function isFunction2(value) {
+          return typeof value === "function";
+        };
+        var toFunctionReference = function toFunctionReference2(string) {
+          var ref = self;
+          var levels = string.split(".");
+          var level = null;
+          while (level = levels.shift()) {
+            ref = ref[level];
+            if (!ref) {
+              return null;
+            }
+          }
+          return ref;
+        };
+        var methods = {
+          process: "POST",
+          patch: "PATCH",
+          revert: "DELETE",
+          fetch: "GET",
+          restore: "GET",
+          load: "GET"
+        };
+        var createServerAPI = function createServerAPI2(outline) {
+          var api = {};
+          api.url = isString(outline) ? outline : outline.url || "";
+          api.timeout = outline.timeout ? parseInt(outline.timeout, 10) : 0;
+          api.headers = outline.headers ? outline.headers : {};
+          forin(methods, function(key) {
+            api[key] = createAction(key, outline[key], methods[key], api.timeout, api.headers);
+          });
+          api.process = outline.process || isString(outline) || outline.url ? api.process : null;
+          api.remove = outline.remove || null;
+          delete api.headers;
+          return api;
+        };
+        var createAction = function createAction2(name2, outline, method, timeout, headers) {
+          if (outline === null) {
+            return null;
+          }
+          if (typeof outline === "function") {
+            return outline;
+          }
+          var action = {
+            url: method === "GET" || method === "PATCH" ? "?" + name2 + "=" : "",
+            method,
+            headers,
+            withCredentials: false,
+            timeout,
+            onload: null,
+            ondata: null,
+            onerror: null
+          };
+          if (isString(outline)) {
+            action.url = outline;
+            return action;
+          }
+          Object.assign(action, outline);
+          if (isString(action.headers)) {
+            var parts = action.headers.split(/:(.+)/);
+            action.headers = {
+              header: parts[0],
+              value: parts[1]
+            };
+          }
+          action.withCredentials = toBoolean(action.withCredentials);
+          return action;
+        };
+        var toServerAPI = function toServerAPI2(value) {
+          return createServerAPI(value);
+        };
+        var isNull = function isNull2(value) {
+          return value === null;
+        };
+        var isObject4 = function isObject5(value) {
+          return typeof value === "object" && value !== null;
+        };
+        var isAPI = function isAPI2(value) {
+          return isObject4(value) && isString(value.url) && isObject4(value.process) && isObject4(value.revert) && isObject4(value.restore) && isObject4(value.fetch);
+        };
+        var getType = function getType2(value) {
+          if (isArray(value)) {
+            return "array";
+          }
+          if (isNull(value)) {
+            return "null";
+          }
+          if (isInt(value)) {
+            return "int";
+          }
+          if (/^[0-9]+ ?(?:GB|MB|KB)$/gi.test(value)) {
+            return "bytes";
+          }
+          if (isAPI(value)) {
+            return "api";
+          }
+          return typeof value;
+        };
+        var replaceSingleQuotes = function replaceSingleQuotes2(str) {
+          return str.replace(/{\s*'/g, '{"').replace(/'\s*}/g, '"}').replace(/'\s*:/g, '":').replace(/:\s*'/g, ':"').replace(/,\s*'/g, ',"').replace(/'\s*,/g, '",');
+        };
+        var conversionTable = {
+          array: toArray,
+          boolean: toBoolean,
+          int: function int(value) {
+            return getType(value) === "bytes" ? toBytes(value) : toInt(value);
+          },
+          number: toFloat,
+          float: toFloat,
+          bytes: toBytes,
+          string: function string(value) {
+            return isFunction(value) ? value : toString(value);
+          },
+          function: function _function(value) {
+            return toFunctionReference(value);
+          },
+          serverapi: toServerAPI,
+          object: function object(value) {
+            try {
+              return JSON.parse(replaceSingleQuotes(value));
+            } catch (e) {
+              return null;
+            }
+          }
+        };
+        var convertTo = function convertTo2(value, type) {
+          return conversionTable[type](value);
+        };
+        var getValueByType = function getValueByType2(newValue, defaultValue, valueType) {
+          if (newValue === defaultValue) {
+            return newValue;
+          }
+          var newValueType = getType(newValue);
+          if (newValueType !== valueType) {
+            var convertedValue = convertTo(newValue, valueType);
+            newValueType = getType(convertedValue);
+            if (convertedValue === null) {
+              throw 'Trying to assign value with incorrect type to "' + option + '", allowed type: "' + valueType + '"';
+            } else {
+              newValue = convertedValue;
+            }
+          }
+          return newValue;
+        };
+        var createOption = function createOption2(defaultValue, valueType) {
+          var currentValue = defaultValue;
+          return {
+            enumerable: true,
+            get: function get() {
+              return currentValue;
+            },
+            set: function set2(newValue) {
+              currentValue = getValueByType(newValue, defaultValue, valueType);
+            }
+          };
+        };
+        var createOptions = function createOptions2(options) {
+          var obj = {};
+          forin(options, function(prop) {
+            var optionDefinition = options[prop];
+            obj[prop] = createOption(optionDefinition[0], optionDefinition[1]);
+          });
+          return createObject(obj);
+        };
+        var createInitialState = function createInitialState2(options) {
+          return {
+            // model
+            items: [],
+            // timeout used for calling update items
+            listUpdateTimeout: null,
+            // timeout used for stacking metadata updates
+            itemUpdateTimeout: null,
+            // queue of items waiting to be processed
+            processingQueue: [],
+            // options
+            options: createOptions(options)
+          };
+        };
+        var fromCamels = function fromCamels2(string) {
+          var separator = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "-";
+          return string.split(/(?=[A-Z])/).map(function(part) {
+            return part.toLowerCase();
+          }).join(separator);
+        };
+        var createOptionAPI = function createOptionAPI2(store, options) {
+          var obj = {};
+          forin(options, function(key) {
+            obj[key] = {
+              get: function get() {
+                return store.getState().options[key];
+              },
+              set: function set2(value) {
+                store.dispatch("SET_" + fromCamels(key, "_").toUpperCase(), {
+                  value
+                });
+              }
+            };
+          });
+          return obj;
+        };
+        var createOptionActions = function createOptionActions2(options) {
+          return function(dispatch2, query, state2) {
+            var obj = {};
+            forin(options, function(key) {
+              var name2 = fromCamels(key, "_").toUpperCase();
+              obj["SET_" + name2] = function(action) {
+                try {
+                  state2.options[key] = action.value;
+                } catch (e) {
+                }
+                dispatch2("DID_SET_" + name2, { value: state2.options[key] });
+              };
+            });
+            return obj;
+          };
+        };
+        var createOptionQueries = function createOptionQueries2(options) {
+          return function(state2) {
+            var obj = {};
+            forin(options, function(key) {
+              obj["GET_" + fromCamels(key, "_").toUpperCase()] = function(action) {
+                return state2.options[key];
+              };
+            });
+            return obj;
+          };
+        };
+        var InteractionMethod = {
+          API: 1,
+          DROP: 2,
+          BROWSE: 3,
+          PASTE: 4,
+          NONE: 5
+        };
+        var getUniqueId = function getUniqueId2() {
+          return Math.random().toString(36).substring(2, 11);
+        };
+        function _typeof(obj) {
+          if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+            _typeof = function(obj2) {
+              return typeof obj2;
+            };
+          } else {
+            _typeof = function(obj2) {
+              return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
+            };
+          }
+          return _typeof(obj);
+        }
+        var REACT_ELEMENT_TYPE;
+        function _jsx(type, props, key, children) {
+          if (!REACT_ELEMENT_TYPE) {
+            REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol["for"] && Symbol["for"]("react.element") || 60103;
+          }
+          var defaultProps = type && type.defaultProps;
+          var childrenLength = arguments.length - 3;
+          if (!props && childrenLength !== 0) {
+            props = {
+              children: void 0
+            };
+          }
+          if (props && defaultProps) {
+            for (var propName in defaultProps) {
+              if (props[propName] === void 0) {
+                props[propName] = defaultProps[propName];
+              }
+            }
+          } else if (!props) {
+            props = defaultProps || {};
+          }
+          if (childrenLength === 1) {
+            props.children = children;
+          } else if (childrenLength > 1) {
+            var childArray = new Array(childrenLength);
+            for (var i = 0; i < childrenLength; i++) {
+              childArray[i] = arguments[i + 3];
+            }
+            props.children = childArray;
+          }
+          return {
+            $$typeof: REACT_ELEMENT_TYPE,
+            type,
+            key: key === void 0 ? null : "" + key,
+            ref: null,
+            props,
+            _owner: null
+          };
+        }
+        function _asyncIterator(iterable) {
+          var method;
+          if (typeof Symbol !== "undefined") {
+            if (Symbol.asyncIterator) {
+              method = iterable[Symbol.asyncIterator];
+              if (method != null) return method.call(iterable);
+            }
+            if (Symbol.iterator) {
+              method = iterable[Symbol.iterator];
+              if (method != null) return method.call(iterable);
+            }
+          }
+          throw new TypeError("Object is not async iterable");
+        }
+        function _AwaitValue(value) {
+          this.wrapped = value;
+        }
+        function _AsyncGenerator(gen) {
+          var front, back;
+          function send(key, arg) {
+            return new Promise(function(resolve, reject) {
+              var request = {
+                key,
+                arg,
+                resolve,
+                reject,
+                next: null
+              };
+              if (back) {
+                back = back.next = request;
+              } else {
+                front = back = request;
+                resume(key, arg);
+              }
+            });
+          }
+          function resume(key, arg) {
+            try {
+              var result = gen[key](arg);
+              var value = result.value;
+              var wrappedAwait = value instanceof _AwaitValue;
+              Promise.resolve(wrappedAwait ? value.wrapped : value).then(
+                function(arg2) {
+                  if (wrappedAwait) {
+                    resume("next", arg2);
+                    return;
+                  }
+                  settle(result.done ? "return" : "normal", arg2);
+                },
+                function(err) {
+                  resume("throw", err);
+                }
+              );
+            } catch (err) {
+              settle("throw", err);
+            }
+          }
+          function settle(type, value) {
+            switch (type) {
+              case "return":
+                front.resolve({
+                  value,
+                  done: true
+                });
+                break;
+              case "throw":
+                front.reject(value);
+                break;
+              default:
+                front.resolve({
+                  value,
+                  done: false
+                });
+                break;
+            }
+            front = front.next;
+            if (front) {
+              resume(front.key, front.arg);
+            } else {
+              back = null;
+            }
+          }
+          this._invoke = send;
+          if (typeof gen.return !== "function") {
+            this.return = void 0;
+          }
+        }
+        if (typeof Symbol === "function" && Symbol.asyncIterator) {
+          _AsyncGenerator.prototype[Symbol.asyncIterator] = function() {
+            return this;
+          };
+        }
+        _AsyncGenerator.prototype.next = function(arg) {
+          return this._invoke("next", arg);
+        };
+        _AsyncGenerator.prototype.throw = function(arg) {
+          return this._invoke("throw", arg);
+        };
+        _AsyncGenerator.prototype.return = function(arg) {
+          return this._invoke("return", arg);
+        };
+        function _wrapAsyncGenerator(fn2) {
+          return function() {
+            return new _AsyncGenerator(fn2.apply(this, arguments));
+          };
+        }
+        function _awaitAsyncGenerator(value) {
+          return new _AwaitValue(value);
+        }
+        function _asyncGeneratorDelegate(inner, awaitWrap) {
+          var iter = {}, waiting = false;
+          function pump(key, value) {
+            waiting = true;
+            value = new Promise(function(resolve) {
+              resolve(inner[key](value));
+            });
+            return {
+              done: false,
+              value: awaitWrap(value)
+            };
+          }
+          if (typeof Symbol === "function" && Symbol.iterator) {
+            iter[Symbol.iterator] = function() {
+              return this;
+            };
+          }
+          iter.next = function(value) {
+            if (waiting) {
+              waiting = false;
+              return value;
+            }
+            return pump("next", value);
+          };
+          if (typeof inner.throw === "function") {
+            iter.throw = function(value) {
+              if (waiting) {
+                waiting = false;
+                throw value;
+              }
+              return pump("throw", value);
+            };
+          }
+          if (typeof inner.return === "function") {
+            iter.return = function(value) {
+              return pump("return", value);
+            };
+          }
+          return iter;
+        }
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+          try {
+            var info = gen[key](arg);
+            var value = info.value;
+          } catch (error2) {
+            reject(error2);
+            return;
+          }
+          if (info.done) {
+            resolve(value);
+          } else {
+            Promise.resolve(value).then(_next, _throw);
+          }
+        }
+        function _asyncToGenerator(fn2) {
+          return function() {
+            var self2 = this, args = arguments;
+            return new Promise(function(resolve, reject) {
+              var gen = fn2.apply(self2, args);
+              function _next(value) {
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+              }
+              function _throw(err) {
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+              }
+              _next(void 0);
+            });
+          };
+        }
+        function _classCallCheck(instance, Constructor) {
+          if (!(instance instanceof Constructor)) {
+            throw new TypeError("Cannot call a class as a function");
+          }
+        }
+        function _defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+          }
+        }
+        function _createClass(Constructor, protoProps, staticProps) {
+          if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) _defineProperties(Constructor, staticProps);
+          return Constructor;
+        }
+        function _defineEnumerableProperties(obj, descs) {
+          for (var key in descs) {
+            var desc = descs[key];
+            desc.configurable = desc.enumerable = true;
+            if ("value" in desc) desc.writable = true;
+            Object.defineProperty(obj, key, desc);
+          }
+          if (Object.getOwnPropertySymbols) {
+            var objectSymbols = Object.getOwnPropertySymbols(descs);
+            for (var i = 0; i < objectSymbols.length; i++) {
+              var sym = objectSymbols[i];
+              var desc = descs[sym];
+              desc.configurable = desc.enumerable = true;
+              if ("value" in desc) desc.writable = true;
+              Object.defineProperty(obj, sym, desc);
+            }
+          }
+          return obj;
+        }
+        function _defaults(obj, defaults2) {
+          var keys = Object.getOwnPropertyNames(defaults2);
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var value = Object.getOwnPropertyDescriptor(defaults2, key);
+            if (value && value.configurable && obj[key] === void 0) {
+              Object.defineProperty(obj, key, value);
+            }
+          }
+          return obj;
+        }
+        function _defineProperty(obj, key, value) {
+          if (key in obj) {
+            Object.defineProperty(obj, key, {
+              value,
+              enumerable: true,
+              configurable: true,
+              writable: true
+            });
+          } else {
+            obj[key] = value;
+          }
+          return obj;
+        }
+        function _extends() {
+          _extends = Object.assign || function(target) {
+            for (var i = 1; i < arguments.length; i++) {
+              var source = arguments[i];
+              for (var key in source) {
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                  target[key] = source[key];
+                }
+              }
+            }
+            return target;
+          };
+          return _extends.apply(this, arguments);
+        }
+        function _objectSpread(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i] != null ? arguments[i] : {};
+            var ownKeys2 = Object.keys(source);
+            if (typeof Object.getOwnPropertySymbols === "function") {
+              ownKeys2 = ownKeys2.concat(
+                Object.getOwnPropertySymbols(source).filter(function(sym) {
+                  return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+                })
+              );
+            }
+            ownKeys2.forEach(function(key) {
+              _defineProperty(target, key, source[key]);
+            });
+          }
+          return target;
+        }
+        function ownKeys(object, enumerableOnly) {
+          var keys = Object.keys(object);
+          if (Object.getOwnPropertySymbols) {
+            var symbols = Object.getOwnPropertySymbols(object);
+            if (enumerableOnly)
+              symbols = symbols.filter(function(sym) {
+                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+              });
+            keys.push.apply(keys, symbols);
+          }
+          return keys;
+        }
+        function _objectSpread2(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i] != null ? arguments[i] : {};
+            if (i % 2) {
+              ownKeys(source, true).forEach(function(key) {
+                _defineProperty(target, key, source[key]);
+              });
+            } else if (Object.getOwnPropertyDescriptors) {
+              Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+            } else {
+              ownKeys(source).forEach(function(key) {
+                Object.defineProperty(
+                  target,
+                  key,
+                  Object.getOwnPropertyDescriptor(source, key)
+                );
+              });
+            }
+          }
+          return target;
+        }
+        function _inherits(subClass, superClass) {
+          if (typeof superClass !== "function" && superClass !== null) {
+            throw new TypeError("Super expression must either be null or a function");
+          }
+          subClass.prototype = Object.create(superClass && superClass.prototype, {
+            constructor: {
+              value: subClass,
+              writable: true,
+              configurable: true
+            }
+          });
+          if (superClass) _setPrototypeOf(subClass, superClass);
+        }
+        function _inheritsLoose(subClass, superClass) {
+          subClass.prototype = Object.create(superClass.prototype);
+          subClass.prototype.constructor = subClass;
+          subClass.__proto__ = superClass;
+        }
+        function _getPrototypeOf(o) {
+          _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf2(o2) {
+            return o2.__proto__ || Object.getPrototypeOf(o2);
+          };
+          return _getPrototypeOf(o);
+        }
+        function _setPrototypeOf(o, p) {
+          _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf2(o2, p2) {
+            o2.__proto__ = p2;
+            return o2;
+          };
+          return _setPrototypeOf(o, p);
+        }
+        function isNativeReflectConstruct() {
+          if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+          if (Reflect.construct.sham) return false;
+          if (typeof Proxy === "function") return true;
+          try {
+            Date.prototype.toString.call(Reflect.construct(Date, [], function() {
+            }));
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+        function _construct(Parent, args, Class) {
+          if (isNativeReflectConstruct()) {
+            _construct = Reflect.construct;
+          } else {
+            _construct = function _construct2(Parent2, args2, Class2) {
+              var a = [null];
+              a.push.apply(a, args2);
+              var Constructor = Function.bind.apply(Parent2, a);
+              var instance = new Constructor();
+              if (Class2) _setPrototypeOf(instance, Class2.prototype);
+              return instance;
+            };
+          }
+          return _construct.apply(null, arguments);
+        }
+        function _isNativeFunction(fn2) {
+          return Function.toString.call(fn2).indexOf("[native code]") !== -1;
+        }
+        function _wrapNativeSuper(Class) {
+          var _cache = typeof Map === "function" ? /* @__PURE__ */ new Map() : void 0;
+          _wrapNativeSuper = function _wrapNativeSuper2(Class2) {
+            if (Class2 === null || !_isNativeFunction(Class2)) return Class2;
+            if (typeof Class2 !== "function") {
+              throw new TypeError("Super expression must either be null or a function");
+            }
+            if (typeof _cache !== "undefined") {
+              if (_cache.has(Class2)) return _cache.get(Class2);
+              _cache.set(Class2, Wrapper);
+            }
+            function Wrapper() {
+              return _construct(Class2, arguments, _getPrototypeOf(this).constructor);
+            }
+            Wrapper.prototype = Object.create(Class2.prototype, {
+              constructor: {
+                value: Wrapper,
+                enumerable: false,
+                writable: true,
+                configurable: true
+              }
+            });
+            return _setPrototypeOf(Wrapper, Class2);
+          };
+          return _wrapNativeSuper(Class);
+        }
+        function _instanceof(left, right) {
+          if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
+            return !!right[Symbol.hasInstance](left);
+          } else {
+            return left instanceof right;
+          }
+        }
+        function _interopRequireDefault(obj) {
+          return obj && obj.__esModule ? obj : {
+            default: obj
+          };
+        }
+        function _interopRequireWildcard(obj) {
+          if (obj && obj.__esModule) {
+            return obj;
+          } else {
+            var newObj = {};
+            if (obj != null) {
+              for (var key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                  var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {};
+                  if (desc.get || desc.set) {
+                    Object.defineProperty(newObj, key, desc);
+                  } else {
+                    newObj[key] = obj[key];
+                  }
+                }
+              }
+            }
+            newObj.default = obj;
+            return newObj;
+          }
+        }
+        function _newArrowCheck(innerThis, boundThis) {
+          if (innerThis !== boundThis) {
+            throw new TypeError("Cannot instantiate an arrow function");
+          }
+        }
+        function _objectDestructuringEmpty(obj) {
+          if (obj == null) throw new TypeError("Cannot destructure undefined");
+        }
+        function _objectWithoutPropertiesLoose(source, excluded) {
+          if (source == null) return {};
+          var target = {};
+          var sourceKeys = Object.keys(source);
+          var key, i;
+          for (i = 0; i < sourceKeys.length; i++) {
+            key = sourceKeys[i];
+            if (excluded.indexOf(key) >= 0) continue;
+            target[key] = source[key];
+          }
+          return target;
+        }
+        function _objectWithoutProperties(source, excluded) {
+          if (source == null) return {};
+          var target = _objectWithoutPropertiesLoose(source, excluded);
+          var key, i;
+          if (Object.getOwnPropertySymbols) {
+            var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+            for (i = 0; i < sourceSymbolKeys.length; i++) {
+              key = sourceSymbolKeys[i];
+              if (excluded.indexOf(key) >= 0) continue;
+              if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+              target[key] = source[key];
+            }
+          }
+          return target;
+        }
+        function _assertThisInitialized(self2) {
+          if (self2 === void 0) {
+            throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+          }
+          return self2;
+        }
+        function _possibleConstructorReturn(self2, call) {
+          if (call && (typeof call === "object" || typeof call === "function")) {
+            return call;
+          }
+          return _assertThisInitialized(self2);
+        }
+        function _superPropBase(object, property) {
+          while (!Object.prototype.hasOwnProperty.call(object, property)) {
+            object = _getPrototypeOf(object);
+            if (object === null) break;
+          }
+          return object;
+        }
+        function _get(target, property, receiver) {
+          if (typeof Reflect !== "undefined" && Reflect.get) {
+            _get = Reflect.get;
+          } else {
+            _get = function _get2(target2, property2, receiver2) {
+              var base = _superPropBase(target2, property2);
+              if (!base) return;
+              var desc = Object.getOwnPropertyDescriptor(base, property2);
+              if (desc.get) {
+                return desc.get.call(receiver2);
+              }
+              return desc.value;
+            };
+          }
+          return _get(target, property, receiver || target);
+        }
+        function set(target, property, value, receiver) {
+          if (typeof Reflect !== "undefined" && Reflect.set) {
+            set = Reflect.set;
+          } else {
+            set = function set2(target2, property2, value2, receiver2) {
+              var base = _superPropBase(target2, property2);
+              var desc;
+              if (base) {
+                desc = Object.getOwnPropertyDescriptor(base, property2);
+                if (desc.set) {
+                  desc.set.call(receiver2, value2);
+                  return true;
+                } else if (!desc.writable) {
+                  return false;
+                }
+              }
+              desc = Object.getOwnPropertyDescriptor(receiver2, property2);
+              if (desc) {
+                if (!desc.writable) {
+                  return false;
+                }
+                desc.value = value2;
+                Object.defineProperty(receiver2, property2, desc);
+              } else {
+                _defineProperty(receiver2, property2, value2);
+              }
+              return true;
+            };
+          }
+          return set(target, property, value, receiver);
+        }
+        function _set(target, property, value, receiver, isStrict) {
+          var s = set(target, property, value, receiver || target);
+          if (!s && isStrict) {
+            throw new Error("failed to set property");
+          }
+          return value;
+        }
+        function _taggedTemplateLiteral(strings, raw) {
+          if (!raw) {
+            raw = strings.slice(0);
+          }
+          return Object.freeze(
+            Object.defineProperties(strings, {
+              raw: {
+                value: Object.freeze(raw)
+              }
+            })
+          );
+        }
+        function _taggedTemplateLiteralLoose(strings, raw) {
+          if (!raw) {
+            raw = strings.slice(0);
+          }
+          strings.raw = raw;
+          return strings;
+        }
+        function _temporalRef(val, name2) {
+          if (val === _temporalUndefined) {
+            throw new ReferenceError(name2 + " is not defined - temporal dead zone");
+          } else {
+            return val;
+          }
+        }
+        function _readOnlyError(name2) {
+          throw new Error('"' + name2 + '" is read-only');
+        }
+        function _classNameTDZError(name2) {
+          throw new Error('Class "' + name2 + '" cannot be referenced in computed property keys.');
+        }
+        var _temporalUndefined = {};
+        function _slicedToArray(arr, i) {
+          return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest();
+        }
+        function _slicedToArrayLoose(arr, i) {
+          return _arrayWithHoles(arr) || _iterableToArrayLimitLoose(arr, i) || _nonIterableRest();
+        }
+        function _toArray(arr) {
+          return _arrayWithHoles(arr) || _iterableToArray(arr) || _nonIterableRest();
+        }
+        function _toConsumableArray(arr) {
+          return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread();
+        }
+        function _arrayWithoutHoles(arr) {
+          if (Array.isArray(arr)) {
+            for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+            return arr2;
+          }
+        }
+        function _arrayWithHoles(arr) {
+          if (Array.isArray(arr)) return arr;
+        }
+        function _iterableToArray(iter) {
+          if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]")
+            return Array.from(iter);
+        }
+        function _iterableToArrayLimit(arr, i) {
+          var _arr = [];
+          var _n = true;
+          var _d = false;
+          var _e = void 0;
+          try {
+            for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+              _arr.push(_s.value);
+              if (i && _arr.length === i) break;
+            }
+          } catch (err) {
+            _d = true;
+            _e = err;
+          } finally {
+            try {
+              if (!_n && _i["return"] != null) _i["return"]();
+            } finally {
+              if (_d) throw _e;
+            }
+          }
+          return _arr;
+        }
+        function _iterableToArrayLimitLoose(arr, i) {
+          var _arr = [];
+          for (var _iterator = arr[Symbol.iterator](), _step; !(_step = _iterator.next()).done; ) {
+            _arr.push(_step.value);
+            if (i && _arr.length === i) break;
+          }
+          return _arr;
+        }
+        function _nonIterableSpread() {
+          throw new TypeError("Invalid attempt to spread non-iterable instance");
+        }
+        function _nonIterableRest() {
+          throw new TypeError("Invalid attempt to destructure non-iterable instance");
+        }
+        function _skipFirstGeneratorNext(fn2) {
+          return function() {
+            var it = fn2.apply(this, arguments);
+            it.next();
+            return it;
+          };
+        }
+        function _toPrimitive(input, hint) {
+          if (typeof input !== "object" || input === null) return input;
+          var prim = input[Symbol.toPrimitive];
+          if (prim !== void 0) {
+            var res2 = prim.call(input, hint || "default");
+            if (typeof res2 !== "object") return res2;
+            throw new TypeError("@@toPrimitive must return a primitive value.");
+          }
+          return (hint === "string" ? String : Number)(input);
+        }
+        function _toPropertyKey(arg) {
+          var key = _toPrimitive(arg, "string");
+          return typeof key === "symbol" ? key : String(key);
+        }
+        function _initializerWarningHelper(descriptor, context) {
+          throw new Error(
+            "Decorating class property failed. Please ensure that proposal-class-properties is enabled and set to use loose mode. To use proposal-class-properties in spec mode with decorators, wait for the next major version of decorators in stage 2."
+          );
+        }
+        function _initializerDefineProperty(target, property, descriptor, context) {
+          if (!descriptor) return;
+          Object.defineProperty(target, property, {
+            enumerable: descriptor.enumerable,
+            configurable: descriptor.configurable,
+            writable: descriptor.writable,
+            value: descriptor.initializer ? descriptor.initializer.call(context) : void 0
+          });
+        }
+        function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
+          var desc = {};
+          Object.keys(descriptor).forEach(function(key) {
+            desc[key] = descriptor[key];
+          });
+          desc.enumerable = !!desc.enumerable;
+          desc.configurable = !!desc.configurable;
+          if ("value" in desc || desc.initializer) {
+            desc.writable = true;
+          }
+          desc = decorators.slice().reverse().reduce(function(desc2, decorator) {
+            return decorator(target, property, desc2) || desc2;
+          }, desc);
+          if (context && desc.initializer !== void 0) {
+            desc.value = desc.initializer ? desc.initializer.call(context) : void 0;
+            desc.initializer = void 0;
+          }
+          if (desc.initializer === void 0) {
+            Object.defineProperty(target, property, desc);
+            desc = null;
+          }
+          return desc;
+        }
+        var id = 0;
+        function _classPrivateFieldLooseKey(name2) {
+          return "__private_" + id++ + "_" + name2;
+        }
+        function _classPrivateFieldLooseBase(receiver, privateKey) {
+          if (!Object.prototype.hasOwnProperty.call(receiver, privateKey)) {
+            throw new TypeError("attempted to use private field on non-instance");
+          }
+          return receiver;
+        }
+        function _classPrivateFieldGet(receiver, privateMap) {
+          var descriptor = privateMap.get(receiver);
+          if (!descriptor) {
+            throw new TypeError("attempted to get private field on non-instance");
+          }
+          if (descriptor.get) {
+            return descriptor.get.call(receiver);
+          }
+          return descriptor.value;
+        }
+        function _classPrivateFieldSet(receiver, privateMap, value) {
+          var descriptor = privateMap.get(receiver);
+          if (!descriptor) {
+            throw new TypeError("attempted to set private field on non-instance");
+          }
+          if (descriptor.set) {
+            descriptor.set.call(receiver, value);
+          } else {
+            if (!descriptor.writable) {
+              throw new TypeError("attempted to set read only private field");
+            }
+            descriptor.value = value;
+          }
+          return value;
+        }
+        function _classPrivateFieldDestructureSet(receiver, privateMap) {
+          if (!privateMap.has(receiver)) {
+            throw new TypeError("attempted to set private field on non-instance");
+          }
+          var descriptor = privateMap.get(receiver);
+          if (descriptor.set) {
+            if (!("__destrObj" in descriptor)) {
+              descriptor.__destrObj = {
+                set value(v) {
+                  descriptor.set.call(receiver, v);
+                }
+              };
+            }
+            return descriptor.__destrObj;
+          } else {
+            if (!descriptor.writable) {
+              throw new TypeError("attempted to set read only private field");
+            }
+            return descriptor;
+          }
+        }
+        function _classStaticPrivateFieldSpecGet(receiver, classConstructor, descriptor) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          return descriptor.value;
+        }
+        function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          if (!descriptor.writable) {
+            throw new TypeError("attempted to set read only private field");
+          }
+          descriptor.value = value;
+          return value;
+        }
+        function _classStaticPrivateMethodGet(receiver, classConstructor, method) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          return method;
+        }
+        function _classStaticPrivateMethodSet() {
+          throw new TypeError("attempted to set read only static private field");
+        }
+        function _decorate(decorators, factory, superClass, mixins) {
+          var api = _getDecoratorsApi();
+          if (mixins) {
+            for (var i = 0; i < mixins.length; i++) {
+              api = mixins[i](api);
+            }
+          }
+          var r = factory(function initialize(O) {
+            api.initializeInstanceElements(O, decorated.elements);
+          }, superClass);
+          var decorated = api.decorateClass(
+            _coalesceClassElements(r.d.map(_createElementDescriptor)),
+            decorators
+          );
+          api.initializeClassElements(r.F, decorated.elements);
+          return api.runClassFinishers(r.F, decorated.finishers);
+        }
+        function _getDecoratorsApi() {
+          _getDecoratorsApi = function() {
+            return api;
+          };
+          var api = {
+            elementsDefinitionOrder: [["method"], ["field"]],
+            initializeInstanceElements: function(O, elements) {
+              ["method", "field"].forEach(function(kind) {
+                elements.forEach(function(element) {
+                  if (element.kind === kind && element.placement === "own") {
+                    this.defineClassElement(O, element);
+                  }
+                }, this);
+              }, this);
+            },
+            initializeClassElements: function(F, elements) {
+              var proto = F.prototype;
+              ["method", "field"].forEach(function(kind) {
+                elements.forEach(function(element) {
+                  var placement = element.placement;
+                  if (element.kind === kind && (placement === "static" || placement === "prototype")) {
+                    var receiver = placement === "static" ? F : proto;
+                    this.defineClassElement(receiver, element);
+                  }
+                }, this);
+              }, this);
+            },
+            defineClassElement: function(receiver, element) {
+              var descriptor = element.descriptor;
+              if (element.kind === "field") {
+                var initializer = element.initializer;
+                descriptor = {
+                  enumerable: descriptor.enumerable,
+                  writable: descriptor.writable,
+                  configurable: descriptor.configurable,
+                  value: initializer === void 0 ? void 0 : initializer.call(receiver)
+                };
+              }
+              Object.defineProperty(receiver, element.key, descriptor);
+            },
+            decorateClass: function(elements, decorators) {
+              var newElements = [];
+              var finishers = [];
+              var placements = {
+                static: [],
+                prototype: [],
+                own: []
+              };
+              elements.forEach(function(element) {
+                this.addElementPlacement(element, placements);
+              }, this);
+              elements.forEach(function(element) {
+                if (!_hasDecorators(element)) return newElements.push(element);
+                var elementFinishersExtras = this.decorateElement(element, placements);
+                newElements.push(elementFinishersExtras.element);
+                newElements.push.apply(newElements, elementFinishersExtras.extras);
+                finishers.push.apply(finishers, elementFinishersExtras.finishers);
+              }, this);
+              if (!decorators) {
+                return {
+                  elements: newElements,
+                  finishers
+                };
+              }
+              var result = this.decorateConstructor(newElements, decorators);
+              finishers.push.apply(finishers, result.finishers);
+              result.finishers = finishers;
+              return result;
+            },
+            addElementPlacement: function(element, placements, silent) {
+              var keys = placements[element.placement];
+              if (!silent && keys.indexOf(element.key) !== -1) {
+                throw new TypeError("Duplicated element (" + element.key + ")");
+              }
+              keys.push(element.key);
+            },
+            decorateElement: function(element, placements) {
+              var extras = [];
+              var finishers = [];
+              for (var decorators = element.decorators, i = decorators.length - 1; i >= 0; i--) {
+                var keys = placements[element.placement];
+                keys.splice(keys.indexOf(element.key), 1);
+                var elementObject = this.fromElementDescriptor(element);
+                var elementFinisherExtras = this.toElementFinisherExtras(
+                  (0, decorators[i])(elementObject) || elementObject
+                );
+                element = elementFinisherExtras.element;
+                this.addElementPlacement(element, placements);
+                if (elementFinisherExtras.finisher) {
+                  finishers.push(elementFinisherExtras.finisher);
+                }
+                var newExtras = elementFinisherExtras.extras;
+                if (newExtras) {
+                  for (var j = 0; j < newExtras.length; j++) {
+                    this.addElementPlacement(newExtras[j], placements);
+                  }
+                  extras.push.apply(extras, newExtras);
+                }
+              }
+              return {
+                element,
+                finishers,
+                extras
+              };
+            },
+            decorateConstructor: function(elements, decorators) {
+              var finishers = [];
+              for (var i = decorators.length - 1; i >= 0; i--) {
+                var obj = this.fromClassDescriptor(elements);
+                var elementsAndFinisher = this.toClassDescriptor(
+                  (0, decorators[i])(obj) || obj
+                );
+                if (elementsAndFinisher.finisher !== void 0) {
+                  finishers.push(elementsAndFinisher.finisher);
+                }
+                if (elementsAndFinisher.elements !== void 0) {
+                  elements = elementsAndFinisher.elements;
+                  for (var j = 0; j < elements.length - 1; j++) {
+                    for (var k = j + 1; k < elements.length; k++) {
+                      if (elements[j].key === elements[k].key && elements[j].placement === elements[k].placement) {
+                        throw new TypeError(
+                          "Duplicated element (" + elements[j].key + ")"
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+              return {
+                elements,
+                finishers
+              };
+            },
+            fromElementDescriptor: function(element) {
+              var obj = {
+                kind: element.kind,
+                key: element.key,
+                placement: element.placement,
+                descriptor: element.descriptor
+              };
+              var desc = {
+                value: "Descriptor",
+                configurable: true
+              };
+              Object.defineProperty(obj, Symbol.toStringTag, desc);
+              if (element.kind === "field") obj.initializer = element.initializer;
+              return obj;
+            },
+            toElementDescriptors: function(elementObjects) {
+              if (elementObjects === void 0) return;
+              return _toArray(elementObjects).map(function(elementObject) {
+                var element = this.toElementDescriptor(elementObject);
+                this.disallowProperty(elementObject, "finisher", "An element descriptor");
+                this.disallowProperty(elementObject, "extras", "An element descriptor");
+                return element;
+              }, this);
+            },
+            toElementDescriptor: function(elementObject) {
+              var kind = String(elementObject.kind);
+              if (kind !== "method" && kind !== "field") {
+                throw new TypeError(
+                  `An element descriptor's .kind property must be either "method" or "field", but a decorator created an element descriptor with .kind "` + kind + '"'
+                );
+              }
+              var key = _toPropertyKey(elementObject.key);
+              var placement = String(elementObject.placement);
+              if (placement !== "static" && placement !== "prototype" && placement !== "own") {
+                throw new TypeError(
+                  `An element descriptor's .placement property must be one of "static", "prototype" or "own", but a decorator created an element descriptor with .placement "` + placement + '"'
+                );
+              }
+              var descriptor = elementObject.descriptor;
+              this.disallowProperty(elementObject, "elements", "An element descriptor");
+              var element = {
+                kind,
+                key,
+                placement,
+                descriptor: Object.assign({}, descriptor)
+              };
+              if (kind !== "field") {
+                this.disallowProperty(elementObject, "initializer", "A method descriptor");
+              } else {
+                this.disallowProperty(
+                  descriptor,
+                  "get",
+                  "The property descriptor of a field descriptor"
+                );
+                this.disallowProperty(
+                  descriptor,
+                  "set",
+                  "The property descriptor of a field descriptor"
+                );
+                this.disallowProperty(
+                  descriptor,
+                  "value",
+                  "The property descriptor of a field descriptor"
+                );
+                element.initializer = elementObject.initializer;
+              }
+              return element;
+            },
+            toElementFinisherExtras: function(elementObject) {
+              var element = this.toElementDescriptor(elementObject);
+              var finisher = _optionalCallableProperty(elementObject, "finisher");
+              var extras = this.toElementDescriptors(elementObject.extras);
+              return {
+                element,
+                finisher,
+                extras
+              };
+            },
+            fromClassDescriptor: function(elements) {
+              var obj = {
+                kind: "class",
+                elements: elements.map(this.fromElementDescriptor, this)
+              };
+              var desc = {
+                value: "Descriptor",
+                configurable: true
+              };
+              Object.defineProperty(obj, Symbol.toStringTag, desc);
+              return obj;
+            },
+            toClassDescriptor: function(obj) {
+              var kind = String(obj.kind);
+              if (kind !== "class") {
+                throw new TypeError(
+                  `A class descriptor's .kind property must be "class", but a decorator created a class descriptor with .kind "` + kind + '"'
+                );
+              }
+              this.disallowProperty(obj, "key", "A class descriptor");
+              this.disallowProperty(obj, "placement", "A class descriptor");
+              this.disallowProperty(obj, "descriptor", "A class descriptor");
+              this.disallowProperty(obj, "initializer", "A class descriptor");
+              this.disallowProperty(obj, "extras", "A class descriptor");
+              var finisher = _optionalCallableProperty(obj, "finisher");
+              var elements = this.toElementDescriptors(obj.elements);
+              return {
+                elements,
+                finisher
+              };
+            },
+            runClassFinishers: function(constructor, finishers) {
+              for (var i = 0; i < finishers.length; i++) {
+                var newConstructor = (0, finishers[i])(constructor);
+                if (newConstructor !== void 0) {
+                  if (typeof newConstructor !== "function") {
+                    throw new TypeError("Finishers must return a constructor.");
+                  }
+                  constructor = newConstructor;
+                }
+              }
+              return constructor;
+            },
+            disallowProperty: function(obj, name2, objectType) {
+              if (obj[name2] !== void 0) {
+                throw new TypeError(objectType + " can't have a ." + name2 + " property.");
+              }
+            }
+          };
+          return api;
+        }
+        function _createElementDescriptor(def) {
+          var key = _toPropertyKey(def.key);
+          var descriptor;
+          if (def.kind === "method") {
+            descriptor = {
+              value: def.value,
+              writable: true,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "get") {
+            descriptor = {
+              get: def.value,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "set") {
+            descriptor = {
+              set: def.value,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "field") {
+            descriptor = {
+              configurable: true,
+              writable: true,
+              enumerable: true
+            };
+          }
+          var element = {
+            kind: def.kind === "field" ? "field" : "method",
+            key,
+            placement: def.static ? "static" : def.kind === "field" ? "own" : "prototype",
+            descriptor
+          };
+          if (def.decorators) element.decorators = def.decorators;
+          if (def.kind === "field") element.initializer = def.value;
+          return element;
+        }
+        function _coalesceGetterSetter(element, other) {
+          if (element.descriptor.get !== void 0) {
+            other.descriptor.get = element.descriptor.get;
+          } else {
+            other.descriptor.set = element.descriptor.set;
+          }
+        }
+        function _coalesceClassElements(elements) {
+          var newElements = [];
+          var isSameElement = function(other2) {
+            return other2.kind === "method" && other2.key === element.key && other2.placement === element.placement;
+          };
+          for (var i = 0; i < elements.length; i++) {
+            var element = elements[i];
+            var other;
+            if (element.kind === "method" && (other = newElements.find(isSameElement))) {
+              if (_isDataDescriptor(element.descriptor) || _isDataDescriptor(other.descriptor)) {
+                if (_hasDecorators(element) || _hasDecorators(other)) {
+                  throw new ReferenceError(
+                    "Duplicated methods (" + element.key + ") can't be decorated."
+                  );
+                }
+                other.descriptor = element.descriptor;
+              } else {
+                if (_hasDecorators(element)) {
+                  if (_hasDecorators(other)) {
+                    throw new ReferenceError(
+                      "Decorators can't be placed on different accessors with for the same property (" + element.key + ")."
+                    );
+                  }
+                  other.decorators = element.decorators;
+                }
+                _coalesceGetterSetter(element, other);
+              }
+            } else {
+              newElements.push(element);
+            }
+          }
+          return newElements;
+        }
+        function _hasDecorators(element) {
+          return element.decorators && element.decorators.length;
+        }
+        function _isDataDescriptor(desc) {
+          return desc !== void 0 && !(desc.value === void 0 && desc.writable === void 0);
+        }
+        function _optionalCallableProperty(obj, name2) {
+          var value = obj[name2];
+          if (value !== void 0 && typeof value !== "function") {
+            throw new TypeError("Expected '" + name2 + "' to be a function");
+          }
+          return value;
+        }
+        function _classPrivateMethodGet(receiver, privateSet, fn2) {
+          if (!privateSet.has(receiver)) {
+            throw new TypeError("attempted to get private field on non-instance");
+          }
+          return fn2;
+        }
+        function _classPrivateMethodSet() {
+          throw new TypeError("attempted to reassign private method");
+        }
+        function _wrapRegExp(re, groups) {
+          _wrapRegExp = function(re2, groups2) {
+            return new BabelRegExp(re2, groups2);
+          };
+          var _RegExp = _wrapNativeSuper(RegExp);
+          var _super = RegExp.prototype;
+          var _groups = /* @__PURE__ */ new WeakMap();
+          function BabelRegExp(re2, groups2) {
+            var _this = _RegExp.call(this, re2);
+            _groups.set(_this, groups2);
+            return _this;
+          }
+          _inherits(BabelRegExp, _RegExp);
+          BabelRegExp.prototype.exec = function(str) {
+            var result = _super.exec.call(this, str);
+            if (result) result.groups = buildGroups(result, this);
+            return result;
+          };
+          BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
+            if (typeof substitution === "string") {
+              var groups2 = _groups.get(this);
+              return _super[Symbol.replace].call(
+                this,
+                str,
+                substitution.replace(/\$<([^>]+)>/g, function(_, name2) {
+                  return "$" + groups2[name2];
+                })
+              );
+            } else if (typeof substitution === "function") {
+              var _this = this;
+              return _super[Symbol.replace].call(this, str, function() {
+                var args = [];
+                args.push.apply(args, arguments);
+                if (typeof args[args.length - 1] !== "object") {
+                  args.push(buildGroups(args, _this));
+                }
+                return substitution.apply(this, args);
+              });
+            } else {
+              return _super[Symbol.replace].call(this, str, substitution);
+            }
+          };
+          function buildGroups(result, re2) {
+            var g = _groups.get(re2);
+            return Object.keys(g).reduce(function(groups2, name2) {
+              groups2[name2] = result[g[name2]];
+              return groups2;
+            }, /* @__PURE__ */ Object.create(null));
+          }
+          return _wrapRegExp.apply(this, arguments);
+        }
+        var arrayRemove = function arrayRemove2(arr, index) {
+          return arr.splice(index, 1);
+        };
+        var run = function run2(cb, sync) {
+          if (sync) {
+            cb();
+          } else if (document.hidden) {
+            Promise.resolve(1).then(cb);
+          } else {
+            setTimeout(cb, 0);
+          }
+        };
+        var on = function on2() {
+          var listeners2 = [];
+          var off = function off2(event, cb) {
+            arrayRemove(
+              listeners2,
+              listeners2.findIndex(function(listener) {
+                return listener.event === event && (listener.cb === cb || !cb);
+              })
+            );
+          };
+          var _fire = function fire(event, args, sync) {
+            listeners2.filter(function(listener) {
+              return listener.event === event;
+            }).map(function(listener) {
+              return listener.cb;
+            }).forEach(function(cb) {
+              return run(function() {
+                return cb.apply(void 0, _toConsumableArray(args));
+              }, sync);
+            });
+          };
+          return {
+            fireSync: function fireSync(event) {
+              for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+                args[_key - 1] = arguments[_key];
+              }
+              _fire(event, args, true);
+            },
+            fire: function fire(event) {
+              for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+                args[_key2 - 1] = arguments[_key2];
+              }
+              _fire(event, args, false);
+            },
+            on: function on3(event, cb) {
+              listeners2.push({ event, cb });
+            },
+            onOnce: function onOnce(event, _cb) {
+              listeners2.push({
+                event,
+                cb: function cb() {
+                  off(event, _cb);
+                  _cb.apply(void 0, arguments);
+                }
+              });
+            },
+            off
+          };
+        };
+        var copyObjectPropertiesToObject = function copyObjectPropertiesToObject2(src, target, excluded) {
+          Object.getOwnPropertyNames(src).filter(function(property) {
+            return !excluded.includes(property);
+          }).forEach(function(key) {
+            return Object.defineProperty(
+              target,
+              key,
+              Object.getOwnPropertyDescriptor(src, key)
+            );
+          });
+        };
+        var PRIVATE = [
+          "fire",
+          "process",
+          "revert",
+          "load",
+          "on",
+          "off",
+          "onOnce",
+          "retryLoad",
+          "extend",
+          "archive",
+          "archived",
+          "release",
+          "released",
+          "requestProcessing",
+          "freeze"
+        ];
+        var createItemAPI = function createItemAPI2(item2) {
+          var api = {};
+          copyObjectPropertiesToObject(item2, api, PRIVATE);
+          return api;
+        };
+        var removeReleasedItems = function removeReleasedItems2(items) {
+          items.forEach(function(item2, index) {
+            if (item2.released) {
+              arrayRemove(items, index);
+            }
+          });
+        };
+        var ItemStatus = {
+          INIT: 1,
+          IDLE: 2,
+          PROCESSING_QUEUED: 9,
+          PROCESSING: 3,
+          PROCESSING_COMPLETE: 5,
+          PROCESSING_ERROR: 6,
+          PROCESSING_REVERT_ERROR: 10,
+          LOADING: 7,
+          LOAD_ERROR: 8
+        };
+        var FileOrigin = {
+          INPUT: 1,
+          LIMBO: 2,
+          LOCAL: 3
+        };
+        var getNonNumeric = function getNonNumeric2(str) {
+          return /[^0-9]+/.exec(str);
+        };
+        var getDecimalSeparator = function getDecimalSeparator2() {
+          return getNonNumeric(1.1.toLocaleString())[0];
+        };
+        var getThousandsSeparator = function getThousandsSeparator2() {
+          var decimalSeparator = getDecimalSeparator();
+          var thousandsStringWithSeparator = 1e3.toLocaleString();
+          var thousandsStringWithoutSeparator = 1e3.toString();
+          if (thousandsStringWithSeparator !== thousandsStringWithoutSeparator) {
+            return getNonNumeric(thousandsStringWithSeparator)[0];
+          }
+          return decimalSeparator === "." ? "," : ".";
+        };
+        var Type = {
+          BOOLEAN: "boolean",
+          INT: "int",
+          NUMBER: "number",
+          STRING: "string",
+          ARRAY: "array",
+          OBJECT: "object",
+          FUNCTION: "function",
+          ACTION: "action",
+          SERVER_API: "serverapi",
+          REGEX: "regex"
+        };
+        var filters = [];
+        var applyFilterChain = function applyFilterChain2(key, value, utils) {
+          return new Promise(function(resolve, reject) {
+            var matchingFilters = filters.filter(function(f) {
+              return f.key === key;
+            }).map(function(f) {
+              return f.cb;
+            });
+            if (matchingFilters.length === 0) {
+              resolve(value);
+              return;
+            }
+            var initialFilter = matchingFilters.shift();
+            matchingFilters.reduce(
+              // loop over promises passing value to next promise
+              function(current, next) {
+                return current.then(function(value2) {
+                  return next(value2, utils);
+                });
+              },
+              // call initial filter, will return a promise
+              initialFilter(value, utils)
+              // all executed
+            ).then(function(value2) {
+              return resolve(value2);
+            }).catch(function(error2) {
+              return reject(error2);
+            });
+          });
+        };
+        var applyFilters = function applyFilters2(key, value, utils) {
+          return filters.filter(function(f) {
+            return f.key === key;
+          }).map(function(f) {
+            return f.cb(value, utils);
+          });
+        };
+        var addFilter = function addFilter2(key, cb) {
+          return filters.push({ key, cb });
+        };
+        var extendDefaultOptions = function extendDefaultOptions2(additionalOptions) {
+          return Object.assign(defaultOptions, additionalOptions);
+        };
+        var getOptions = function getOptions2() {
+          return Object.assign({}, defaultOptions);
+        };
+        var setOptions = function setOptions2(opts) {
+          forin(opts, function(key, value) {
+            if (!defaultOptions[key]) {
+              return;
+            }
+            defaultOptions[key][0] = getValueByType(
+              value,
+              defaultOptions[key][0],
+              defaultOptions[key][1]
+            );
+          });
+        };
+        var defaultOptions = {
+          // the id to add to the root element
+          id: [null, Type.STRING],
+          // input field name to use
+          name: ["filepond", Type.STRING],
+          // disable the field
+          disabled: [false, Type.BOOLEAN],
+          // classname to put on wrapper
+          className: [null, Type.STRING],
+          // is the field required
+          required: [false, Type.BOOLEAN],
+          // Allow media capture when value is set
+          captureMethod: [null, Type.STRING],
+          // - "camera", "microphone" or "camcorder",
+          // - Does not work with multiple on apple devices
+          // - If set, acceptedFileTypes must be made to match with media wildcard "image/*", "audio/*" or "video/*"
+          // sync `acceptedFileTypes` property with `accept` attribute
+          allowSyncAcceptAttribute: [true, Type.BOOLEAN],
+          // Feature toggles
+          allowDrop: [true, Type.BOOLEAN],
+          // Allow dropping of files
+          allowBrowse: [true, Type.BOOLEAN],
+          // Allow browsing the file system
+          allowPaste: [true, Type.BOOLEAN],
+          // Allow pasting files
+          allowMultiple: [false, Type.BOOLEAN],
+          // Allow multiple files (disabled by default, as multiple attribute is also required on input to allow multiple)
+          allowReplace: [true, Type.BOOLEAN],
+          // Allow dropping a file on other file to replace it (only works when multiple is set to false)
+          allowRevert: [true, Type.BOOLEAN],
+          // Allows user to revert file upload
+          allowRemove: [true, Type.BOOLEAN],
+          // Allow user to remove a file
+          allowProcess: [true, Type.BOOLEAN],
+          // Allows user to process a file, when set to false, this removes the file upload button
+          allowReorder: [false, Type.BOOLEAN],
+          // Allow reordering of files
+          allowDirectoriesOnly: [false, Type.BOOLEAN],
+          // Allow only selecting directories with browse (no support for filtering dnd at this point)
+          // Try store file if `server` not set
+          storeAsFile: [false, Type.BOOLEAN],
+          // Revert mode
+          forceRevert: [false, Type.BOOLEAN],
+          // Set to 'force' to require the file to be reverted before removal
+          // Input requirements
+          maxFiles: [null, Type.INT],
+          // Max number of files
+          checkValidity: [false, Type.BOOLEAN],
+          // Enables custom validity messages
+          // Where to put file
+          itemInsertLocationFreedom: [true, Type.BOOLEAN],
+          // Set to false to always add items to begin or end of list
+          itemInsertLocation: ["before", Type.STRING],
+          // Default index in list to add items that have been dropped at the top of the list
+          itemInsertInterval: [75, Type.INT],
+          // Drag 'n Drop related
+          dropOnPage: [false, Type.BOOLEAN],
+          // Allow dropping of files anywhere on page (prevents browser from opening file if dropped outside of Up)
+          dropOnElement: [true, Type.BOOLEAN],
+          // Drop needs to happen on element (set to false to also load drops outside of Up)
+          dropValidation: [false, Type.BOOLEAN],
+          // Enable or disable validating files on drop
+          ignoredFiles: [[".ds_store", "thumbs.db", "desktop.ini"], Type.ARRAY],
+          // Upload related
+          instantUpload: [true, Type.BOOLEAN],
+          // Should upload files immediately on drop
+          maxParallelUploads: [2, Type.INT],
+          // Maximum files to upload in parallel
+          allowMinimumUploadDuration: [true, Type.BOOLEAN],
+          // if true uploads take at least 750 ms, this ensures the user sees the upload progress giving trust the upload actually happened
+          // Chunks
+          chunkUploads: [false, Type.BOOLEAN],
+          // Enable chunked uploads
+          chunkForce: [false, Type.BOOLEAN],
+          // Force use of chunk uploads even for files smaller than chunk size
+          chunkSize: [5e6, Type.INT],
+          // Size of chunks (5MB default)
+          chunkRetryDelays: [[500, 1e3, 3e3], Type.ARRAY],
+          // Amount of times to retry upload of a chunk when it fails
+          // The server api end points to use for uploading (see docs)
+          server: [null, Type.SERVER_API],
+          // File size calculations, can set to 1024, this is only used for display, properties use file size base 1000
+          fileSizeBase: [1e3, Type.INT],
+          // Labels and status messages
+          labelFileSizeBytes: ["bytes", Type.STRING],
+          labelFileSizeKilobytes: ["KB", Type.STRING],
+          labelFileSizeMegabytes: ["MB", Type.STRING],
+          labelFileSizeGigabytes: ["GB", Type.STRING],
+          labelDecimalSeparator: [getDecimalSeparator(), Type.STRING],
+          // Default is locale separator
+          labelThousandsSeparator: [getThousandsSeparator(), Type.STRING],
+          // Default is locale separator
+          labelIdle: [
+            'Drag & Drop your files or <span class="filepond--label-action">Browse</span>',
+            Type.STRING
+          ],
+          labelInvalidField: ["Field contains invalid files", Type.STRING],
+          labelFileWaitingForSize: ["Waiting for size", Type.STRING],
+          labelFileSizeNotAvailable: ["Size not available", Type.STRING],
+          labelFileCountSingular: ["file in list", Type.STRING],
+          labelFileCountPlural: ["files in list", Type.STRING],
+          labelFileLoading: ["Loading", Type.STRING],
+          labelFileAdded: ["Added", Type.STRING],
+          // assistive only
+          labelFileLoadError: ["Error during load", Type.STRING],
+          labelFileRemoved: ["Removed", Type.STRING],
+          // assistive only
+          labelFileRemoveError: ["Error during remove", Type.STRING],
+          labelFileProcessing: ["Uploading", Type.STRING],
+          labelFileProcessingComplete: ["Upload complete", Type.STRING],
+          labelFileProcessingAborted: ["Upload cancelled", Type.STRING],
+          labelFileProcessingError: ["Error during upload", Type.STRING],
+          labelFileProcessingRevertError: ["Error during revert", Type.STRING],
+          labelTapToCancel: ["tap to cancel", Type.STRING],
+          labelTapToRetry: ["tap to retry", Type.STRING],
+          labelTapToUndo: ["tap to undo", Type.STRING],
+          labelButtonRemoveItem: ["Remove", Type.STRING],
+          labelButtonAbortItemLoad: ["Abort", Type.STRING],
+          labelButtonRetryItemLoad: ["Retry", Type.STRING],
+          labelButtonAbortItemProcessing: ["Cancel", Type.STRING],
+          labelButtonUndoItemProcessing: ["Undo", Type.STRING],
+          labelButtonRetryItemProcessing: ["Retry", Type.STRING],
+          labelButtonProcessItem: ["Upload", Type.STRING],
+          // make sure width and height plus viewpox are even numbers so icons are nicely centered
+          iconRemove: [
+            '<svg width="26" height="26" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg"><path d="M11.586 13l-2.293 2.293a1 1 0 0 0 1.414 1.414L13 14.414l2.293 2.293a1 1 0 0 0 1.414-1.414L14.414 13l2.293-2.293a1 1 0 0 0-1.414-1.414L13 11.586l-2.293-2.293a1 1 0 0 0-1.414 1.414L11.586 13z" fill="currentColor" fill-rule="nonzero"/></svg>',
+            Type.STRING
+          ],
+          iconProcess: [
+            '<svg width="26" height="26" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg"><path d="M14 10.414v3.585a1 1 0 0 1-2 0v-3.585l-1.293 1.293a1 1 0 0 1-1.414-1.415l3-3a1 1 0 0 1 1.414 0l3 3a1 1 0 0 1-1.414 1.415L14 10.414zM9 18a1 1 0 0 1 0-2h8a1 1 0 0 1 0 2H9z" fill="currentColor" fill-rule="evenodd"/></svg>',
+            Type.STRING
+          ],
+          iconRetry: [
+            '<svg width="26" height="26" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg"><path d="M10.81 9.185l-.038.02A4.997 4.997 0 0 0 8 13.683a5 5 0 0 0 5 5 5 5 0 0 0 5-5 1 1 0 0 1 2 0A7 7 0 1 1 9.722 7.496l-.842-.21a.999.999 0 1 1 .484-1.94l3.23.806c.535.133.86.675.73 1.21l-.804 3.233a.997.997 0 0 1-1.21.73.997.997 0 0 1-.73-1.21l.23-.928v-.002z" fill="currentColor" fill-rule="nonzero"/></svg>',
+            Type.STRING
+          ],
+          iconUndo: [
+            '<svg width="26" height="26" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg"><path d="M9.185 10.81l.02-.038A4.997 4.997 0 0 1 13.683 8a5 5 0 0 1 5 5 5 5 0 0 1-5 5 1 1 0 0 0 0 2A7 7 0 1 0 7.496 9.722l-.21-.842a.999.999 0 1 0-1.94.484l.806 3.23c.133.535.675.86 1.21.73l3.233-.803a.997.997 0 0 0 .73-1.21.997.997 0 0 0-1.21-.73l-.928.23-.002-.001z" fill="currentColor" fill-rule="nonzero"/></svg>',
+            Type.STRING
+          ],
+          iconDone: [
+            '<svg width="26" height="26" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg"><path d="M18.293 9.293a1 1 0 0 1 1.414 1.414l-7.002 7a1 1 0 0 1-1.414 0l-3.998-4a1 1 0 1 1 1.414-1.414L12 15.586l6.294-6.293z" fill="currentColor" fill-rule="nonzero"/></svg>',
+            Type.STRING
+          ],
+          // event handlers
+          oninit: [null, Type.FUNCTION],
+          onwarning: [null, Type.FUNCTION],
+          onerror: [null, Type.FUNCTION],
+          onactivatefile: [null, Type.FUNCTION],
+          oninitfile: [null, Type.FUNCTION],
+          onaddfilestart: [null, Type.FUNCTION],
+          onaddfileprogress: [null, Type.FUNCTION],
+          onaddfile: [null, Type.FUNCTION],
+          onprocessfilestart: [null, Type.FUNCTION],
+          onprocessfileprogress: [null, Type.FUNCTION],
+          onprocessfileabort: [null, Type.FUNCTION],
+          onprocessfilerevert: [null, Type.FUNCTION],
+          onprocessfile: [null, Type.FUNCTION],
+          onprocessfiles: [null, Type.FUNCTION],
+          onremovefile: [null, Type.FUNCTION],
+          onpreparefile: [null, Type.FUNCTION],
+          onupdatefiles: [null, Type.FUNCTION],
+          onreorderfiles: [null, Type.FUNCTION],
+          // hooks
+          beforeDropFile: [null, Type.FUNCTION],
+          beforeAddFile: [null, Type.FUNCTION],
+          beforeRemoveFile: [null, Type.FUNCTION],
+          beforePrepareFile: [null, Type.FUNCTION],
+          // styles
+          stylePanelLayout: [null, Type.STRING],
+          // null 'integrated', 'compact', 'circle'
+          stylePanelAspectRatio: [null, Type.STRING],
+          // null or '3:2' or 1
+          styleItemPanelAspectRatio: [null, Type.STRING],
+          styleButtonRemoveItemPosition: ["left", Type.STRING],
+          styleButtonProcessItemPosition: ["right", Type.STRING],
+          styleLoadIndicatorPosition: ["right", Type.STRING],
+          styleProgressIndicatorPosition: ["right", Type.STRING],
+          styleButtonRemoveItemAlign: [false, Type.BOOLEAN],
+          // custom initial files array
+          files: [[], Type.ARRAY],
+          // show support by displaying credits
+          credits: [["https://filepond.com", "Powered by FilePond"], Type.ARRAY]
+        };
+        var getItemByQuery = function getItemByQuery2(items, query) {
+          if (isEmpty(query)) {
+            return items[0] || null;
+          }
+          if (isInt(query)) {
+            return items[query] || null;
+          }
+          if (typeof query === "object") {
+            query = query.id;
+          }
+          return items.find(function(item2) {
+            return item2.id === query;
+          }) || null;
+        };
+        var getNumericAspectRatioFromString = function getNumericAspectRatioFromString2(aspectRatio) {
+          if (isEmpty(aspectRatio)) {
+            return aspectRatio;
+          }
+          if (/:/.test(aspectRatio)) {
+            var parts = aspectRatio.split(":");
+            return parts[1] / parts[0];
+          }
+          return parseFloat(aspectRatio);
+        };
+        var getActiveItems = function getActiveItems2(items) {
+          return items.filter(function(item2) {
+            return !item2.archived;
+          });
+        };
+        var Status = {
+          EMPTY: 0,
+          IDLE: 1,
+          // waiting
+          ERROR: 2,
+          // a file is in error state
+          BUSY: 3,
+          // busy processing or loading
+          READY: 4
+          // all files uploaded
+        };
+        var res = null;
+        var canUpdateFileInput = function canUpdateFileInput2() {
+          if (res === null) {
+            try {
+              var dataTransfer = new DataTransfer();
+              dataTransfer.items.add(new File(["hello world"], "This_Works.txt"));
+              var el = document.createElement("input");
+              el.setAttribute("type", "file");
+              el.files = dataTransfer.files;
+              res = el.files.length === 1;
+            } catch (err) {
+              res = false;
+            }
+          }
+          return res;
+        };
+        var ITEM_ERROR = [
+          ItemStatus.LOAD_ERROR,
+          ItemStatus.PROCESSING_ERROR,
+          ItemStatus.PROCESSING_REVERT_ERROR
+        ];
+        var ITEM_BUSY = [
+          ItemStatus.LOADING,
+          ItemStatus.PROCESSING,
+          ItemStatus.PROCESSING_QUEUED,
+          ItemStatus.INIT
+        ];
+        var ITEM_READY = [ItemStatus.PROCESSING_COMPLETE];
+        var isItemInErrorState = function isItemInErrorState2(item2) {
+          return ITEM_ERROR.includes(item2.status);
+        };
+        var isItemInBusyState = function isItemInBusyState2(item2) {
+          return ITEM_BUSY.includes(item2.status);
+        };
+        var isItemInReadyState = function isItemInReadyState2(item2) {
+          return ITEM_READY.includes(item2.status);
+        };
+        var isAsync = function isAsync2(state2) {
+          return isObject4(state2.options.server) && (isObject4(state2.options.server.process) || isFunction(state2.options.server.process));
+        };
+        var queries = function queries2(state2) {
+          return {
+            GET_STATUS: function GET_STATUS() {
+              var items = getActiveItems(state2.items);
+              var EMPTY = Status.EMPTY, ERROR = Status.ERROR, BUSY = Status.BUSY, IDLE = Status.IDLE, READY = Status.READY;
+              if (items.length === 0) return EMPTY;
+              if (items.some(isItemInErrorState)) return ERROR;
+              if (items.some(isItemInBusyState)) return BUSY;
+              if (items.some(isItemInReadyState)) return READY;
+              return IDLE;
+            },
+            GET_ITEM: function GET_ITEM(query) {
+              return getItemByQuery(state2.items, query);
+            },
+            GET_ACTIVE_ITEM: function GET_ACTIVE_ITEM(query) {
+              return getItemByQuery(getActiveItems(state2.items), query);
+            },
+            GET_ACTIVE_ITEMS: function GET_ACTIVE_ITEMS() {
+              return getActiveItems(state2.items);
+            },
+            GET_ITEMS: function GET_ITEMS() {
+              return state2.items;
+            },
+            GET_ITEM_NAME: function GET_ITEM_NAME(query) {
+              var item2 = getItemByQuery(state2.items, query);
+              return item2 ? item2.filename : null;
+            },
+            GET_ITEM_SIZE: function GET_ITEM_SIZE(query) {
+              var item2 = getItemByQuery(state2.items, query);
+              return item2 ? item2.fileSize : null;
+            },
+            GET_STYLES: function GET_STYLES() {
+              return Object.keys(state2.options).filter(function(key) {
+                return /^style/.test(key);
+              }).map(function(option2) {
+                return {
+                  name: option2,
+                  value: state2.options[option2]
+                };
+              });
+            },
+            GET_PANEL_ASPECT_RATIO: function GET_PANEL_ASPECT_RATIO() {
+              var isShapeCircle = /circle/.test(state2.options.stylePanelLayout);
+              var aspectRatio = isShapeCircle ? 1 : getNumericAspectRatioFromString(state2.options.stylePanelAspectRatio);
+              return aspectRatio;
+            },
+            GET_ITEM_PANEL_ASPECT_RATIO: function GET_ITEM_PANEL_ASPECT_RATIO() {
+              return state2.options.styleItemPanelAspectRatio;
+            },
+            GET_ITEMS_BY_STATUS: function GET_ITEMS_BY_STATUS(status) {
+              return getActiveItems(state2.items).filter(function(item2) {
+                return item2.status === status;
+              });
+            },
+            GET_TOTAL_ITEMS: function GET_TOTAL_ITEMS() {
+              return getActiveItems(state2.items).length;
+            },
+            SHOULD_UPDATE_FILE_INPUT: function SHOULD_UPDATE_FILE_INPUT() {
+              return state2.options.storeAsFile && canUpdateFileInput() && !isAsync(state2);
+            },
+            IS_ASYNC: function IS_ASYNC() {
+              return isAsync(state2);
+            },
+            GET_FILE_SIZE_LABELS: function GET_FILE_SIZE_LABELS(query) {
+              return {
+                labelBytes: query("GET_LABEL_FILE_SIZE_BYTES") || void 0,
+                labelKilobytes: query("GET_LABEL_FILE_SIZE_KILOBYTES") || void 0,
+                labelMegabytes: query("GET_LABEL_FILE_SIZE_MEGABYTES") || void 0,
+                labelGigabytes: query("GET_LABEL_FILE_SIZE_GIGABYTES") || void 0
+              };
+            }
+          };
+        };
+        var hasRoomForItem = function hasRoomForItem2(state2) {
+          var count = getActiveItems(state2.items).length;
+          if (!state2.options.allowMultiple) {
+            return count === 0;
+          }
+          var maxFileCount = state2.options.maxFiles;
+          if (maxFileCount === null) {
+            return true;
+          }
+          if (count < maxFileCount) {
+            return true;
+          }
+          return false;
+        };
+        var limit = function limit2(value, min, max) {
+          return Math.max(Math.min(max, value), min);
+        };
+        var arrayInsert = function arrayInsert2(arr, index, item2) {
+          return arr.splice(index, 0, item2);
+        };
+        var insertItem = function insertItem2(items, item2, index) {
+          if (isEmpty(item2)) {
+            return null;
+          }
+          if (typeof index === "undefined") {
+            items.push(item2);
+            return item2;
+          }
+          index = limit(index, 0, items.length);
+          arrayInsert(items, index, item2);
+          return item2;
+        };
+        var isBase64DataURI = function isBase64DataURI2(str) {
+          return /^\s*data:([a-z]+\/[a-z0-9-+.]+(;[a-z-]+=[a-z0-9-]+)?)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*)\s*$/i.test(
+            str
+          );
+        };
+        var getFilenameFromURL = function getFilenameFromURL2(url) {
+          return ("" + url).split("/").pop().split("?").shift();
+        };
+        var getExtensionFromFilename = function getExtensionFromFilename2(name2) {
+          return name2.split(".").pop();
+        };
+        var guesstimateExtension = function guesstimateExtension2(type) {
+          if (typeof type !== "string") {
+            return "";
+          }
+          var subtype = type.split("/").pop();
+          if (/svg/.test(subtype)) {
+            return "svg";
+          }
+          if (/zip|compressed/.test(subtype)) {
+            return "zip";
+          }
+          if (/plain/.test(subtype)) {
+            return "txt";
+          }
+          if (/msword/.test(subtype)) {
+            return "doc";
+          }
+          if (/[a-z]+/.test(subtype)) {
+            if (subtype === "jpeg") {
+              return "jpg";
+            }
+            return subtype;
+          }
+          return "";
+        };
+        var leftPad = function leftPad2(value) {
+          var padding = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "";
+          return (padding + value).slice(-padding.length);
+        };
+        var getDateString = function getDateString2() {
+          var date = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : /* @__PURE__ */ new Date();
+          return date.getFullYear() + "-" + leftPad(date.getMonth() + 1, "00") + "-" + leftPad(date.getDate(), "00") + "_" + leftPad(date.getHours(), "00") + "-" + leftPad(date.getMinutes(), "00") + "-" + leftPad(date.getSeconds(), "00");
+        };
+        var getFileFromBlob = function getFileFromBlob2(blob2, filename) {
+          var type = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : null;
+          var extension = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : null;
+          var file2 = typeof type === "string" ? blob2.slice(0, blob2.size, type) : blob2.slice(0, blob2.size, blob2.type);
+          file2.lastModifiedDate = /* @__PURE__ */ new Date();
+          if (blob2._relativePath) file2._relativePath = blob2._relativePath;
+          if (!isString(filename)) {
+            filename = getDateString();
+          }
+          if (filename && extension === null && getExtensionFromFilename(filename)) {
+            file2.name = filename;
+          } else {
+            extension = extension || guesstimateExtension(file2.type);
+            file2.name = filename + (extension ? "." + extension : "");
+          }
+          return file2;
+        };
+        var getBlobBuilder = function getBlobBuilder2() {
+          return window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder || window.MSBlobBuilder;
+        };
+        var createBlob = function createBlob2(arrayBuffer, mimeType) {
+          var BB = getBlobBuilder();
+          if (BB) {
+            var bb = new BB();
+            bb.append(arrayBuffer);
+            return bb.getBlob(mimeType);
+          }
+          return new Blob([arrayBuffer], {
+            type: mimeType
+          });
+        };
+        var getBlobFromByteStringWithMimeType = function getBlobFromByteStringWithMimeType2(byteString, mimeType) {
+          var ab = new ArrayBuffer(byteString.length);
+          var ia = new Uint8Array(ab);
+          for (var i = 0; i < byteString.length; i++) {
+            ia[i] = byteString.charCodeAt(i);
+          }
+          return createBlob(ab, mimeType);
+        };
+        var getMimeTypeFromBase64DataURI = function getMimeTypeFromBase64DataURI2(dataURI) {
+          return (/^data:(.+);/.exec(dataURI) || [])[1] || null;
+        };
+        var getBase64DataFromBase64DataURI = function getBase64DataFromBase64DataURI2(dataURI) {
+          var data3 = dataURI.split(",")[1];
+          return data3.replace(/\s/g, "");
+        };
+        var getByteStringFromBase64DataURI = function getByteStringFromBase64DataURI2(dataURI) {
+          return atob(getBase64DataFromBase64DataURI(dataURI));
+        };
+        var getBlobFromBase64DataURI = function getBlobFromBase64DataURI2(dataURI) {
+          var mimeType = getMimeTypeFromBase64DataURI(dataURI);
+          var byteString = getByteStringFromBase64DataURI(dataURI);
+          return getBlobFromByteStringWithMimeType(byteString, mimeType);
+        };
+        var getFileFromBase64DataURI = function getFileFromBase64DataURI2(dataURI, filename, extension) {
+          return getFileFromBlob(getBlobFromBase64DataURI(dataURI), filename, null, extension);
+        };
+        var getFileNameFromHeader = function getFileNameFromHeader2(header) {
+          if (!/^content-disposition:/i.test(header)) return null;
+          var matches = header.split(/filename=|filename\*=.+''/).splice(1).map(function(name2) {
+            return name2.trim().replace(/^["']|[;"']{0,2}$/g, "");
+          }).filter(function(name2) {
+            return name2.length;
+          });
+          return matches.length ? decodeURI(matches[matches.length - 1]) : null;
+        };
+        var getFileSizeFromHeader = function getFileSizeFromHeader2(header) {
+          if (/content-length:/i.test(header)) {
+            var size = header.match(/[0-9]+/)[0];
+            return size ? parseInt(size, 10) : null;
+          }
+          return null;
+        };
+        var getTranfserIdFromHeader = function getTranfserIdFromHeader2(header) {
+          if (/x-content-transfer-id:/i.test(header)) {
+            var id2 = (header.split(":")[1] || "").trim();
+            return id2 || null;
+          }
+          return null;
+        };
+        var getFileInfoFromHeaders = function getFileInfoFromHeaders2(headers) {
+          var info = {
+            source: null,
+            name: null,
+            size: null
+          };
+          var rows = headers.split("\n");
+          var _iteratorNormalCompletion = true;
+          var _didIteratorError = false;
+          var _iteratorError = void 0;
+          try {
+            for (var _iterator = rows[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+              var header = _step.value;
+              var name2 = getFileNameFromHeader(header);
+              if (name2) {
+                info.name = name2;
+                continue;
+              }
+              var size = getFileSizeFromHeader(header);
+              if (size) {
+                info.size = size;
+                continue;
+              }
+              var source = getTranfserIdFromHeader(header);
+              if (source) {
+                info.source = source;
+                continue;
+              }
+            }
+          } catch (err) {
+            _didIteratorError = true;
+            _iteratorError = err;
+          } finally {
+            try {
+              if (!_iteratorNormalCompletion && _iterator.return != null) {
+                _iterator.return();
+              }
+            } finally {
+              if (_didIteratorError) {
+                throw _iteratorError;
+              }
+            }
+          }
+          return info;
+        };
+        var createFileLoader = function createFileLoader2(fetchFn) {
+          var state2 = {
+            source: null,
+            complete: false,
+            progress: 0,
+            size: null,
+            timestamp: null,
+            duration: 0,
+            request: null
+          };
+          var getProgress = function getProgress2() {
+            return state2.progress;
+          };
+          var abort = function abort2() {
+            if (state2.request && state2.request.abort) {
+              state2.request.abort();
+            }
+          };
+          var load = function load2() {
+            var source = state2.source;
+            api.fire("init", source);
+            if (source instanceof File) {
+              api.fire("load", source);
+            } else if (source instanceof Blob) {
+              api.fire("load", getFileFromBlob(source, source.name));
+            } else if (isBase64DataURI(source)) {
+              api.fire("load", getFileFromBase64DataURI(source));
+            } else {
+              loadURL(source);
+            }
+          };
+          var loadURL = function loadURL2(url) {
+            if (!fetchFn) {
+              api.fire("error", {
+                type: "error",
+                body: "Can't load URL",
+                code: 400
+              });
+              return;
+            }
+            state2.timestamp = Date.now();
+            state2.request = fetchFn(
+              url,
+              function(response) {
+                state2.duration = Date.now() - state2.timestamp;
+                state2.complete = true;
+                if (response instanceof Blob) {
+                  response = getFileFromBlob(
+                    response,
+                    response.name || getFilenameFromURL(url)
+                  );
+                }
+                api.fire(
+                  "load",
+                  // if has received blob, we go with blob, if no response, we return null
+                  response instanceof Blob ? response : response ? response.body : null
+                );
+              },
+              function(error2) {
+                api.fire(
+                  "error",
+                  typeof error2 === "string" ? {
+                    type: "error",
+                    code: 0,
+                    body: error2
+                  } : error2
+                );
+              },
+              function(computable, current, total) {
+                if (total) {
+                  state2.size = total;
+                }
+                state2.duration = Date.now() - state2.timestamp;
+                if (!computable) {
+                  state2.progress = null;
+                  return;
+                }
+                state2.progress = current / total;
+                api.fire("progress", state2.progress);
+              },
+              function() {
+                api.fire("abort");
+              },
+              function(response) {
+                var fileinfo = getFileInfoFromHeaders(
+                  typeof response === "string" ? response : response.headers
+                );
+                api.fire("meta", {
+                  size: state2.size || fileinfo.size,
+                  filename: fileinfo.name,
+                  source: fileinfo.source
+                });
+              }
+            );
+          };
+          var api = Object.assign({}, on(), {
+            setSource: function setSource(source) {
+              return state2.source = source;
+            },
+            getProgress,
+            // file load progress
+            abort,
+            // abort file load
+            load
+            // start load
+          });
+          return api;
+        };
+        var isGet = function isGet2(method) {
+          return /GET|HEAD/.test(method);
+        };
+        var sendRequest = function sendRequest2(data3, url, options) {
+          var api = {
+            onheaders: function onheaders() {
+            },
+            onprogress: function onprogress() {
+            },
+            onload: function onload() {
+            },
+            ontimeout: function ontimeout() {
+            },
+            onerror: function onerror() {
+            },
+            onabort: function onabort() {
+            },
+            abort: function abort() {
+              aborted = true;
+              xhr.abort();
+            }
+          };
+          var aborted = false;
+          var headersReceived = false;
+          options = Object.assign(
+            {
+              method: "POST",
+              headers: {},
+              withCredentials: false
+            },
+            options
+          );
+          url = encodeURI(url);
+          if (isGet(options.method) && data3) {
+            url = "" + url + encodeURIComponent(typeof data3 === "string" ? data3 : JSON.stringify(data3));
+          }
+          var xhr = new XMLHttpRequest();
+          var process2 = isGet(options.method) ? xhr : xhr.upload;
+          process2.onprogress = function(e) {
+            if (aborted) {
+              return;
+            }
+            api.onprogress(e.lengthComputable, e.loaded, e.total);
+          };
+          xhr.onreadystatechange = function() {
+            if (xhr.readyState < 2) {
+              return;
+            }
+            if (xhr.readyState === 4 && xhr.status === 0) {
+              return;
+            }
+            if (headersReceived) {
+              return;
+            }
+            headersReceived = true;
+            api.onheaders(xhr);
+          };
+          xhr.onload = function() {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              api.onload(xhr);
+            } else {
+              api.onerror(xhr);
+            }
+          };
+          xhr.onerror = function() {
+            return api.onerror(xhr);
+          };
+          xhr.onabort = function() {
+            aborted = true;
+            api.onabort();
+          };
+          xhr.ontimeout = function() {
+            return api.ontimeout(xhr);
+          };
+          xhr.open(options.method, url, true);
+          if (isInt(options.timeout)) {
+            xhr.timeout = options.timeout;
+          }
+          Object.keys(options.headers).forEach(function(key) {
+            var value = unescape(encodeURIComponent(options.headers[key]));
+            xhr.setRequestHeader(key, value);
+          });
+          if (options.responseType) {
+            xhr.responseType = options.responseType;
+          }
+          if (options.withCredentials) {
+            xhr.withCredentials = true;
+          }
+          xhr.send(data3);
+          return api;
+        };
+        var createResponse = function createResponse2(type, code, body, headers) {
+          return {
+            type,
+            code,
+            body,
+            headers
+          };
+        };
+        var createTimeoutResponse = function createTimeoutResponse2(cb) {
+          return function(xhr) {
+            cb(createResponse("error", 0, "Timeout", xhr.getAllResponseHeaders()));
+          };
+        };
+        var hasQS = function hasQS2(str) {
+          return /\?/.test(str);
+        };
+        var buildURL = function buildURL2() {
+          var url = "";
+          for (var _len = arguments.length, parts = new Array(_len), _key = 0; _key < _len; _key++) {
+            parts[_key] = arguments[_key];
+          }
+          parts.forEach(function(part) {
+            url += hasQS(url) && hasQS(part) ? part.replace(/\?/, "&") : part;
+          });
+          return url;
+        };
+        var createFetchFunction = function createFetchFunction2() {
+          var apiUrl = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "";
+          var action = arguments.length > 1 ? arguments[1] : void 0;
+          if (typeof action === "function") {
+            return action;
+          }
+          if (!action || !isString(action.url)) {
+            return null;
+          }
+          var onload = action.onload || function(res2) {
+            return res2;
+          };
+          var onerror = action.onerror || function(res2) {
+            return null;
+          };
+          return function(url, load, error2, progress, abort, headers) {
+            var request = sendRequest(
+              url,
+              buildURL(apiUrl, action.url),
+              Object.assign({}, action, {
+                responseType: "blob"
+              })
+            );
+            request.onload = function(xhr) {
+              var headers2 = xhr.getAllResponseHeaders();
+              var filename = getFileInfoFromHeaders(headers2).name || getFilenameFromURL(url);
+              load(
+                createResponse(
+                  "load",
+                  xhr.status,
+                  action.method === "HEAD" ? null : getFileFromBlob(onload(xhr.response), filename),
+                  headers2
+                )
+              );
+            };
+            request.onerror = function(xhr) {
+              error2(
+                createResponse(
+                  "error",
+                  xhr.status,
+                  onerror(xhr.response) || xhr.statusText,
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.onheaders = function(xhr) {
+              headers(createResponse("headers", xhr.status, null, xhr.getAllResponseHeaders()));
+            };
+            request.ontimeout = createTimeoutResponse(error2);
+            request.onprogress = progress;
+            request.onabort = abort;
+            return request;
+          };
+        };
+        var ChunkStatus = {
+          QUEUED: 0,
+          COMPLETE: 1,
+          PROCESSING: 2,
+          ERROR: 3,
+          WAITING: 4
+        };
+        var processFileChunked = function processFileChunked2(apiUrl, action, name2, file2, metadata, load, error2, progress, abort, transfer, options) {
+          var chunks = [];
+          var chunkTransferId = options.chunkTransferId, chunkServer = options.chunkServer, chunkSize = options.chunkSize, chunkRetryDelays = options.chunkRetryDelays;
+          var state2 = {
+            serverId: chunkTransferId,
+            aborted: false
+          };
+          var ondata = action.ondata || function(fd) {
+            return fd;
+          };
+          var onload = action.onload || function(xhr, method) {
+            return method === "HEAD" ? xhr.getResponseHeader("Upload-Offset") : xhr.response;
+          };
+          var onerror = action.onerror || function(res2) {
+            return null;
+          };
+          var requestTransferId = function requestTransferId2(cb) {
+            var formData = new FormData();
+            if (isObject4(metadata)) formData.append(name2, JSON.stringify(metadata));
+            var headers = typeof action.headers === "function" ? action.headers(file2, metadata) : Object.assign(
+              {},
+              action.headers,
+              {
+                "Upload-Length": file2.size
+              }
+            );
+            var requestParams = Object.assign({}, action, {
+              headers
+            });
+            var request = sendRequest(
+              ondata(formData),
+              buildURL(apiUrl, action.url),
+              requestParams
+            );
+            request.onload = function(xhr) {
+              return cb(onload(xhr, requestParams.method));
+            };
+            request.onerror = function(xhr) {
+              return error2(
+                createResponse(
+                  "error",
+                  xhr.status,
+                  onerror(xhr.response) || xhr.statusText,
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.ontimeout = createTimeoutResponse(error2);
+          };
+          var requestTransferOffset = function requestTransferOffset2(cb) {
+            var requestUrl = buildURL(apiUrl, chunkServer.url, state2.serverId);
+            var headers = typeof action.headers === "function" ? action.headers(state2.serverId) : Object.assign(
+              {},
+              action.headers
+            );
+            var requestParams = {
+              headers,
+              method: "HEAD"
+            };
+            var request = sendRequest(null, requestUrl, requestParams);
+            request.onload = function(xhr) {
+              return cb(onload(xhr, requestParams.method));
+            };
+            request.onerror = function(xhr) {
+              return error2(
+                createResponse(
+                  "error",
+                  xhr.status,
+                  onerror(xhr.response) || xhr.statusText,
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.ontimeout = createTimeoutResponse(error2);
+          };
+          var lastChunkIndex = Math.floor(file2.size / chunkSize);
+          for (var i = 0; i <= lastChunkIndex; i++) {
+            var offset = i * chunkSize;
+            var data3 = file2.slice(offset, offset + chunkSize, "application/offset+octet-stream");
+            chunks[i] = {
+              index: i,
+              size: data3.size,
+              offset,
+              data: data3,
+              file: file2,
+              progress: 0,
+              retries: _toConsumableArray(chunkRetryDelays),
+              status: ChunkStatus.QUEUED,
+              error: null,
+              request: null,
+              timeout: null
+            };
+          }
+          var completeProcessingChunks = function completeProcessingChunks2() {
+            return load(state2.serverId);
+          };
+          var canProcessChunk = function canProcessChunk2(chunk) {
+            return chunk.status === ChunkStatus.QUEUED || chunk.status === ChunkStatus.ERROR;
+          };
+          var processChunk = function processChunk2(chunk) {
+            if (state2.aborted) return;
+            chunk = chunk || chunks.find(canProcessChunk);
+            if (!chunk) {
+              if (chunks.every(function(chunk2) {
+                return chunk2.status === ChunkStatus.COMPLETE;
+              })) {
+                completeProcessingChunks();
+              }
+              return;
+            }
+            chunk.status = ChunkStatus.PROCESSING;
+            chunk.progress = null;
+            var ondata2 = chunkServer.ondata || function(fd) {
+              return fd;
+            };
+            var onerror2 = chunkServer.onerror || function(res2) {
+              return null;
+            };
+            var onload2 = chunkServer.onload || function() {
+            };
+            var requestUrl = buildURL(apiUrl, chunkServer.url, state2.serverId);
+            var headers = typeof chunkServer.headers === "function" ? chunkServer.headers(chunk) : Object.assign(
+              {},
+              chunkServer.headers,
+              {
+                "Content-Type": "application/offset+octet-stream",
+                "Upload-Offset": chunk.offset,
+                "Upload-Length": file2.size,
+                "Upload-Name": file2.name
+              }
+            );
+            var request = chunk.request = sendRequest(
+              ondata2(chunk.data),
+              requestUrl,
+              Object.assign({}, chunkServer, {
+                headers
+              })
+            );
+            request.onload = function(xhr) {
+              onload2(xhr, chunk.index, chunks.length);
+              chunk.status = ChunkStatus.COMPLETE;
+              chunk.request = null;
+              processChunks();
+            };
+            request.onprogress = function(lengthComputable, loaded, total) {
+              chunk.progress = lengthComputable ? loaded : null;
+              updateTotalProgress();
+            };
+            request.onerror = function(xhr) {
+              chunk.status = ChunkStatus.ERROR;
+              chunk.request = null;
+              chunk.error = onerror2(xhr.response) || xhr.statusText;
+              if (!retryProcessChunk(chunk)) {
+                error2(
+                  createResponse(
+                    "error",
+                    xhr.status,
+                    onerror2(xhr.response) || xhr.statusText,
+                    xhr.getAllResponseHeaders()
+                  )
+                );
+              }
+            };
+            request.ontimeout = function(xhr) {
+              chunk.status = ChunkStatus.ERROR;
+              chunk.request = null;
+              if (!retryProcessChunk(chunk)) {
+                createTimeoutResponse(error2)(xhr);
+              }
+            };
+            request.onabort = function() {
+              chunk.status = ChunkStatus.QUEUED;
+              chunk.request = null;
+              abort();
+            };
+          };
+          var retryProcessChunk = function retryProcessChunk2(chunk) {
+            if (chunk.retries.length === 0) return false;
+            chunk.status = ChunkStatus.WAITING;
+            clearTimeout(chunk.timeout);
+            chunk.timeout = setTimeout(function() {
+              processChunk(chunk);
+            }, chunk.retries.shift());
+            return true;
+          };
+          var updateTotalProgress = function updateTotalProgress2() {
+            var totalBytesTransfered = chunks.reduce(function(p, chunk) {
+              if (p === null || chunk.progress === null) return null;
+              return p + chunk.progress;
+            }, 0);
+            if (totalBytesTransfered === null) return progress(false, 0, 0);
+            var totalSize = chunks.reduce(function(total, chunk) {
+              return total + chunk.size;
+            }, 0);
+            progress(true, totalBytesTransfered, totalSize);
+          };
+          var processChunks = function processChunks2() {
+            var totalProcessing = chunks.filter(function(chunk) {
+              return chunk.status === ChunkStatus.PROCESSING;
+            }).length;
+            if (totalProcessing >= 1) return;
+            processChunk();
+          };
+          var abortChunks = function abortChunks2() {
+            chunks.forEach(function(chunk) {
+              clearTimeout(chunk.timeout);
+              if (chunk.request) {
+                chunk.request.abort();
+              }
+            });
+          };
+          if (!state2.serverId) {
+            requestTransferId(function(serverId) {
+              if (state2.aborted) return;
+              transfer(serverId);
+              state2.serverId = serverId;
+              processChunks();
+            });
+          } else {
+            requestTransferOffset(function(offset2) {
+              if (state2.aborted) return;
+              chunks.filter(function(chunk) {
+                return chunk.offset < offset2;
+              }).forEach(function(chunk) {
+                chunk.status = ChunkStatus.COMPLETE;
+                chunk.progress = chunk.size;
+              });
+              processChunks();
+            });
+          }
+          return {
+            abort: function abort2() {
+              state2.aborted = true;
+              abortChunks();
+            }
+          };
+        };
+        var createFileProcessorFunction = function createFileProcessorFunction2(apiUrl, action, name2, options) {
+          return function(file2, metadata, load, error2, progress, abort, transfer) {
+            if (!file2) return;
+            var canChunkUpload = options.chunkUploads;
+            var shouldChunkUpload = canChunkUpload && file2.size > options.chunkSize;
+            var willChunkUpload = canChunkUpload && (shouldChunkUpload || options.chunkForce);
+            if (file2 instanceof Blob && willChunkUpload)
+              return processFileChunked(
+                apiUrl,
+                action,
+                name2,
+                file2,
+                metadata,
+                load,
+                error2,
+                progress,
+                abort,
+                transfer,
+                options
+              );
+            var ondata = action.ondata || function(fd) {
+              return fd;
+            };
+            var onload = action.onload || function(res2) {
+              return res2;
+            };
+            var onerror = action.onerror || function(res2) {
+              return null;
+            };
+            var headers = typeof action.headers === "function" ? action.headers(file2, metadata) || {} : Object.assign(
+              {},
+              action.headers
+            );
+            var requestParams = Object.assign({}, action, {
+              headers
+            });
+            var formData = new FormData();
+            if (isObject4(metadata)) {
+              formData.append(name2, JSON.stringify(metadata));
+            }
+            (file2 instanceof Blob ? [{ name: null, file: file2 }] : file2).forEach(function(item2) {
+              formData.append(
+                name2,
+                item2.file,
+                item2.name === null ? item2.file.name : "" + item2.name + item2.file.name
+              );
+            });
+            var request = sendRequest(
+              ondata(formData),
+              buildURL(apiUrl, action.url),
+              requestParams
+            );
+            request.onload = function(xhr) {
+              load(
+                createResponse(
+                  "load",
+                  xhr.status,
+                  onload(xhr.response),
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.onerror = function(xhr) {
+              error2(
+                createResponse(
+                  "error",
+                  xhr.status,
+                  onerror(xhr.response) || xhr.statusText,
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.ontimeout = createTimeoutResponse(error2);
+            request.onprogress = progress;
+            request.onabort = abort;
+            return request;
+          };
+        };
+        var createProcessorFunction = function createProcessorFunction2() {
+          var apiUrl = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "";
+          var action = arguments.length > 1 ? arguments[1] : void 0;
+          var name2 = arguments.length > 2 ? arguments[2] : void 0;
+          var options = arguments.length > 3 ? arguments[3] : void 0;
+          if (typeof action === "function")
+            return function() {
+              for (var _len = arguments.length, params = new Array(_len), _key = 0; _key < _len; _key++) {
+                params[_key] = arguments[_key];
+              }
+              return action.apply(void 0, [name2].concat(params, [options]));
+            };
+          if (!action || !isString(action.url)) return null;
+          return createFileProcessorFunction(apiUrl, action, name2, options);
+        };
+        var createRevertFunction = function createRevertFunction2() {
+          var apiUrl = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "";
+          var action = arguments.length > 1 ? arguments[1] : void 0;
+          if (typeof action === "function") {
+            return action;
+          }
+          if (!action || !isString(action.url)) {
+            return function(uniqueFileId, load) {
+              return load();
+            };
+          }
+          var onload = action.onload || function(res2) {
+            return res2;
+          };
+          var onerror = action.onerror || function(res2) {
+            return null;
+          };
+          return function(uniqueFileId, load, error2) {
+            var request = sendRequest(
+              uniqueFileId,
+              apiUrl + action.url,
+              action
+              // contains method, headers and withCredentials properties
+            );
+            request.onload = function(xhr) {
+              load(
+                createResponse(
+                  "load",
+                  xhr.status,
+                  onload(xhr.response),
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.onerror = function(xhr) {
+              error2(
+                createResponse(
+                  "error",
+                  xhr.status,
+                  onerror(xhr.response) || xhr.statusText,
+                  xhr.getAllResponseHeaders()
+                )
+              );
+            };
+            request.ontimeout = createTimeoutResponse(error2);
+            return request;
+          };
+        };
+        var getRandomNumber = function getRandomNumber2() {
+          var min = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : 0;
+          var max = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 1;
+          return min + Math.random() * (max - min);
+        };
+        var createPerceivedPerformanceUpdater = function createPerceivedPerformanceUpdater2(cb) {
+          var duration = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 1e3;
+          var offset = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 0;
+          var tickMin = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : 25;
+          var tickMax = arguments.length > 4 && arguments[4] !== void 0 ? arguments[4] : 250;
+          var timeout = null;
+          var start = Date.now();
+          var tick = function tick2() {
+            var runtime = Date.now() - start;
+            var delay = getRandomNumber(tickMin, tickMax);
+            if (runtime + delay > duration) {
+              delay = runtime + delay - duration;
+            }
+            var progress = runtime / duration;
+            if (progress >= 1 || document.hidden) {
+              cb(1);
+              return;
+            }
+            cb(progress);
+            timeout = setTimeout(tick2, delay);
+          };
+          if (duration > 0) tick();
+          return {
+            clear: function clear2() {
+              clearTimeout(timeout);
+            }
+          };
+        };
+        var createFileProcessor = function createFileProcessor2(processFn, options) {
+          var state2 = {
+            complete: false,
+            perceivedProgress: 0,
+            perceivedPerformanceUpdater: null,
+            progress: null,
+            timestamp: null,
+            perceivedDuration: 0,
+            duration: 0,
+            request: null,
+            response: null
+          };
+          var allowMinimumUploadDuration = options.allowMinimumUploadDuration;
+          var process2 = function process3(file2, metadata) {
+            var progressFn = function progressFn2() {
+              if (state2.duration === 0 || state2.progress === null) return;
+              api.fire("progress", api.getProgress());
+            };
+            var completeFn = function completeFn2() {
+              state2.complete = true;
+              api.fire("load-perceived", state2.response.body);
+            };
+            api.fire("start");
+            state2.timestamp = Date.now();
+            state2.perceivedPerformanceUpdater = createPerceivedPerformanceUpdater(
+              function(progress) {
+                state2.perceivedProgress = progress;
+                state2.perceivedDuration = Date.now() - state2.timestamp;
+                progressFn();
+                if (state2.response && state2.perceivedProgress === 1 && !state2.complete) {
+                  completeFn();
+                }
+              },
+              // random delay as in a list of files you start noticing
+              // files uploading at the exact same speed
+              allowMinimumUploadDuration ? getRandomNumber(750, 1500) : 0
+            );
+            state2.request = processFn(
+              // the file to process
+              file2,
+              // the metadata to send along
+              metadata,
+              // callbacks (load, error, progress, abort, transfer)
+              // load expects the body to be a server id if
+              // you want to make use of revert
+              function(response) {
+                state2.response = isObject4(response) ? response : {
+                  type: "load",
+                  code: 200,
+                  body: "" + response,
+                  headers: {}
+                };
+                state2.duration = Date.now() - state2.timestamp;
+                state2.progress = 1;
+                api.fire("load", state2.response.body);
+                if (!allowMinimumUploadDuration || allowMinimumUploadDuration && state2.perceivedProgress === 1) {
+                  completeFn();
+                }
+              },
+              // error is expected to be an object with type, code, body
+              function(error2) {
+                state2.perceivedPerformanceUpdater.clear();
+                api.fire(
+                  "error",
+                  isObject4(error2) ? error2 : {
+                    type: "error",
+                    code: 0,
+                    body: "" + error2
+                  }
+                );
+              },
+              // actual processing progress
+              function(computable, current, total) {
+                state2.duration = Date.now() - state2.timestamp;
+                state2.progress = computable ? current / total : null;
+                progressFn();
+              },
+              // abort does not expect a value
+              function() {
+                state2.perceivedPerformanceUpdater.clear();
+                api.fire("abort", state2.response ? state2.response.body : null);
+              },
+              // register the id for this transfer
+              function(transferId) {
+                api.fire("transfer", transferId);
+              }
+            );
+          };
+          var abort = function abort2() {
+            if (!state2.request) return;
+            state2.perceivedPerformanceUpdater.clear();
+            if (state2.request.abort) state2.request.abort();
+            state2.complete = true;
+          };
+          var reset = function reset2() {
+            abort();
+            state2.complete = false;
+            state2.perceivedProgress = 0;
+            state2.progress = 0;
+            state2.timestamp = null;
+            state2.perceivedDuration = 0;
+            state2.duration = 0;
+            state2.request = null;
+            state2.response = null;
+          };
+          var getProgress = allowMinimumUploadDuration ? function() {
+            return state2.progress ? Math.min(state2.progress, state2.perceivedProgress) : null;
+          } : function() {
+            return state2.progress || null;
+          };
+          var getDuration = allowMinimumUploadDuration ? function() {
+            return Math.min(state2.duration, state2.perceivedDuration);
+          } : function() {
+            return state2.duration;
+          };
+          var api = Object.assign({}, on(), {
+            process: process2,
+            // start processing file
+            abort,
+            // abort active process request
+            getProgress,
+            getDuration,
+            reset
+          });
+          return api;
+        };
+        var getFilenameWithoutExtension = function getFilenameWithoutExtension2(name2) {
+          return name2.substring(0, name2.lastIndexOf(".")) || name2;
+        };
+        var createFileStub = function createFileStub2(source) {
+          var data3 = [source.name, source.size, source.type];
+          if (source instanceof Blob || isBase64DataURI(source)) {
+            data3[0] = source.name || getDateString();
+          } else if (isBase64DataURI(source)) {
+            data3[1] = source.length;
+            data3[2] = getMimeTypeFromBase64DataURI(source);
+          } else if (isString(source)) {
+            data3[0] = getFilenameFromURL(source);
+            data3[1] = 0;
+            data3[2] = "application/octet-stream";
+          }
+          return {
+            name: data3[0],
+            size: data3[1],
+            type: data3[2]
+          };
+        };
+        var isFile = function isFile2(value) {
+          return !!(value instanceof File || value instanceof Blob && value.name);
+        };
+        var deepCloneObject = function deepCloneObject2(src) {
+          if (!isObject4(src)) return src;
+          var target = isArray(src) ? [] : {};
+          for (var key in src) {
+            if (!src.hasOwnProperty(key)) continue;
+            var v = src[key];
+            target[key] = v && isObject4(v) ? deepCloneObject2(v) : v;
+          }
+          return target;
+        };
+        var createItem = function createItem2() {
+          var origin = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : null;
+          var serverFileReference = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : null;
+          var file2 = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : null;
+          var id2 = getUniqueId();
+          var state2 = {
+            // is archived
+            archived: false,
+            // if is frozen, no longer fires events
+            frozen: false,
+            // removed from view
+            released: false,
+            // original source
+            source: null,
+            // file model reference
+            file: file2,
+            // id of file on server
+            serverFileReference,
+            // id of file transfer on server
+            transferId: null,
+            // is aborted
+            processingAborted: false,
+            // current item status
+            status: serverFileReference ? ItemStatus.PROCESSING_COMPLETE : ItemStatus.INIT,
+            // active processes
+            activeLoader: null,
+            activeProcessor: null
+          };
+          var abortProcessingRequestComplete = null;
+          var metadata = {};
+          var setStatus = function setStatus2(status) {
+            return state2.status = status;
+          };
+          var fire = function fire2(event) {
+            if (state2.released || state2.frozen) return;
+            for (var _len = arguments.length, params = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+              params[_key - 1] = arguments[_key];
+            }
+            api.fire.apply(api, [event].concat(params));
+          };
+          var getFileExtension = function getFileExtension2() {
+            return getExtensionFromFilename(state2.file.name);
+          };
+          var getFileType = function getFileType2() {
+            return state2.file.type;
+          };
+          var getFileSize = function getFileSize2() {
+            return state2.file.size;
+          };
+          var getFile = function getFile2() {
+            return state2.file;
+          };
+          var load = function load2(source, loader, onload) {
+            state2.source = source;
+            api.fireSync("init");
+            if (state2.file) {
+              api.fireSync("load-skip");
+              return;
+            }
+            state2.file = createFileStub(source);
+            loader.on("init", function() {
+              fire("load-init");
+            });
+            loader.on("meta", function(meta) {
+              state2.file.size = meta.size;
+              state2.file.filename = meta.filename;
+              if (meta.source) {
+                origin = FileOrigin.LIMBO;
+                state2.serverFileReference = meta.source;
+                state2.status = ItemStatus.PROCESSING_COMPLETE;
+              }
+              fire("load-meta");
+            });
+            loader.on("progress", function(progress) {
+              setStatus(ItemStatus.LOADING);
+              fire("load-progress", progress);
+            });
+            loader.on("error", function(error2) {
+              setStatus(ItemStatus.LOAD_ERROR);
+              fire("load-request-error", error2);
+            });
+            loader.on("abort", function() {
+              setStatus(ItemStatus.INIT);
+              fire("load-abort");
+            });
+            loader.on("load", function(file3) {
+              state2.activeLoader = null;
+              var success = function success2(result) {
+                state2.file = isFile(result) ? result : state2.file;
+                if (origin === FileOrigin.LIMBO && state2.serverFileReference) {
+                  setStatus(ItemStatus.PROCESSING_COMPLETE);
+                } else {
+                  setStatus(ItemStatus.IDLE);
+                }
+                fire("load");
+              };
+              var error2 = function error3(result) {
+                state2.file = file3;
+                fire("load-meta");
+                setStatus(ItemStatus.LOAD_ERROR);
+                fire("load-file-error", result);
+              };
+              if (state2.serverFileReference) {
+                success(file3);
+                return;
+              }
+              onload(file3, success, error2);
+            });
+            loader.setSource(source);
+            state2.activeLoader = loader;
+            loader.load();
+          };
+          var retryLoad = function retryLoad2() {
+            if (!state2.activeLoader) {
+              return;
+            }
+            state2.activeLoader.load();
+          };
+          var abortLoad = function abortLoad2() {
+            if (state2.activeLoader) {
+              state2.activeLoader.abort();
+              return;
+            }
+            setStatus(ItemStatus.INIT);
+            fire("load-abort");
+          };
+          var process2 = function process3(processor, onprocess) {
+            if (state2.processingAborted) {
+              state2.processingAborted = false;
+              return;
+            }
+            setStatus(ItemStatus.PROCESSING);
+            abortProcessingRequestComplete = null;
+            if (!(state2.file instanceof Blob)) {
+              api.on("load", function() {
+                process3(processor, onprocess);
+              });
+              return;
+            }
+            processor.on("load", function(serverFileReference2) {
+              state2.transferId = null;
+              state2.serverFileReference = serverFileReference2;
+            });
+            processor.on("transfer", function(transferId) {
+              state2.transferId = transferId;
+            });
+            processor.on("load-perceived", function(serverFileReference2) {
+              state2.activeProcessor = null;
+              state2.transferId = null;
+              state2.serverFileReference = serverFileReference2;
+              setStatus(ItemStatus.PROCESSING_COMPLETE);
+              fire("process-complete", serverFileReference2);
+            });
+            processor.on("start", function() {
+              fire("process-start");
+            });
+            processor.on("error", function(error3) {
+              state2.activeProcessor = null;
+              setStatus(ItemStatus.PROCESSING_ERROR);
+              fire("process-error", error3);
+            });
+            processor.on("abort", function(serverFileReference2) {
+              state2.activeProcessor = null;
+              state2.serverFileReference = serverFileReference2;
+              setStatus(ItemStatus.IDLE);
+              fire("process-abort");
+              if (abortProcessingRequestComplete) {
+                abortProcessingRequestComplete();
+              }
+            });
+            processor.on("progress", function(progress) {
+              fire("process-progress", progress);
+            });
+            var success = function success2(file3) {
+              if (state2.archived) return;
+              processor.process(file3, Object.assign({}, metadata));
+            };
+            var error2 = console.error;
+            onprocess(state2.file, success, error2);
+            state2.activeProcessor = processor;
+          };
+          var requestProcessing = function requestProcessing2() {
+            state2.processingAborted = false;
+            setStatus(ItemStatus.PROCESSING_QUEUED);
+          };
+          var abortProcessing = function abortProcessing2() {
+            return new Promise(function(resolve) {
+              if (!state2.activeProcessor) {
+                state2.processingAborted = true;
+                setStatus(ItemStatus.IDLE);
+                fire("process-abort");
+                resolve();
+                return;
+              }
+              abortProcessingRequestComplete = function abortProcessingRequestComplete2() {
+                resolve();
+              };
+              state2.activeProcessor.abort();
+            });
+          };
+          var revert = function revert2(revertFileUpload, forceRevert) {
+            return new Promise(function(resolve, reject) {
+              var serverTransferId = state2.serverFileReference !== null ? state2.serverFileReference : state2.transferId;
+              if (serverTransferId === null) {
+                resolve();
+                return;
+              }
+              revertFileUpload(
+                serverTransferId,
+                function() {
+                  state2.serverFileReference = null;
+                  state2.transferId = null;
+                  resolve();
+                },
+                function(error2) {
+                  if (!forceRevert) {
+                    resolve();
+                    return;
+                  }
+                  setStatus(ItemStatus.PROCESSING_REVERT_ERROR);
+                  fire("process-revert-error");
+                  reject(error2);
+                }
+              );
+              setStatus(ItemStatus.IDLE);
+              fire("process-revert");
+            });
+          };
+          var _setMetadata = function setMetadata(key, value, silent) {
+            var keys = key.split(".");
+            var root2 = keys[0];
+            var last = keys.pop();
+            var data3 = metadata;
+            keys.forEach(function(key2) {
+              return data3 = data3[key2];
+            });
+            if (JSON.stringify(data3[last]) === JSON.stringify(value)) return;
+            data3[last] = value;
+            fire("metadata-update", {
+              key: root2,
+              value: metadata[root2],
+              silent
+            });
+          };
+          var getMetadata = function getMetadata2(key) {
+            return deepCloneObject(key ? metadata[key] : metadata);
+          };
+          var api = Object.assign(
+            {
+              id: {
+                get: function get() {
+                  return id2;
+                }
+              },
+              origin: {
+                get: function get() {
+                  return origin;
+                },
+                set: function set2(value) {
+                  return origin = value;
+                }
+              },
+              serverId: {
+                get: function get() {
+                  return state2.serverFileReference;
+                }
+              },
+              transferId: {
+                get: function get() {
+                  return state2.transferId;
+                }
+              },
+              status: {
+                get: function get() {
+                  return state2.status;
+                }
+              },
+              filename: {
+                get: function get() {
+                  return state2.file.name;
+                }
+              },
+              filenameWithoutExtension: {
+                get: function get() {
+                  return getFilenameWithoutExtension(state2.file.name);
+                }
+              },
+              fileExtension: { get: getFileExtension },
+              fileType: { get: getFileType },
+              fileSize: { get: getFileSize },
+              file: { get: getFile },
+              relativePath: {
+                get: function get() {
+                  return state2.file._relativePath;
+                }
+              },
+              source: {
+                get: function get() {
+                  return state2.source;
+                }
+              },
+              getMetadata,
+              setMetadata: function setMetadata(key, value, silent) {
+                if (isObject4(key)) {
+                  var data3 = key;
+                  Object.keys(data3).forEach(function(key2) {
+                    _setMetadata(key2, data3[key2], value);
+                  });
+                  return key;
+                }
+                _setMetadata(key, value, silent);
+                return value;
+              },
+              extend: function extend(name2, handler) {
+                return itemAPI[name2] = handler;
+              },
+              abortLoad,
+              retryLoad,
+              requestProcessing,
+              abortProcessing,
+              load,
+              process: process2,
+              revert
+            },
+            on(),
+            {
+              freeze: function freeze() {
+                return state2.frozen = true;
+              },
+              release: function release() {
+                return state2.released = true;
+              },
+              released: {
+                get: function get() {
+                  return state2.released;
+                }
+              },
+              archive: function archive() {
+                return state2.archived = true;
+              },
+              archived: {
+                get: function get() {
+                  return state2.archived;
+                }
+              },
+              // replace source and file object
+              setFile: function setFile(file3) {
+                return state2.file = file3;
+              }
+            }
+          );
+          var itemAPI = createObject(api);
+          return itemAPI;
+        };
+        var getItemIndexByQuery = function getItemIndexByQuery2(items, query) {
+          if (isEmpty(query)) {
+            return 0;
+          }
+          if (!isString(query)) {
+            return -1;
+          }
+          return items.findIndex(function(item2) {
+            return item2.id === query;
+          });
+        };
+        var getItemById = function getItemById2(items, itemId) {
+          var index = getItemIndexByQuery(items, itemId);
+          if (index < 0) {
+            return;
+          }
+          return items[index] || null;
+        };
+        var fetchBlob = function fetchBlob2(url, load, error2, progress, abort, headers) {
+          var request = sendRequest(null, url, {
+            method: "GET",
+            responseType: "blob"
+          });
+          request.onload = function(xhr) {
+            var headers2 = xhr.getAllResponseHeaders();
+            var filename = getFileInfoFromHeaders(headers2).name || getFilenameFromURL(url);
+            load(
+              createResponse("load", xhr.status, getFileFromBlob(xhr.response, filename), headers2)
+            );
+          };
+          request.onerror = function(xhr) {
+            error2(createResponse("error", xhr.status, xhr.statusText, xhr.getAllResponseHeaders()));
+          };
+          request.onheaders = function(xhr) {
+            headers(createResponse("headers", xhr.status, null, xhr.getAllResponseHeaders()));
+          };
+          request.ontimeout = createTimeoutResponse(error2);
+          request.onprogress = progress;
+          request.onabort = abort;
+          return request;
+        };
+        var getDomainFromURL = function getDomainFromURL2(url) {
+          if (url.indexOf("//") === 0) {
+            url = location.protocol + url;
+          }
+          return url.toLowerCase().replace("blob:", "").replace(/([a-z])?:\/\//, "$1").split("/")[0];
+        };
+        var isExternalURL = function isExternalURL2(url) {
+          return (url.indexOf(":") > -1 || url.indexOf("//") > -1) && getDomainFromURL(location.href) !== getDomainFromURL(url);
+        };
+        var dynamicLabel = function dynamicLabel2(label) {
+          return function() {
+            return isFunction(label) ? label.apply(void 0, arguments) : label;
+          };
+        };
+        var isMockItem = function isMockItem2(item2) {
+          return !isFile(item2.file);
+        };
+        var listUpdated = function listUpdated2(dispatch2, state2) {
+          clearTimeout(state2.listUpdateTimeout);
+          state2.listUpdateTimeout = setTimeout(function() {
+            dispatch2("DID_UPDATE_ITEMS", { items: getActiveItems(state2.items) });
+          }, 0);
+        };
+        var optionalPromise = function optionalPromise2(fn2) {
+          for (var _len = arguments.length, params = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+            params[_key - 1] = arguments[_key];
+          }
+          return new Promise(function(resolve) {
+            if (!fn2) {
+              return resolve(true);
+            }
+            var result = fn2.apply(void 0, params);
+            if (result == null) {
+              return resolve(true);
+            }
+            if (typeof result === "boolean") {
+              return resolve(result);
+            }
+            if (typeof result.then === "function") {
+              result.then(resolve);
+            }
+          });
+        };
+        var sortItems = function sortItems2(state2, compare) {
+          state2.items.sort(function(a, b) {
+            return compare(createItemAPI(a), createItemAPI(b));
+          });
+        };
+        var getItemByQueryFromState = function getItemByQueryFromState2(state2, itemHandler) {
+          return function() {
+            var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+            var query = _ref.query, _ref$success = _ref.success, success = _ref$success === void 0 ? function() {
+            } : _ref$success, _ref$failure = _ref.failure, failure2 = _ref$failure === void 0 ? function() {
+            } : _ref$failure, options = _objectWithoutProperties(_ref, ["query", "success", "failure"]);
+            var item2 = getItemByQuery(state2.items, query);
+            if (!item2) {
+              failure2({
+                error: createResponse("error", 0, "Item not found"),
+                file: null
+              });
+              return;
+            }
+            itemHandler(item2, success, failure2, options || {});
+          };
+        };
+        var actions = function actions2(dispatch2, query, state2) {
+          return {
+            /**
+             * Aborts all ongoing processes
+             */
+            ABORT_ALL: function ABORT_ALL() {
+              getActiveItems(state2.items).forEach(function(item2) {
+                item2.freeze();
+                item2.abortLoad();
+                item2.abortProcessing();
+              });
+            },
+            /**
+             * Sets initial files
+             */
+            DID_SET_FILES: function DID_SET_FILES(_ref2) {
+              var _ref2$value = _ref2.value, value = _ref2$value === void 0 ? [] : _ref2$value;
+              var files = value.map(function(file2) {
+                return {
+                  source: file2.source ? file2.source : file2,
+                  options: file2.options
+                };
+              });
+              var activeItems = getActiveItems(state2.items);
+              activeItems.forEach(function(item2) {
+                if (!files.find(function(file2) {
+                  return file2.source === item2.source || file2.source === item2.file;
+                })) {
+                  dispatch2("REMOVE_ITEM", { query: item2, remove: false });
+                }
+              });
+              activeItems = getActiveItems(state2.items);
+              files.forEach(function(file2, index) {
+                if (activeItems.find(function(item2) {
+                  return item2.source === file2.source || item2.file === file2.source;
+                }))
+                  return;
+                dispatch2(
+                  "ADD_ITEM",
+                  Object.assign({}, file2, {
+                    interactionMethod: InteractionMethod.NONE,
+                    index
+                  })
+                );
+              });
+            },
+            DID_UPDATE_ITEM_METADATA: function DID_UPDATE_ITEM_METADATA(_ref3) {
+              var id2 = _ref3.id, action = _ref3.action, change = _ref3.change;
+              if (change.silent) return;
+              clearTimeout(state2.itemUpdateTimeout);
+              state2.itemUpdateTimeout = setTimeout(function() {
+                var item2 = getItemById(state2.items, id2);
+                if (!query("IS_ASYNC")) {
+                  applyFilterChain("SHOULD_PREPARE_OUTPUT", false, {
+                    item: item2,
+                    query,
+                    action,
+                    change
+                  }).then(function(shouldPrepareOutput) {
+                    var beforePrepareFile = query("GET_BEFORE_PREPARE_FILE");
+                    if (beforePrepareFile)
+                      shouldPrepareOutput = beforePrepareFile(item2, shouldPrepareOutput);
+                    if (!shouldPrepareOutput) return;
+                    dispatch2(
+                      "REQUEST_PREPARE_OUTPUT",
+                      {
+                        query: id2,
+                        item: item2,
+                        success: function success(file2) {
+                          dispatch2("DID_PREPARE_OUTPUT", { id: id2, file: file2 });
+                        }
+                      },
+                      true
+                    );
+                  });
+                  return;
+                }
+                if (item2.origin === FileOrigin.LOCAL) {
+                  dispatch2("DID_LOAD_ITEM", {
+                    id: item2.id,
+                    error: null,
+                    serverFileReference: item2.source
+                  });
+                }
+                var upload = function upload2() {
+                  setTimeout(function() {
+                    dispatch2("REQUEST_ITEM_PROCESSING", { query: id2 });
+                  }, 32);
+                };
+                var revert = function revert2(doUpload) {
+                  item2.revert(
+                    createRevertFunction(
+                      state2.options.server.url,
+                      state2.options.server.revert
+                    ),
+                    query("GET_FORCE_REVERT")
+                  ).then(doUpload ? upload : function() {
+                  }).catch(function() {
+                  });
+                };
+                var abort = function abort2(doUpload) {
+                  item2.abortProcessing().then(doUpload ? upload : function() {
+                  });
+                };
+                if (item2.status === ItemStatus.PROCESSING_COMPLETE) {
+                  return revert(state2.options.instantUpload);
+                }
+                if (item2.status === ItemStatus.PROCESSING) {
+                  return abort(state2.options.instantUpload);
+                }
+                if (state2.options.instantUpload) {
+                  upload();
+                }
+              }, 0);
+            },
+            MOVE_ITEM: function MOVE_ITEM(_ref4) {
+              var query2 = _ref4.query, index = _ref4.index;
+              var item2 = getItemByQuery(state2.items, query2);
+              if (!item2) return;
+              var currentIndex = state2.items.indexOf(item2);
+              index = limit(index, 0, state2.items.length - 1);
+              if (currentIndex === index) return;
+              state2.items.splice(index, 0, state2.items.splice(currentIndex, 1)[0]);
+            },
+            SORT: function SORT(_ref5) {
+              var compare = _ref5.compare;
+              sortItems(state2, compare);
+              dispatch2("DID_SORT_ITEMS", {
+                items: query("GET_ACTIVE_ITEMS")
+              });
+            },
+            ADD_ITEMS: function ADD_ITEMS(_ref6) {
+              var items = _ref6.items, index = _ref6.index, interactionMethod = _ref6.interactionMethod, _ref6$success = _ref6.success, success = _ref6$success === void 0 ? function() {
+              } : _ref6$success, _ref6$failure = _ref6.failure, failure2 = _ref6$failure === void 0 ? function() {
+              } : _ref6$failure;
+              var currentIndex = index;
+              if (index === -1 || typeof index === "undefined") {
+                var insertLocation = query("GET_ITEM_INSERT_LOCATION");
+                var totalItems = query("GET_TOTAL_ITEMS");
+                currentIndex = insertLocation === "before" ? 0 : totalItems;
+              }
+              var ignoredFiles = query("GET_IGNORED_FILES");
+              var isValidFile = function isValidFile2(source) {
+                return isFile(source) ? !ignoredFiles.includes(source.name.toLowerCase()) : !isEmpty(source);
+              };
+              var validItems = items.filter(isValidFile);
+              var promises = validItems.map(function(source) {
+                return new Promise(function(resolve, reject) {
+                  dispatch2("ADD_ITEM", {
+                    interactionMethod,
+                    source: source.source || source,
+                    success: resolve,
+                    failure: reject,
+                    index: currentIndex++,
+                    options: source.options || {}
+                  });
+                });
+              });
+              Promise.all(promises).then(success).catch(failure2);
+            },
+            /**
+             * @param source
+             * @param index
+             * @param interactionMethod
+             */
+            ADD_ITEM: function ADD_ITEM(_ref7) {
+              var source = _ref7.source, _ref7$index = _ref7.index, index = _ref7$index === void 0 ? -1 : _ref7$index, interactionMethod = _ref7.interactionMethod, _ref7$success = _ref7.success, success = _ref7$success === void 0 ? function() {
+              } : _ref7$success, _ref7$failure = _ref7.failure, failure2 = _ref7$failure === void 0 ? function() {
+              } : _ref7$failure, _ref7$options = _ref7.options, options = _ref7$options === void 0 ? {} : _ref7$options;
+              if (isEmpty(source)) {
+                failure2({
+                  error: createResponse("error", 0, "No source"),
+                  file: null
+                });
+                return;
+              }
+              if (isFile(source) && state2.options.ignoredFiles.includes(source.name.toLowerCase())) {
+                return;
+              }
+              if (!hasRoomForItem(state2)) {
+                if (state2.options.allowMultiple || !state2.options.allowMultiple && !state2.options.allowReplace) {
+                  var error2 = createResponse("warning", 0, "Max files");
+                  dispatch2("DID_THROW_MAX_FILES", {
+                    source,
+                    error: error2
+                  });
+                  failure2({ error: error2, file: null });
+                  return;
+                }
+                var _item = getActiveItems(state2.items)[0];
+                if (_item.status === ItemStatus.PROCESSING_COMPLETE || _item.status === ItemStatus.PROCESSING_REVERT_ERROR) {
+                  var forceRevert = query("GET_FORCE_REVERT");
+                  _item.revert(
+                    createRevertFunction(
+                      state2.options.server.url,
+                      state2.options.server.revert
+                    ),
+                    forceRevert
+                  ).then(function() {
+                    if (!forceRevert) return;
+                    dispatch2("ADD_ITEM", {
+                      source,
+                      index,
+                      interactionMethod,
+                      success,
+                      failure: failure2,
+                      options
+                    });
+                  }).catch(function() {
+                  });
+                  if (forceRevert) return;
+                }
+                dispatch2("REMOVE_ITEM", { query: _item.id });
+              }
+              var origin = options.type === "local" ? FileOrigin.LOCAL : options.type === "limbo" ? FileOrigin.LIMBO : FileOrigin.INPUT;
+              var item2 = createItem(
+                // where did this file come from
+                origin,
+                // an input file never has a server file reference
+                origin === FileOrigin.INPUT ? null : source,
+                // file mock data, if defined
+                options.file
+              );
+              Object.keys(options.metadata || {}).forEach(function(key) {
+                item2.setMetadata(key, options.metadata[key]);
+              });
+              applyFilters("DID_CREATE_ITEM", item2, { query, dispatch: dispatch2 });
+              var itemInsertLocation = query("GET_ITEM_INSERT_LOCATION");
+              if (!state2.options.itemInsertLocationFreedom) {
+                index = itemInsertLocation === "before" ? -1 : state2.items.length;
+              }
+              insertItem(state2.items, item2, index);
+              if (isFunction(itemInsertLocation) && source) {
+                sortItems(state2, itemInsertLocation);
+              }
+              var id2 = item2.id;
+              item2.on("init", function() {
+                dispatch2("DID_INIT_ITEM", { id: id2 });
+              });
+              item2.on("load-init", function() {
+                dispatch2("DID_START_ITEM_LOAD", { id: id2 });
+              });
+              item2.on("load-meta", function() {
+                dispatch2("DID_UPDATE_ITEM_META", { id: id2 });
+              });
+              item2.on("load-progress", function(progress) {
+                dispatch2("DID_UPDATE_ITEM_LOAD_PROGRESS", { id: id2, progress });
+              });
+              item2.on("load-request-error", function(error3) {
+                var mainStatus = dynamicLabel(state2.options.labelFileLoadError)(error3);
+                if (error3.code >= 400 && error3.code < 500) {
+                  dispatch2("DID_THROW_ITEM_INVALID", {
+                    id: id2,
+                    error: error3,
+                    status: {
+                      main: mainStatus,
+                      sub: error3.code + " (" + error3.body + ")"
+                    }
+                  });
+                  failure2({ error: error3, file: createItemAPI(item2) });
+                  return;
+                }
+                dispatch2("DID_THROW_ITEM_LOAD_ERROR", {
+                  id: id2,
+                  error: error3,
+                  status: {
+                    main: mainStatus,
+                    sub: state2.options.labelTapToRetry
+                  }
+                });
+              });
+              item2.on("load-file-error", function(error3) {
+                dispatch2("DID_THROW_ITEM_INVALID", {
+                  id: id2,
+                  error: error3.status,
+                  status: error3.status
+                });
+                failure2({ error: error3.status, file: createItemAPI(item2) });
+              });
+              item2.on("load-abort", function() {
+                dispatch2("REMOVE_ITEM", { query: id2 });
+              });
+              item2.on("load-skip", function() {
+                item2.on("metadata-update", function(change) {
+                  if (!isFile(item2.file)) return;
+                  dispatch2("DID_UPDATE_ITEM_METADATA", { id: id2, change });
+                });
+                dispatch2("COMPLETE_LOAD_ITEM", {
+                  query: id2,
+                  item: item2,
+                  data: {
+                    source,
+                    success
+                  }
+                });
+              });
+              item2.on("load", function() {
+                var handleAdd = function handleAdd2(shouldAdd) {
+                  if (!shouldAdd) {
+                    dispatch2("REMOVE_ITEM", {
+                      query: id2
+                    });
+                    return;
+                  }
+                  item2.on("metadata-update", function(change) {
+                    dispatch2("DID_UPDATE_ITEM_METADATA", { id: id2, change });
+                  });
+                  applyFilterChain("SHOULD_PREPARE_OUTPUT", false, {
+                    item: item2,
+                    query
+                  }).then(function(shouldPrepareOutput) {
+                    var beforePrepareFile = query("GET_BEFORE_PREPARE_FILE");
+                    if (beforePrepareFile)
+                      shouldPrepareOutput = beforePrepareFile(item2, shouldPrepareOutput);
+                    var loadComplete = function loadComplete2() {
+                      dispatch2("COMPLETE_LOAD_ITEM", {
+                        query: id2,
+                        item: item2,
+                        data: {
+                          source,
+                          success
+                        }
+                      });
+                      listUpdated(dispatch2, state2);
+                    };
+                    if (shouldPrepareOutput) {
+                      dispatch2(
+                        "REQUEST_PREPARE_OUTPUT",
+                        {
+                          query: id2,
+                          item: item2,
+                          success: function success2(file2) {
+                            dispatch2("DID_PREPARE_OUTPUT", { id: id2, file: file2 });
+                            loadComplete();
+                          }
+                        },
+                        true
+                      );
+                      return;
+                    }
+                    loadComplete();
+                  });
+                };
+                applyFilterChain("DID_LOAD_ITEM", item2, { query, dispatch: dispatch2 }).then(function() {
+                  optionalPromise(query("GET_BEFORE_ADD_FILE"), createItemAPI(item2)).then(
+                    handleAdd
+                  );
+                }).catch(function(e) {
+                  if (!e || !e.error || !e.status) return handleAdd(false);
+                  dispatch2("DID_THROW_ITEM_INVALID", {
+                    id: id2,
+                    error: e.error,
+                    status: e.status
+                  });
+                });
+              });
+              item2.on("process-start", function() {
+                dispatch2("DID_START_ITEM_PROCESSING", { id: id2 });
+              });
+              item2.on("process-progress", function(progress) {
+                dispatch2("DID_UPDATE_ITEM_PROCESS_PROGRESS", { id: id2, progress });
+              });
+              item2.on("process-error", function(error3) {
+                dispatch2("DID_THROW_ITEM_PROCESSING_ERROR", {
+                  id: id2,
+                  error: error3,
+                  status: {
+                    main: dynamicLabel(state2.options.labelFileProcessingError)(error3),
+                    sub: state2.options.labelTapToRetry
+                  }
+                });
+              });
+              item2.on("process-revert-error", function(error3) {
+                dispatch2("DID_THROW_ITEM_PROCESSING_REVERT_ERROR", {
+                  id: id2,
+                  error: error3,
+                  status: {
+                    main: dynamicLabel(state2.options.labelFileProcessingRevertError)(error3),
+                    sub: state2.options.labelTapToRetry
+                  }
+                });
+              });
+              item2.on("process-complete", function(serverFileReference) {
+                dispatch2("DID_COMPLETE_ITEM_PROCESSING", {
+                  id: id2,
+                  error: null,
+                  serverFileReference
+                });
+                dispatch2("DID_DEFINE_VALUE", { id: id2, value: serverFileReference });
+              });
+              item2.on("process-abort", function() {
+                dispatch2("DID_ABORT_ITEM_PROCESSING", { id: id2 });
+              });
+              item2.on("process-revert", function() {
+                dispatch2("DID_REVERT_ITEM_PROCESSING", { id: id2 });
+                dispatch2("DID_DEFINE_VALUE", { id: id2, value: null });
+              });
+              dispatch2("DID_ADD_ITEM", {
+                id: id2,
+                index,
+                interactionMethod
+              });
+              listUpdated(dispatch2, state2);
+              var _ref8 = state2.options.server || {}, url = _ref8.url, load = _ref8.load, restore = _ref8.restore, fetch = _ref8.fetch;
+              item2.load(
+                source,
+                // this creates a function that loads the file based on the type of file (string, base64, blob, file) and location of file (local, remote, limbo)
+                createFileLoader(
+                  origin === FileOrigin.INPUT ? (
+                    // input, if is remote, see if should use custom fetch, else use default fetchBlob
+                    isString(source) && isExternalURL(source) ? fetch ? createFetchFunction(url, fetch) : fetchBlob : fetchBlob
+                  ) : (
+                    // limbo or local
+                    origin === FileOrigin.LIMBO ? createFetchFunction(url, restore) : createFetchFunction(url, load)
+                  )
+                  // local
+                ),
+                // called when the file is loaded so it can be piped through the filters
+                function(file2, success2, error3) {
+                  applyFilterChain("LOAD_FILE", file2, { query }).then(success2).catch(error3);
+                }
+              );
+            },
+            REQUEST_PREPARE_OUTPUT: function REQUEST_PREPARE_OUTPUT(_ref9) {
+              var item2 = _ref9.item, success = _ref9.success, _ref9$failure = _ref9.failure, failure2 = _ref9$failure === void 0 ? function() {
+              } : _ref9$failure;
+              var err = {
+                error: createResponse("error", 0, "Item not found"),
+                file: null
+              };
+              if (item2.archived) return failure2(err);
+              applyFilterChain("PREPARE_OUTPUT", item2.file, { query, item: item2 }).then(
+                function(result) {
+                  applyFilterChain("COMPLETE_PREPARE_OUTPUT", result, {
+                    query,
+                    item: item2
+                  }).then(function(result2) {
+                    if (item2.archived) return failure2(err);
+                    success(result2);
+                  });
+                }
+              );
+            },
+            COMPLETE_LOAD_ITEM: function COMPLETE_LOAD_ITEM(_ref10) {
+              var item2 = _ref10.item, data3 = _ref10.data;
+              var success = data3.success, source = data3.source;
+              var itemInsertLocation = query("GET_ITEM_INSERT_LOCATION");
+              if (isFunction(itemInsertLocation) && source) {
+                sortItems(state2, itemInsertLocation);
+              }
+              dispatch2("DID_LOAD_ITEM", {
+                id: item2.id,
+                error: null,
+                serverFileReference: item2.origin === FileOrigin.INPUT ? null : source
+              });
+              success(createItemAPI(item2));
+              if (item2.origin === FileOrigin.LOCAL) {
+                dispatch2("DID_LOAD_LOCAL_ITEM", { id: item2.id });
+                return;
+              }
+              if (item2.origin === FileOrigin.LIMBO) {
+                dispatch2("DID_COMPLETE_ITEM_PROCESSING", {
+                  id: item2.id,
+                  error: null,
+                  serverFileReference: source
+                });
+                dispatch2("DID_DEFINE_VALUE", {
+                  id: item2.id,
+                  value: item2.serverId || source
+                });
+                return;
+              }
+              if (query("IS_ASYNC") && state2.options.instantUpload) {
+                dispatch2("REQUEST_ITEM_PROCESSING", { query: item2.id });
+              }
+            },
+            RETRY_ITEM_LOAD: getItemByQueryFromState(state2, function(item2) {
+              item2.retryLoad();
+            }),
+            REQUEST_ITEM_PREPARE: getItemByQueryFromState(state2, function(item2, _success, failure2) {
+              dispatch2(
+                "REQUEST_PREPARE_OUTPUT",
+                {
+                  query: item2.id,
+                  item: item2,
+                  success: function success(file2) {
+                    dispatch2("DID_PREPARE_OUTPUT", { id: item2.id, file: file2 });
+                    _success({
+                      file: item2,
+                      output: file2
+                    });
+                  },
+                  failure: failure2
+                },
+                true
+              );
+            }),
+            REQUEST_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2, success, failure2) {
+              var itemCanBeQueuedForProcessing = (
+                // waiting for something
+                item2.status === ItemStatus.IDLE || // processing went wrong earlier
+                item2.status === ItemStatus.PROCESSING_ERROR
+              );
+              if (!itemCanBeQueuedForProcessing) {
+                var processNow = function processNow2() {
+                  return dispatch2("REQUEST_ITEM_PROCESSING", {
+                    query: item2,
+                    success,
+                    failure: failure2
+                  });
+                };
+                var process2 = function process3() {
+                  return document.hidden ? processNow() : setTimeout(processNow, 32);
+                };
+                if (item2.status === ItemStatus.PROCESSING_COMPLETE || item2.status === ItemStatus.PROCESSING_REVERT_ERROR) {
+                  item2.revert(
+                    createRevertFunction(
+                      state2.options.server.url,
+                      state2.options.server.revert
+                    ),
+                    query("GET_FORCE_REVERT")
+                  ).then(process2).catch(function() {
+                  });
+                } else if (item2.status === ItemStatus.PROCESSING) {
+                  item2.abortProcessing().then(process2);
+                }
+                return;
+              }
+              if (item2.status === ItemStatus.PROCESSING_QUEUED) return;
+              item2.requestProcessing();
+              dispatch2("DID_REQUEST_ITEM_PROCESSING", { id: item2.id });
+              dispatch2("PROCESS_ITEM", { query: item2, success, failure: failure2 }, true);
+            }),
+            PROCESS_ITEM: getItemByQueryFromState(state2, function(item2, success, failure2) {
+              var maxParallelUploads = query("GET_MAX_PARALLEL_UPLOADS");
+              var totalCurrentUploads = query("GET_ITEMS_BY_STATUS", ItemStatus.PROCESSING).length;
+              if (totalCurrentUploads === maxParallelUploads) {
+                state2.processingQueue.push({
+                  id: item2.id,
+                  success,
+                  failure: failure2
+                });
+                return;
+              }
+              if (item2.status === ItemStatus.PROCESSING) return;
+              var processNext = function processNext2() {
+                var queueEntry = state2.processingQueue.shift();
+                if (!queueEntry) return;
+                var id2 = queueEntry.id, success2 = queueEntry.success, failure3 = queueEntry.failure;
+                var itemReference = getItemByQuery(state2.items, id2);
+                if (!itemReference || itemReference.archived) {
+                  processNext2();
+                  return;
+                }
+                dispatch2(
+                  "PROCESS_ITEM",
+                  { query: id2, success: success2, failure: failure3 },
+                  true
+                );
+              };
+              item2.onOnce("process-complete", function() {
+                success(createItemAPI(item2));
+                processNext();
+                var server = state2.options.server;
+                var instantUpload = state2.options.instantUpload;
+                if (instantUpload && item2.origin === FileOrigin.LOCAL && isFunction(server.remove)) {
+                  var noop = function noop2() {
+                  };
+                  item2.origin = FileOrigin.LIMBO;
+                  state2.options.server.remove(item2.source, noop, noop);
+                }
+                var allItemsProcessed = query("GET_ITEMS_BY_STATUS", ItemStatus.PROCESSING_COMPLETE).length === state2.items.length;
+                if (allItemsProcessed) {
+                  dispatch2("DID_COMPLETE_ITEM_PROCESSING_ALL");
+                }
+              });
+              item2.onOnce("process-error", function(error2) {
+                failure2({ error: error2, file: createItemAPI(item2) });
+                processNext();
+              });
+              item2.onOnce("process-abort", function() {
+                processNext();
+              });
+              var options = state2.options;
+              item2.process(
+                createFileProcessor(
+                  createProcessorFunction(
+                    options.server.url,
+                    options.server.process,
+                    options.name,
+                    {
+                      chunkTransferId: item2.transferId,
+                      chunkServer: options.server.patch,
+                      chunkUploads: options.chunkUploads,
+                      chunkForce: options.chunkForce,
+                      chunkSize: options.chunkSize,
+                      chunkRetryDelays: options.chunkRetryDelays
+                    }
+                  ),
+                  {
+                    allowMinimumUploadDuration: query("GET_ALLOW_MINIMUM_UPLOAD_DURATION")
+                  }
+                ),
+                // called when the file is about to be processed so it can be piped through the transform filters
+                function(file2, success2, error2) {
+                  applyFilterChain("PREPARE_OUTPUT", file2, { query, item: item2 }).then(function(file3) {
+                    dispatch2("DID_PREPARE_OUTPUT", { id: item2.id, file: file3 });
+                    success2(file3);
+                  }).catch(error2);
+                }
+              );
+            }),
+            RETRY_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2) {
+              dispatch2("REQUEST_ITEM_PROCESSING", { query: item2 });
+            }),
+            REQUEST_REMOVE_ITEM: getItemByQueryFromState(state2, function(item2) {
+              optionalPromise(query("GET_BEFORE_REMOVE_FILE"), createItemAPI(item2)).then(function(shouldRemove) {
+                if (!shouldRemove) {
+                  return;
+                }
+                dispatch2("REMOVE_ITEM", { query: item2 });
+              });
+            }),
+            RELEASE_ITEM: getItemByQueryFromState(state2, function(item2) {
+              item2.release();
+            }),
+            REMOVE_ITEM: getItemByQueryFromState(state2, function(item2, success, failure2, options) {
+              var removeFromView = function removeFromView2() {
+                var id2 = item2.id;
+                getItemById(state2.items, id2).archive();
+                dispatch2("DID_REMOVE_ITEM", { error: null, id: id2, item: item2 });
+                listUpdated(dispatch2, state2);
+                success(createItemAPI(item2));
+              };
+              var server = state2.options.server;
+              if (item2.origin === FileOrigin.LOCAL && server && isFunction(server.remove) && options.remove !== false) {
+                dispatch2("DID_START_ITEM_REMOVE", { id: item2.id });
+                server.remove(
+                  item2.source,
+                  function() {
+                    return removeFromView();
+                  },
+                  function(status) {
+                    dispatch2("DID_THROW_ITEM_REMOVE_ERROR", {
+                      id: item2.id,
+                      error: createResponse("error", 0, status, null),
+                      status: {
+                        main: dynamicLabel(state2.options.labelFileRemoveError)(status),
+                        sub: state2.options.labelTapToRetry
+                      }
+                    });
+                  }
+                );
+              } else {
+                if (options.revert && item2.origin !== FileOrigin.LOCAL && item2.serverId !== null || // if chunked uploads are enabled and we're uploading in chunks for this specific file
+                // or if the file isn't big enough for chunked uploads but chunkForce is set then call
+                // revert before removing from the view...
+                state2.options.chunkUploads && item2.file.size > state2.options.chunkSize || state2.options.chunkUploads && state2.options.chunkForce) {
+                  item2.revert(
+                    createRevertFunction(
+                      state2.options.server.url,
+                      state2.options.server.revert
+                    ),
+                    query("GET_FORCE_REVERT")
+                  );
+                }
+                removeFromView();
+              }
+            }),
+            ABORT_ITEM_LOAD: getItemByQueryFromState(state2, function(item2) {
+              item2.abortLoad();
+            }),
+            ABORT_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2) {
+              if (item2.serverId) {
+                dispatch2("REVERT_ITEM_PROCESSING", { id: item2.id });
+                return;
+              }
+              item2.abortProcessing().then(function() {
+                var shouldRemove = state2.options.instantUpload;
+                if (shouldRemove) {
+                  dispatch2("REMOVE_ITEM", { query: item2.id });
+                }
+              });
+            }),
+            REQUEST_REVERT_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2) {
+              if (!state2.options.instantUpload) {
+                dispatch2("REVERT_ITEM_PROCESSING", { query: item2 });
+                return;
+              }
+              var handleRevert = function handleRevert2(shouldRevert) {
+                if (!shouldRevert) return;
+                dispatch2("REVERT_ITEM_PROCESSING", { query: item2 });
+              };
+              var fn2 = query("GET_BEFORE_REMOVE_FILE");
+              if (!fn2) {
+                return handleRevert(true);
+              }
+              var requestRemoveResult = fn2(createItemAPI(item2));
+              if (requestRemoveResult == null) {
+                return handleRevert(true);
+              }
+              if (typeof requestRemoveResult === "boolean") {
+                return handleRevert(requestRemoveResult);
+              }
+              if (typeof requestRemoveResult.then === "function") {
+                requestRemoveResult.then(handleRevert);
+              }
+            }),
+            REVERT_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2) {
+              item2.revert(
+                createRevertFunction(state2.options.server.url, state2.options.server.revert),
+                query("GET_FORCE_REVERT")
+              ).then(function() {
+                var shouldRemove = state2.options.instantUpload || isMockItem(item2);
+                if (shouldRemove) {
+                  dispatch2("REMOVE_ITEM", { query: item2.id });
+                }
+              }).catch(function() {
+              });
+            }),
+            SET_OPTIONS: function SET_OPTIONS(_ref11) {
+              var options = _ref11.options;
+              var optionKeys = Object.keys(options);
+              var prioritizedOptionKeys = PrioritizedOptions.filter(function(key) {
+                return optionKeys.includes(key);
+              });
+              var orderedOptionKeys = [].concat(
+                _toConsumableArray(prioritizedOptionKeys),
+                _toConsumableArray(
+                  Object.keys(options).filter(function(key) {
+                    return !prioritizedOptionKeys.includes(key);
+                  })
+                )
+              );
+              orderedOptionKeys.forEach(function(key) {
+                dispatch2("SET_" + fromCamels(key, "_").toUpperCase(), {
+                  value: options[key]
+                });
+              });
+            }
+          };
+        };
+        var PrioritizedOptions = ["server"];
+        var formatFilename = function formatFilename2(name2) {
+          return name2;
+        };
+        var createElement$1 = function createElement4(tagName) {
+          return document.createElement(tagName);
+        };
+        var text = function text2(node, value) {
+          var textNode = node.childNodes[0];
+          if (!textNode) {
+            textNode = document.createTextNode(value);
+            node.appendChild(textNode);
+          } else if (value !== textNode.nodeValue) {
+            textNode.nodeValue = value;
+          }
+        };
+        var polarToCartesian = function polarToCartesian2(centerX, centerY, radius, angleInDegrees) {
+          var angleInRadians = (angleInDegrees % 360 - 90) * Math.PI / 180;
+          return {
+            x: centerX + radius * Math.cos(angleInRadians),
+            y: centerY + radius * Math.sin(angleInRadians)
+          };
+        };
+        var describeArc = function describeArc2(x, y, radius, startAngle, endAngle, arcSweep) {
+          var start = polarToCartesian(x, y, radius, endAngle);
+          var end = polarToCartesian(x, y, radius, startAngle);
+          return ["M", start.x, start.y, "A", radius, radius, 0, arcSweep, 0, end.x, end.y].join(" ");
+        };
+        var percentageArc = function percentageArc2(x, y, radius, from, to) {
+          var arcSweep = 1;
+          if (to > from && to - from <= 0.5) {
+            arcSweep = 0;
+          }
+          if (from > to && from - to >= 0.5) {
+            arcSweep = 0;
+          }
+          return describeArc(
+            x,
+            y,
+            radius,
+            Math.min(0.9999, from) * 360,
+            Math.min(0.9999, to) * 360,
+            arcSweep
+          );
+        };
+        var create = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          props.spin = false;
+          props.progress = 0;
+          props.opacity = 0;
+          var svg = createElement3("svg");
+          root2.ref.path = createElement3("path", {
+            "stroke-width": 2,
+            "stroke-linecap": "round"
+          });
+          svg.appendChild(root2.ref.path);
+          root2.ref.svg = svg;
+          root2.appendChild(svg);
+        };
+        var write = function write2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          if (props.opacity === 0) {
+            return;
+          }
+          if (props.align) {
+            root2.element.dataset.align = props.align;
+          }
+          var ringStrokeWidth = parseInt(attr(root2.ref.path, "stroke-width"), 10);
+          var size = root2.rect.element.width * 0.5;
+          var ringFrom = 0;
+          var ringTo = 0;
+          if (props.spin) {
+            ringFrom = 0;
+            ringTo = 0.5;
+          } else {
+            ringFrom = 0;
+            ringTo = props.progress;
+          }
+          var coordinates = percentageArc(size, size, size - ringStrokeWidth, ringFrom, ringTo);
+          attr(root2.ref.path, "d", coordinates);
+          attr(root2.ref.path, "stroke-opacity", props.spin || props.progress > 0 ? 1 : 0);
+        };
+        var progressIndicator = createView({
+          tag: "div",
+          name: "progress-indicator",
+          ignoreRectUpdate: true,
+          ignoreRect: true,
+          create,
+          write,
+          mixins: {
+            apis: ["progress", "spin", "align"],
+            styles: ["opacity"],
+            animations: {
+              opacity: { type: "tween", duration: 500 },
+              progress: {
+                type: "spring",
+                stiffness: 0.95,
+                damping: 0.65,
+                mass: 10
+              }
+            }
+          }
+        });
+        var create$1 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.element.innerHTML = (props.icon || "") + ("<span>" + props.label + "</span>");
+          props.isDisabled = false;
+        };
+        var write$1 = function write2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          var isDisabled = props.isDisabled;
+          var shouldDisable = root2.query("GET_DISABLED") || props.opacity === 0;
+          if (shouldDisable && !isDisabled) {
+            props.isDisabled = true;
+            attr(root2.element, "disabled", "disabled");
+          } else if (!shouldDisable && isDisabled) {
+            props.isDisabled = false;
+            root2.element.removeAttribute("disabled");
+          }
+        };
+        var fileActionButton = createView({
+          tag: "button",
+          attributes: {
+            type: "button"
+          },
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          name: "file-action-button",
+          mixins: {
+            apis: ["label"],
+            styles: ["translateX", "translateY", "scaleX", "scaleY", "opacity"],
+            animations: {
+              scaleX: "spring",
+              scaleY: "spring",
+              translateX: "spring",
+              translateY: "spring",
+              opacity: { type: "tween", duration: 250 }
+            },
+            listeners: true
+          },
+          create: create$1,
+          write: write$1
+        });
+        var toNaturalFileSize = function toNaturalFileSize2(bytes) {
+          var decimalSeparator = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : ".";
+          var base = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 1e3;
+          var options = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : {};
+          var _options$labelBytes = options.labelBytes, labelBytes = _options$labelBytes === void 0 ? "bytes" : _options$labelBytes, _options$labelKilobyt = options.labelKilobytes, labelKilobytes = _options$labelKilobyt === void 0 ? "KB" : _options$labelKilobyt, _options$labelMegabyt = options.labelMegabytes, labelMegabytes = _options$labelMegabyt === void 0 ? "MB" : _options$labelMegabyt, _options$labelGigabyt = options.labelGigabytes, labelGigabytes = _options$labelGigabyt === void 0 ? "GB" : _options$labelGigabyt;
+          bytes = Math.round(Math.abs(bytes));
+          var KB = base;
+          var MB = base * base;
+          var GB = base * base * base;
+          if (bytes < KB) {
+            return bytes + " " + labelBytes;
+          }
+          if (bytes < MB) {
+            return Math.floor(bytes / KB) + " " + labelKilobytes;
+          }
+          if (bytes < GB) {
+            return removeDecimalsWhenZero(bytes / MB, 1, decimalSeparator) + " " + labelMegabytes;
+          }
+          return removeDecimalsWhenZero(bytes / GB, 2, decimalSeparator) + " " + labelGigabytes;
+        };
+        var removeDecimalsWhenZero = function removeDecimalsWhenZero2(value, decimalCount, separator) {
+          return value.toFixed(decimalCount).split(".").filter(function(part) {
+            return part !== "0";
+          }).join(separator);
+        };
+        var create$2 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          var fileName = createElement$1("span");
+          fileName.className = "filepond--file-info-main";
+          attr(fileName, "aria-hidden", "true");
+          root2.appendChild(fileName);
+          root2.ref.fileName = fileName;
+          var fileSize = createElement$1("span");
+          fileSize.className = "filepond--file-info-sub";
+          root2.appendChild(fileSize);
+          root2.ref.fileSize = fileSize;
+          text(fileSize, root2.query("GET_LABEL_FILE_WAITING_FOR_SIZE"));
+          text(fileName, formatFilename(root2.query("GET_ITEM_NAME", props.id)));
+        };
+        var updateFile = function updateFile2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          text(
+            root2.ref.fileSize,
+            toNaturalFileSize(
+              root2.query("GET_ITEM_SIZE", props.id),
+              ".",
+              root2.query("GET_FILE_SIZE_BASE"),
+              root2.query("GET_FILE_SIZE_LABELS", root2.query)
+            )
+          );
+          text(root2.ref.fileName, formatFilename(root2.query("GET_ITEM_NAME", props.id)));
+        };
+        var updateFileSizeOnError = function updateFileSizeOnError2(_ref3) {
+          var root2 = _ref3.root, props = _ref3.props;
+          if (isInt(root2.query("GET_ITEM_SIZE", props.id))) {
+            updateFile({ root: root2, props });
+            return;
+          }
+          text(root2.ref.fileSize, root2.query("GET_LABEL_FILE_SIZE_NOT_AVAILABLE"));
+        };
+        var fileInfo = createView({
+          name: "file-info",
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          write: createRoute({
+            DID_LOAD_ITEM: updateFile,
+            DID_UPDATE_ITEM_META: updateFile,
+            DID_THROW_ITEM_LOAD_ERROR: updateFileSizeOnError,
+            DID_THROW_ITEM_INVALID: updateFileSizeOnError
+          }),
+          didCreateView: function didCreateView(root2) {
+            applyFilters("CREATE_VIEW", Object.assign({}, root2, { view: root2 }));
+          },
+          create: create$2,
+          mixins: {
+            styles: ["translateX", "translateY"],
+            animations: {
+              translateX: "spring",
+              translateY: "spring"
+            }
+          }
+        });
+        var toPercentage = function toPercentage2(value) {
+          return Math.round(value * 100);
+        };
+        var create$3 = function create2(_ref) {
+          var root2 = _ref.root;
+          var main = createElement$1("span");
+          main.className = "filepond--file-status-main";
+          root2.appendChild(main);
+          root2.ref.main = main;
+          var sub = createElement$1("span");
+          sub.className = "filepond--file-status-sub";
+          root2.appendChild(sub);
+          root2.ref.sub = sub;
+          didSetItemLoadProgress({ root: root2, action: { progress: null } });
+        };
+        var didSetItemLoadProgress = function didSetItemLoadProgress2(_ref2) {
+          var root2 = _ref2.root, action = _ref2.action;
+          var title = action.progress === null ? root2.query("GET_LABEL_FILE_LOADING") : root2.query("GET_LABEL_FILE_LOADING") + " " + toPercentage(action.progress) + "%";
+          text(root2.ref.main, title);
+          text(root2.ref.sub, root2.query("GET_LABEL_TAP_TO_CANCEL"));
+        };
+        var didSetItemProcessProgress = function didSetItemProcessProgress2(_ref3) {
+          var root2 = _ref3.root, action = _ref3.action;
+          var title = action.progress === null ? root2.query("GET_LABEL_FILE_PROCESSING") : root2.query("GET_LABEL_FILE_PROCESSING") + " " + toPercentage(action.progress) + "%";
+          text(root2.ref.main, title);
+          text(root2.ref.sub, root2.query("GET_LABEL_TAP_TO_CANCEL"));
+        };
+        var didRequestItemProcessing = function didRequestItemProcessing2(_ref4) {
+          var root2 = _ref4.root;
+          text(root2.ref.main, root2.query("GET_LABEL_FILE_PROCESSING"));
+          text(root2.ref.sub, root2.query("GET_LABEL_TAP_TO_CANCEL"));
+        };
+        var didAbortItemProcessing = function didAbortItemProcessing2(_ref5) {
+          var root2 = _ref5.root;
+          text(root2.ref.main, root2.query("GET_LABEL_FILE_PROCESSING_ABORTED"));
+          text(root2.ref.sub, root2.query("GET_LABEL_TAP_TO_RETRY"));
+        };
+        var didCompleteItemProcessing = function didCompleteItemProcessing2(_ref6) {
+          var root2 = _ref6.root;
+          text(root2.ref.main, root2.query("GET_LABEL_FILE_PROCESSING_COMPLETE"));
+          text(root2.ref.sub, root2.query("GET_LABEL_TAP_TO_UNDO"));
+        };
+        var clear = function clear2(_ref7) {
+          var root2 = _ref7.root;
+          text(root2.ref.main, "");
+          text(root2.ref.sub, "");
+        };
+        var error = function error2(_ref8) {
+          var root2 = _ref8.root, action = _ref8.action;
+          text(root2.ref.main, action.status.main);
+          text(root2.ref.sub, action.status.sub);
+        };
+        var fileStatus = createView({
+          name: "file-status",
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          write: createRoute({
+            DID_LOAD_ITEM: clear,
+            DID_REVERT_ITEM_PROCESSING: clear,
+            DID_REQUEST_ITEM_PROCESSING: didRequestItemProcessing,
+            DID_ABORT_ITEM_PROCESSING: didAbortItemProcessing,
+            DID_COMPLETE_ITEM_PROCESSING: didCompleteItemProcessing,
+            DID_UPDATE_ITEM_PROCESS_PROGRESS: didSetItemProcessProgress,
+            DID_UPDATE_ITEM_LOAD_PROGRESS: didSetItemLoadProgress,
+            DID_THROW_ITEM_LOAD_ERROR: error,
+            DID_THROW_ITEM_INVALID: error,
+            DID_THROW_ITEM_PROCESSING_ERROR: error,
+            DID_THROW_ITEM_PROCESSING_REVERT_ERROR: error,
+            DID_THROW_ITEM_REMOVE_ERROR: error
+          }),
+          didCreateView: function didCreateView(root2) {
+            applyFilters("CREATE_VIEW", Object.assign({}, root2, { view: root2 }));
+          },
+          create: create$3,
+          mixins: {
+            styles: ["translateX", "translateY", "opacity"],
+            animations: {
+              opacity: { type: "tween", duration: 250 },
+              translateX: "spring",
+              translateY: "spring"
+            }
+          }
+        });
+        var Buttons = {
+          AbortItemLoad: {
+            label: "GET_LABEL_BUTTON_ABORT_ITEM_LOAD",
+            action: "ABORT_ITEM_LOAD",
+            className: "filepond--action-abort-item-load",
+            align: "LOAD_INDICATOR_POSITION"
+            // right
+          },
+          RetryItemLoad: {
+            label: "GET_LABEL_BUTTON_RETRY_ITEM_LOAD",
+            action: "RETRY_ITEM_LOAD",
+            icon: "GET_ICON_RETRY",
+            className: "filepond--action-retry-item-load",
+            align: "BUTTON_PROCESS_ITEM_POSITION"
+            // right
+          },
+          RemoveItem: {
+            label: "GET_LABEL_BUTTON_REMOVE_ITEM",
+            action: "REQUEST_REMOVE_ITEM",
+            icon: "GET_ICON_REMOVE",
+            className: "filepond--action-remove-item",
+            align: "BUTTON_REMOVE_ITEM_POSITION"
+            // left
+          },
+          ProcessItem: {
+            label: "GET_LABEL_BUTTON_PROCESS_ITEM",
+            action: "REQUEST_ITEM_PROCESSING",
+            icon: "GET_ICON_PROCESS",
+            className: "filepond--action-process-item",
+            align: "BUTTON_PROCESS_ITEM_POSITION"
+            // right
+          },
+          AbortItemProcessing: {
+            label: "GET_LABEL_BUTTON_ABORT_ITEM_PROCESSING",
+            action: "ABORT_ITEM_PROCESSING",
+            className: "filepond--action-abort-item-processing",
+            align: "BUTTON_PROCESS_ITEM_POSITION"
+            // right
+          },
+          RetryItemProcessing: {
+            label: "GET_LABEL_BUTTON_RETRY_ITEM_PROCESSING",
+            action: "RETRY_ITEM_PROCESSING",
+            icon: "GET_ICON_RETRY",
+            className: "filepond--action-retry-item-processing",
+            align: "BUTTON_PROCESS_ITEM_POSITION"
+            // right
+          },
+          RevertItemProcessing: {
+            label: "GET_LABEL_BUTTON_UNDO_ITEM_PROCESSING",
+            action: "REQUEST_REVERT_ITEM_PROCESSING",
+            icon: "GET_ICON_UNDO",
+            className: "filepond--action-revert-item-processing",
+            align: "BUTTON_PROCESS_ITEM_POSITION"
+            // right
+          }
+        };
+        var ButtonKeys = [];
+        forin(Buttons, function(key) {
+          ButtonKeys.push(key);
+        });
+        var calculateFileInfoOffset = function calculateFileInfoOffset2(root2) {
+          if (getRemoveIndicatorAligment(root2) === "right") return 0;
+          var buttonRect = root2.ref.buttonRemoveItem.rect.element;
+          return buttonRect.hidden ? null : buttonRect.width + buttonRect.left;
+        };
+        var calculateButtonWidth = function calculateButtonWidth2(root2) {
+          var buttonRect = root2.ref.buttonAbortItemLoad.rect.element;
+          return buttonRect.width;
+        };
+        var calculateFileVerticalCenterOffset = function calculateFileVerticalCenterOffset2(root2) {
+          return Math.floor(root2.ref.buttonRemoveItem.rect.element.height / 4);
+        };
+        var calculateFileHorizontalCenterOffset = function calculateFileHorizontalCenterOffset2(root2) {
+          return Math.floor(root2.ref.buttonRemoveItem.rect.element.left / 2);
+        };
+        var getLoadIndicatorAlignment = function getLoadIndicatorAlignment2(root2) {
+          return root2.query("GET_STYLE_LOAD_INDICATOR_POSITION");
+        };
+        var getProcessIndicatorAlignment = function getProcessIndicatorAlignment2(root2) {
+          return root2.query("GET_STYLE_PROGRESS_INDICATOR_POSITION");
+        };
+        var getRemoveIndicatorAligment = function getRemoveIndicatorAligment2(root2) {
+          return root2.query("GET_STYLE_BUTTON_REMOVE_ITEM_POSITION");
+        };
+        var DefaultStyle = {
+          buttonAbortItemLoad: { opacity: 0 },
+          buttonRetryItemLoad: { opacity: 0 },
+          buttonRemoveItem: { opacity: 0 },
+          buttonProcessItem: { opacity: 0 },
+          buttonAbortItemProcessing: { opacity: 0 },
+          buttonRetryItemProcessing: { opacity: 0 },
+          buttonRevertItemProcessing: { opacity: 0 },
+          loadProgressIndicator: { opacity: 0, align: getLoadIndicatorAlignment },
+          processProgressIndicator: { opacity: 0, align: getProcessIndicatorAlignment },
+          processingCompleteIndicator: { opacity: 0, scaleX: 0.75, scaleY: 0.75 },
+          info: { translateX: 0, translateY: 0, opacity: 0 },
+          status: { translateX: 0, translateY: 0, opacity: 0 }
+        };
+        var IdleStyle = {
+          buttonRemoveItem: { opacity: 1 },
+          buttonProcessItem: { opacity: 1 },
+          info: { translateX: calculateFileInfoOffset },
+          status: { translateX: calculateFileInfoOffset }
+        };
+        var ProcessingStyle = {
+          buttonAbortItemProcessing: { opacity: 1 },
+          processProgressIndicator: { opacity: 1 },
+          status: { opacity: 1 }
+        };
+        var StyleMap = {
+          DID_THROW_ITEM_INVALID: {
+            buttonRemoveItem: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset },
+            status: { translateX: calculateFileInfoOffset, opacity: 1 }
+          },
+          DID_START_ITEM_LOAD: {
+            buttonAbortItemLoad: { opacity: 1 },
+            loadProgressIndicator: { opacity: 1 },
+            status: { opacity: 1 }
+          },
+          DID_THROW_ITEM_LOAD_ERROR: {
+            buttonRetryItemLoad: { opacity: 1 },
+            buttonRemoveItem: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset },
+            status: { opacity: 1 }
+          },
+          DID_START_ITEM_REMOVE: {
+            processProgressIndicator: { opacity: 1, align: getRemoveIndicatorAligment },
+            info: { translateX: calculateFileInfoOffset },
+            status: { opacity: 0 }
+          },
+          DID_THROW_ITEM_REMOVE_ERROR: {
+            processProgressIndicator: { opacity: 0, align: getRemoveIndicatorAligment },
+            buttonRemoveItem: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset },
+            status: { opacity: 1, translateX: calculateFileInfoOffset }
+          },
+          DID_LOAD_ITEM: IdleStyle,
+          DID_LOAD_LOCAL_ITEM: {
+            buttonRemoveItem: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset },
+            status: { translateX: calculateFileInfoOffset }
+          },
+          DID_START_ITEM_PROCESSING: ProcessingStyle,
+          DID_REQUEST_ITEM_PROCESSING: ProcessingStyle,
+          DID_UPDATE_ITEM_PROCESS_PROGRESS: ProcessingStyle,
+          DID_COMPLETE_ITEM_PROCESSING: {
+            buttonRevertItemProcessing: { opacity: 1 },
+            info: { opacity: 1 },
+            status: { opacity: 1 }
+          },
+          DID_THROW_ITEM_PROCESSING_ERROR: {
+            buttonRemoveItem: { opacity: 1 },
+            buttonRetryItemProcessing: { opacity: 1 },
+            status: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset }
+          },
+          DID_THROW_ITEM_PROCESSING_REVERT_ERROR: {
+            buttonRevertItemProcessing: { opacity: 1 },
+            status: { opacity: 1 },
+            info: { opacity: 1 }
+          },
+          DID_ABORT_ITEM_PROCESSING: {
+            buttonRemoveItem: { opacity: 1 },
+            buttonProcessItem: { opacity: 1 },
+            info: { translateX: calculateFileInfoOffset },
+            status: { opacity: 1 }
+          },
+          DID_REVERT_ITEM_PROCESSING: IdleStyle
+        };
+        var processingCompleteIndicatorView = createView({
+          create: function create2(_ref) {
+            var root2 = _ref.root;
+            root2.element.innerHTML = root2.query("GET_ICON_DONE");
+          },
+          name: "processing-complete-indicator",
+          ignoreRect: true,
+          mixins: {
+            styles: ["scaleX", "scaleY", "opacity"],
+            animations: {
+              scaleX: "spring",
+              scaleY: "spring",
+              opacity: { type: "tween", duration: 250 }
+            }
+          }
+        });
+        var create$4 = function create2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          var LocalButtons = Object.keys(Buttons).reduce(function(prev, curr) {
+            prev[curr] = Object.assign({}, Buttons[curr]);
+            return prev;
+          }, {});
+          var id2 = props.id;
+          var allowRevert = root2.query("GET_ALLOW_REVERT");
+          var allowRemove = root2.query("GET_ALLOW_REMOVE");
+          var allowProcess = root2.query("GET_ALLOW_PROCESS");
+          var instantUpload = root2.query("GET_INSTANT_UPLOAD");
+          var isAsync2 = root2.query("IS_ASYNC");
+          var alignRemoveItemButton = root2.query("GET_STYLE_BUTTON_REMOVE_ITEM_ALIGN");
+          var buttonFilter;
+          if (isAsync2) {
+            if (allowProcess && !allowRevert) {
+              buttonFilter = function buttonFilter2(key) {
+                return !/RevertItemProcessing/.test(key);
+              };
+            } else if (!allowProcess && allowRevert) {
+              buttonFilter = function buttonFilter2(key) {
+                return !/ProcessItem|RetryItemProcessing|AbortItemProcessing/.test(key);
+              };
+            } else if (!allowProcess && !allowRevert) {
+              buttonFilter = function buttonFilter2(key) {
+                return !/Process/.test(key);
+              };
+            }
+          } else {
+            buttonFilter = function buttonFilter2(key) {
+              return !/Process/.test(key);
+            };
+          }
+          var enabledButtons = buttonFilter ? ButtonKeys.filter(buttonFilter) : ButtonKeys.concat();
+          if (instantUpload && allowRevert) {
+            LocalButtons["RevertItemProcessing"].label = "GET_LABEL_BUTTON_REMOVE_ITEM";
+            LocalButtons["RevertItemProcessing"].icon = "GET_ICON_REMOVE";
+          }
+          if (isAsync2 && !allowRevert) {
+            var map2 = StyleMap["DID_COMPLETE_ITEM_PROCESSING"];
+            map2.info.translateX = calculateFileHorizontalCenterOffset;
+            map2.info.translateY = calculateFileVerticalCenterOffset;
+            map2.status.translateY = calculateFileVerticalCenterOffset;
+            map2.processingCompleteIndicator = { opacity: 1, scaleX: 1, scaleY: 1 };
+          }
+          if (isAsync2 && !allowProcess) {
+            [
+              "DID_START_ITEM_PROCESSING",
+              "DID_REQUEST_ITEM_PROCESSING",
+              "DID_UPDATE_ITEM_PROCESS_PROGRESS",
+              "DID_THROW_ITEM_PROCESSING_ERROR"
+            ].forEach(function(key) {
+              StyleMap[key].status.translateY = calculateFileVerticalCenterOffset;
+            });
+            StyleMap["DID_THROW_ITEM_PROCESSING_ERROR"].status.translateX = calculateButtonWidth;
+          }
+          if (alignRemoveItemButton && allowRevert) {
+            LocalButtons["RevertItemProcessing"].align = "BUTTON_REMOVE_ITEM_POSITION";
+            var _map = StyleMap["DID_COMPLETE_ITEM_PROCESSING"];
+            _map.info.translateX = calculateFileInfoOffset;
+            _map.status.translateY = calculateFileVerticalCenterOffset;
+            _map.processingCompleteIndicator = { opacity: 1, scaleX: 1, scaleY: 1 };
+          }
+          if (!allowRemove) {
+            LocalButtons["RemoveItem"].disabled = true;
+          }
+          forin(LocalButtons, function(key, definition) {
+            var buttonView = root2.createChildView(fileActionButton, {
+              label: root2.query(definition.label),
+              icon: root2.query(definition.icon),
+              opacity: 0
+            });
+            if (enabledButtons.includes(key)) {
+              root2.appendChildView(buttonView);
+            }
+            if (definition.disabled) {
+              buttonView.element.setAttribute("disabled", "disabled");
+              buttonView.element.setAttribute("hidden", "hidden");
+            }
+            buttonView.element.dataset.align = root2.query("GET_STYLE_" + definition.align);
+            buttonView.element.classList.add(definition.className);
+            buttonView.on("click", function(e) {
+              e.stopPropagation();
+              if (definition.disabled) return;
+              root2.dispatch(definition.action, { query: id2 });
+            });
+            root2.ref["button" + key] = buttonView;
+          });
+          root2.ref.processingCompleteIndicator = root2.appendChildView(
+            root2.createChildView(processingCompleteIndicatorView)
+          );
+          root2.ref.processingCompleteIndicator.element.dataset.align = root2.query(
+            "GET_STYLE_BUTTON_PROCESS_ITEM_POSITION"
+          );
+          root2.ref.info = root2.appendChildView(root2.createChildView(fileInfo, { id: id2 }));
+          root2.ref.status = root2.appendChildView(root2.createChildView(fileStatus, { id: id2 }));
+          var loadIndicatorView = root2.appendChildView(
+            root2.createChildView(progressIndicator, {
+              opacity: 0,
+              align: root2.query("GET_STYLE_LOAD_INDICATOR_POSITION")
+            })
+          );
+          loadIndicatorView.element.classList.add("filepond--load-indicator");
+          root2.ref.loadProgressIndicator = loadIndicatorView;
+          var progressIndicatorView = root2.appendChildView(
+            root2.createChildView(progressIndicator, {
+              opacity: 0,
+              align: root2.query("GET_STYLE_PROGRESS_INDICATOR_POSITION")
+            })
+          );
+          progressIndicatorView.element.classList.add("filepond--process-indicator");
+          root2.ref.processProgressIndicator = progressIndicatorView;
+          root2.ref.activeStyles = [];
+        };
+        var write$2 = function write2(_ref3) {
+          var root2 = _ref3.root, actions2 = _ref3.actions, props = _ref3.props;
+          route({ root: root2, actions: actions2, props });
+          var action = actions2.concat().filter(function(action2) {
+            return /^DID_/.test(action2.type);
+          }).reverse().find(function(action2) {
+            return StyleMap[action2.type];
+          });
+          if (action) {
+            root2.ref.activeStyles = [];
+            var stylesToApply = StyleMap[action.type];
+            forin(DefaultStyle, function(name2, defaultStyles) {
+              var control = root2.ref[name2];
+              forin(defaultStyles, function(key, defaultValue) {
+                var value = stylesToApply[name2] && typeof stylesToApply[name2][key] !== "undefined" ? stylesToApply[name2][key] : defaultValue;
+                root2.ref.activeStyles.push({ control, key, value });
+              });
+            });
+          }
+          root2.ref.activeStyles.forEach(function(_ref4) {
+            var control = _ref4.control, key = _ref4.key, value = _ref4.value;
+            control[key] = typeof value === "function" ? value(root2) : value;
+          });
+        };
+        var route = createRoute({
+          DID_SET_LABEL_BUTTON_ABORT_ITEM_PROCESSING: function DID_SET_LABEL_BUTTON_ABORT_ITEM_PROCESSING(_ref5) {
+            var root2 = _ref5.root, action = _ref5.action;
+            root2.ref.buttonAbortItemProcessing.label = action.value;
+          },
+          DID_SET_LABEL_BUTTON_ABORT_ITEM_LOAD: function DID_SET_LABEL_BUTTON_ABORT_ITEM_LOAD(_ref6) {
+            var root2 = _ref6.root, action = _ref6.action;
+            root2.ref.buttonAbortItemLoad.label = action.value;
+          },
+          DID_SET_LABEL_BUTTON_ABORT_ITEM_REMOVAL: function DID_SET_LABEL_BUTTON_ABORT_ITEM_REMOVAL(_ref7) {
+            var root2 = _ref7.root, action = _ref7.action;
+            root2.ref.buttonAbortItemRemoval.label = action.value;
+          },
+          DID_REQUEST_ITEM_PROCESSING: function DID_REQUEST_ITEM_PROCESSING(_ref8) {
+            var root2 = _ref8.root;
+            root2.ref.processProgressIndicator.spin = true;
+            root2.ref.processProgressIndicator.progress = 0;
+          },
+          DID_START_ITEM_LOAD: function DID_START_ITEM_LOAD(_ref9) {
+            var root2 = _ref9.root;
+            root2.ref.loadProgressIndicator.spin = true;
+            root2.ref.loadProgressIndicator.progress = 0;
+          },
+          DID_START_ITEM_REMOVE: function DID_START_ITEM_REMOVE(_ref10) {
+            var root2 = _ref10.root;
+            root2.ref.processProgressIndicator.spin = true;
+            root2.ref.processProgressIndicator.progress = 0;
+          },
+          DID_UPDATE_ITEM_LOAD_PROGRESS: function DID_UPDATE_ITEM_LOAD_PROGRESS(_ref11) {
+            var root2 = _ref11.root, action = _ref11.action;
+            root2.ref.loadProgressIndicator.spin = false;
+            root2.ref.loadProgressIndicator.progress = action.progress;
+          },
+          DID_UPDATE_ITEM_PROCESS_PROGRESS: function DID_UPDATE_ITEM_PROCESS_PROGRESS(_ref12) {
+            var root2 = _ref12.root, action = _ref12.action;
+            root2.ref.processProgressIndicator.spin = false;
+            root2.ref.processProgressIndicator.progress = action.progress;
+          }
+        });
+        var file = createView({
+          create: create$4,
+          write: write$2,
+          didCreateView: function didCreateView(root2) {
+            applyFilters("CREATE_VIEW", Object.assign({}, root2, { view: root2 }));
+          },
+          name: "file"
+        });
+        var create$5 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.ref.fileName = createElement$1("legend");
+          root2.appendChild(root2.ref.fileName);
+          root2.ref.file = root2.appendChildView(root2.createChildView(file, { id: props.id }));
+          root2.ref.data = false;
+        };
+        var didLoadItem = function didLoadItem2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          text(root2.ref.fileName, formatFilename(root2.query("GET_ITEM_NAME", props.id)));
+        };
+        var fileWrapper = createView({
+          create: create$5,
+          ignoreRect: true,
+          write: createRoute({
+            DID_LOAD_ITEM: didLoadItem
+          }),
+          didCreateView: function didCreateView(root2) {
+            applyFilters("CREATE_VIEW", Object.assign({}, root2, { view: root2 }));
+          },
+          tag: "fieldset",
+          name: "file-wrapper"
+        });
+        var PANEL_SPRING_PROPS = { type: "spring", damping: 0.6, mass: 7 };
+        var create$6 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          [
+            {
+              name: "top"
+            },
+            {
+              name: "center",
+              props: {
+                translateY: null,
+                scaleY: null
+              },
+              mixins: {
+                animations: {
+                  scaleY: PANEL_SPRING_PROPS
+                },
+                styles: ["translateY", "scaleY"]
+              }
+            },
+            {
+              name: "bottom",
+              props: {
+                translateY: null
+              },
+              mixins: {
+                animations: {
+                  translateY: PANEL_SPRING_PROPS
+                },
+                styles: ["translateY"]
+              }
+            }
+          ].forEach(function(section) {
+            createSection(root2, section, props.name);
+          });
+          root2.element.classList.add("filepond--" + props.name);
+          root2.ref.scalable = null;
+        };
+        var createSection = function createSection2(root2, section, className) {
+          var viewConstructor = createView({
+            name: "panel-" + section.name + " filepond--" + className,
+            mixins: section.mixins,
+            ignoreRectUpdate: true
+          });
+          var view = root2.createChildView(viewConstructor, section.props);
+          root2.ref[section.name] = root2.appendChildView(view);
+        };
+        var write$3 = function write2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props;
+          if (root2.ref.scalable === null || props.scalable !== root2.ref.scalable) {
+            root2.ref.scalable = isBoolean(props.scalable) ? props.scalable : true;
+            root2.element.dataset.scalable = root2.ref.scalable;
+          }
+          if (!props.height) return;
+          var topRect = root2.ref.top.rect.element;
+          var bottomRect = root2.ref.bottom.rect.element;
+          var height = Math.max(topRect.height + bottomRect.height, props.height);
+          root2.ref.center.translateY = topRect.height;
+          root2.ref.center.scaleY = (height - topRect.height - bottomRect.height) / 100;
+          root2.ref.bottom.translateY = height - bottomRect.height;
+        };
+        var panel = createView({
+          name: "panel",
+          read: function read(_ref3) {
+            var root2 = _ref3.root, props = _ref3.props;
+            return props.heightCurrent = root2.ref.bottom.translateY;
+          },
+          write: write$3,
+          create: create$6,
+          ignoreRect: true,
+          mixins: {
+            apis: ["height", "heightCurrent", "scalable"]
+          }
+        });
+        var createDragHelper = function createDragHelper2(items) {
+          var itemIds = items.map(function(item2) {
+            return item2.id;
+          });
+          var prevIndex = void 0;
+          return {
+            setIndex: function setIndex(index) {
+              prevIndex = index;
+            },
+            getIndex: function getIndex() {
+              return prevIndex;
+            },
+            getItemIndex: function getItemIndex(item2) {
+              return itemIds.indexOf(item2.id);
+            }
+          };
+        };
+        var ITEM_TRANSLATE_SPRING = {
+          type: "spring",
+          stiffness: 0.75,
+          damping: 0.45,
+          mass: 10
+        };
+        var ITEM_SCALE_SPRING = "spring";
+        var StateMap = {
+          DID_START_ITEM_LOAD: "busy",
+          DID_UPDATE_ITEM_LOAD_PROGRESS: "loading",
+          DID_THROW_ITEM_INVALID: "load-invalid",
+          DID_THROW_ITEM_LOAD_ERROR: "load-error",
+          DID_LOAD_ITEM: "idle",
+          DID_THROW_ITEM_REMOVE_ERROR: "remove-error",
+          DID_START_ITEM_REMOVE: "busy",
+          DID_START_ITEM_PROCESSING: "busy processing",
+          DID_REQUEST_ITEM_PROCESSING: "busy processing",
+          DID_UPDATE_ITEM_PROCESS_PROGRESS: "processing",
+          DID_COMPLETE_ITEM_PROCESSING: "processing-complete",
+          DID_THROW_ITEM_PROCESSING_ERROR: "processing-error",
+          DID_THROW_ITEM_PROCESSING_REVERT_ERROR: "processing-revert-error",
+          DID_ABORT_ITEM_PROCESSING: "cancelled",
+          DID_REVERT_ITEM_PROCESSING: "idle"
+        };
+        var create$7 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.ref.handleClick = function(e) {
+            return root2.dispatch("DID_ACTIVATE_ITEM", { id: props.id });
+          };
+          root2.element.id = "filepond--item-" + props.id;
+          root2.element.addEventListener("click", root2.ref.handleClick);
+          root2.ref.container = root2.appendChildView(
+            root2.createChildView(fileWrapper, { id: props.id })
+          );
+          root2.ref.panel = root2.appendChildView(root2.createChildView(panel, { name: "item-panel" }));
+          root2.ref.panel.height = null;
+          props.markedForRemoval = false;
+          if (!root2.query("GET_ALLOW_REORDER")) return;
+          root2.element.dataset.dragState = "idle";
+          var grab = function grab2(e) {
+            if (!e.isPrimary) return;
+            var removedActivateListener = false;
+            var origin = {
+              x: e.pageX,
+              y: e.pageY
+            };
+            props.dragOrigin = {
+              x: root2.translateX,
+              y: root2.translateY
+            };
+            props.dragCenter = {
+              x: e.offsetX,
+              y: e.offsetY
+            };
+            var dragState = createDragHelper(root2.query("GET_ACTIVE_ITEMS"));
+            root2.dispatch("DID_GRAB_ITEM", { id: props.id, dragState });
+            var drag = function drag2(e2) {
+              if (!e2.isPrimary) return;
+              e2.stopPropagation();
+              e2.preventDefault();
+              props.dragOffset = {
+                x: e2.pageX - origin.x,
+                y: e2.pageY - origin.y
+              };
+              var dist = props.dragOffset.x * props.dragOffset.x + props.dragOffset.y * props.dragOffset.y;
+              if (dist > 16 && !removedActivateListener) {
+                removedActivateListener = true;
+                root2.element.removeEventListener("click", root2.ref.handleClick);
+              }
+              root2.dispatch("DID_DRAG_ITEM", { id: props.id, dragState });
+            };
+            var drop2 = function drop3(e2) {
+              if (!e2.isPrimary) return;
+              props.dragOffset = {
+                x: e2.pageX - origin.x,
+                y: e2.pageY - origin.y
+              };
+              reset();
+            };
+            var cancel = function cancel2() {
+              reset();
+            };
+            var reset = function reset2() {
+              document.removeEventListener("pointercancel", cancel);
+              document.removeEventListener("pointermove", drag);
+              document.removeEventListener("pointerup", drop2);
+              root2.dispatch("DID_DROP_ITEM", { id: props.id, dragState });
+              if (removedActivateListener) {
+                setTimeout(function() {
+                  return root2.element.addEventListener("click", root2.ref.handleClick);
+                }, 0);
+              }
+            };
+            document.addEventListener("pointercancel", cancel);
+            document.addEventListener("pointermove", drag);
+            document.addEventListener("pointerup", drop2);
+          };
+          root2.element.addEventListener("pointerdown", grab);
+        };
+        var route$1 = createRoute({
+          DID_UPDATE_PANEL_HEIGHT: function DID_UPDATE_PANEL_HEIGHT(_ref2) {
+            var root2 = _ref2.root, action = _ref2.action;
+            root2.height = action.height;
+          }
+        });
+        var write$4 = createRoute(
+          {
+            DID_GRAB_ITEM: function DID_GRAB_ITEM(_ref3) {
+              var root2 = _ref3.root, props = _ref3.props;
+              props.dragOrigin = {
+                x: root2.translateX,
+                y: root2.translateY
+              };
+            },
+            DID_DRAG_ITEM: function DID_DRAG_ITEM(_ref4) {
+              var root2 = _ref4.root;
+              root2.element.dataset.dragState = "drag";
+            },
+            DID_DROP_ITEM: function DID_DROP_ITEM(_ref5) {
+              var root2 = _ref5.root, props = _ref5.props;
+              props.dragOffset = null;
+              props.dragOrigin = null;
+              root2.element.dataset.dragState = "drop";
+            }
+          },
+          function(_ref6) {
+            var root2 = _ref6.root, actions2 = _ref6.actions, props = _ref6.props, shouldOptimize = _ref6.shouldOptimize;
+            if (root2.element.dataset.dragState === "drop") {
+              if (root2.scaleX <= 1) {
+                root2.element.dataset.dragState = "idle";
+              }
+            }
+            var action = actions2.concat().filter(function(action2) {
+              return /^DID_/.test(action2.type);
+            }).reverse().find(function(action2) {
+              return StateMap[action2.type];
+            });
+            if (action && action.type !== props.currentState) {
+              props.currentState = action.type;
+              root2.element.dataset.filepondItemState = StateMap[props.currentState] || "";
+            }
+            var aspectRatio = root2.query("GET_ITEM_PANEL_ASPECT_RATIO") || root2.query("GET_PANEL_ASPECT_RATIO");
+            if (!aspectRatio) {
+              route$1({ root: root2, actions: actions2, props });
+              if (!root2.height && root2.ref.container.rect.element.height > 0) {
+                root2.height = root2.ref.container.rect.element.height;
+              }
+            } else if (!shouldOptimize) {
+              root2.height = root2.rect.element.width * aspectRatio;
+            }
+            if (shouldOptimize) {
+              root2.ref.panel.height = null;
+            }
+            root2.ref.panel.height = root2.height;
+          }
+        );
+        var item = createView({
+          create: create$7,
+          write: write$4,
+          destroy: function destroy(_ref7) {
+            var root2 = _ref7.root, props = _ref7.props;
+            root2.element.removeEventListener("click", root2.ref.handleClick);
+            root2.dispatch("RELEASE_ITEM", { query: props.id });
+          },
+          tag: "li",
+          name: "item",
+          mixins: {
+            apis: [
+              "id",
+              "interactionMethod",
+              "markedForRemoval",
+              "spawnDate",
+              "dragCenter",
+              "dragOrigin",
+              "dragOffset"
+            ],
+            styles: ["translateX", "translateY", "scaleX", "scaleY", "opacity", "height"],
+            animations: {
+              scaleX: ITEM_SCALE_SPRING,
+              scaleY: ITEM_SCALE_SPRING,
+              translateX: ITEM_TRANSLATE_SPRING,
+              translateY: ITEM_TRANSLATE_SPRING,
+              opacity: { type: "tween", duration: 150 }
+            }
+          }
+        });
+        var getItemsPerRow = function(horizontalSpace, itemWidth) {
+          return Math.max(1, Math.floor((horizontalSpace + 1) / itemWidth));
+        };
+        var getItemIndexByPosition = function getItemIndexByPosition2(view, children, positionInView) {
+          if (!positionInView) return;
+          var horizontalSpace = view.rect.element.width;
+          var l = children.length;
+          var last = null;
+          if (l === 0 || positionInView.top < children[0].rect.element.top) return -1;
+          var item2 = children[0];
+          var itemRect = item2.rect.element;
+          var itemHorizontalMargin = itemRect.marginLeft + itemRect.marginRight;
+          var itemWidth = itemRect.width + itemHorizontalMargin;
+          var itemsPerRow = getItemsPerRow(horizontalSpace, itemWidth);
+          if (itemsPerRow === 1) {
+            for (var index = 0; index < l; index++) {
+              var child = children[index];
+              var childMid = child.rect.outer.top + child.rect.element.height * 0.5;
+              if (positionInView.top < childMid) {
+                return index;
+              }
+            }
+            return l;
+          }
+          var itemVerticalMargin = itemRect.marginTop + itemRect.marginBottom;
+          var itemHeight = itemRect.height + itemVerticalMargin;
+          for (var _index = 0; _index < l; _index++) {
+            var indexX = _index % itemsPerRow;
+            var indexY = Math.floor(_index / itemsPerRow);
+            var offsetX = indexX * itemWidth;
+            var offsetY = indexY * itemHeight;
+            var itemTop = offsetY - itemRect.marginTop;
+            var itemRight = offsetX + itemWidth;
+            var itemBottom = offsetY + itemHeight + itemRect.marginBottom;
+            if (positionInView.top < itemBottom && positionInView.top > itemTop) {
+              if (positionInView.left < itemRight) {
+                return _index;
+              } else if (_index !== l - 1) {
+                last = _index;
+              } else {
+                last = null;
+              }
+            }
+          }
+          if (last !== null) {
+            return last;
+          }
+          return l;
+        };
+        var dropAreaDimensions = {
+          height: 0,
+          width: 0,
+          get getHeight() {
+            return this.height;
+          },
+          set setHeight(val) {
+            if (this.height === 0 || val === 0) this.height = val;
+          },
+          get getWidth() {
+            return this.width;
+          },
+          set setWidth(val) {
+            if (this.width === 0 || val === 0) this.width = val;
+          },
+          setDimensions: function setDimensions(height, width) {
+            if (this.height === 0 || height === 0) this.height = height;
+            if (this.width === 0 || width === 0) this.width = width;
+          }
+        };
+        var create$8 = function create2(_ref) {
+          var root2 = _ref.root;
+          attr(root2.element, "role", "list");
+          root2.ref.lastItemSpanwDate = Date.now();
+        };
+        var addItemView = function addItemView2(_ref2) {
+          var root2 = _ref2.root, action = _ref2.action;
+          var id2 = action.id, index = action.index, interactionMethod = action.interactionMethod;
+          root2.ref.addIndex = index;
+          var now = Date.now();
+          var spawnDate = now;
+          var opacity = 1;
+          if (interactionMethod !== InteractionMethod.NONE) {
+            opacity = 0;
+            var cooldown = root2.query("GET_ITEM_INSERT_INTERVAL");
+            var dist = now - root2.ref.lastItemSpanwDate;
+            spawnDate = dist < cooldown ? now + (cooldown - dist) : now;
+          }
+          root2.ref.lastItemSpanwDate = spawnDate;
+          root2.appendChildView(
+            root2.createChildView(
+              // view type
+              item,
+              // props
+              {
+                spawnDate,
+                id: id2,
+                opacity,
+                interactionMethod
+              }
+            ),
+            index
+          );
+        };
+        var moveItem = function moveItem2(item2, x, y) {
+          var vx = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : 0;
+          var vy = arguments.length > 4 && arguments[4] !== void 0 ? arguments[4] : 1;
+          if (item2.dragOffset) {
+            item2.translateX = null;
+            item2.translateY = null;
+            item2.translateX = item2.dragOrigin.x + item2.dragOffset.x;
+            item2.translateY = item2.dragOrigin.y + item2.dragOffset.y;
+            item2.scaleX = 1.025;
+            item2.scaleY = 1.025;
+          } else {
+            item2.translateX = x;
+            item2.translateY = y;
+            if (Date.now() > item2.spawnDate) {
+              if (item2.opacity === 0) {
+                introItemView(item2, x, y, vx, vy);
+              }
+              item2.scaleX = 1;
+              item2.scaleY = 1;
+              item2.opacity = 1;
+            }
+          }
+        };
+        var introItemView = function introItemView2(item2, x, y, vx, vy) {
+          if (item2.interactionMethod === InteractionMethod.NONE) {
+            item2.translateX = null;
+            item2.translateX = x;
+            item2.translateY = null;
+            item2.translateY = y;
+          } else if (item2.interactionMethod === InteractionMethod.DROP) {
+            item2.translateX = null;
+            item2.translateX = x - vx * 20;
+            item2.translateY = null;
+            item2.translateY = y - vy * 10;
+            item2.scaleX = 0.8;
+            item2.scaleY = 0.8;
+          } else if (item2.interactionMethod === InteractionMethod.BROWSE) {
+            item2.translateY = null;
+            item2.translateY = y - 30;
+          } else if (item2.interactionMethod === InteractionMethod.API) {
+            item2.translateX = null;
+            item2.translateX = x - 30;
+            item2.translateY = null;
+          }
+        };
+        var removeItemView = function removeItemView2(_ref3) {
+          var root2 = _ref3.root, action = _ref3.action;
+          var id2 = action.id;
+          var view = root2.childViews.find(function(child) {
+            return child.id === id2;
+          });
+          if (!view) {
+            return;
+          }
+          view.scaleX = 0.9;
+          view.scaleY = 0.9;
+          view.opacity = 0;
+          view.markedForRemoval = true;
+        };
+        var getItemHeight = function getItemHeight2(child) {
+          return child.rect.element.height + child.rect.element.marginBottom + child.rect.element.marginTop;
+        };
+        var getItemWidth = function getItemWidth2(child) {
+          return child.rect.element.width + child.rect.element.marginLeft * 0.5 + child.rect.element.marginRight * 0.5;
+        };
+        var dragItem = function dragItem2(_ref4) {
+          var root2 = _ref4.root, action = _ref4.action;
+          var id2 = action.id, dragState = action.dragState;
+          var item2 = root2.query("GET_ITEM", { id: id2 });
+          var view = root2.childViews.find(function(child) {
+            return child.id === id2;
+          });
+          var numItems = root2.childViews.length;
+          var oldIndex = dragState.getItemIndex(item2);
+          if (!view) return;
+          var dragPosition = {
+            x: view.dragOrigin.x + view.dragOffset.x + view.dragCenter.x,
+            y: view.dragOrigin.y + view.dragOffset.y + view.dragCenter.y
+          };
+          var dragHeight = getItemHeight(view);
+          var dragWidth = getItemWidth(view);
+          var cols = Math.floor(root2.rect.outer.width / dragWidth);
+          if (cols > numItems) cols = numItems;
+          var rows = Math.floor(numItems / cols + 1);
+          dropAreaDimensions.setHeight = dragHeight * rows;
+          dropAreaDimensions.setWidth = dragWidth * cols;
+          var location2 = {
+            y: Math.floor(dragPosition.y / dragHeight),
+            x: Math.floor(dragPosition.x / dragWidth),
+            getGridIndex: function getGridIndex() {
+              if (dragPosition.y > dropAreaDimensions.getHeight || dragPosition.y < 0 || dragPosition.x > dropAreaDimensions.getWidth || dragPosition.x < 0)
+                return oldIndex;
+              return this.y * cols + this.x;
+            },
+            getColIndex: function getColIndex() {
+              var items = root2.query("GET_ACTIVE_ITEMS");
+              var visibleChildren = root2.childViews.filter(function(child) {
+                return child.rect.element.height;
+              });
+              var children = items.map(function(item3) {
+                return visibleChildren.find(function(childView) {
+                  return childView.id === item3.id;
+                });
+              });
+              var currentIndex2 = children.findIndex(function(child) {
+                return child === view;
+              });
+              var dragHeight2 = getItemHeight(view);
+              var l = children.length;
+              var idx = l;
+              var childHeight = 0;
+              var childBottom = 0;
+              var childTop = 0;
+              for (var i = 0; i < l; i++) {
+                childHeight = getItemHeight(children[i]);
+                childTop = childBottom;
+                childBottom = childTop + childHeight;
+                if (dragPosition.y < childBottom) {
+                  if (currentIndex2 > i) {
+                    if (dragPosition.y < childTop + dragHeight2) {
+                      idx = i;
+                      break;
+                    }
+                    continue;
+                  }
+                  idx = i;
+                  break;
+                }
+              }
+              return idx;
+            }
+          };
+          var index = cols > 1 ? location2.getGridIndex() : location2.getColIndex();
+          root2.dispatch("MOVE_ITEM", { query: view, index });
+          var currentIndex = dragState.getIndex();
+          if (currentIndex === void 0 || currentIndex !== index) {
+            dragState.setIndex(index);
+            if (currentIndex === void 0) return;
+            root2.dispatch("DID_REORDER_ITEMS", {
+              items: root2.query("GET_ACTIVE_ITEMS"),
+              origin: oldIndex,
+              target: index
+            });
+          }
+        };
+        var route$2 = createRoute({
+          DID_ADD_ITEM: addItemView,
+          DID_REMOVE_ITEM: removeItemView,
+          DID_DRAG_ITEM: dragItem
+        });
+        var write$5 = function write2(_ref5) {
+          var root2 = _ref5.root, props = _ref5.props, actions2 = _ref5.actions, shouldOptimize = _ref5.shouldOptimize;
+          route$2({ root: root2, props, actions: actions2 });
+          var dragCoordinates = props.dragCoordinates;
+          var horizontalSpace = root2.rect.element.width;
+          var visibleChildren = root2.childViews.filter(function(child) {
+            return child.rect.element.height;
+          });
+          var children = root2.query("GET_ACTIVE_ITEMS").map(function(item2) {
+            return visibleChildren.find(function(child) {
+              return child.id === item2.id;
+            });
+          }).filter(function(item2) {
+            return item2;
+          });
+          var dragIndex = dragCoordinates ? getItemIndexByPosition(root2, children, dragCoordinates) : null;
+          var addIndex = root2.ref.addIndex || null;
+          root2.ref.addIndex = null;
+          var dragIndexOffset = 0;
+          var removeIndexOffset = 0;
+          var addIndexOffset = 0;
+          if (children.length === 0) return;
+          var childRect = children[0].rect.element;
+          var itemVerticalMargin = childRect.marginTop + childRect.marginBottom;
+          var itemHorizontalMargin = childRect.marginLeft + childRect.marginRight;
+          var itemWidth = childRect.width + itemHorizontalMargin;
+          var itemHeight = childRect.height + itemVerticalMargin;
+          var itemsPerRow = getItemsPerRow(horizontalSpace, itemWidth);
+          if (itemsPerRow === 1) {
+            var offsetY = 0;
+            var dragOffset = 0;
+            children.forEach(function(child, index) {
+              if (dragIndex) {
+                var dist = index - dragIndex;
+                if (dist === -2) {
+                  dragOffset = -itemVerticalMargin * 0.25;
+                } else if (dist === -1) {
+                  dragOffset = -itemVerticalMargin * 0.75;
+                } else if (dist === 0) {
+                  dragOffset = itemVerticalMargin * 0.75;
+                } else if (dist === 1) {
+                  dragOffset = itemVerticalMargin * 0.25;
+                } else {
+                  dragOffset = 0;
+                }
+              }
+              if (shouldOptimize) {
+                child.translateX = null;
+                child.translateY = null;
+              }
+              if (!child.markedForRemoval) {
+                moveItem(child, 0, offsetY + dragOffset);
+              }
+              var itemHeight2 = child.rect.element.height + itemVerticalMargin;
+              var visualHeight = itemHeight2 * (child.markedForRemoval ? child.opacity : 1);
+              offsetY += visualHeight;
+            });
+          } else {
+            var prevX = 0;
+            var prevY = 0;
+            children.forEach(function(child, index) {
+              if (index === dragIndex) {
+                dragIndexOffset = 1;
+              }
+              if (index === addIndex) {
+                addIndexOffset += 1;
+              }
+              if (child.markedForRemoval && child.opacity < 0.5) {
+                removeIndexOffset -= 1;
+              }
+              var visualIndex = index + addIndexOffset + dragIndexOffset + removeIndexOffset;
+              var indexX = visualIndex % itemsPerRow;
+              var indexY = Math.floor(visualIndex / itemsPerRow);
+              var offsetX = indexX * itemWidth;
+              var offsetY2 = indexY * itemHeight;
+              var vectorX = Math.sign(offsetX - prevX);
+              var vectorY = Math.sign(offsetY2 - prevY);
+              prevX = offsetX;
+              prevY = offsetY2;
+              if (child.markedForRemoval) return;
+              if (shouldOptimize) {
+                child.translateX = null;
+                child.translateY = null;
+              }
+              moveItem(child, offsetX, offsetY2, vectorX, vectorY);
+            });
+          }
+        };
+        var filterSetItemActions = function filterSetItemActions2(child, actions2) {
+          return actions2.filter(function(action) {
+            if (action.data && action.data.id) {
+              return child.id === action.data.id;
+            }
+            return true;
+          });
+        };
+        var list = createView({
+          create: create$8,
+          write: write$5,
+          tag: "ul",
+          name: "list",
+          didWriteView: function didWriteView(_ref6) {
+            var root2 = _ref6.root;
+            root2.childViews.filter(function(view) {
+              return view.markedForRemoval && view.opacity === 0 && view.resting;
+            }).forEach(function(view) {
+              view._destroy();
+              root2.removeChildView(view);
+            });
+          },
+          filterFrameActionsForChild: filterSetItemActions,
+          mixins: {
+            apis: ["dragCoordinates"]
+          }
+        });
+        var create$9 = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.ref.list = root2.appendChildView(root2.createChildView(list));
+          props.dragCoordinates = null;
+          props.overflowing = false;
+        };
+        var storeDragCoordinates = function storeDragCoordinates2(_ref2) {
+          var root2 = _ref2.root, props = _ref2.props, action = _ref2.action;
+          if (!root2.query("GET_ITEM_INSERT_LOCATION_FREEDOM")) return;
+          props.dragCoordinates = {
+            left: action.position.scopeLeft - root2.ref.list.rect.element.left,
+            top: action.position.scopeTop - (root2.rect.outer.top + root2.rect.element.marginTop + root2.rect.element.scrollTop)
+          };
+        };
+        var clearDragCoordinates = function clearDragCoordinates2(_ref3) {
+          var props = _ref3.props;
+          props.dragCoordinates = null;
+        };
+        var route$3 = createRoute({
+          DID_DRAG: storeDragCoordinates,
+          DID_END_DRAG: clearDragCoordinates
+        });
+        var write$6 = function write2(_ref4) {
+          var root2 = _ref4.root, props = _ref4.props, actions2 = _ref4.actions;
+          route$3({ root: root2, props, actions: actions2 });
+          root2.ref.list.dragCoordinates = props.dragCoordinates;
+          if (props.overflowing && !props.overflow) {
+            props.overflowing = false;
+            root2.element.dataset.state = "";
+            root2.height = null;
+          }
+          if (props.overflow) {
+            var newHeight = Math.round(props.overflow);
+            if (newHeight !== root2.height) {
+              props.overflowing = true;
+              root2.element.dataset.state = "overflow";
+              root2.height = newHeight;
+            }
+          }
+        };
+        var listScroller = createView({
+          create: create$9,
+          write: write$6,
+          name: "list-scroller",
+          mixins: {
+            apis: ["overflow", "dragCoordinates"],
+            styles: ["height", "translateY"],
+            animations: {
+              translateY: "spring"
+            }
+          }
+        });
+        var attrToggle = function attrToggle2(element, name2, state2) {
+          var enabledValue = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : "";
+          if (state2) {
+            attr(element, name2, enabledValue);
+          } else {
+            element.removeAttribute(name2);
+          }
+        };
+        var resetFileInput = function resetFileInput2(input) {
+          if (!input || input.value === "") {
+            return;
+          }
+          try {
+            input.value = "";
+          } catch (err) {
+          }
+          if (input.value) {
+            var form = createElement$1("form");
+            var parentNode = input.parentNode;
+            var ref = input.nextSibling;
+            form.appendChild(input);
+            form.reset();
+            if (ref) {
+              parentNode.insertBefore(input, ref);
+            } else {
+              parentNode.appendChild(input);
+            }
+          }
+        };
+        var create$a = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.element.id = "filepond--browser-" + props.id;
+          attr(root2.element, "name", root2.query("GET_NAME"));
+          attr(root2.element, "aria-controls", "filepond--assistant-" + props.id);
+          attr(root2.element, "aria-labelledby", "filepond--drop-label-" + props.id);
+          setAcceptedFileTypes({
+            root: root2,
+            action: { value: root2.query("GET_ACCEPTED_FILE_TYPES") }
+          });
+          toggleAllowMultiple({ root: root2, action: { value: root2.query("GET_ALLOW_MULTIPLE") } });
+          toggleDirectoryFilter({
+            root: root2,
+            action: { value: root2.query("GET_ALLOW_DIRECTORIES_ONLY") }
+          });
+          toggleDisabled({ root: root2 });
+          toggleRequired({ root: root2, action: { value: root2.query("GET_REQUIRED") } });
+          setCaptureMethod({ root: root2, action: { value: root2.query("GET_CAPTURE_METHOD") } });
+          root2.ref.handleChange = function(e) {
+            if (!root2.element.value) {
+              return;
+            }
+            var files = Array.from(root2.element.files).map(function(file2) {
+              file2._relativePath = file2.webkitRelativePath;
+              return file2;
+            });
+            setTimeout(function() {
+              props.onload(files);
+              resetFileInput(root2.element);
+            }, 250);
+          };
+          root2.element.addEventListener("change", root2.ref.handleChange);
+        };
+        var setAcceptedFileTypes = function setAcceptedFileTypes2(_ref2) {
+          var root2 = _ref2.root, action = _ref2.action;
+          if (!root2.query("GET_ALLOW_SYNC_ACCEPT_ATTRIBUTE")) return;
+          attrToggle(
+            root2.element,
+            "accept",
+            !!action.value,
+            action.value ? action.value.join(",") : ""
+          );
+        };
+        var toggleAllowMultiple = function toggleAllowMultiple2(_ref3) {
+          var root2 = _ref3.root, action = _ref3.action;
+          attrToggle(root2.element, "multiple", action.value);
+        };
+        var toggleDirectoryFilter = function toggleDirectoryFilter2(_ref4) {
+          var root2 = _ref4.root, action = _ref4.action;
+          attrToggle(root2.element, "webkitdirectory", action.value);
+        };
+        var toggleDisabled = function toggleDisabled2(_ref5) {
+          var root2 = _ref5.root;
+          var isDisabled = root2.query("GET_DISABLED");
+          var doesAllowBrowse = root2.query("GET_ALLOW_BROWSE");
+          var disableField = isDisabled || !doesAllowBrowse;
+          attrToggle(root2.element, "disabled", disableField);
+        };
+        var toggleRequired = function toggleRequired2(_ref6) {
+          var root2 = _ref6.root, action = _ref6.action;
+          if (!action.value) {
+            attrToggle(root2.element, "required", false);
+          } else if (root2.query("GET_TOTAL_ITEMS") === 0) {
+            attrToggle(root2.element, "required", true);
+          }
+        };
+        var setCaptureMethod = function setCaptureMethod2(_ref7) {
+          var root2 = _ref7.root, action = _ref7.action;
+          attrToggle(
+            root2.element,
+            "capture",
+            !!action.value,
+            action.value === true ? "" : action.value
+          );
+        };
+        var updateRequiredStatus = function updateRequiredStatus2(_ref8) {
+          var root2 = _ref8.root;
+          var element = root2.element;
+          if (root2.query("GET_TOTAL_ITEMS") > 0) {
+            attrToggle(element, "required", false);
+            attrToggle(element, "name", false);
+            var activeItems = root2.query("GET_ACTIVE_ITEMS");
+            var hasInvalidField = false;
+            for (var i = 0; i < activeItems.length; i++) {
+              if (activeItems[i].status === ItemStatus.LOAD_ERROR) {
+                hasInvalidField = true;
+              }
+            }
+            root2.element.setCustomValidity(
+              hasInvalidField ? root2.query("GET_LABEL_INVALID_FIELD") : ""
+            );
+          } else {
+            attrToggle(element, "name", true, root2.query("GET_NAME"));
+            var shouldCheckValidity = root2.query("GET_CHECK_VALIDITY");
+            if (shouldCheckValidity) {
+              element.setCustomValidity("");
+            }
+            if (root2.query("GET_REQUIRED")) {
+              attrToggle(element, "required", true);
+            }
+          }
+        };
+        var updateFieldValidityStatus = function updateFieldValidityStatus2(_ref9) {
+          var root2 = _ref9.root;
+          var shouldCheckValidity = root2.query("GET_CHECK_VALIDITY");
+          if (!shouldCheckValidity) return;
+          root2.element.setCustomValidity(root2.query("GET_LABEL_INVALID_FIELD"));
+        };
+        var browser = createView({
+          tag: "input",
+          name: "browser",
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          attributes: {
+            type: "file"
+          },
+          create: create$a,
+          destroy: function destroy(_ref10) {
+            var root2 = _ref10.root;
+            root2.element.removeEventListener("change", root2.ref.handleChange);
+          },
+          write: createRoute({
+            DID_LOAD_ITEM: updateRequiredStatus,
+            DID_REMOVE_ITEM: updateRequiredStatus,
+            DID_THROW_ITEM_INVALID: updateFieldValidityStatus,
+            DID_SET_DISABLED: toggleDisabled,
+            DID_SET_ALLOW_BROWSE: toggleDisabled,
+            DID_SET_ALLOW_DIRECTORIES_ONLY: toggleDirectoryFilter,
+            DID_SET_ALLOW_MULTIPLE: toggleAllowMultiple,
+            DID_SET_ACCEPTED_FILE_TYPES: setAcceptedFileTypes,
+            DID_SET_CAPTURE_METHOD: setCaptureMethod,
+            DID_SET_REQUIRED: toggleRequired
+          })
+        });
+        var Key = {
+          ENTER: 13,
+          SPACE: 32
+        };
+        var create$b = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          var label = createElement$1("label");
+          attr(label, "for", "filepond--browser-" + props.id);
+          attr(label, "id", "filepond--drop-label-" + props.id);
+          root2.ref.handleKeyDown = function(e) {
+            var isActivationKey = e.keyCode === Key.ENTER || e.keyCode === Key.SPACE;
+            if (!isActivationKey) return;
+            e.preventDefault();
+            root2.ref.label.click();
+          };
+          root2.ref.handleClick = function(e) {
+            var isLabelClick = e.target === label || label.contains(e.target);
+            if (isLabelClick) return;
+            root2.ref.label.click();
+          };
+          label.addEventListener("keydown", root2.ref.handleKeyDown);
+          root2.element.addEventListener("click", root2.ref.handleClick);
+          updateLabelValue(label, props.caption);
+          root2.appendChild(label);
+          root2.ref.label = label;
+        };
+        var updateLabelValue = function updateLabelValue2(label, value) {
+          label.innerHTML = value;
+          var clickable = label.querySelector(".filepond--label-action");
+          if (clickable) {
+            attr(clickable, "tabindex", "0");
+          }
+          return value;
+        };
+        var dropLabel = createView({
+          name: "drop-label",
+          ignoreRect: true,
+          create: create$b,
+          destroy: function destroy(_ref2) {
+            var root2 = _ref2.root;
+            root2.ref.label.addEventListener("keydown", root2.ref.handleKeyDown);
+            root2.element.removeEventListener("click", root2.ref.handleClick);
+          },
+          write: createRoute({
+            DID_SET_LABEL_IDLE: function DID_SET_LABEL_IDLE(_ref3) {
+              var root2 = _ref3.root, action = _ref3.action;
+              updateLabelValue(root2.ref.label, action.value);
+            }
+          }),
+          mixins: {
+            styles: ["opacity", "translateX", "translateY"],
+            animations: {
+              opacity: { type: "tween", duration: 150 },
+              translateX: "spring",
+              translateY: "spring"
+            }
+          }
+        });
+        var blob = createView({
+          name: "drip-blob",
+          ignoreRect: true,
+          mixins: {
+            styles: ["translateX", "translateY", "scaleX", "scaleY", "opacity"],
+            animations: {
+              scaleX: "spring",
+              scaleY: "spring",
+              translateX: "spring",
+              translateY: "spring",
+              opacity: { type: "tween", duration: 250 }
+            }
+          }
+        });
+        var addBlob = function addBlob2(_ref) {
+          var root2 = _ref.root;
+          var centerX = root2.rect.element.width * 0.5;
+          var centerY = root2.rect.element.height * 0.5;
+          root2.ref.blob = root2.appendChildView(
+            root2.createChildView(blob, {
+              opacity: 0,
+              scaleX: 2.5,
+              scaleY: 2.5,
+              translateX: centerX,
+              translateY: centerY
+            })
+          );
+        };
+        var moveBlob = function moveBlob2(_ref2) {
+          var root2 = _ref2.root, action = _ref2.action;
+          if (!root2.ref.blob) {
+            addBlob({ root: root2 });
+            return;
+          }
+          root2.ref.blob.translateX = action.position.scopeLeft;
+          root2.ref.blob.translateY = action.position.scopeTop;
+          root2.ref.blob.scaleX = 1;
+          root2.ref.blob.scaleY = 1;
+          root2.ref.blob.opacity = 1;
+        };
+        var hideBlob = function hideBlob2(_ref3) {
+          var root2 = _ref3.root;
+          if (!root2.ref.blob) {
+            return;
+          }
+          root2.ref.blob.opacity = 0;
+        };
+        var explodeBlob = function explodeBlob2(_ref4) {
+          var root2 = _ref4.root;
+          if (!root2.ref.blob) {
+            return;
+          }
+          root2.ref.blob.scaleX = 2.5;
+          root2.ref.blob.scaleY = 2.5;
+          root2.ref.blob.opacity = 0;
+        };
+        var write$7 = function write2(_ref5) {
+          var root2 = _ref5.root, props = _ref5.props, actions2 = _ref5.actions;
+          route$4({ root: root2, props, actions: actions2 });
+          var blob2 = root2.ref.blob;
+          if (actions2.length === 0 && blob2 && blob2.opacity === 0) {
+            root2.removeChildView(blob2);
+            root2.ref.blob = null;
+          }
+        };
+        var route$4 = createRoute({
+          DID_DRAG: moveBlob,
+          DID_DROP: explodeBlob,
+          DID_END_DRAG: hideBlob
+        });
+        var drip = createView({
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          name: "drip",
+          write: write$7
+        });
+        var setInputFiles = function setInputFiles2(element, files) {
+          try {
+            var dataTransfer = new DataTransfer();
+            files.forEach(function(file2) {
+              if (file2 instanceof File) {
+                dataTransfer.items.add(file2);
+              } else {
+                dataTransfer.items.add(
+                  new File([file2], file2.name, {
+                    type: file2.type
+                  })
+                );
+              }
+            });
+            element.files = dataTransfer.files;
+          } catch (err) {
+            return false;
+          }
+          return true;
+        };
+        var create$c = function create2(_ref) {
+          var root2 = _ref.root;
+          root2.ref.fields = {};
+          var legend = document.createElement("legend");
+          legend.textContent = "Files";
+          root2.element.appendChild(legend);
+        };
+        var getField = function getField2(root2, id2) {
+          return root2.ref.fields[id2];
+        };
+        var syncFieldPositionsWithItems = function syncFieldPositionsWithItems2(root2) {
+          root2.query("GET_ACTIVE_ITEMS").forEach(function(item2) {
+            if (!root2.ref.fields[item2.id]) return;
+            root2.element.appendChild(root2.ref.fields[item2.id]);
+          });
+        };
+        var didReorderItems = function didReorderItems2(_ref2) {
+          var root2 = _ref2.root;
+          return syncFieldPositionsWithItems(root2);
+        };
+        var didAddItem = function didAddItem2(_ref3) {
+          var root2 = _ref3.root, action = _ref3.action;
+          var fileItem = root2.query("GET_ITEM", action.id);
+          var isLocalFile = fileItem.origin === FileOrigin.LOCAL;
+          var shouldUseFileInput = !isLocalFile && root2.query("SHOULD_UPDATE_FILE_INPUT");
+          var dataContainer = createElement$1("input");
+          dataContainer.type = shouldUseFileInput ? "file" : "hidden";
+          dataContainer.name = root2.query("GET_NAME");
+          root2.ref.fields[action.id] = dataContainer;
+          syncFieldPositionsWithItems(root2);
+        };
+        var didLoadItem$1 = function didLoadItem2(_ref4) {
+          var root2 = _ref4.root, action = _ref4.action;
+          var field = getField(root2, action.id);
+          if (!field) return;
+          if (action.serverFileReference !== null) field.value = action.serverFileReference;
+          if (!root2.query("SHOULD_UPDATE_FILE_INPUT")) return;
+          var fileItem = root2.query("GET_ITEM", action.id);
+          setInputFiles(field, [fileItem.file]);
+        };
+        var didPrepareOutput = function didPrepareOutput2(_ref5) {
+          var root2 = _ref5.root, action = _ref5.action;
+          if (!root2.query("SHOULD_UPDATE_FILE_INPUT")) return;
+          setTimeout(function() {
+            var field = getField(root2, action.id);
+            if (!field) return;
+            setInputFiles(field, [action.file]);
+          }, 0);
+        };
+        var didSetDisabled = function didSetDisabled2(_ref6) {
+          var root2 = _ref6.root;
+          root2.element.disabled = root2.query("GET_DISABLED");
+        };
+        var didRemoveItem = function didRemoveItem2(_ref7) {
+          var root2 = _ref7.root, action = _ref7.action;
+          var field = getField(root2, action.id);
+          if (!field) return;
+          if (field.parentNode) field.parentNode.removeChild(field);
+          delete root2.ref.fields[action.id];
+        };
+        var didDefineValue = function didDefineValue2(_ref8) {
+          var root2 = _ref8.root, action = _ref8.action;
+          var field = getField(root2, action.id);
+          if (!field) return;
+          if (action.value === null) {
+            field.removeAttribute("value");
+          } else {
+            if (field.type != "file") {
+              field.value = action.value;
+            }
+          }
+          syncFieldPositionsWithItems(root2);
+        };
+        var write$8 = createRoute({
+          DID_SET_DISABLED: didSetDisabled,
+          DID_ADD_ITEM: didAddItem,
+          DID_LOAD_ITEM: didLoadItem$1,
+          DID_REMOVE_ITEM: didRemoveItem,
+          DID_DEFINE_VALUE: didDefineValue,
+          DID_PREPARE_OUTPUT: didPrepareOutput,
+          DID_REORDER_ITEMS: didReorderItems,
+          DID_SORT_ITEMS: didReorderItems
+        });
+        var data2 = createView({
+          tag: "fieldset",
+          name: "data",
+          create: create$c,
+          write: write$8,
+          ignoreRect: true
+        });
+        var getRootNode = function getRootNode2(element) {
+          return "getRootNode" in element ? element.getRootNode() : document;
+        };
+        var images = ["jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "tiff"];
+        var text$1 = ["css", "csv", "html", "txt"];
+        var map = {
+          zip: "zip|compressed",
+          epub: "application/epub+zip"
+        };
+        var guesstimateMimeType = function guesstimateMimeType2() {
+          var extension = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "";
+          extension = extension.toLowerCase();
+          if (images.includes(extension)) {
+            return "image/" + (extension === "jpg" ? "jpeg" : extension === "svg" ? "svg+xml" : extension);
+          }
+          if (text$1.includes(extension)) {
+            return "text/" + extension;
+          }
+          return map[extension] || "";
+        };
+        var requestDataTransferItems = function requestDataTransferItems2(dataTransfer) {
+          return new Promise(function(resolve, reject) {
+            var links = getLinks(dataTransfer);
+            if (links.length && !hasFiles(dataTransfer)) {
+              return resolve(links);
+            }
+            getFiles(dataTransfer).then(resolve);
+          });
+        };
+        var hasFiles = function hasFiles2(dataTransfer) {
+          if (dataTransfer.files) return dataTransfer.files.length > 0;
+          return false;
+        };
+        var getFiles = function getFiles2(dataTransfer) {
+          return new Promise(function(resolve, reject) {
+            var promisedFiles = (dataTransfer.items ? Array.from(dataTransfer.items) : []).filter(function(item2) {
+              return isFileSystemItem(item2);
+            }).map(function(item2) {
+              return getFilesFromItem(item2);
+            });
+            if (!promisedFiles.length) {
+              resolve(dataTransfer.files ? Array.from(dataTransfer.files) : []);
+              return;
+            }
+            Promise.all(promisedFiles).then(function(returnedFileGroups) {
+              var files = [];
+              returnedFileGroups.forEach(function(group) {
+                files.push.apply(files, group);
+              });
+              resolve(
+                files.filter(function(file2) {
+                  return file2;
+                }).map(function(file2) {
+                  if (!file2._relativePath)
+                    file2._relativePath = file2.webkitRelativePath;
+                  return file2;
+                })
+              );
+            }).catch(console.error);
+          });
+        };
+        var isFileSystemItem = function isFileSystemItem2(item2) {
+          if (isEntry(item2)) {
+            var entry = getAsEntry(item2);
+            if (entry) {
+              return entry.isFile || entry.isDirectory;
+            }
+          }
+          return item2.kind === "file";
+        };
+        var getFilesFromItem = function getFilesFromItem2(item2) {
+          return new Promise(function(resolve, reject) {
+            if (isDirectoryEntry(item2)) {
+              getFilesInDirectory(getAsEntry(item2)).then(resolve).catch(reject);
+              return;
+            }
+            resolve([item2.getAsFile()]);
+          });
+        };
+        var getFilesInDirectory = function getFilesInDirectory2(entry) {
+          return new Promise(function(resolve, reject) {
+            var files = [];
+            var dirCounter = 0;
+            var fileCounter = 0;
+            var resolveIfDone = function resolveIfDone2() {
+              if (fileCounter === 0 && dirCounter === 0) {
+                resolve(files);
+              }
+            };
+            var readEntries = function readEntries2(dirEntry) {
+              dirCounter++;
+              var directoryReader = dirEntry.createReader();
+              var readBatch = function readBatch2() {
+                directoryReader.readEntries(function(entries) {
+                  if (entries.length === 0) {
+                    dirCounter--;
+                    resolveIfDone();
+                    return;
+                  }
+                  entries.forEach(function(entry2) {
+                    if (entry2.isDirectory) {
+                      readEntries2(entry2);
+                    } else {
+                      fileCounter++;
+                      entry2.file(function(file2) {
+                        var correctedFile = correctMissingFileType(file2);
+                        if (entry2.fullPath)
+                          correctedFile._relativePath = entry2.fullPath;
+                        files.push(correctedFile);
+                        fileCounter--;
+                        resolveIfDone();
+                      });
+                    }
+                  });
+                  readBatch2();
+                }, reject);
+              };
+              readBatch();
+            };
+            readEntries(entry);
+          });
+        };
+        var correctMissingFileType = function correctMissingFileType2(file2) {
+          if (file2.type.length) return file2;
+          var date = file2.lastModifiedDate;
+          var name2 = file2.name;
+          var type = guesstimateMimeType(getExtensionFromFilename(file2.name));
+          if (!type.length) return file2;
+          file2 = file2.slice(0, file2.size, type);
+          file2.name = name2;
+          file2.lastModifiedDate = date;
+          return file2;
+        };
+        var isDirectoryEntry = function isDirectoryEntry2(item2) {
+          return isEntry(item2) && (getAsEntry(item2) || {}).isDirectory;
+        };
+        var isEntry = function isEntry2(item2) {
+          return "webkitGetAsEntry" in item2;
+        };
+        var getAsEntry = function getAsEntry2(item2) {
+          return item2.webkitGetAsEntry();
+        };
+        var getLinks = function getLinks2(dataTransfer) {
+          var links = [];
+          try {
+            links = getLinksFromTransferMetaData(dataTransfer);
+            if (links.length) {
+              return links;
+            }
+            links = getLinksFromTransferURLData(dataTransfer);
+          } catch (e) {
+          }
+          return links;
+        };
+        var getLinksFromTransferURLData = function getLinksFromTransferURLData2(dataTransfer) {
+          var data3 = dataTransfer.getData("url");
+          if (typeof data3 === "string" && data3.length) {
+            return [data3];
+          }
+          return [];
+        };
+        var getLinksFromTransferMetaData = function getLinksFromTransferMetaData2(dataTransfer) {
+          var data3 = dataTransfer.getData("text/html");
+          if (typeof data3 === "string" && data3.length) {
+            var matches = data3.match(/src\s*=\s*"(.+?)"/);
+            if (matches) {
+              return [matches[1]];
+            }
+          }
+          return [];
+        };
+        var dragNDropObservers = [];
+        var eventPosition = function eventPosition2(e) {
+          return {
+            pageLeft: e.pageX,
+            pageTop: e.pageY,
+            scopeLeft: e.offsetX || e.layerX,
+            scopeTop: e.offsetY || e.layerY
+          };
+        };
+        var createDragNDropClient = function createDragNDropClient2(element, scopeToObserve, filterElement) {
+          var observer = getDragNDropObserver(scopeToObserve);
+          var client = {
+            element,
+            filterElement,
+            state: null,
+            ondrop: function ondrop() {
+            },
+            onenter: function onenter() {
+            },
+            ondrag: function ondrag() {
+            },
+            onexit: function onexit() {
+            },
+            onload: function onload() {
+            },
+            allowdrop: function allowdrop() {
+            }
+          };
+          client.destroy = observer.addListener(client);
+          return client;
+        };
+        var getDragNDropObserver = function getDragNDropObserver2(element) {
+          var observer = dragNDropObservers.find(function(item2) {
+            return item2.element === element;
+          });
+          if (observer) {
+            return observer;
+          }
+          var newObserver = createDragNDropObserver(element);
+          dragNDropObservers.push(newObserver);
+          return newObserver;
+        };
+        var createDragNDropObserver = function createDragNDropObserver2(element) {
+          var clients = [];
+          var routes = {
+            dragenter,
+            dragover,
+            dragleave,
+            drop
+          };
+          var handlers = {};
+          forin(routes, function(event, createHandler) {
+            handlers[event] = createHandler(element, clients);
+            element.addEventListener(event, handlers[event], false);
+          });
+          var observer = {
+            element,
+            addListener: function addListener(client) {
+              clients.push(client);
+              return function() {
+                clients.splice(clients.indexOf(client), 1);
+                if (clients.length === 0) {
+                  dragNDropObservers.splice(dragNDropObservers.indexOf(observer), 1);
+                  forin(routes, function(event) {
+                    element.removeEventListener(event, handlers[event], false);
+                  });
+                }
+              };
+            }
+          };
+          return observer;
+        };
+        var elementFromPoint = function elementFromPoint2(root2, point) {
+          if (!("elementFromPoint" in root2)) {
+            root2 = document;
+          }
+          return root2.elementFromPoint(point.x, point.y);
+        };
+        var isEventTarget = function isEventTarget2(e, target) {
+          var root2 = getRootNode(target);
+          var elementAtPosition = elementFromPoint(root2, {
+            x: e.pageX - window.pageXOffset,
+            y: e.pageY - window.pageYOffset
+          });
+          return elementAtPosition === target || target.contains(elementAtPosition);
+        };
+        var initialTarget = null;
+        var setDropEffect = function setDropEffect2(dataTransfer, effect) {
+          try {
+            dataTransfer.dropEffect = effect;
+          } catch (e) {
+          }
+        };
+        var dragenter = function dragenter2(root2, clients) {
+          return function(e) {
+            e.preventDefault();
+            initialTarget = e.target;
+            clients.forEach(function(client) {
+              var element = client.element, onenter = client.onenter;
+              if (isEventTarget(e, element)) {
+                client.state = "enter";
+                onenter(eventPosition(e));
+              }
+            });
+          };
+        };
+        var dragover = function dragover2(root2, clients) {
+          return function(e) {
+            e.preventDefault();
+            var dataTransfer = e.dataTransfer;
+            requestDataTransferItems(dataTransfer).then(function(items) {
+              var overDropTarget = false;
+              clients.some(function(client) {
+                var filterElement = client.filterElement, element = client.element, onenter = client.onenter, onexit = client.onexit, ondrag = client.ondrag, allowdrop = client.allowdrop;
+                setDropEffect(dataTransfer, "copy");
+                var allowsTransfer = allowdrop(items);
+                if (!allowsTransfer) {
+                  setDropEffect(dataTransfer, "none");
+                  return;
+                }
+                if (isEventTarget(e, element)) {
+                  overDropTarget = true;
+                  if (client.state === null) {
+                    client.state = "enter";
+                    onenter(eventPosition(e));
+                    return;
+                  }
+                  client.state = "over";
+                  if (filterElement && !allowsTransfer) {
+                    setDropEffect(dataTransfer, "none");
+                    return;
+                  }
+                  ondrag(eventPosition(e));
+                } else {
+                  if (filterElement && !overDropTarget) {
+                    setDropEffect(dataTransfer, "none");
+                  }
+                  if (client.state) {
+                    client.state = null;
+                    onexit(eventPosition(e));
+                  }
+                }
+              });
+            });
+          };
+        };
+        var drop = function drop2(root2, clients) {
+          return function(e) {
+            e.preventDefault();
+            var dataTransfer = e.dataTransfer;
+            requestDataTransferItems(dataTransfer).then(function(items) {
+              clients.forEach(function(client) {
+                var filterElement = client.filterElement, element = client.element, ondrop = client.ondrop, onexit = client.onexit, allowdrop = client.allowdrop;
+                client.state = null;
+                if (filterElement && !isEventTarget(e, element)) return;
+                if (!allowdrop(items)) return onexit(eventPosition(e));
+                ondrop(eventPosition(e), items);
+              });
+            });
+          };
+        };
+        var dragleave = function dragleave2(root2, clients) {
+          return function(e) {
+            if (initialTarget !== e.target) {
+              return;
+            }
+            clients.forEach(function(client) {
+              var onexit = client.onexit;
+              client.state = null;
+              onexit(eventPosition(e));
+            });
+          };
+        };
+        var createHopper = function createHopper2(scope, validateItems, options) {
+          scope.classList.add("filepond--hopper");
+          var catchesDropsOnPage = options.catchesDropsOnPage, requiresDropOnElement = options.requiresDropOnElement, _options$filterItems = options.filterItems, filterItems = _options$filterItems === void 0 ? function(items) {
+            return items;
+          } : _options$filterItems;
+          var client = createDragNDropClient(
+            scope,
+            catchesDropsOnPage ? document.documentElement : scope,
+            requiresDropOnElement
+          );
+          var lastState = "";
+          var currentState = "";
+          client.allowdrop = function(items) {
+            return validateItems(filterItems(items));
+          };
+          client.ondrop = function(position, items) {
+            var filteredItems = filterItems(items);
+            if (!validateItems(filteredItems)) {
+              api.ondragend(position);
+              return;
+            }
+            currentState = "drag-drop";
+            api.onload(filteredItems, position);
+          };
+          client.ondrag = function(position) {
+            api.ondrag(position);
+          };
+          client.onenter = function(position) {
+            currentState = "drag-over";
+            api.ondragstart(position);
+          };
+          client.onexit = function(position) {
+            currentState = "drag-exit";
+            api.ondragend(position);
+          };
+          var api = {
+            updateHopperState: function updateHopperState() {
+              if (lastState !== currentState) {
+                scope.dataset.hopperState = currentState;
+                lastState = currentState;
+              }
+            },
+            onload: function onload() {
+            },
+            ondragstart: function ondragstart() {
+            },
+            ondrag: function ondrag() {
+            },
+            ondragend: function ondragend() {
+            },
+            destroy: function destroy() {
+              client.destroy();
+            }
+          };
+          return api;
+        };
+        var listening = false;
+        var listeners$1 = [];
+        var handlePaste = function handlePaste2(e) {
+          var activeEl = document.activeElement;
+          var isActiveElementEditable = activeEl && (/textarea|input/i.test(activeEl.nodeName) || activeEl.getAttribute("contenteditable") === "true" || activeEl.getAttribute("contenteditable") === "");
+          if (isActiveElementEditable) {
+            var inScope = false;
+            var element = activeEl;
+            while (element !== document.body) {
+              if (element.classList.contains("filepond--root")) {
+                inScope = true;
+                break;
+              }
+              element = element.parentNode;
+            }
+            if (!inScope) return;
+          }
+          requestDataTransferItems(e.clipboardData).then(function(files) {
+            if (!files.length) {
+              return;
+            }
+            listeners$1.forEach(function(listener) {
+              return listener(files);
+            });
+          });
+        };
+        var listen = function listen2(cb) {
+          if (listeners$1.includes(cb)) {
+            return;
+          }
+          listeners$1.push(cb);
+          if (listening) {
+            return;
+          }
+          listening = true;
+          document.addEventListener("paste", handlePaste);
+        };
+        var unlisten = function unlisten2(listener) {
+          arrayRemove(listeners$1, listeners$1.indexOf(listener));
+          if (listeners$1.length === 0) {
+            document.removeEventListener("paste", handlePaste);
+            listening = false;
+          }
+        };
+        var createPaster = function createPaster2() {
+          var cb = function cb2(files) {
+            api.onload(files);
+          };
+          var api = {
+            destroy: function destroy() {
+              unlisten(cb);
+            },
+            onload: function onload() {
+            }
+          };
+          listen(cb);
+          return api;
+        };
+        var create$d = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          root2.element.id = "filepond--assistant-" + props.id;
+          attr(root2.element, "role", "alert");
+          attr(root2.element, "aria-live", "polite");
+          attr(root2.element, "aria-relevant", "additions");
+        };
+        var addFilesNotificationTimeout = null;
+        var notificationClearTimeout = null;
+        var filenames = [];
+        var assist = function assist2(root2, message) {
+          root2.element.textContent = message;
+        };
+        var clear$1 = function clear2(root2) {
+          root2.element.textContent = "";
+        };
+        var listModified = function listModified2(root2, filename, label) {
+          var total = root2.query("GET_TOTAL_ITEMS");
+          assist(
+            root2,
+            label + " " + filename + ", " + total + " " + (total === 1 ? root2.query("GET_LABEL_FILE_COUNT_SINGULAR") : root2.query("GET_LABEL_FILE_COUNT_PLURAL"))
+          );
+          clearTimeout(notificationClearTimeout);
+          notificationClearTimeout = setTimeout(function() {
+            clear$1(root2);
+          }, 1500);
+        };
+        var isUsingFilePond = function isUsingFilePond2(root2) {
+          return root2.element.parentNode.contains(document.activeElement);
+        };
+        var itemAdded = function itemAdded2(_ref2) {
+          var root2 = _ref2.root, action = _ref2.action;
+          if (!isUsingFilePond(root2)) {
+            return;
+          }
+          root2.element.textContent = "";
+          var item2 = root2.query("GET_ITEM", action.id);
+          filenames.push(item2.filename);
+          clearTimeout(addFilesNotificationTimeout);
+          addFilesNotificationTimeout = setTimeout(function() {
+            listModified(root2, filenames.join(", "), root2.query("GET_LABEL_FILE_ADDED"));
+            filenames.length = 0;
+          }, 750);
+        };
+        var itemRemoved = function itemRemoved2(_ref3) {
+          var root2 = _ref3.root, action = _ref3.action;
+          if (!isUsingFilePond(root2)) {
+            return;
+          }
+          var item2 = action.item;
+          listModified(root2, item2.filename, root2.query("GET_LABEL_FILE_REMOVED"));
+        };
+        var itemProcessed = function itemProcessed2(_ref4) {
+          var root2 = _ref4.root, action = _ref4.action;
+          var item2 = root2.query("GET_ITEM", action.id);
+          var filename = item2.filename;
+          var label = root2.query("GET_LABEL_FILE_PROCESSING_COMPLETE");
+          assist(root2, filename + " " + label);
+        };
+        var itemProcessedUndo = function itemProcessedUndo2(_ref5) {
+          var root2 = _ref5.root, action = _ref5.action;
+          var item2 = root2.query("GET_ITEM", action.id);
+          var filename = item2.filename;
+          var label = root2.query("GET_LABEL_FILE_PROCESSING_ABORTED");
+          assist(root2, filename + " " + label);
+        };
+        var itemError = function itemError2(_ref6) {
+          var root2 = _ref6.root, action = _ref6.action;
+          var item2 = root2.query("GET_ITEM", action.id);
+          var filename = item2.filename;
+          assist(root2, action.status.main + " " + filename + " " + action.status.sub);
+        };
+        var assistant = createView({
+          create: create$d,
+          ignoreRect: true,
+          ignoreRectUpdate: true,
+          write: createRoute({
+            DID_LOAD_ITEM: itemAdded,
+            DID_REMOVE_ITEM: itemRemoved,
+            DID_COMPLETE_ITEM_PROCESSING: itemProcessed,
+            DID_ABORT_ITEM_PROCESSING: itemProcessedUndo,
+            DID_REVERT_ITEM_PROCESSING: itemProcessedUndo,
+            DID_THROW_ITEM_REMOVE_ERROR: itemError,
+            DID_THROW_ITEM_LOAD_ERROR: itemError,
+            DID_THROW_ITEM_INVALID: itemError,
+            DID_THROW_ITEM_PROCESSING_ERROR: itemError
+          }),
+          tag: "span",
+          name: "assistant"
+        });
+        var toCamels = function toCamels2(string) {
+          var separator = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "-";
+          return string.replace(new RegExp(separator + ".", "g"), function(sub) {
+            return sub.charAt(1).toUpperCase();
+          });
+        };
+        var debounce = function debounce2(func) {
+          var interval = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 16;
+          var immidiateOnly = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : true;
+          var last = Date.now();
+          var timeout = null;
+          return function() {
+            for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+              args[_key] = arguments[_key];
+            }
+            clearTimeout(timeout);
+            var dist = Date.now() - last;
+            var fn2 = function fn3() {
+              last = Date.now();
+              func.apply(void 0, args);
+            };
+            if (dist < interval) {
+              if (!immidiateOnly) {
+                timeout = setTimeout(fn2, interval - dist);
+              }
+            } else {
+              fn2();
+            }
+          };
+        };
+        var MAX_FILES_LIMIT = 1e6;
+        var prevent = function prevent2(e) {
+          return e.preventDefault();
+        };
+        var create$e = function create2(_ref) {
+          var root2 = _ref.root, props = _ref.props;
+          var id2 = root2.query("GET_ID");
+          if (id2) {
+            root2.element.id = id2;
+          }
+          var className = root2.query("GET_CLASS_NAME");
+          if (className) {
+            className.split(" ").filter(function(name2) {
+              return name2.length;
+            }).forEach(function(name2) {
+              root2.element.classList.add(name2);
+            });
+          }
+          root2.ref.label = root2.appendChildView(
+            root2.createChildView(
+              dropLabel,
+              Object.assign({}, props, {
+                translateY: null,
+                caption: root2.query("GET_LABEL_IDLE")
+              })
+            )
+          );
+          root2.ref.list = root2.appendChildView(
+            root2.createChildView(listScroller, { translateY: null })
+          );
+          root2.ref.panel = root2.appendChildView(root2.createChildView(panel, { name: "panel-root" }));
+          root2.ref.assistant = root2.appendChildView(
+            root2.createChildView(assistant, Object.assign({}, props))
+          );
+          root2.ref.data = root2.appendChildView(root2.createChildView(data2, Object.assign({}, props)));
+          root2.ref.measure = createElement$1("div");
+          root2.ref.measure.style.height = "100%";
+          root2.element.appendChild(root2.ref.measure);
+          root2.ref.bounds = null;
+          root2.query("GET_STYLES").filter(function(style) {
+            return !isEmpty(style.value);
+          }).map(function(_ref2) {
+            var name2 = _ref2.name, value = _ref2.value;
+            root2.element.dataset[name2] = value;
+          });
+          root2.ref.widthPrevious = null;
+          root2.ref.widthUpdated = debounce(function() {
+            root2.ref.updateHistory = [];
+            root2.dispatch("DID_RESIZE_ROOT");
+          }, 250);
+          root2.ref.previousAspectRatio = null;
+          root2.ref.updateHistory = [];
+          var canHover = window.matchMedia("(pointer: fine) and (hover: hover)").matches;
+          var hasPointerEvents = "PointerEvent" in window;
+          if (root2.query("GET_ALLOW_REORDER") && hasPointerEvents && !canHover) {
+            root2.element.addEventListener("touchmove", prevent, { passive: false });
+            root2.element.addEventListener("gesturestart", prevent);
+          }
+          var credits = root2.query("GET_CREDITS");
+          var hasCredits = credits.length === 2;
+          if (hasCredits) {
+            var frag = document.createElement("a");
+            frag.className = "filepond--credits";
+            frag.href = credits[0];
+            frag.tabIndex = -1;
+            frag.target = "_blank";
+            frag.rel = "noopener noreferrer nofollow";
+            frag.textContent = credits[1];
+            root2.element.appendChild(frag);
+            root2.ref.credits = frag;
+          }
+        };
+        var write$9 = function write2(_ref3) {
+          var root2 = _ref3.root, props = _ref3.props, actions2 = _ref3.actions;
+          route$5({ root: root2, props, actions: actions2 });
+          actions2.filter(function(action) {
+            return /^DID_SET_STYLE_/.test(action.type);
+          }).filter(function(action) {
+            return !isEmpty(action.data.value);
+          }).map(function(_ref4) {
+            var type = _ref4.type, data3 = _ref4.data;
+            var name2 = toCamels(type.substring(8).toLowerCase(), "_");
+            root2.element.dataset[name2] = data3.value;
+            root2.invalidateLayout();
+          });
+          if (root2.rect.element.hidden) return;
+          if (root2.rect.element.width !== root2.ref.widthPrevious) {
+            root2.ref.widthPrevious = root2.rect.element.width;
+            root2.ref.widthUpdated();
+          }
+          var bounds = root2.ref.bounds;
+          if (!bounds) {
+            bounds = root2.ref.bounds = calculateRootBoundingBoxHeight(root2);
+            root2.element.removeChild(root2.ref.measure);
+            root2.ref.measure = null;
+          }
+          var _root$ref = root2.ref, hopper = _root$ref.hopper, label = _root$ref.label, list2 = _root$ref.list, panel2 = _root$ref.panel;
+          if (hopper) {
+            hopper.updateHopperState();
+          }
+          var aspectRatio = root2.query("GET_PANEL_ASPECT_RATIO");
+          var isMultiItem = root2.query("GET_ALLOW_MULTIPLE");
+          var totalItems = root2.query("GET_TOTAL_ITEMS");
+          var maxItems = isMultiItem ? root2.query("GET_MAX_FILES") || MAX_FILES_LIMIT : 1;
+          var atMaxCapacity = totalItems === maxItems;
+          var addAction = actions2.find(function(action) {
+            return action.type === "DID_ADD_ITEM";
+          });
+          if (atMaxCapacity && addAction) {
+            var interactionMethod = addAction.data.interactionMethod;
+            label.opacity = 0;
+            if (isMultiItem) {
+              label.translateY = -40;
+            } else {
+              if (interactionMethod === InteractionMethod.API) {
+                label.translateX = 40;
+              } else if (interactionMethod === InteractionMethod.BROWSE) {
+                label.translateY = 40;
+              } else {
+                label.translateY = 30;
+              }
+            }
+          } else if (!atMaxCapacity) {
+            label.opacity = 1;
+            label.translateX = 0;
+            label.translateY = 0;
+          }
+          var listItemMargin = calculateListItemMargin(root2);
+          var listHeight = calculateListHeight(root2);
+          var labelHeight = label.rect.element.height;
+          var currentLabelHeight = !isMultiItem || atMaxCapacity ? 0 : labelHeight;
+          var listMarginTop = atMaxCapacity ? list2.rect.element.marginTop : 0;
+          var listMarginBottom = totalItems === 0 ? 0 : list2.rect.element.marginBottom;
+          var visualHeight = currentLabelHeight + listMarginTop + listHeight.visual + listMarginBottom;
+          var boundsHeight = currentLabelHeight + listMarginTop + listHeight.bounds + listMarginBottom;
+          list2.translateY = Math.max(0, currentLabelHeight - list2.rect.element.marginTop) - listItemMargin.top;
+          if (aspectRatio) {
+            var width = root2.rect.element.width;
+            var height = width * aspectRatio;
+            if (aspectRatio !== root2.ref.previousAspectRatio) {
+              root2.ref.previousAspectRatio = aspectRatio;
+              root2.ref.updateHistory = [];
+            }
+            var history = root2.ref.updateHistory;
+            history.push(width);
+            var MAX_BOUNCES = 2;
+            if (history.length > MAX_BOUNCES * 2) {
+              var l = history.length;
+              var bottom = l - 10;
+              var bounces = 0;
+              for (var i = l; i >= bottom; i--) {
+                if (history[i] === history[i - 2]) {
+                  bounces++;
+                }
+                if (bounces >= MAX_BOUNCES) {
+                  return;
+                }
+              }
+            }
+            panel2.scalable = false;
+            panel2.height = height;
+            var listAvailableHeight = (
+              // the height of the panel minus the label height
+              height - currentLabelHeight - // the room we leave open between the end of the list and the panel bottom
+              (listMarginBottom - listItemMargin.bottom) - // if we're full we need to leave some room between the top of the panel and the list
+              (atMaxCapacity ? listMarginTop : 0)
+            );
+            if (listHeight.visual > listAvailableHeight) {
+              list2.overflow = listAvailableHeight;
+            } else {
+              list2.overflow = null;
+            }
+            root2.height = height;
+          } else if (bounds.fixedHeight) {
+            panel2.scalable = false;
+            var _listAvailableHeight = (
+              // the height of the panel minus the label height
+              bounds.fixedHeight - currentLabelHeight - // the room we leave open between the end of the list and the panel bottom
+              (listMarginBottom - listItemMargin.bottom) - // if we're full we need to leave some room between the top of the panel and the list
+              (atMaxCapacity ? listMarginTop : 0)
+            );
+            if (listHeight.visual > _listAvailableHeight) {
+              list2.overflow = _listAvailableHeight;
+            } else {
+              list2.overflow = null;
+            }
+          } else if (bounds.cappedHeight) {
+            var isCappedHeight = visualHeight >= bounds.cappedHeight;
+            var panelHeight = Math.min(bounds.cappedHeight, visualHeight);
+            panel2.scalable = true;
+            panel2.height = isCappedHeight ? panelHeight : panelHeight - listItemMargin.top - listItemMargin.bottom;
+            var _listAvailableHeight2 = (
+              // the height of the panel minus the label height
+              panelHeight - currentLabelHeight - // the room we leave open between the end of the list and the panel bottom
+              (listMarginBottom - listItemMargin.bottom) - // if we're full we need to leave some room between the top of the panel and the list
+              (atMaxCapacity ? listMarginTop : 0)
+            );
+            if (visualHeight > bounds.cappedHeight && listHeight.visual > _listAvailableHeight2) {
+              list2.overflow = _listAvailableHeight2;
+            } else {
+              list2.overflow = null;
+            }
+            root2.height = Math.min(
+              bounds.cappedHeight,
+              boundsHeight - listItemMargin.top - listItemMargin.bottom
+            );
+          } else {
+            var itemMargin = totalItems > 0 ? listItemMargin.top + listItemMargin.bottom : 0;
+            panel2.scalable = true;
+            panel2.height = Math.max(labelHeight, visualHeight - itemMargin);
+            root2.height = Math.max(labelHeight, boundsHeight - itemMargin);
+          }
+          if (root2.ref.credits && panel2.heightCurrent)
+            root2.ref.credits.style.transform = "translateY(" + panel2.heightCurrent + "px)";
+        };
+        var calculateListItemMargin = function calculateListItemMargin2(root2) {
+          var item2 = root2.ref.list.childViews[0].childViews[0];
+          return item2 ? {
+            top: item2.rect.element.marginTop,
+            bottom: item2.rect.element.marginBottom
+          } : {
+            top: 0,
+            bottom: 0
+          };
+        };
+        var calculateListHeight = function calculateListHeight2(root2) {
+          var visual = 0;
+          var bounds = 0;
+          var scrollList = root2.ref.list;
+          var itemList = scrollList.childViews[0];
+          var visibleChildren = itemList.childViews.filter(function(child) {
+            return child.rect.element.height;
+          });
+          var children = root2.query("GET_ACTIVE_ITEMS").map(function(item2) {
+            return visibleChildren.find(function(child) {
+              return child.id === item2.id;
+            });
+          }).filter(function(item2) {
+            return item2;
+          });
+          if (children.length === 0) return { visual, bounds };
+          var horizontalSpace = itemList.rect.element.width;
+          var dragIndex = getItemIndexByPosition(itemList, children, scrollList.dragCoordinates);
+          var childRect = children[0].rect.element;
+          var itemVerticalMargin = childRect.marginTop + childRect.marginBottom;
+          var itemHorizontalMargin = childRect.marginLeft + childRect.marginRight;
+          var itemWidth = childRect.width + itemHorizontalMargin;
+          var itemHeight = childRect.height + itemVerticalMargin;
+          var newItem = typeof dragIndex !== "undefined" && dragIndex >= 0 ? 1 : 0;
+          var removedItem = children.find(function(child) {
+            return child.markedForRemoval && child.opacity < 0.45;
+          }) ? -1 : 0;
+          var verticalItemCount = children.length + newItem + removedItem;
+          var itemsPerRow = getItemsPerRow(horizontalSpace, itemWidth);
+          if (itemsPerRow === 1) {
+            children.forEach(function(item2) {
+              var height = item2.rect.element.height + itemVerticalMargin;
+              bounds += height;
+              visual += height * item2.opacity;
+            });
+          } else {
+            bounds = Math.ceil(verticalItemCount / itemsPerRow) * itemHeight;
+            visual = bounds;
+          }
+          return { visual, bounds };
+        };
+        var calculateRootBoundingBoxHeight = function calculateRootBoundingBoxHeight2(root2) {
+          var height = root2.ref.measureHeight || null;
+          var cappedHeight = parseInt(root2.style.maxHeight, 10) || null;
+          var fixedHeight = height === 0 ? null : height;
+          return {
+            cappedHeight,
+            fixedHeight
+          };
+        };
+        var exceedsMaxFiles = function exceedsMaxFiles2(root2, items) {
+          var allowReplace = root2.query("GET_ALLOW_REPLACE");
+          var allowMultiple = root2.query("GET_ALLOW_MULTIPLE");
+          var totalItems = root2.query("GET_TOTAL_ITEMS");
+          var maxItems = root2.query("GET_MAX_FILES");
+          var totalBrowseItems = items.length;
+          if (!allowMultiple && totalBrowseItems > 1) {
+            root2.dispatch("DID_THROW_MAX_FILES", {
+              source: items,
+              error: createResponse("warning", 0, "Max files")
+            });
+            return true;
+          }
+          maxItems = allowMultiple ? maxItems : 1;
+          if (!allowMultiple && allowReplace) {
+            return false;
+          }
+          var hasMaxItems = isInt(maxItems);
+          if (hasMaxItems && totalItems + totalBrowseItems > maxItems) {
+            root2.dispatch("DID_THROW_MAX_FILES", {
+              source: items,
+              error: createResponse("warning", 0, "Max files")
+            });
+            return true;
+          }
+          return false;
+        };
+        var getDragIndex = function getDragIndex2(list2, children, position) {
+          var itemList = list2.childViews[0];
+          return getItemIndexByPosition(itemList, children, {
+            left: position.scopeLeft - itemList.rect.element.left,
+            top: position.scopeTop - (list2.rect.outer.top + list2.rect.element.marginTop + list2.rect.element.scrollTop)
+          });
+        };
+        var toggleDrop = function toggleDrop2(root2) {
+          var isAllowed = root2.query("GET_ALLOW_DROP");
+          var isDisabled = root2.query("GET_DISABLED");
+          var enabled = isAllowed && !isDisabled;
+          if (enabled && !root2.ref.hopper) {
+            var hopper = createHopper(
+              root2.element,
+              function(items) {
+                var beforeDropFile = root2.query("GET_BEFORE_DROP_FILE") || function() {
+                  return true;
+                };
+                var dropValidation = root2.query("GET_DROP_VALIDATION");
+                return dropValidation ? items.every(function(item2) {
+                  return applyFilters("ALLOW_HOPPER_ITEM", item2, {
+                    query: root2.query
+                  }).every(function(result) {
+                    return result === true;
+                  }) && beforeDropFile(item2);
+                }) : true;
+              },
+              {
+                filterItems: function filterItems(items) {
+                  var ignoredFiles = root2.query("GET_IGNORED_FILES");
+                  return items.filter(function(item2) {
+                    if (isFile(item2)) {
+                      return !ignoredFiles.includes(item2.name.toLowerCase());
+                    }
+                    return true;
+                  });
+                },
+                catchesDropsOnPage: root2.query("GET_DROP_ON_PAGE"),
+                requiresDropOnElement: root2.query("GET_DROP_ON_ELEMENT")
+              }
+            );
+            hopper.onload = function(items, position) {
+              var list2 = root2.ref.list.childViews[0];
+              var visibleChildren = list2.childViews.filter(function(child) {
+                return child.rect.element.height;
+              });
+              var children = root2.query("GET_ACTIVE_ITEMS").map(function(item2) {
+                return visibleChildren.find(function(child) {
+                  return child.id === item2.id;
+                });
+              }).filter(function(item2) {
+                return item2;
+              });
+              applyFilterChain("ADD_ITEMS", items, { dispatch: root2.dispatch }).then(function(queue) {
+                if (exceedsMaxFiles(root2, queue)) return false;
+                root2.dispatch("ADD_ITEMS", {
+                  items: queue,
+                  index: getDragIndex(root2.ref.list, children, position),
+                  interactionMethod: InteractionMethod.DROP
+                });
+              });
+              root2.dispatch("DID_DROP", { position });
+              root2.dispatch("DID_END_DRAG", { position });
+            };
+            hopper.ondragstart = function(position) {
+              root2.dispatch("DID_START_DRAG", { position });
+            };
+            hopper.ondrag = debounce(function(position) {
+              root2.dispatch("DID_DRAG", { position });
+            });
+            hopper.ondragend = function(position) {
+              root2.dispatch("DID_END_DRAG", { position });
+            };
+            root2.ref.hopper = hopper;
+            root2.ref.drip = root2.appendChildView(root2.createChildView(drip));
+          } else if (!enabled && root2.ref.hopper) {
+            root2.ref.hopper.destroy();
+            root2.ref.hopper = null;
+            root2.removeChildView(root2.ref.drip);
+          }
+        };
+        var toggleBrowse = function toggleBrowse2(root2, props) {
+          var isAllowed = root2.query("GET_ALLOW_BROWSE");
+          var isDisabled = root2.query("GET_DISABLED");
+          var enabled = isAllowed && !isDisabled;
+          if (enabled && !root2.ref.browser) {
+            root2.ref.browser = root2.appendChildView(
+              root2.createChildView(
+                browser,
+                Object.assign({}, props, {
+                  onload: function onload(items) {
+                    applyFilterChain("ADD_ITEMS", items, {
+                      dispatch: root2.dispatch
+                    }).then(function(queue) {
+                      if (exceedsMaxFiles(root2, queue)) return false;
+                      root2.dispatch("ADD_ITEMS", {
+                        items: queue,
+                        index: -1,
+                        interactionMethod: InteractionMethod.BROWSE
+                      });
+                    });
+                  }
+                })
+              ),
+              0
+            );
+          } else if (!enabled && root2.ref.browser) {
+            root2.removeChildView(root2.ref.browser);
+            root2.ref.browser = null;
+          }
+        };
+        var togglePaste = function togglePaste2(root2) {
+          var isAllowed = root2.query("GET_ALLOW_PASTE");
+          var isDisabled = root2.query("GET_DISABLED");
+          var enabled = isAllowed && !isDisabled;
+          if (enabled && !root2.ref.paster) {
+            root2.ref.paster = createPaster();
+            root2.ref.paster.onload = function(items) {
+              applyFilterChain("ADD_ITEMS", items, { dispatch: root2.dispatch }).then(function(queue) {
+                if (exceedsMaxFiles(root2, queue)) return false;
+                root2.dispatch("ADD_ITEMS", {
+                  items: queue,
+                  index: -1,
+                  interactionMethod: InteractionMethod.PASTE
+                });
+              });
+            };
+          } else if (!enabled && root2.ref.paster) {
+            root2.ref.paster.destroy();
+            root2.ref.paster = null;
+          }
+        };
+        var route$5 = createRoute({
+          DID_SET_ALLOW_BROWSE: function DID_SET_ALLOW_BROWSE(_ref5) {
+            var root2 = _ref5.root, props = _ref5.props;
+            toggleBrowse(root2, props);
+          },
+          DID_SET_ALLOW_DROP: function DID_SET_ALLOW_DROP(_ref6) {
+            var root2 = _ref6.root;
+            toggleDrop(root2);
+          },
+          DID_SET_ALLOW_PASTE: function DID_SET_ALLOW_PASTE(_ref7) {
+            var root2 = _ref7.root;
+            togglePaste(root2);
+          },
+          DID_SET_DISABLED: function DID_SET_DISABLED(_ref8) {
+            var root2 = _ref8.root, props = _ref8.props;
+            toggleDrop(root2);
+            togglePaste(root2);
+            toggleBrowse(root2, props);
+            var isDisabled = root2.query("GET_DISABLED");
+            if (isDisabled) {
+              root2.element.dataset.disabled = "disabled";
+            } else {
+              root2.element.removeAttribute("data-disabled");
+            }
+          }
+        });
+        var root = createView({
+          name: "root",
+          read: function read(_ref9) {
+            var root2 = _ref9.root;
+            if (root2.ref.measure) {
+              root2.ref.measureHeight = root2.ref.measure.offsetHeight;
+            }
+          },
+          create: create$e,
+          write: write$9,
+          destroy: function destroy(_ref10) {
+            var root2 = _ref10.root;
+            if (root2.ref.paster) {
+              root2.ref.paster.destroy();
+            }
+            if (root2.ref.hopper) {
+              root2.ref.hopper.destroy();
+            }
+            root2.element.removeEventListener("touchmove", prevent);
+            root2.element.removeEventListener("gesturestart", prevent);
+          },
+          mixins: {
+            styles: ["height"]
+          }
+        });
+        var createApp = function createApp2() {
+          var initialOptions = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+          var originalElement = null;
+          var defaultOptions2 = getOptions();
+          var store = createStore(
+            // initial state (should be serializable)
+            createInitialState(defaultOptions2),
+            // queries
+            [queries, createOptionQueries(defaultOptions2)],
+            // action handlers
+            [actions, createOptionActions(defaultOptions2)]
+          );
+          store.dispatch("SET_OPTIONS", { options: initialOptions });
+          var visibilityHandler = function visibilityHandler2() {
+            if (document.hidden) return;
+            store.dispatch("KICK");
+          };
+          document.addEventListener("visibilitychange", visibilityHandler);
+          var resizeDoneTimer = null;
+          var isResizing = false;
+          var isResizingHorizontally = false;
+          var initialWindowWidth = null;
+          var currentWindowWidth = null;
+          var resizeHandler = function resizeHandler2() {
+            if (!isResizing) {
+              isResizing = true;
+            }
+            clearTimeout(resizeDoneTimer);
+            resizeDoneTimer = setTimeout(function() {
+              isResizing = false;
+              initialWindowWidth = null;
+              currentWindowWidth = null;
+              if (isResizingHorizontally) {
+                isResizingHorizontally = false;
+                store.dispatch("DID_STOP_RESIZE");
+              }
+            }, 500);
+          };
+          window.addEventListener("resize", resizeHandler);
+          var view = root(store, { id: getUniqueId() });
+          var isResting = false;
+          var isHidden = false;
+          var readWriteApi = {
+            // necessary for update loop
+            /**
+             * Reads from dom (never call manually)
+             * @private
+             */
+            _read: function _read() {
+              if (isResizing) {
+                currentWindowWidth = window.innerWidth;
+                if (!initialWindowWidth) {
+                  initialWindowWidth = currentWindowWidth;
+                }
+                if (!isResizingHorizontally && currentWindowWidth !== initialWindowWidth) {
+                  store.dispatch("DID_START_RESIZE");
+                  isResizingHorizontally = true;
+                }
+              }
+              if (isHidden && isResting) {
+                isResting = view.element.offsetParent === null;
+              }
+              if (isResting) return;
+              view._read();
+              isHidden = view.rect.element.hidden;
+            },
+            /**
+             * Writes to dom (never call manually)
+             * @private
+             */
+            _write: function _write(ts) {
+              var actions2 = store.processActionQueue().filter(function(action) {
+                return !/^SET_/.test(action.type);
+              });
+              if (isResting && !actions2.length) return;
+              routeActionsToEvents(actions2);
+              isResting = view._write(ts, actions2, isResizingHorizontally);
+              removeReleasedItems(store.query("GET_ITEMS"));
+              if (isResting) {
+                store.processDispatchQueue();
+              }
+            }
+          };
+          var createEvent = function createEvent2(name2) {
+            return function(data3) {
+              var event = {
+                type: name2
+              };
+              if (!data3) {
+                return event;
+              }
+              if (data3.hasOwnProperty("error")) {
+                event.error = data3.error ? Object.assign({}, data3.error) : null;
+              }
+              if (data3.status) {
+                event.status = Object.assign({}, data3.status);
+              }
+              if (data3.file) {
+                event.output = data3.file;
+              }
+              if (data3.source) {
+                event.file = data3.source;
+              } else if (data3.item || data3.id) {
+                var item2 = data3.item ? data3.item : store.query("GET_ITEM", data3.id);
+                event.file = item2 ? createItemAPI(item2) : null;
+              }
+              if (data3.items) {
+                event.items = data3.items.map(createItemAPI);
+              }
+              if (/progress/.test(name2)) {
+                event.progress = data3.progress;
+              }
+              if (data3.hasOwnProperty("origin") && data3.hasOwnProperty("target")) {
+                event.origin = data3.origin;
+                event.target = data3.target;
+              }
+              return event;
+            };
+          };
+          var eventRoutes = {
+            DID_DESTROY: createEvent("destroy"),
+            DID_INIT: createEvent("init"),
+            DID_THROW_MAX_FILES: createEvent("warning"),
+            DID_INIT_ITEM: createEvent("initfile"),
+            DID_START_ITEM_LOAD: createEvent("addfilestart"),
+            DID_UPDATE_ITEM_LOAD_PROGRESS: createEvent("addfileprogress"),
+            DID_LOAD_ITEM: createEvent("addfile"),
+            DID_THROW_ITEM_INVALID: [createEvent("error"), createEvent("addfile")],
+            DID_THROW_ITEM_LOAD_ERROR: [createEvent("error"), createEvent("addfile")],
+            DID_THROW_ITEM_REMOVE_ERROR: [createEvent("error"), createEvent("removefile")],
+            DID_PREPARE_OUTPUT: createEvent("preparefile"),
+            DID_START_ITEM_PROCESSING: createEvent("processfilestart"),
+            DID_UPDATE_ITEM_PROCESS_PROGRESS: createEvent("processfileprogress"),
+            DID_ABORT_ITEM_PROCESSING: createEvent("processfileabort"),
+            DID_COMPLETE_ITEM_PROCESSING: createEvent("processfile"),
+            DID_COMPLETE_ITEM_PROCESSING_ALL: createEvent("processfiles"),
+            DID_REVERT_ITEM_PROCESSING: createEvent("processfilerevert"),
+            DID_THROW_ITEM_PROCESSING_ERROR: [createEvent("error"), createEvent("processfile")],
+            DID_REMOVE_ITEM: createEvent("removefile"),
+            DID_UPDATE_ITEMS: createEvent("updatefiles"),
+            DID_ACTIVATE_ITEM: createEvent("activatefile"),
+            DID_REORDER_ITEMS: createEvent("reorderfiles")
+          };
+          var exposeEvent = function exposeEvent2(event) {
+            var detail = Object.assign({ pond: exports3 }, event);
+            delete detail.type;
+            view.element.dispatchEvent(
+              new CustomEvent("FilePond:" + event.type, {
+                // event info
+                detail,
+                // event behaviour
+                bubbles: true,
+                cancelable: true,
+                composed: true
+                // triggers listeners outside of shadow root
+              })
+            );
+            var params = [];
+            if (event.hasOwnProperty("error")) {
+              params.push(event.error);
+            }
+            if (event.hasOwnProperty("file")) {
+              params.push(event.file);
+            }
+            var filtered = ["type", "error", "file"];
+            Object.keys(event).filter(function(key) {
+              return !filtered.includes(key);
+            }).forEach(function(key) {
+              return params.push(event[key]);
+            });
+            exports3.fire.apply(exports3, [event.type].concat(params));
+            var handler = store.query("GET_ON" + event.type.toUpperCase());
+            if (handler) {
+              handler.apply(void 0, params);
+            }
+          };
+          var routeActionsToEvents = function routeActionsToEvents2(actions2) {
+            if (!actions2.length) return;
+            actions2.filter(function(action) {
+              return eventRoutes[action.type];
+            }).forEach(function(action) {
+              var routes = eventRoutes[action.type];
+              (Array.isArray(routes) ? routes : [routes]).forEach(function(route2) {
+                if (action.type === "DID_INIT_ITEM") {
+                  exposeEvent(route2(action.data));
+                } else {
+                  setTimeout(function() {
+                    exposeEvent(route2(action.data));
+                  }, 0);
+                }
+              });
+            });
+          };
+          var setOptions2 = function setOptions3(options) {
+            return store.dispatch("SET_OPTIONS", { options });
+          };
+          var getFile = function getFile2(query) {
+            return store.query("GET_ACTIVE_ITEM", query);
+          };
+          var prepareFile = function prepareFile2(query) {
+            return new Promise(function(resolve, reject) {
+              store.dispatch("REQUEST_ITEM_PREPARE", {
+                query,
+                success: function success(item2) {
+                  resolve(item2);
+                },
+                failure: function failure2(error2) {
+                  reject(error2);
+                }
+              });
+            });
+          };
+          var addFile = function addFile2(source) {
+            var options = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+            return new Promise(function(resolve, reject) {
+              addFiles([{ source, options }], { index: options.index }).then(function(items) {
+                return resolve(items && items[0]);
+              }).catch(reject);
+            });
+          };
+          var isFilePondFile = function isFilePondFile2(obj) {
+            return obj.file && obj.id;
+          };
+          var removeFile = function removeFile2(query, options) {
+            if (typeof query === "object" && !isFilePondFile(query) && !options) {
+              options = query;
+              query = void 0;
+            }
+            store.dispatch("REMOVE_ITEM", Object.assign({}, options, { query }));
+            return store.query("GET_ACTIVE_ITEM", query) === null;
+          };
+          var addFiles = function addFiles2() {
+            for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+              args[_key] = arguments[_key];
+            }
+            return new Promise(function(resolve, reject) {
+              var sources = [];
+              var options = {};
+              if (isArray(args[0])) {
+                sources.push.apply(sources, args[0]);
+                Object.assign(options, args[1] || {});
+              } else {
+                var lastArgument = args[args.length - 1];
+                if (typeof lastArgument === "object" && !(lastArgument instanceof Blob)) {
+                  Object.assign(options, args.pop());
+                }
+                sources.push.apply(sources, args);
+              }
+              store.dispatch("ADD_ITEMS", {
+                items: sources,
+                index: options.index,
+                interactionMethod: InteractionMethod.API,
+                success: resolve,
+                failure: reject
+              });
+            });
+          };
+          var getFiles2 = function getFiles3() {
+            return store.query("GET_ACTIVE_ITEMS");
+          };
+          var processFile = function processFile2(query) {
+            return new Promise(function(resolve, reject) {
+              store.dispatch("REQUEST_ITEM_PROCESSING", {
+                query,
+                success: function success(item2) {
+                  resolve(item2);
+                },
+                failure: function failure2(error2) {
+                  reject(error2);
+                }
+              });
+            });
+          };
+          var prepareFiles = function prepareFiles2() {
+            for (var _len2 = arguments.length, args = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+              args[_key2] = arguments[_key2];
+            }
+            var queries2 = Array.isArray(args[0]) ? args[0] : args;
+            var items = queries2.length ? queries2 : getFiles2();
+            return Promise.all(items.map(prepareFile));
+          };
+          var processFiles = function processFiles2() {
+            for (var _len3 = arguments.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+              args[_key3] = arguments[_key3];
+            }
+            var queries2 = Array.isArray(args[0]) ? args[0] : args;
+            if (!queries2.length) {
+              var files = getFiles2().filter(function(item2) {
+                return !(item2.status === ItemStatus.IDLE && item2.origin === FileOrigin.LOCAL) && item2.status !== ItemStatus.PROCESSING && item2.status !== ItemStatus.PROCESSING_COMPLETE && item2.status !== ItemStatus.PROCESSING_REVERT_ERROR;
+              });
+              return Promise.all(files.map(processFile));
+            }
+            return Promise.all(queries2.map(processFile));
+          };
+          var removeFiles = function removeFiles2() {
+            for (var _len4 = arguments.length, args = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
+              args[_key4] = arguments[_key4];
+            }
+            var queries2 = Array.isArray(args[0]) ? args[0] : args;
+            var options;
+            if (typeof queries2[queries2.length - 1] === "object") {
+              options = queries2.pop();
+            } else if (Array.isArray(args[0])) {
+              options = args[1];
+            }
+            var files = getFiles2();
+            if (!queries2.length)
+              return Promise.all(
+                files.map(function(file2) {
+                  return removeFile(file2, options);
+                })
+              );
+            var mappedQueries = queries2.map(function(query) {
+              return isNumber(query) ? files[query] ? files[query].id : null : query;
+            }).filter(function(query) {
+              return query;
+            });
+            return mappedQueries.map(function(q) {
+              return removeFile(q, options);
+            });
+          };
+          var exports3 = Object.assign(
+            {},
+            on(),
+            {},
+            readWriteApi,
+            {},
+            createOptionAPI(store, defaultOptions2),
+            {
+              /**
+               * Override options defined in options object
+               * @param options
+               */
+              setOptions: setOptions2,
+              /**
+               * Load the given file
+               * @param source - the source of the file (either a File, base64 data uri or url)
+               * @param options - object, { index: 0 }
+               */
+              addFile,
+              /**
+               * Load the given files
+               * @param sources - the sources of the files to load
+               * @param options - object, { index: 0 }
+               */
+              addFiles,
+              /**
+               * Returns the file objects matching the given query
+               * @param query { string, number, null }
+               */
+              getFile,
+              /**
+               * Upload file with given name
+               * @param query { string, number, null  }
+               */
+              processFile,
+              /**
+               * Request prepare output for file with given name
+               * @param query { string, number, null  }
+               */
+              prepareFile,
+              /**
+               * Removes a file by its name
+               * @param query { string, number, null  }
+               */
+              removeFile,
+              /**
+               * Moves a file to a new location in the files list
+               */
+              moveFile: function moveFile(query, index) {
+                return store.dispatch("MOVE_ITEM", { query, index });
+              },
+              /**
+               * Returns all files (wrapped in public api)
+               */
+              getFiles: getFiles2,
+              /**
+               * Starts uploading all files
+               */
+              processFiles,
+              /**
+               * Clears all files from the files list
+               */
+              removeFiles,
+              /**
+               * Starts preparing output of all files
+               */
+              prepareFiles,
+              /**
+               * Sort list of files
+               */
+              sort: function sort(compare) {
+                return store.dispatch("SORT", { compare });
+              },
+              /**
+               * Browse the file system for a file
+               */
+              browse: function browse() {
+                var input = view.element.querySelector("input[type=file]");
+                if (input) {
+                  input.click();
+                }
+              },
+              /**
+               * Destroys the app
+               */
+              destroy: function destroy() {
+                exports3.fire("destroy", view.element);
+                store.dispatch("ABORT_ALL");
+                view._destroy();
+                window.removeEventListener("resize", resizeHandler);
+                document.removeEventListener("visibilitychange", visibilityHandler);
+                store.dispatch("DID_DESTROY");
+              },
+              /**
+               * Inserts the plugin before the target element
+               */
+              insertBefore: function insertBefore$1(element) {
+                return insertBefore(view.element, element);
+              },
+              /**
+               * Inserts the plugin after the target element
+               */
+              insertAfter: function insertAfter$1(element) {
+                return insertAfter(view.element, element);
+              },
+              /**
+               * Appends the plugin to the target element
+               */
+              appendTo: function appendTo(element) {
+                return element.appendChild(view.element);
+              },
+              /**
+               * Replaces an element with the app
+               */
+              replaceElement: function replaceElement(element) {
+                insertBefore(view.element, element);
+                element.parentNode.removeChild(element);
+                originalElement = element;
+              },
+              /**
+               * Restores the original element
+               */
+              restoreElement: function restoreElement() {
+                if (!originalElement) {
+                  return;
+                }
+                insertAfter(originalElement, view.element);
+                view.element.parentNode.removeChild(view.element);
+                originalElement = null;
+              },
+              /**
+               * Returns true if the app root is attached to given element
+               * @param element
+               */
+              isAttachedTo: function isAttachedTo(element) {
+                return view.element === element || originalElement === element;
+              },
+              /**
+               * Returns the root element
+               */
+              element: {
+                get: function get() {
+                  return view.element;
+                }
+              },
+              /**
+               * Returns the current pond status
+               */
+              status: {
+                get: function get() {
+                  return store.query("GET_STATUS");
+                }
+              }
+            }
+          );
+          store.dispatch("DID_INIT");
+          return createObject(exports3);
+        };
+        var createAppObject = function createAppObject2() {
+          var customOptions = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
+          var defaultOptions2 = {};
+          forin(getOptions(), function(key, value) {
+            defaultOptions2[key] = value[0];
+          });
+          var app = createApp(
+            Object.assign(
+              {},
+              defaultOptions2,
+              {},
+              customOptions
+            )
+          );
+          return app;
+        };
+        var lowerCaseFirstLetter = function lowerCaseFirstLetter2(string) {
+          return string.charAt(0).toLowerCase() + string.slice(1);
+        };
+        var attributeNameToPropertyName = function attributeNameToPropertyName2(attributeName) {
+          return toCamels(attributeName.replace(/^data-/, ""));
+        };
+        var mapObject = function mapObject2(object, propertyMap) {
+          forin(propertyMap, function(selector, mapping) {
+            forin(object, function(property, value) {
+              var selectorRegExp = new RegExp(selector);
+              var matches = selectorRegExp.test(property);
+              if (!matches) {
+                return;
+              }
+              delete object[property];
+              if (mapping === false) {
+                return;
+              }
+              if (isString(mapping)) {
+                object[mapping] = value;
+                return;
+              }
+              var group = mapping.group;
+              if (isObject4(mapping) && !object[group]) {
+                object[group] = {};
+              }
+              object[group][lowerCaseFirstLetter(property.replace(selectorRegExp, ""))] = value;
+            });
+            if (mapping.mapping) {
+              mapObject2(object[mapping.group], mapping.mapping);
+            }
+          });
+        };
+        var getAttributesAsObject = function getAttributesAsObject2(node) {
+          var attributeMapping = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+          var attributes = [];
+          forin(node.attributes, function(index) {
+            attributes.push(node.attributes[index]);
+          });
+          var output = attributes.filter(function(attribute) {
+            return attribute.name;
+          }).reduce(function(obj, attribute) {
+            var value = attr(node, attribute.name);
+            obj[attributeNameToPropertyName(attribute.name)] = value === attribute.name ? true : value;
+            return obj;
+          }, {});
+          mapObject(output, attributeMapping);
+          return output;
+        };
+        var createAppAtElement = function createAppAtElement2(element) {
+          var options = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+          var attributeMapping = {
+            // translate to other name
+            "^class$": "className",
+            "^multiple$": "allowMultiple",
+            "^capture$": "captureMethod",
+            "^webkitdirectory$": "allowDirectoriesOnly",
+            // group under single property
+            "^server": {
+              group: "server",
+              mapping: {
+                "^process": {
+                  group: "process"
+                },
+                "^revert": {
+                  group: "revert"
+                },
+                "^fetch": {
+                  group: "fetch"
+                },
+                "^restore": {
+                  group: "restore"
+                },
+                "^load": {
+                  group: "load"
+                }
+              }
+            },
+            // don't include in object
+            "^type$": false,
+            "^files$": false
+          };
+          applyFilters("SET_ATTRIBUTE_TO_OPTION_MAP", attributeMapping);
+          var mergedOptions = Object.assign({}, options);
+          var attributeOptions = getAttributesAsObject(
+            element.nodeName === "FIELDSET" ? element.querySelector("input[type=file]") : element,
+            attributeMapping
+          );
+          Object.keys(attributeOptions).forEach(function(key) {
+            if (isObject4(attributeOptions[key])) {
+              if (!isObject4(mergedOptions[key])) {
+                mergedOptions[key] = {};
+              }
+              Object.assign(mergedOptions[key], attributeOptions[key]);
+            } else {
+              mergedOptions[key] = attributeOptions[key];
+            }
+          });
+          mergedOptions.files = (options.files || []).concat(
+            Array.from(element.querySelectorAll("input:not([type=file])")).map(function(input) {
+              return {
+                source: input.value,
+                options: {
+                  type: input.dataset.type
+                }
+              };
+            })
+          );
+          var app = createAppObject(mergedOptions);
+          if (element.files) {
+            Array.from(element.files).forEach(function(file2) {
+              app.addFile(file2);
+            });
+          }
+          app.replaceElement(element);
+          return app;
+        };
+        var createApp$1 = function createApp2() {
+          return isNode(arguments.length <= 0 ? void 0 : arguments[0]) ? createAppAtElement.apply(void 0, arguments) : createAppObject.apply(void 0, arguments);
+        };
+        var PRIVATE_METHODS = ["fire", "_read", "_write"];
+        var createAppAPI = function createAppAPI2(app) {
+          var api = {};
+          copyObjectPropertiesToObject(app, api, PRIVATE_METHODS);
+          return api;
+        };
+        var replaceInString = function replaceInString2(string, replacements) {
+          return string.replace(/(?:{([a-zA-Z]+)})/g, function(match, group) {
+            return replacements[group];
+          });
+        };
+        var createWorker = function createWorker2(fn2) {
+          var workerBlob = new Blob(["(", fn2.toString(), ")()"], {
+            type: "application/javascript"
+          });
+          var workerURL = URL.createObjectURL(workerBlob);
+          var worker = new Worker(workerURL);
+          return {
+            transfer: function transfer(message, cb) {
+            },
+            post: function post(message, cb, transferList) {
+              var id2 = getUniqueId();
+              worker.onmessage = function(e) {
+                if (e.data.id === id2) {
+                  cb(e.data.message);
+                }
+              };
+              worker.postMessage(
+                {
+                  id: id2,
+                  message
+                },
+                transferList
+              );
+            },
+            terminate: function terminate() {
+              worker.terminate();
+              URL.revokeObjectURL(workerURL);
+            }
+          };
+        };
+        var loadImage = function loadImage2(url) {
+          return new Promise(function(resolve, reject) {
+            var img = new Image();
+            img.onload = function() {
+              resolve(img);
+            };
+            img.onerror = function(e) {
+              reject(e);
+            };
+            img.src = url;
+          });
+        };
+        var renameFile = function renameFile2(file2, name2) {
+          var renamedFile = file2.slice(0, file2.size, file2.type);
+          renamedFile.lastModifiedDate = file2.lastModifiedDate;
+          renamedFile.name = name2;
+          return renamedFile;
+        };
+        var copyFile = function copyFile2(file2) {
+          return renameFile(file2, file2.name);
+        };
+        var registeredPlugins = [];
+        var createAppPlugin = function createAppPlugin2(plugin) {
+          if (registeredPlugins.includes(plugin)) {
+            return;
+          }
+          registeredPlugins.push(plugin);
+          var pluginOutline = plugin({
+            addFilter,
+            utils: {
+              Type,
+              forin,
+              isString,
+              isFile,
+              toNaturalFileSize,
+              replaceInString,
+              getExtensionFromFilename,
+              getFilenameWithoutExtension,
+              guesstimateMimeType,
+              getFileFromBlob,
+              getFilenameFromURL,
+              createRoute,
+              createWorker,
+              createView,
+              createItemAPI,
+              loadImage,
+              copyFile,
+              renameFile,
+              createBlob,
+              applyFilterChain,
+              text,
+              getNumericAspectRatioFromString
+            },
+            views: {
+              fileActionButton
+            }
+          });
+          extendDefaultOptions(pluginOutline.options);
+        };
+        var isOperaMini = function isOperaMini2() {
+          return Object.prototype.toString.call(window.operamini) === "[object OperaMini]";
+        };
+        var hasPromises = function hasPromises2() {
+          return "Promise" in window;
+        };
+        var hasBlobSlice = function hasBlobSlice2() {
+          return "slice" in Blob.prototype;
+        };
+        var hasCreateObjectURL = function hasCreateObjectURL2() {
+          return "URL" in window && "createObjectURL" in window.URL;
+        };
+        var hasVisibility = function hasVisibility2() {
+          return "visibilityState" in document;
+        };
+        var hasTiming = function hasTiming2() {
+          return "performance" in window;
+        };
+        var hasCSSSupports = function hasCSSSupports2() {
+          return "supports" in (window.CSS || {});
+        };
+        var isIE11 = function isIE112() {
+          return /MSIE|Trident/.test(window.navigator.userAgent);
+        };
+        var supported = function() {
+          var isSupported = (
+            // Has to be a browser
+            isBrowser() && // Can't run on Opera Mini due to lack of everything
+            !isOperaMini() && // Require these APIs to feature detect a modern browser
+            hasVisibility() && hasPromises() && hasBlobSlice() && hasCreateObjectURL() && hasTiming() && // doesn't need CSSSupports but is a good way to detect Safari 9+ (we do want to support IE11 though)
+            (hasCSSSupports() || isIE11())
+          );
+          return function() {
+            return isSupported;
+          };
+        }();
+        var state = {
+          // active app instances, used to redraw the apps and to find the later
+          apps: []
+        };
+        var name = "filepond";
+        var fn = function fn2() {
+        };
+        exports2.Status = {};
+        exports2.FileStatus = {};
+        exports2.FileOrigin = {};
+        exports2.OptionTypes = {};
+        exports2.create = fn;
+        exports2.destroy = fn;
+        exports2.parse = fn;
+        exports2.find = fn;
+        exports2.registerPlugin = fn;
+        exports2.getOptions = fn;
+        exports2.setOptions = fn;
+        if (supported()) {
+          createPainter(
+            function() {
+              state.apps.forEach(function(app) {
+                return app._read();
+              });
+            },
+            function(ts) {
+              state.apps.forEach(function(app) {
+                return app._write(ts);
+              });
+            }
+          );
+          var dispatch = function dispatch2() {
+            document.dispatchEvent(
+              new CustomEvent("FilePond:loaded", {
+                detail: {
+                  supported,
+                  create: exports2.create,
+                  destroy: exports2.destroy,
+                  parse: exports2.parse,
+                  find: exports2.find,
+                  registerPlugin: exports2.registerPlugin,
+                  setOptions: exports2.setOptions
+                }
+              })
+            );
+            document.removeEventListener("DOMContentLoaded", dispatch2);
+          };
+          if (document.readyState !== "loading") {
+            setTimeout(function() {
+              return dispatch();
+            }, 0);
+          } else {
+            document.addEventListener("DOMContentLoaded", dispatch);
+          }
+          var updateOptionTypes = function updateOptionTypes2() {
+            return forin(getOptions(), function(key, value) {
+              exports2.OptionTypes[key] = value[1];
+            });
+          };
+          exports2.Status = Object.assign({}, Status);
+          exports2.FileOrigin = Object.assign({}, FileOrigin);
+          exports2.FileStatus = Object.assign({}, ItemStatus);
+          exports2.OptionTypes = {};
+          updateOptionTypes();
+          exports2.create = function create2() {
+            var app = createApp$1.apply(void 0, arguments);
+            app.on("destroy", exports2.destroy);
+            state.apps.push(app);
+            return createAppAPI(app);
+          };
+          exports2.destroy = function destroy(hook) {
+            var indexToRemove = state.apps.findIndex(function(app2) {
+              return app2.isAttachedTo(hook);
+            });
+            if (indexToRemove >= 0) {
+              var app = state.apps.splice(indexToRemove, 1)[0];
+              app.restoreElement();
+              return true;
+            }
+            return false;
+          };
+          exports2.parse = function parse(context) {
+            var matchedHooks = Array.from(context.querySelectorAll("." + name));
+            var newHooks = matchedHooks.filter(function(newHook) {
+              return !state.apps.find(function(app) {
+                return app.isAttachedTo(newHook);
+              });
+            });
+            return newHooks.map(function(hook) {
+              return exports2.create(hook);
+            });
+          };
+          exports2.find = function find(hook) {
+            var app = state.apps.find(function(app2) {
+              return app2.isAttachedTo(hook);
+            });
+            if (!app) {
+              return null;
+            }
+            return createAppAPI(app);
+          };
+          exports2.registerPlugin = function registerPlugin2() {
+            for (var _len = arguments.length, plugins = new Array(_len), _key = 0; _key < _len; _key++) {
+              plugins[_key] = arguments[_key];
+            }
+            plugins.forEach(createAppPlugin);
+            updateOptionTypes();
+          };
+          exports2.getOptions = function getOptions$1() {
+            var opts = {};
+            forin(getOptions(), function(key, value) {
+              opts[key] = value[0];
+            });
+            return opts;
+          };
+          exports2.setOptions = function setOptions$1(opts) {
+            if (isObject4(opts)) {
+              state.apps.forEach(function(app) {
+                app.setOptions(opts);
+              });
+              setOptions(opts);
+            }
+            return exports2.getOptions();
+          };
+        }
+        exports2.supported = supported;
+        Object.defineProperty(exports2, "__esModule", { value: true });
+      });
+    }
+  });
+
+  // node_modules/react-filepond/dist/react-filepond.js
+  var require_react_filepond = __commonJS({
+    "node_modules/react-filepond/dist/react-filepond.js"(exports) {
+      "use strict";
+      Object.defineProperty(exports, "__esModule", {
+        value: true
+      });
+      exports.FilePond = exports.FileStatus = exports.registerPlugin = void 0;
+      var _createClass = /* @__PURE__ */ function() {
+        function defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+          }
+        }
+        return function(Constructor, protoProps, staticProps) {
+          if (protoProps) defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) defineProperties(Constructor, staticProps);
+          return Constructor;
+        };
+      }();
+      var _react = require_react();
+      var _react2 = _interopRequireDefault(_react);
+      var _filepond = require_filepond();
+      function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+      function _classCallCheck(instance, Constructor) {
+        if (!(instance instanceof Constructor)) {
+          throw new TypeError("Cannot call a class as a function");
+        }
+      }
+      function _possibleConstructorReturn(self2, call) {
+        if (!self2) {
+          throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+        }
+        return call && (typeof call === "object" || typeof call === "function") ? call : self2;
+      }
+      function _inherits(subClass, superClass) {
+        if (typeof superClass !== "function" && superClass !== null) {
+          throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+        }
+        subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });
+        if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+      }
+      exports.registerPlugin = _filepond.registerPlugin;
+      exports.FileStatus = _filepond.FileStatus;
+      var isSupported = (0, _filepond.supported)();
+      var filteredMethods = ["setOptions", "on", "off", "onOnce", "appendTo", "insertAfter", "insertBefore", "isAttachedTo", "replaceElement", "restoreElement", "destroy"];
+      var FilePond2 = exports.FilePond = function(_React$Component) {
+        _inherits(FilePond3, _React$Component);
+        function FilePond3(props) {
+          _classCallCheck(this, FilePond3);
+          var _this = _possibleConstructorReturn(this, (FilePond3.__proto__ || Object.getPrototypeOf(FilePond3)).call(this, props));
+          _this.allowFilesSync = true;
+          return _this;
+        }
+        _createClass(FilePond3, [{
+          key: "componentDidMount",
+          value: function componentDidMount() {
+            var _this2 = this;
+            this._input = this._element.querySelector('input[type="file"]');
+            this._inputClone = this._input.cloneNode();
+            if (!isSupported) return;
+            var options = Object.assign({}, this.props);
+            if (options.onupdatefiles) {
+              var cb = options.onupdatefiles;
+              options.onupdatefiles = function(items) {
+                _this2.allowFilesSync = false;
+                cb(items);
+              };
+            }
+            this._pond = (0, _filepond.create)(this._input, options);
+            Object.keys(this._pond).filter(function(key) {
+              return !filteredMethods.includes(key);
+            }).forEach(function(key) {
+              _this2[key] = _this2._pond[key];
+            });
+          }
+          // Will clean up FilePond instance when unmounted
+        }, {
+          key: "componentWillUnmount",
+          value: function componentWillUnmount() {
+            if (!this._pond) return;
+            var bin = document.createElement("div");
+            bin.append(this._pond.element);
+            bin.id = "foo";
+            this._pond.destroy();
+            this._pond = void 0;
+            this._element.append(this._inputClone);
+          }
+        }, {
+          key: "shouldComponentUpdate",
+          value: function shouldComponentUpdate() {
+            if (!this.allowFilesSync) {
+              this.allowFilesSync = true;
+              return false;
+            }
+            return true;
+          }
+          // Something changed
+        }, {
+          key: "componentDidUpdate",
+          value: function componentDidUpdate() {
+            if (!this._pond) return;
+            var options = Object.assign({}, this.props);
+            delete options.onupdatefiles;
+            this._pond.setOptions(options);
+          }
+          // Renders basic element hook for FilePond to attach to
+        }, {
+          key: "render",
+          value: function render() {
+            var _this3 = this;
+            var _props = this.props, id = _props.id, name = _props.name, className = _props.className, allowMultiple = _props.allowMultiple, required = _props.required, captureMethod = _props.captureMethod, acceptedFileTypes = _props.acceptedFileTypes;
+            return (0, _react.createElement)("div", {
+              className: "filepond--wrapper",
+              ref: function ref(element) {
+                return _this3._element = element;
+              }
+            }, (0, _react.createElement)("input", {
+              type: "file",
+              name,
+              id,
+              accept: acceptedFileTypes,
+              multiple: allowMultiple,
+              required,
+              className,
+              capture: captureMethod
+            }));
+          }
+        }]);
+        return FilePond3;
+      }(_react2.default.Component);
+    }
+  });
+
+  // node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js
+  var require_filepond_plugin_image_preview = __commonJS({
+    "node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"(exports, module) {
+      (function(global, factory) {
+        typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = global || self, global.FilePondPluginImagePreview = factory());
+      })(exports, function() {
+        "use strict";
+        var isPreviewableImage = function isPreviewableImage2(file) {
+          return /^image/.test(file.type);
+        };
+        function _typeof(obj) {
+          if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+            _typeof = function(obj2) {
+              return typeof obj2;
+            };
+          } else {
+            _typeof = function(obj2) {
+              return obj2 && typeof Symbol === "function" && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
+            };
+          }
+          return _typeof(obj);
+        }
+        var REACT_ELEMENT_TYPE;
+        function _jsx(type, props, key, children) {
+          if (!REACT_ELEMENT_TYPE) {
+            REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 60103;
+          }
+          var defaultProps = type && type.defaultProps;
+          var childrenLength = arguments.length - 3;
+          if (!props && childrenLength !== 0) {
+            props = {
+              children: void 0
+            };
+          }
+          if (props && defaultProps) {
+            for (var propName in defaultProps) {
+              if (props[propName] === void 0) {
+                props[propName] = defaultProps[propName];
+              }
+            }
+          } else if (!props) {
+            props = defaultProps || {};
+          }
+          if (childrenLength === 1) {
+            props.children = children;
+          } else if (childrenLength > 1) {
+            var childArray = new Array(childrenLength);
+            for (var i = 0; i < childrenLength; i++) {
+              childArray[i] = arguments[i + 3];
+            }
+            props.children = childArray;
+          }
+          return {
+            $$typeof: REACT_ELEMENT_TYPE,
+            type,
+            key: key === void 0 ? null : "" + key,
+            ref: null,
+            props,
+            _owner: null
+          };
+        }
+        function _asyncIterator(iterable) {
+          var method;
+          if (typeof Symbol === "function") {
+            if (Symbol.asyncIterator) {
+              method = iterable[Symbol.asyncIterator];
+              if (method != null) return method.call(iterable);
+            }
+            if (Symbol.iterator) {
+              method = iterable[Symbol.iterator];
+              if (method != null) return method.call(iterable);
+            }
+          }
+          throw new TypeError("Object is not async iterable");
+        }
+        function _AwaitValue(value) {
+          this.wrapped = value;
+        }
+        function _AsyncGenerator(gen) {
+          var front, back;
+          function send(key, arg) {
+            return new Promise(function(resolve, reject) {
+              var request = {
+                key,
+                arg,
+                resolve,
+                reject,
+                next: null
+              };
+              if (back) {
+                back = back.next = request;
+              } else {
+                front = back = request;
+                resume(key, arg);
+              }
+            });
+          }
+          function resume(key, arg) {
+            try {
+              var result = gen[key](arg);
+              var value = result.value;
+              var wrappedAwait = value instanceof _AwaitValue;
+              Promise.resolve(wrappedAwait ? value.wrapped : value).then(
+                function(arg2) {
+                  if (wrappedAwait) {
+                    resume("next", arg2);
+                    return;
+                  }
+                  settle(result.done ? "return" : "normal", arg2);
+                },
+                function(err) {
+                  resume("throw", err);
+                }
+              );
+            } catch (err) {
+              settle("throw", err);
+            }
+          }
+          function settle(type, value) {
+            switch (type) {
+              case "return":
+                front.resolve({
+                  value,
+                  done: true
+                });
+                break;
+              case "throw":
+                front.reject(value);
+                break;
+              default:
+                front.resolve({
+                  value,
+                  done: false
+                });
+                break;
+            }
+            front = front.next;
+            if (front) {
+              resume(front.key, front.arg);
+            } else {
+              back = null;
+            }
+          }
+          this._invoke = send;
+          if (typeof gen.return !== "function") {
+            this.return = void 0;
+          }
+        }
+        if (typeof Symbol === "function" && Symbol.asyncIterator) {
+          _AsyncGenerator.prototype[Symbol.asyncIterator] = function() {
+            return this;
+          };
+        }
+        _AsyncGenerator.prototype.next = function(arg) {
+          return this._invoke("next", arg);
+        };
+        _AsyncGenerator.prototype.throw = function(arg) {
+          return this._invoke("throw", arg);
+        };
+        _AsyncGenerator.prototype.return = function(arg) {
+          return this._invoke("return", arg);
+        };
+        function _wrapAsyncGenerator(fn) {
+          return function() {
+            return new _AsyncGenerator(fn.apply(this, arguments));
+          };
+        }
+        function _awaitAsyncGenerator(value) {
+          return new _AwaitValue(value);
+        }
+        function _asyncGeneratorDelegate(inner, awaitWrap) {
+          var iter = {}, waiting = false;
+          function pump(key, value) {
+            waiting = true;
+            value = new Promise(function(resolve) {
+              resolve(inner[key](value));
+            });
+            return {
+              done: false,
+              value: awaitWrap(value)
+            };
+          }
+          if (typeof Symbol === "function" && Symbol.iterator) {
+            iter[Symbol.iterator] = function() {
+              return this;
+            };
+          }
+          iter.next = function(value) {
+            if (waiting) {
+              waiting = false;
+              return value;
+            }
+            return pump("next", value);
+          };
+          if (typeof inner.throw === "function") {
+            iter.throw = function(value) {
+              if (waiting) {
+                waiting = false;
+                throw value;
+              }
+              return pump("throw", value);
+            };
+          }
+          if (typeof inner.return === "function") {
+            iter.return = function(value) {
+              return pump("return", value);
+            };
+          }
+          return iter;
+        }
+        function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+          try {
+            var info = gen[key](arg);
+            var value = info.value;
+          } catch (error) {
+            reject(error);
+            return;
+          }
+          if (info.done) {
+            resolve(value);
+          } else {
+            Promise.resolve(value).then(_next, _throw);
+          }
+        }
+        function _asyncToGenerator(fn) {
+          return function() {
+            var self2 = this, args = arguments;
+            return new Promise(function(resolve, reject) {
+              var gen = fn.apply(self2, args);
+              function _next(value) {
+                asyncGeneratorStep(
+                  gen,
+                  resolve,
+                  reject,
+                  _next,
+                  _throw,
+                  "next",
+                  value
+                );
+              }
+              function _throw(err) {
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+              }
+              _next(void 0);
+            });
+          };
+        }
+        function _classCallCheck(instance, Constructor) {
+          if (!(instance instanceof Constructor)) {
+            throw new TypeError("Cannot call a class as a function");
+          }
+        }
+        function _defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+          }
+        }
+        function _createClass(Constructor, protoProps, staticProps) {
+          if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) _defineProperties(Constructor, staticProps);
+          return Constructor;
+        }
+        function _defineEnumerableProperties(obj, descs) {
+          for (var key in descs) {
+            var desc = descs[key];
+            desc.configurable = desc.enumerable = true;
+            if ("value" in desc) desc.writable = true;
+            Object.defineProperty(obj, key, desc);
+          }
+          if (Object.getOwnPropertySymbols) {
+            var objectSymbols = Object.getOwnPropertySymbols(descs);
+            for (var i = 0; i < objectSymbols.length; i++) {
+              var sym = objectSymbols[i];
+              var desc = descs[sym];
+              desc.configurable = desc.enumerable = true;
+              if ("value" in desc) desc.writable = true;
+              Object.defineProperty(obj, sym, desc);
+            }
+          }
+          return obj;
+        }
+        function _defaults(obj, defaults) {
+          var keys = Object.getOwnPropertyNames(defaults);
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var value = Object.getOwnPropertyDescriptor(defaults, key);
+            if (value && value.configurable && obj[key] === void 0) {
+              Object.defineProperty(obj, key, value);
+            }
+          }
+          return obj;
+        }
+        function _defineProperty(obj, key, value) {
+          if (key in obj) {
+            Object.defineProperty(obj, key, {
+              value,
+              enumerable: true,
+              configurable: true,
+              writable: true
+            });
+          } else {
+            obj[key] = value;
+          }
+          return obj;
+        }
+        function _extends() {
+          _extends = Object.assign || function(target) {
+            for (var i = 1; i < arguments.length; i++) {
+              var source = arguments[i];
+              for (var key in source) {
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                  target[key] = source[key];
+                }
+              }
+            }
+            return target;
+          };
+          return _extends.apply(this, arguments);
+        }
+        function _objectSpread(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i] != null ? arguments[i] : {};
+            var ownKeys = Object.keys(source);
+            if (typeof Object.getOwnPropertySymbols === "function") {
+              ownKeys = ownKeys.concat(
+                Object.getOwnPropertySymbols(source).filter(function(sym) {
+                  return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+                })
+              );
+            }
+            ownKeys.forEach(function(key) {
+              _defineProperty(target, key, source[key]);
+            });
+          }
+          return target;
+        }
+        function _inherits(subClass, superClass) {
+          if (typeof superClass !== "function" && superClass !== null) {
+            throw new TypeError("Super expression must either be null or a function");
+          }
+          subClass.prototype = Object.create(superClass && superClass.prototype, {
+            constructor: {
+              value: subClass,
+              writable: true,
+              configurable: true
+            }
+          });
+          if (superClass) _setPrototypeOf(subClass, superClass);
+        }
+        function _inheritsLoose(subClass, superClass) {
+          subClass.prototype = Object.create(superClass.prototype);
+          subClass.prototype.constructor = subClass;
+          subClass.__proto__ = superClass;
+        }
+        function _getPrototypeOf(o) {
+          _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf2(o2) {
+            return o2.__proto__ || Object.getPrototypeOf(o2);
+          };
+          return _getPrototypeOf(o);
+        }
+        function _setPrototypeOf(o, p) {
+          _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf2(o2, p2) {
+            o2.__proto__ = p2;
+            return o2;
+          };
+          return _setPrototypeOf(o, p);
+        }
+        function isNativeReflectConstruct() {
+          if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+          if (Reflect.construct.sham) return false;
+          if (typeof Proxy === "function") return true;
+          try {
+            Date.prototype.toString.call(Reflect.construct(Date, [], function() {
+            }));
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+        function _construct(Parent, args, Class) {
+          if (isNativeReflectConstruct()) {
+            _construct = Reflect.construct;
+          } else {
+            _construct = function _construct2(Parent2, args2, Class2) {
+              var a = [null];
+              a.push.apply(a, args2);
+              var Constructor = Function.bind.apply(Parent2, a);
+              var instance = new Constructor();
+              if (Class2) _setPrototypeOf(instance, Class2.prototype);
+              return instance;
+            };
+          }
+          return _construct.apply(null, arguments);
+        }
+        function _isNativeFunction(fn) {
+          return Function.toString.call(fn).indexOf("[native code]") !== -1;
+        }
+        function _wrapNativeSuper(Class) {
+          var _cache = typeof Map === "function" ? /* @__PURE__ */ new Map() : void 0;
+          _wrapNativeSuper = function _wrapNativeSuper2(Class2) {
+            if (Class2 === null || !_isNativeFunction(Class2)) return Class2;
+            if (typeof Class2 !== "function") {
+              throw new TypeError(
+                "Super expression must either be null or a function"
+              );
+            }
+            if (typeof _cache !== "undefined") {
+              if (_cache.has(Class2)) return _cache.get(Class2);
+              _cache.set(Class2, Wrapper);
+            }
+            function Wrapper() {
+              return _construct(Class2, arguments, _getPrototypeOf(this).constructor);
+            }
+            Wrapper.prototype = Object.create(Class2.prototype, {
+              constructor: {
+                value: Wrapper,
+                enumerable: false,
+                writable: true,
+                configurable: true
+              }
+            });
+            return _setPrototypeOf(Wrapper, Class2);
+          };
+          return _wrapNativeSuper(Class);
+        }
+        function _instanceof(left, right) {
+          if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
+            return right[Symbol.hasInstance](left);
+          } else {
+            return left instanceof right;
+          }
+        }
+        function _interopRequireDefault(obj) {
+          return obj && obj.__esModule ? obj : {
+            default: obj
+          };
+        }
+        function _interopRequireWildcard(obj) {
+          if (obj && obj.__esModule) {
+            return obj;
+          } else {
+            var newObj = {};
+            if (obj != null) {
+              for (var key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                  var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {};
+                  if (desc.get || desc.set) {
+                    Object.defineProperty(newObj, key, desc);
+                  } else {
+                    newObj[key] = obj[key];
+                  }
+                }
+              }
+            }
+            newObj.default = obj;
+            return newObj;
+          }
+        }
+        function _newArrowCheck(innerThis, boundThis) {
+          if (innerThis !== boundThis) {
+            throw new TypeError("Cannot instantiate an arrow function");
+          }
+        }
+        function _objectDestructuringEmpty(obj) {
+          if (obj == null) throw new TypeError("Cannot destructure undefined");
+        }
+        function _objectWithoutPropertiesLoose(source, excluded) {
+          if (source == null) return {};
+          var target = {};
+          var sourceKeys = Object.keys(source);
+          var key, i;
+          for (i = 0; i < sourceKeys.length; i++) {
+            key = sourceKeys[i];
+            if (excluded.indexOf(key) >= 0) continue;
+            target[key] = source[key];
+          }
+          return target;
+        }
+        function _objectWithoutProperties(source, excluded) {
+          if (source == null) return {};
+          var target = _objectWithoutPropertiesLoose(source, excluded);
+          var key, i;
+          if (Object.getOwnPropertySymbols) {
+            var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
+            for (i = 0; i < sourceSymbolKeys.length; i++) {
+              key = sourceSymbolKeys[i];
+              if (excluded.indexOf(key) >= 0) continue;
+              if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
+              target[key] = source[key];
+            }
+          }
+          return target;
+        }
+        function _assertThisInitialized(self2) {
+          if (self2 === void 0) {
+            throw new ReferenceError(
+              "this hasn't been initialised - super() hasn't been called"
+            );
+          }
+          return self2;
+        }
+        function _possibleConstructorReturn(self2, call) {
+          if (call && (typeof call === "object" || typeof call === "function")) {
+            return call;
+          }
+          return _assertThisInitialized(self2);
+        }
+        function _superPropBase(object, property) {
+          while (!Object.prototype.hasOwnProperty.call(object, property)) {
+            object = _getPrototypeOf(object);
+            if (object === null) break;
+          }
+          return object;
+        }
+        function _get(target, property, receiver) {
+          if (typeof Reflect !== "undefined" && Reflect.get) {
+            _get = Reflect.get;
+          } else {
+            _get = function _get2(target2, property2, receiver2) {
+              var base = _superPropBase(target2, property2);
+              if (!base) return;
+              var desc = Object.getOwnPropertyDescriptor(base, property2);
+              if (desc.get) {
+                return desc.get.call(receiver2);
+              }
+              return desc.value;
+            };
+          }
+          return _get(target, property, receiver || target);
+        }
+        function set(target, property, value, receiver) {
+          if (typeof Reflect !== "undefined" && Reflect.set) {
+            set = Reflect.set;
+          } else {
+            set = function set2(target2, property2, value2, receiver2) {
+              var base = _superPropBase(target2, property2);
+              var desc;
+              if (base) {
+                desc = Object.getOwnPropertyDescriptor(base, property2);
+                if (desc.set) {
+                  desc.set.call(receiver2, value2);
+                  return true;
+                } else if (!desc.writable) {
+                  return false;
+                }
+              }
+              desc = Object.getOwnPropertyDescriptor(receiver2, property2);
+              if (desc) {
+                if (!desc.writable) {
+                  return false;
+                }
+                desc.value = value2;
+                Object.defineProperty(receiver2, property2, desc);
+              } else {
+                _defineProperty(receiver2, property2, value2);
+              }
+              return true;
+            };
+          }
+          return set(target, property, value, receiver);
+        }
+        function _set(target, property, value, receiver, isStrict) {
+          var s = set(target, property, value, receiver || target);
+          if (!s && isStrict) {
+            throw new Error("failed to set property");
+          }
+          return value;
+        }
+        function _taggedTemplateLiteral(strings, raw) {
+          if (!raw) {
+            raw = strings.slice(0);
+          }
+          return Object.freeze(
+            Object.defineProperties(strings, {
+              raw: {
+                value: Object.freeze(raw)
+              }
+            })
+          );
+        }
+        function _taggedTemplateLiteralLoose(strings, raw) {
+          if (!raw) {
+            raw = strings.slice(0);
+          }
+          strings.raw = raw;
+          return strings;
+        }
+        function _temporalRef(val, name) {
+          if (val === _temporalUndefined) {
+            throw new ReferenceError(name + " is not defined - temporal dead zone");
+          } else {
+            return val;
+          }
+        }
+        function _readOnlyError(name) {
+          throw new Error('"' + name + '" is read-only');
+        }
+        function _classNameTDZError(name) {
+          throw new Error(
+            'Class "' + name + '" cannot be referenced in computed property keys.'
+          );
+        }
+        var _temporalUndefined = {};
+        function _slicedToArray(arr, i) {
+          return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest();
+        }
+        function _slicedToArrayLoose(arr, i) {
+          return _arrayWithHoles(arr) || _iterableToArrayLimitLoose(arr, i) || _nonIterableRest();
+        }
+        function _toArray(arr) {
+          return _arrayWithHoles(arr) || _iterableToArray(arr) || _nonIterableRest();
+        }
+        function _toConsumableArray(arr) {
+          return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread();
+        }
+        function _arrayWithoutHoles(arr) {
+          if (Array.isArray(arr)) {
+            for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++)
+              arr2[i] = arr[i];
+            return arr2;
+          }
+        }
+        function _arrayWithHoles(arr) {
+          if (Array.isArray(arr)) return arr;
+        }
+        function _iterableToArray(iter) {
+          if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]")
+            return Array.from(iter);
+        }
+        function _iterableToArrayLimit(arr, i) {
+          var _arr = [];
+          var _n = true;
+          var _d = false;
+          var _e = void 0;
+          try {
+            for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+              _arr.push(_s.value);
+              if (i && _arr.length === i) break;
+            }
+          } catch (err) {
+            _d = true;
+            _e = err;
+          } finally {
+            try {
+              if (!_n && _i["return"] != null) _i["return"]();
+            } finally {
+              if (_d) throw _e;
+            }
+          }
+          return _arr;
+        }
+        function _iterableToArrayLimitLoose(arr, i) {
+          var _arr = [];
+          for (var _iterator = arr[Symbol.iterator](), _step; !(_step = _iterator.next()).done; ) {
+            _arr.push(_step.value);
+            if (i && _arr.length === i) break;
+          }
+          return _arr;
+        }
+        function _nonIterableSpread() {
+          throw new TypeError("Invalid attempt to spread non-iterable instance");
+        }
+        function _nonIterableRest() {
+          throw new TypeError("Invalid attempt to destructure non-iterable instance");
+        }
+        function _skipFirstGeneratorNext(fn) {
+          return function() {
+            var it = fn.apply(this, arguments);
+            it.next();
+            return it;
+          };
+        }
+        function _toPrimitive(input, hint) {
+          if (typeof input !== "object" || input === null) return input;
+          var prim = input[Symbol.toPrimitive];
+          if (prim !== void 0) {
+            var res = prim.call(input, hint || "default");
+            if (typeof res !== "object") return res;
+            throw new TypeError("@@toPrimitive must return a primitive value.");
+          }
+          return (hint === "string" ? String : Number)(input);
+        }
+        function _toPropertyKey(arg) {
+          var key = _toPrimitive(arg, "string");
+          return typeof key === "symbol" ? key : String(key);
+        }
+        function _initializerWarningHelper(descriptor, context) {
+          throw new Error(
+            "Decorating class property failed. Please ensure that proposal-class-properties is enabled and set to use loose mode. To use proposal-class-properties in spec mode with decorators, wait for the next major version of decorators in stage 2."
+          );
+        }
+        function _initializerDefineProperty(target, property, descriptor, context) {
+          if (!descriptor) return;
+          Object.defineProperty(target, property, {
+            enumerable: descriptor.enumerable,
+            configurable: descriptor.configurable,
+            writable: descriptor.writable,
+            value: descriptor.initializer ? descriptor.initializer.call(context) : void 0
+          });
+        }
+        function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) {
+          var desc = {};
+          Object.keys(descriptor).forEach(function(key) {
+            desc[key] = descriptor[key];
+          });
+          desc.enumerable = !!desc.enumerable;
+          desc.configurable = !!desc.configurable;
+          if ("value" in desc || desc.initializer) {
+            desc.writable = true;
+          }
+          desc = decorators.slice().reverse().reduce(function(desc2, decorator) {
+            return decorator(target, property, desc2) || desc2;
+          }, desc);
+          if (context && desc.initializer !== void 0) {
+            desc.value = desc.initializer ? desc.initializer.call(context) : void 0;
+            desc.initializer = void 0;
+          }
+          if (desc.initializer === void 0) {
+            Object.defineProperty(target, property, desc);
+            desc = null;
+          }
+          return desc;
+        }
+        var id = 0;
+        function _classPrivateFieldLooseKey(name) {
+          return "__private_" + id++ + "_" + name;
+        }
+        function _classPrivateFieldLooseBase(receiver, privateKey) {
+          if (!Object.prototype.hasOwnProperty.call(receiver, privateKey)) {
+            throw new TypeError("attempted to use private field on non-instance");
+          }
+          return receiver;
+        }
+        function _classPrivateFieldGet(receiver, privateMap) {
+          if (!privateMap.has(receiver)) {
+            throw new TypeError("attempted to get private field on non-instance");
+          }
+          var descriptor = privateMap.get(receiver);
+          if (descriptor.get) {
+            return descriptor.get.call(receiver);
+          }
+          return descriptor.value;
+        }
+        function _classPrivateFieldSet(receiver, privateMap, value) {
+          if (!privateMap.has(receiver)) {
+            throw new TypeError("attempted to set private field on non-instance");
+          }
+          var descriptor = privateMap.get(receiver);
+          if (descriptor.set) {
+            descriptor.set.call(receiver, value);
+          } else {
+            if (!descriptor.writable) {
+              throw new TypeError("attempted to set read only private field");
+            }
+            descriptor.value = value;
+          }
+          return value;
+        }
+        function _classStaticPrivateFieldSpecGet(receiver, classConstructor, descriptor) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          return descriptor.value;
+        }
+        function _classStaticPrivateFieldSpecSet(receiver, classConstructor, descriptor, value) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          if (!descriptor.writable) {
+            throw new TypeError("attempted to set read only private field");
+          }
+          descriptor.value = value;
+          return value;
+        }
+        function _classStaticPrivateMethodGet(receiver, classConstructor, method) {
+          if (receiver !== classConstructor) {
+            throw new TypeError("Private static access of wrong provenance");
+          }
+          return method;
+        }
+        function _classStaticPrivateMethodSet() {
+          throw new TypeError("attempted to set read only static private field");
+        }
+        function _decorate(decorators, factory, superClass, mixins) {
+          var api = _getDecoratorsApi();
+          if (mixins) {
+            for (var i = 0; i < mixins.length; i++) {
+              api = mixins[i](api);
+            }
+          }
+          var r = factory(function initialize(O) {
+            api.initializeInstanceElements(O, decorated.elements);
+          }, superClass);
+          var decorated = api.decorateClass(
+            _coalesceClassElements(r.d.map(_createElementDescriptor)),
+            decorators
+          );
+          api.initializeClassElements(r.F, decorated.elements);
+          return api.runClassFinishers(r.F, decorated.finishers);
+        }
+        function _getDecoratorsApi() {
+          _getDecoratorsApi = function() {
+            return api;
+          };
+          var api = {
+            elementsDefinitionOrder: [["method"], ["field"]],
+            initializeInstanceElements: function(O, elements) {
+              ["method", "field"].forEach(function(kind) {
+                elements.forEach(function(element) {
+                  if (element.kind === kind && element.placement === "own") {
+                    this.defineClassElement(O, element);
+                  }
+                }, this);
+              }, this);
+            },
+            initializeClassElements: function(F, elements) {
+              var proto = F.prototype;
+              ["method", "field"].forEach(function(kind) {
+                elements.forEach(function(element) {
+                  var placement = element.placement;
+                  if (element.kind === kind && (placement === "static" || placement === "prototype")) {
+                    var receiver = placement === "static" ? F : proto;
+                    this.defineClassElement(receiver, element);
+                  }
+                }, this);
+              }, this);
+            },
+            defineClassElement: function(receiver, element) {
+              var descriptor = element.descriptor;
+              if (element.kind === "field") {
+                var initializer = element.initializer;
+                descriptor = {
+                  enumerable: descriptor.enumerable,
+                  writable: descriptor.writable,
+                  configurable: descriptor.configurable,
+                  value: initializer === void 0 ? void 0 : initializer.call(receiver)
+                };
+              }
+              Object.defineProperty(receiver, element.key, descriptor);
+            },
+            decorateClass: function(elements, decorators) {
+              var newElements = [];
+              var finishers = [];
+              var placements = {
+                static: [],
+                prototype: [],
+                own: []
+              };
+              elements.forEach(function(element) {
+                this.addElementPlacement(element, placements);
+              }, this);
+              elements.forEach(function(element) {
+                if (!_hasDecorators(element)) return newElements.push(element);
+                var elementFinishersExtras = this.decorateElement(
+                  element,
+                  placements
+                );
+                newElements.push(elementFinishersExtras.element);
+                newElements.push.apply(newElements, elementFinishersExtras.extras);
+                finishers.push.apply(finishers, elementFinishersExtras.finishers);
+              }, this);
+              if (!decorators) {
+                return {
+                  elements: newElements,
+                  finishers
+                };
+              }
+              var result = this.decorateConstructor(newElements, decorators);
+              finishers.push.apply(finishers, result.finishers);
+              result.finishers = finishers;
+              return result;
+            },
+            addElementPlacement: function(element, placements, silent) {
+              var keys = placements[element.placement];
+              if (!silent && keys.indexOf(element.key) !== -1) {
+                throw new TypeError("Duplicated element (" + element.key + ")");
+              }
+              keys.push(element.key);
+            },
+            decorateElement: function(element, placements) {
+              var extras = [];
+              var finishers = [];
+              for (var decorators = element.decorators, i = decorators.length - 1; i >= 0; i--) {
+                var keys = placements[element.placement];
+                keys.splice(keys.indexOf(element.key), 1);
+                var elementObject = this.fromElementDescriptor(element);
+                var elementFinisherExtras = this.toElementFinisherExtras(
+                  (0, decorators[i])(elementObject) || elementObject
+                );
+                element = elementFinisherExtras.element;
+                this.addElementPlacement(element, placements);
+                if (elementFinisherExtras.finisher) {
+                  finishers.push(elementFinisherExtras.finisher);
+                }
+                var newExtras = elementFinisherExtras.extras;
+                if (newExtras) {
+                  for (var j = 0; j < newExtras.length; j++) {
+                    this.addElementPlacement(newExtras[j], placements);
+                  }
+                  extras.push.apply(extras, newExtras);
+                }
+              }
+              return {
+                element,
+                finishers,
+                extras
+              };
+            },
+            decorateConstructor: function(elements, decorators) {
+              var finishers = [];
+              for (var i = decorators.length - 1; i >= 0; i--) {
+                var obj = this.fromClassDescriptor(elements);
+                var elementsAndFinisher = this.toClassDescriptor(
+                  (0, decorators[i])(obj) || obj
+                );
+                if (elementsAndFinisher.finisher !== void 0) {
+                  finishers.push(elementsAndFinisher.finisher);
+                }
+                if (elementsAndFinisher.elements !== void 0) {
+                  elements = elementsAndFinisher.elements;
+                  for (var j = 0; j < elements.length - 1; j++) {
+                    for (var k = j + 1; k < elements.length; k++) {
+                      if (elements[j].key === elements[k].key && elements[j].placement === elements[k].placement) {
+                        throw new TypeError(
+                          "Duplicated element (" + elements[j].key + ")"
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+              return {
+                elements,
+                finishers
+              };
+            },
+            fromElementDescriptor: function(element) {
+              var obj = {
+                kind: element.kind,
+                key: element.key,
+                placement: element.placement,
+                descriptor: element.descriptor
+              };
+              var desc = {
+                value: "Descriptor",
+                configurable: true
+              };
+              Object.defineProperty(obj, Symbol.toStringTag, desc);
+              if (element.kind === "field") obj.initializer = element.initializer;
+              return obj;
+            },
+            toElementDescriptors: function(elementObjects) {
+              if (elementObjects === void 0) return;
+              return _toArray(elementObjects).map(function(elementObject) {
+                var element = this.toElementDescriptor(elementObject);
+                this.disallowProperty(
+                  elementObject,
+                  "finisher",
+                  "An element descriptor"
+                );
+                this.disallowProperty(
+                  elementObject,
+                  "extras",
+                  "An element descriptor"
+                );
+                return element;
+              }, this);
+            },
+            toElementDescriptor: function(elementObject) {
+              var kind = String(elementObject.kind);
+              if (kind !== "method" && kind !== "field") {
+                throw new TypeError(
+                  `An element descriptor's .kind property must be either "method" or "field", but a decorator created an element descriptor with .kind "` + kind + '"'
+                );
+              }
+              var key = _toPropertyKey(elementObject.key);
+              var placement = String(elementObject.placement);
+              if (placement !== "static" && placement !== "prototype" && placement !== "own") {
+                throw new TypeError(
+                  `An element descriptor's .placement property must be one of "static", "prototype" or "own", but a decorator created an element descriptor with .placement "` + placement + '"'
+                );
+              }
+              var descriptor = elementObject.descriptor;
+              this.disallowProperty(
+                elementObject,
+                "elements",
+                "An element descriptor"
+              );
+              var element = {
+                kind,
+                key,
+                placement,
+                descriptor: Object.assign({}, descriptor)
+              };
+              if (kind !== "field") {
+                this.disallowProperty(
+                  elementObject,
+                  "initializer",
+                  "A method descriptor"
+                );
+              } else {
+                this.disallowProperty(
+                  descriptor,
+                  "get",
+                  "The property descriptor of a field descriptor"
+                );
+                this.disallowProperty(
+                  descriptor,
+                  "set",
+                  "The property descriptor of a field descriptor"
+                );
+                this.disallowProperty(
+                  descriptor,
+                  "value",
+                  "The property descriptor of a field descriptor"
+                );
+                element.initializer = elementObject.initializer;
+              }
+              return element;
+            },
+            toElementFinisherExtras: function(elementObject) {
+              var element = this.toElementDescriptor(elementObject);
+              var finisher = _optionalCallableProperty(elementObject, "finisher");
+              var extras = this.toElementDescriptors(elementObject.extras);
+              return {
+                element,
+                finisher,
+                extras
+              };
+            },
+            fromClassDescriptor: function(elements) {
+              var obj = {
+                kind: "class",
+                elements: elements.map(this.fromElementDescriptor, this)
+              };
+              var desc = {
+                value: "Descriptor",
+                configurable: true
+              };
+              Object.defineProperty(obj, Symbol.toStringTag, desc);
+              return obj;
+            },
+            toClassDescriptor: function(obj) {
+              var kind = String(obj.kind);
+              if (kind !== "class") {
+                throw new TypeError(
+                  `A class descriptor's .kind property must be "class", but a decorator created a class descriptor with .kind "` + kind + '"'
+                );
+              }
+              this.disallowProperty(obj, "key", "A class descriptor");
+              this.disallowProperty(obj, "placement", "A class descriptor");
+              this.disallowProperty(obj, "descriptor", "A class descriptor");
+              this.disallowProperty(obj, "initializer", "A class descriptor");
+              this.disallowProperty(obj, "extras", "A class descriptor");
+              var finisher = _optionalCallableProperty(obj, "finisher");
+              var elements = this.toElementDescriptors(obj.elements);
+              return {
+                elements,
+                finisher
+              };
+            },
+            runClassFinishers: function(constructor, finishers) {
+              for (var i = 0; i < finishers.length; i++) {
+                var newConstructor = (0, finishers[i])(constructor);
+                if (newConstructor !== void 0) {
+                  if (typeof newConstructor !== "function") {
+                    throw new TypeError("Finishers must return a constructor.");
+                  }
+                  constructor = newConstructor;
+                }
+              }
+              return constructor;
+            },
+            disallowProperty: function(obj, name, objectType) {
+              if (obj[name] !== void 0) {
+                throw new TypeError(
+                  objectType + " can't have a ." + name + " property."
+                );
+              }
+            }
+          };
+          return api;
+        }
+        function _createElementDescriptor(def) {
+          var key = _toPropertyKey(def.key);
+          var descriptor;
+          if (def.kind === "method") {
+            descriptor = {
+              value: def.value,
+              writable: true,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "get") {
+            descriptor = {
+              get: def.value,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "set") {
+            descriptor = {
+              set: def.value,
+              configurable: true,
+              enumerable: false
+            };
+          } else if (def.kind === "field") {
+            descriptor = {
+              configurable: true,
+              writable: true,
+              enumerable: true
+            };
+          }
+          var element = {
+            kind: def.kind === "field" ? "field" : "method",
+            key,
+            placement: def.static ? "static" : def.kind === "field" ? "own" : "prototype",
+            descriptor
+          };
+          if (def.decorators) element.decorators = def.decorators;
+          if (def.kind === "field") element.initializer = def.value;
+          return element;
+        }
+        function _coalesceGetterSetter(element, other) {
+          if (element.descriptor.get !== void 0) {
+            other.descriptor.get = element.descriptor.get;
+          } else {
+            other.descriptor.set = element.descriptor.set;
+          }
+        }
+        function _coalesceClassElements(elements) {
+          var newElements = [];
+          var isSameElement = function(other2) {
+            return other2.kind === "method" && other2.key === element.key && other2.placement === element.placement;
+          };
+          for (var i = 0; i < elements.length; i++) {
+            var element = elements[i];
+            var other;
+            if (element.kind === "method" && (other = newElements.find(isSameElement))) {
+              if (_isDataDescriptor(element.descriptor) || _isDataDescriptor(other.descriptor)) {
+                if (_hasDecorators(element) || _hasDecorators(other)) {
+                  throw new ReferenceError(
+                    "Duplicated methods (" + element.key + ") can't be decorated."
+                  );
+                }
+                other.descriptor = element.descriptor;
+              } else {
+                if (_hasDecorators(element)) {
+                  if (_hasDecorators(other)) {
+                    throw new ReferenceError(
+                      "Decorators can't be placed on different accessors with for the same property (" + element.key + ")."
+                    );
+                  }
+                  other.decorators = element.decorators;
+                }
+                _coalesceGetterSetter(element, other);
+              }
+            } else {
+              newElements.push(element);
+            }
+          }
+          return newElements;
+        }
+        function _hasDecorators(element) {
+          return element.decorators && element.decorators.length;
+        }
+        function _isDataDescriptor(desc) {
+          return desc !== void 0 && !(desc.value === void 0 && desc.writable === void 0);
+        }
+        function _optionalCallableProperty(obj, name) {
+          var value = obj[name];
+          if (value !== void 0 && typeof value !== "function") {
+            throw new TypeError("Expected '" + name + "' to be a function");
+          }
+          return value;
+        }
+        function _classPrivateMethodGet(receiver, privateSet, fn) {
+          if (!privateSet.has(receiver)) {
+            throw new TypeError("attempted to get private field on non-instance");
+          }
+          return fn;
+        }
+        function _classPrivateMethodSet() {
+          throw new TypeError("attempted to reassign private method");
+        }
+        function _wrapRegExp(re, groups) {
+          _wrapRegExp = function(re2, groups2) {
+            return new BabelRegExp(re2, groups2);
+          };
+          var _RegExp = _wrapNativeSuper(RegExp);
+          var _super = RegExp.prototype;
+          var _groups = /* @__PURE__ */ new WeakMap();
+          function BabelRegExp(re2, groups2) {
+            var _this = _RegExp.call(this, re2);
+            _groups.set(_this, groups2);
+            return _this;
+          }
+          _inherits(BabelRegExp, _RegExp);
+          BabelRegExp.prototype.exec = function(str) {
+            var result = _super.exec.call(this, str);
+            if (result) result.groups = buildGroups(result, this);
+            return result;
+          };
+          BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
+            if (typeof substitution === "string") {
+              var groups2 = _groups.get(this);
+              return _super[Symbol.replace].call(
+                this,
+                str,
+                substitution.replace(/\$<([^>]+)>/g, function(_, name) {
+                  return "$" + groups2[name];
+                })
+              );
+            } else if (typeof substitution === "function") {
+              var _this = this;
+              return _super[Symbol.replace].call(this, str, function() {
+                var args = [];
+                args.push.apply(args, arguments);
+                if (typeof args[args.length - 1] !== "object") {
+                  args.push(buildGroups(args, _this));
+                }
+                return substitution.apply(this, args);
+              });
+            } else {
+              return _super[Symbol.replace].call(this, str, substitution);
+            }
+          };
+          function buildGroups(result, re2) {
+            var g = _groups.get(re2);
+            return Object.keys(g).reduce(function(groups2, name) {
+              groups2[name] = result[g[name]];
+              return groups2;
+            }, /* @__PURE__ */ Object.create(null));
+          }
+          return _wrapRegExp.apply(this, arguments);
+        }
+        var vectorMultiply = function vectorMultiply2(v, amount) {
+          return createVector(v.x * amount, v.y * amount);
+        };
+        var vectorAdd = function vectorAdd2(a, b) {
+          return createVector(a.x + b.x, a.y + b.y);
+        };
+        var vectorNormalize = function vectorNormalize2(v) {
+          var l = Math.sqrt(v.x * v.x + v.y * v.y);
+          if (l === 0) {
+            return {
+              x: 0,
+              y: 0
+            };
+          }
+          return createVector(v.x / l, v.y / l);
+        };
+        var vectorRotate = function vectorRotate2(v, radians, origin) {
+          var cos = Math.cos(radians);
+          var sin = Math.sin(radians);
+          var t = createVector(v.x - origin.x, v.y - origin.y);
+          return createVector(
+            origin.x + cos * t.x - sin * t.y,
+            origin.y + sin * t.x + cos * t.y
+          );
+        };
+        var createVector = function createVector2() {
+          var x = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : 0;
+          var y = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 0;
+          return { x, y };
+        };
+        var getMarkupValue = function getMarkupValue2(value, size) {
+          var scalar = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 1;
+          var axis = arguments.length > 3 ? arguments[3] : void 0;
+          if (typeof value === "string") {
+            return parseFloat(value) * scalar;
+          }
+          if (typeof value === "number") {
+            return value * (axis ? size[axis] : Math.min(size.width, size.height));
+          }
+          return;
+        };
+        var getMarkupStyles = function getMarkupStyles2(markup, size, scale) {
+          var lineStyle = markup.borderStyle || markup.lineStyle || "solid";
+          var fill = markup.backgroundColor || markup.fontColor || "transparent";
+          var stroke = markup.borderColor || markup.lineColor || "transparent";
+          var strokeWidth = getMarkupValue(
+            markup.borderWidth || markup.lineWidth,
+            size,
+            scale
+          );
+          var lineCap = markup.lineCap || "round";
+          var lineJoin = markup.lineJoin || "round";
+          var dashes = typeof lineStyle === "string" ? "" : lineStyle.map(function(v) {
+            return getMarkupValue(v, size, scale);
+          }).join(",");
+          var opacity = markup.opacity || 1;
+          return {
+            "stroke-linecap": lineCap,
+            "stroke-linejoin": lineJoin,
+            "stroke-width": strokeWidth || 0,
+            "stroke-dasharray": dashes,
+            stroke,
+            fill,
+            opacity
+          };
+        };
+        var isDefined = function isDefined2(value) {
+          return value != null;
+        };
+        var getMarkupRect = function getMarkupRect2(rect, size) {
+          var scalar = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 1;
+          var left = getMarkupValue(rect.x, size, scalar, "width") || getMarkupValue(rect.left, size, scalar, "width");
+          var top = getMarkupValue(rect.y, size, scalar, "height") || getMarkupValue(rect.top, size, scalar, "height");
+          var width = getMarkupValue(rect.width, size, scalar, "width");
+          var height = getMarkupValue(rect.height, size, scalar, "height");
+          var right = getMarkupValue(rect.right, size, scalar, "width");
+          var bottom = getMarkupValue(rect.bottom, size, scalar, "height");
+          if (!isDefined(top)) {
+            if (isDefined(height) && isDefined(bottom)) {
+              top = size.height - height - bottom;
+            } else {
+              top = bottom;
+            }
+          }
+          if (!isDefined(left)) {
+            if (isDefined(width) && isDefined(right)) {
+              left = size.width - width - right;
+            } else {
+              left = right;
+            }
+          }
+          if (!isDefined(width)) {
+            if (isDefined(left) && isDefined(right)) {
+              width = size.width - left - right;
+            } else {
+              width = 0;
+            }
+          }
+          if (!isDefined(height)) {
+            if (isDefined(top) && isDefined(bottom)) {
+              height = size.height - top - bottom;
+            } else {
+              height = 0;
+            }
+          }
+          return {
+            x: left || 0,
+            y: top || 0,
+            width: width || 0,
+            height: height || 0
+          };
+        };
+        var pointsToPathShape = function pointsToPathShape2(points) {
+          return points.map(function(point, index) {
+            return "".concat(index === 0 ? "M" : "L", " ").concat(point.x, " ").concat(point.y);
+          }).join(" ");
+        };
+        var setAttributes = function setAttributes2(element, attr) {
+          return Object.keys(attr).forEach(function(key) {
+            return element.setAttribute(key, attr[key]);
+          });
+        };
+        var ns = "http://www.w3.org/2000/svg";
+        var svg = function svg2(tag, attr) {
+          var element = document.createElementNS(ns, tag);
+          if (attr) {
+            setAttributes(element, attr);
+          }
+          return element;
+        };
+        var updateRect = function updateRect2(element) {
+          return setAttributes(
+            element,
+            Object.assign({}, element.rect, element.styles)
+          );
+        };
+        var updateEllipse = function updateEllipse2(element) {
+          var cx = element.rect.x + element.rect.width * 0.5;
+          var cy = element.rect.y + element.rect.height * 0.5;
+          var rx = element.rect.width * 0.5;
+          var ry = element.rect.height * 0.5;
+          return setAttributes(
+            element,
+            Object.assign(
+              {
+                cx,
+                cy,
+                rx,
+                ry
+              },
+              element.styles
+            )
+          );
+        };
+        var IMAGE_FIT_STYLE = {
+          contain: "xMidYMid meet",
+          cover: "xMidYMid slice"
+        };
+        var updateImage = function updateImage2(element, markup) {
+          setAttributes(
+            element,
+            Object.assign({}, element.rect, element.styles, {
+              preserveAspectRatio: IMAGE_FIT_STYLE[markup.fit] || "none"
+            })
+          );
+        };
+        var TEXT_ANCHOR = {
+          left: "start",
+          center: "middle",
+          right: "end"
+        };
+        var updateText = function updateText2(element, markup, size, scale) {
+          var fontSize = getMarkupValue(markup.fontSize, size, scale);
+          var fontFamily = markup.fontFamily || "sans-serif";
+          var fontWeight = markup.fontWeight || "normal";
+          var textAlign = TEXT_ANCHOR[markup.textAlign] || "start";
+          setAttributes(
+            element,
+            Object.assign({}, element.rect, element.styles, {
+              "stroke-width": 0,
+              "font-weight": fontWeight,
+              "font-size": fontSize,
+              "font-family": fontFamily,
+              "text-anchor": textAlign
+            })
+          );
+          if (element.text !== markup.text) {
+            element.text = markup.text;
+            element.textContent = markup.text.length ? markup.text : " ";
+          }
+        };
+        var updateLine = function updateLine2(element, markup, size, scale) {
+          setAttributes(
+            element,
+            Object.assign({}, element.rect, element.styles, {
+              fill: "none"
+            })
+          );
+          var line = element.childNodes[0];
+          var begin = element.childNodes[1];
+          var end = element.childNodes[2];
+          var origin = element.rect;
+          var target = {
+            x: element.rect.x + element.rect.width,
+            y: element.rect.y + element.rect.height
+          };
+          setAttributes(line, {
+            x1: origin.x,
+            y1: origin.y,
+            x2: target.x,
+            y2: target.y
+          });
+          if (!markup.lineDecoration) return;
+          begin.style.display = "none";
+          end.style.display = "none";
+          var v = vectorNormalize({
+            x: target.x - origin.x,
+            y: target.y - origin.y
+          });
+          var l = getMarkupValue(0.05, size, scale);
+          if (markup.lineDecoration.indexOf("arrow-begin") !== -1) {
+            var arrowBeginRotationPoint = vectorMultiply(v, l);
+            var arrowBeginCenter = vectorAdd(origin, arrowBeginRotationPoint);
+            var arrowBeginA = vectorRotate(origin, 2, arrowBeginCenter);
+            var arrowBeginB = vectorRotate(origin, -2, arrowBeginCenter);
+            setAttributes(begin, {
+              style: "display:block;",
+              d: "M".concat(arrowBeginA.x, ",").concat(arrowBeginA.y, " L").concat(origin.x, ",").concat(origin.y, " L").concat(arrowBeginB.x, ",").concat(arrowBeginB.y)
+            });
+          }
+          if (markup.lineDecoration.indexOf("arrow-end") !== -1) {
+            var arrowEndRotationPoint = vectorMultiply(v, -l);
+            var arrowEndCenter = vectorAdd(target, arrowEndRotationPoint);
+            var arrowEndA = vectorRotate(target, 2, arrowEndCenter);
+            var arrowEndB = vectorRotate(target, -2, arrowEndCenter);
+            setAttributes(end, {
+              style: "display:block;",
+              d: "M".concat(arrowEndA.x, ",").concat(arrowEndA.y, " L").concat(target.x, ",").concat(target.y, " L").concat(arrowEndB.x, ",").concat(arrowEndB.y)
+            });
+          }
+        };
+        var updatePath = function updatePath2(element, markup, size, scale) {
+          setAttributes(
+            element,
+            Object.assign({}, element.styles, {
+              fill: "none",
+              d: pointsToPathShape(
+                markup.points.map(function(point) {
+                  return {
+                    x: getMarkupValue(point.x, size, scale, "width"),
+                    y: getMarkupValue(point.y, size, scale, "height")
+                  };
+                })
+              )
+            })
+          );
+        };
+        var createShape = function createShape2(node) {
+          return function(markup) {
+            return svg(node, { id: markup.id });
+          };
+        };
+        var createImage = function createImage2(markup) {
+          var shape = svg("image", {
+            id: markup.id,
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+            opacity: "0"
+          });
+          shape.onload = function() {
+            shape.setAttribute("opacity", markup.opacity || 1);
+          };
+          shape.setAttributeNS(
+            "http://www.w3.org/1999/xlink",
+            "xlink:href",
+            markup.src
+          );
+          return shape;
+        };
+        var createLine = function createLine2(markup) {
+          var shape = svg("g", {
+            id: markup.id,
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round"
+          });
+          var line = svg("line");
+          shape.appendChild(line);
+          var begin = svg("path");
+          shape.appendChild(begin);
+          var end = svg("path");
+          shape.appendChild(end);
+          return shape;
+        };
+        var CREATE_TYPE_ROUTES = {
+          image: createImage,
+          rect: createShape("rect"),
+          ellipse: createShape("ellipse"),
+          text: createShape("text"),
+          path: createShape("path"),
+          line: createLine
+        };
+        var UPDATE_TYPE_ROUTES = {
+          rect: updateRect,
+          ellipse: updateEllipse,
+          image: updateImage,
+          text: updateText,
+          path: updatePath,
+          line: updateLine
+        };
+        var createMarkupByType = function createMarkupByType2(type, markup) {
+          return CREATE_TYPE_ROUTES[type](markup);
+        };
+        var updateMarkupByType = function updateMarkupByType2(element, type, markup, size, scale) {
+          if (type !== "path") {
+            element.rect = getMarkupRect(markup, size, scale);
+          }
+          element.styles = getMarkupStyles(markup, size, scale);
+          UPDATE_TYPE_ROUTES[type](element, markup, size, scale);
+        };
+        var MARKUP_RECT = [
+          "x",
+          "y",
+          "left",
+          "top",
+          "right",
+          "bottom",
+          "width",
+          "height"
+        ];
+        var toOptionalFraction = function toOptionalFraction2(value) {
+          return typeof value === "string" && /%/.test(value) ? parseFloat(value) / 100 : value;
+        };
+        var prepareMarkup = function prepareMarkup2(markup) {
+          var _markup = _slicedToArray(markup, 2), type = _markup[0], props = _markup[1];
+          var rect = props.points ? {} : MARKUP_RECT.reduce(function(prev, curr) {
+            prev[curr] = toOptionalFraction(props[curr]);
+            return prev;
+          }, {});
+          return [
+            type,
+            Object.assign(
+              {
+                zIndex: 0
+              },
+              props,
+              rect
+            )
+          ];
+        };
+        var sortMarkupByZIndex = function sortMarkupByZIndex2(a, b) {
+          if (a[1].zIndex > b[1].zIndex) {
+            return 1;
+          }
+          if (a[1].zIndex < b[1].zIndex) {
+            return -1;
+          }
+          return 0;
+        };
+        var createMarkupView = function createMarkupView2(_) {
+          return _.utils.createView({
+            name: "image-preview-markup",
+            tag: "svg",
+            ignoreRect: true,
+            mixins: {
+              apis: ["width", "height", "crop", "markup", "resize", "dirty"]
+            },
+            write: function write(_ref) {
+              var root = _ref.root, props = _ref.props;
+              if (!props.dirty) return;
+              var crop = props.crop, resize = props.resize, markup = props.markup;
+              var viewWidth = props.width;
+              var viewHeight = props.height;
+              var cropWidth = crop.width;
+              var cropHeight = crop.height;
+              if (resize) {
+                var _size = resize.size;
+                var outputWidth = _size && _size.width;
+                var outputHeight = _size && _size.height;
+                var outputFit = resize.mode;
+                var outputUpscale = resize.upscale;
+                if (outputWidth && !outputHeight) outputHeight = outputWidth;
+                if (outputHeight && !outputWidth) outputWidth = outputHeight;
+                var shouldUpscale = cropWidth < outputWidth && cropHeight < outputHeight;
+                if (!shouldUpscale || shouldUpscale && outputUpscale) {
+                  var scalarWidth = outputWidth / cropWidth;
+                  var scalarHeight = outputHeight / cropHeight;
+                  if (outputFit === "force") {
+                    cropWidth = outputWidth;
+                    cropHeight = outputHeight;
+                  } else {
+                    var scalar;
+                    if (outputFit === "cover") {
+                      scalar = Math.max(scalarWidth, scalarHeight);
+                    } else if (outputFit === "contain") {
+                      scalar = Math.min(scalarWidth, scalarHeight);
+                    }
+                    cropWidth = cropWidth * scalar;
+                    cropHeight = cropHeight * scalar;
+                  }
+                }
+              }
+              var size = {
+                width: viewWidth,
+                height: viewHeight
+              };
+              root.element.setAttribute("width", size.width);
+              root.element.setAttribute("height", size.height);
+              var scale = Math.min(viewWidth / cropWidth, viewHeight / cropHeight);
+              root.element.innerHTML = "";
+              var markupFilter = root.query("GET_IMAGE_PREVIEW_MARKUP_FILTER");
+              markup.filter(markupFilter).map(prepareMarkup).sort(sortMarkupByZIndex).forEach(function(markup2) {
+                var _markup = _slicedToArray(markup2, 2), type = _markup[0], settings = _markup[1];
+                var element = createMarkupByType(type, settings);
+                updateMarkupByType(element, type, settings, size, scale);
+                root.element.appendChild(element);
+              });
+            }
+          });
+        };
+        var createVector$1 = function createVector2(x, y) {
+          return { x, y };
+        };
+        var vectorDot = function vectorDot2(a, b) {
+          return a.x * b.x + a.y * b.y;
+        };
+        var vectorSubtract = function vectorSubtract2(a, b) {
+          return createVector$1(a.x - b.x, a.y - b.y);
+        };
+        var vectorDistanceSquared = function vectorDistanceSquared2(a, b) {
+          return vectorDot(vectorSubtract(a, b), vectorSubtract(a, b));
+        };
+        var vectorDistance = function vectorDistance2(a, b) {
+          return Math.sqrt(vectorDistanceSquared(a, b));
+        };
+        var getOffsetPointOnEdge = function getOffsetPointOnEdge2(length, rotation) {
+          var a = length;
+          var A2 = 1.5707963267948966;
+          var B = rotation;
+          var C2 = 1.5707963267948966 - rotation;
+          var sinA = Math.sin(A2);
+          var sinB = Math.sin(B);
+          var sinC = Math.sin(C2);
+          var cosC = Math.cos(C2);
+          var ratio = a / sinA;
+          var b = ratio * sinB;
+          var c = ratio * sinC;
+          return createVector$1(cosC * b, cosC * c);
+        };
+        var getRotatedRectSize = function getRotatedRectSize2(rect, rotation) {
+          var w = rect.width;
+          var h = rect.height;
+          var hor = getOffsetPointOnEdge(w, rotation);
+          var ver = getOffsetPointOnEdge(h, rotation);
+          var tl = createVector$1(rect.x + Math.abs(hor.x), rect.y - Math.abs(hor.y));
+          var tr = createVector$1(
+            rect.x + rect.width + Math.abs(ver.y),
+            rect.y + Math.abs(ver.x)
+          );
+          var bl = createVector$1(
+            rect.x - Math.abs(ver.y),
+            rect.y + rect.height - Math.abs(ver.x)
+          );
+          return {
+            width: vectorDistance(tl, tr),
+            height: vectorDistance(tl, bl)
+          };
+        };
+        var calculateCanvasSize = function calculateCanvasSize2(image, canvasAspectRatio) {
+          var zoom = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 1;
+          var imageAspectRatio = image.height / image.width;
+          var canvasWidth = 1;
+          var canvasHeight = canvasAspectRatio;
+          var imgWidth = 1;
+          var imgHeight = imageAspectRatio;
+          if (imgHeight > canvasHeight) {
+            imgHeight = canvasHeight;
+            imgWidth = imgHeight / imageAspectRatio;
+          }
+          var scalar = Math.max(canvasWidth / imgWidth, canvasHeight / imgHeight);
+          var width = image.width / (zoom * scalar * imgWidth);
+          var height = width * canvasAspectRatio;
+          return {
+            width,
+            height
+          };
+        };
+        var getImageRectZoomFactor = function getImageRectZoomFactor2(imageRect, cropRect, rotation, center) {
+          var cx = center.x > 0.5 ? 1 - center.x : center.x;
+          var cy = center.y > 0.5 ? 1 - center.y : center.y;
+          var imageWidth = cx * 2 * imageRect.width;
+          var imageHeight = cy * 2 * imageRect.height;
+          var rotatedCropSize = getRotatedRectSize(cropRect, rotation);
+          return Math.max(
+            rotatedCropSize.width / imageWidth,
+            rotatedCropSize.height / imageHeight
+          );
+        };
+        var getCenteredCropRect = function getCenteredCropRect2(container, aspectRatio) {
+          var width = container.width;
+          var height = width * aspectRatio;
+          if (height > container.height) {
+            height = container.height;
+            width = height / aspectRatio;
+          }
+          var x = (container.width - width) * 0.5;
+          var y = (container.height - height) * 0.5;
+          return {
+            x,
+            y,
+            width,
+            height
+          };
+        };
+        var getCurrentCropSize = function getCurrentCropSize2(imageSize) {
+          var crop = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+          var zoom = crop.zoom, rotation = crop.rotation, center = crop.center, aspectRatio = crop.aspectRatio;
+          if (!aspectRatio) aspectRatio = imageSize.height / imageSize.width;
+          var canvasSize = calculateCanvasSize(imageSize, aspectRatio, zoom);
+          var canvasCenter = {
+            x: canvasSize.width * 0.5,
+            y: canvasSize.height * 0.5
+          };
+          var stage = {
+            x: 0,
+            y: 0,
+            width: canvasSize.width,
+            height: canvasSize.height,
+            center: canvasCenter
+          };
+          var shouldLimit = typeof crop.scaleToFit === "undefined" || crop.scaleToFit;
+          var stageZoomFactor = getImageRectZoomFactor(
+            imageSize,
+            getCenteredCropRect(stage, aspectRatio),
+            rotation,
+            shouldLimit ? center : { x: 0.5, y: 0.5 }
+          );
+          var scale = zoom * stageZoomFactor;
+          return {
+            widthFloat: canvasSize.width / scale,
+            heightFloat: canvasSize.height / scale,
+            width: Math.round(canvasSize.width / scale),
+            height: Math.round(canvasSize.height / scale)
+          };
+        };
+        var IMAGE_SCALE_SPRING_PROPS = {
+          type: "spring",
+          stiffness: 0.5,
+          damping: 0.45,
+          mass: 10
+        };
+        var createBitmapView = function createBitmapView2(_) {
+          return _.utils.createView({
+            name: "image-bitmap",
+            ignoreRect: true,
+            mixins: { styles: ["scaleX", "scaleY"] },
+            create: function create(_ref) {
+              var root = _ref.root, props = _ref.props;
+              root.appendChild(props.image);
+            }
+          });
+        };
+        var createImageCanvasWrapper = function createImageCanvasWrapper2(_) {
+          return _.utils.createView({
+            name: "image-canvas-wrapper",
+            tag: "div",
+            ignoreRect: true,
+            mixins: {
+              apis: ["crop", "width", "height"],
+              styles: [
+                "originX",
+                "originY",
+                "translateX",
+                "translateY",
+                "scaleX",
+                "scaleY",
+                "rotateZ"
+              ],
+              animations: {
+                originX: IMAGE_SCALE_SPRING_PROPS,
+                originY: IMAGE_SCALE_SPRING_PROPS,
+                scaleX: IMAGE_SCALE_SPRING_PROPS,
+                scaleY: IMAGE_SCALE_SPRING_PROPS,
+                translateX: IMAGE_SCALE_SPRING_PROPS,
+                translateY: IMAGE_SCALE_SPRING_PROPS,
+                rotateZ: IMAGE_SCALE_SPRING_PROPS
+              }
+            },
+            create: function create(_ref2) {
+              var root = _ref2.root, props = _ref2.props;
+              props.width = props.image.width;
+              props.height = props.image.height;
+              root.ref.bitmap = root.appendChildView(
+                root.createChildView(createBitmapView(_), { image: props.image })
+              );
+            },
+            write: function write(_ref3) {
+              var root = _ref3.root, props = _ref3.props;
+              var flip = props.crop.flip;
+              var bitmap = root.ref.bitmap;
+              bitmap.scaleX = flip.horizontal ? -1 : 1;
+              bitmap.scaleY = flip.vertical ? -1 : 1;
+            }
+          });
+        };
+        var createClipView = function createClipView2(_) {
+          return _.utils.createView({
+            name: "image-clip",
+            tag: "div",
+            ignoreRect: true,
+            mixins: {
+              apis: [
+                "crop",
+                "markup",
+                "resize",
+                "width",
+                "height",
+                "dirty",
+                "background"
+              ],
+              styles: ["width", "height", "opacity"],
+              animations: {
+                opacity: { type: "tween", duration: 250 }
+              }
+            },
+            didWriteView: function didWriteView(_ref4) {
+              var root = _ref4.root, props = _ref4.props;
+              if (!props.background) return;
+              root.element.style.backgroundColor = props.background;
+            },
+            create: function create(_ref5) {
+              var root = _ref5.root, props = _ref5.props;
+              root.ref.image = root.appendChildView(
+                root.createChildView(
+                  createImageCanvasWrapper(_),
+                  Object.assign({}, props)
+                )
+              );
+              root.ref.createMarkup = function() {
+                if (root.ref.markup) return;
+                root.ref.markup = root.appendChildView(
+                  root.createChildView(createMarkupView(_), Object.assign({}, props))
+                );
+              };
+              root.ref.destroyMarkup = function() {
+                if (!root.ref.markup) return;
+                root.removeChildView(root.ref.markup);
+                root.ref.markup = null;
+              };
+              var transparencyIndicator = root.query(
+                "GET_IMAGE_PREVIEW_TRANSPARENCY_INDICATOR"
+              );
+              if (transparencyIndicator === null) return;
+              if (transparencyIndicator === "grid") {
+                root.element.dataset.transparencyIndicator = transparencyIndicator;
+              } else {
+                root.element.dataset.transparencyIndicator = "color";
+              }
+            },
+            write: function write(_ref6) {
+              var root = _ref6.root, props = _ref6.props, shouldOptimize = _ref6.shouldOptimize;
+              var crop = props.crop, markup = props.markup, resize = props.resize, dirty = props.dirty, width = props.width, height = props.height;
+              root.ref.image.crop = crop;
+              var stage = {
+                x: 0,
+                y: 0,
+                width,
+                height,
+                center: {
+                  x: width * 0.5,
+                  y: height * 0.5
+                }
+              };
+              var image = {
+                width: root.ref.image.width,
+                height: root.ref.image.height
+              };
+              var origin = {
+                x: crop.center.x * image.width,
+                y: crop.center.y * image.height
+              };
+              var translation = {
+                x: stage.center.x - image.width * crop.center.x,
+                y: stage.center.y - image.height * crop.center.y
+              };
+              var rotation = Math.PI * 2 + crop.rotation % (Math.PI * 2);
+              var cropAspectRatio = crop.aspectRatio || image.height / image.width;
+              var shouldLimit = typeof crop.scaleToFit === "undefined" || crop.scaleToFit;
+              var stageZoomFactor = getImageRectZoomFactor(
+                image,
+                getCenteredCropRect(stage, cropAspectRatio),
+                rotation,
+                shouldLimit ? crop.center : { x: 0.5, y: 0.5 }
+              );
+              var scale = crop.zoom * stageZoomFactor;
+              if (markup && markup.length) {
+                root.ref.createMarkup();
+                root.ref.markup.width = width;
+                root.ref.markup.height = height;
+                root.ref.markup.resize = resize;
+                root.ref.markup.dirty = dirty;
+                root.ref.markup.markup = markup;
+                root.ref.markup.crop = getCurrentCropSize(image, crop);
+              } else if (root.ref.markup) {
+                root.ref.destroyMarkup();
+              }
+              var imageView = root.ref.image;
+              if (shouldOptimize) {
+                imageView.originX = null;
+                imageView.originY = null;
+                imageView.translateX = null;
+                imageView.translateY = null;
+                imageView.rotateZ = null;
+                imageView.scaleX = null;
+                imageView.scaleY = null;
+                return;
+              }
+              imageView.originX = origin.x;
+              imageView.originY = origin.y;
+              imageView.translateX = translation.x;
+              imageView.translateY = translation.y;
+              imageView.rotateZ = rotation;
+              imageView.scaleX = scale;
+              imageView.scaleY = scale;
+            }
+          });
+        };
+        var createImageView = function createImageView2(_) {
+          return _.utils.createView({
+            name: "image-preview",
+            tag: "div",
+            ignoreRect: true,
+            mixins: {
+              apis: ["image", "crop", "markup", "resize", "dirty", "background"],
+              styles: ["translateY", "scaleX", "scaleY", "opacity"],
+              animations: {
+                scaleX: IMAGE_SCALE_SPRING_PROPS,
+                scaleY: IMAGE_SCALE_SPRING_PROPS,
+                translateY: IMAGE_SCALE_SPRING_PROPS,
+                opacity: { type: "tween", duration: 400 }
+              }
+            },
+            create: function create(_ref7) {
+              var root = _ref7.root, props = _ref7.props;
+              root.ref.clip = root.appendChildView(
+                root.createChildView(createClipView(_), {
+                  id: props.id,
+                  image: props.image,
+                  crop: props.crop,
+                  markup: props.markup,
+                  resize: props.resize,
+                  dirty: props.dirty,
+                  background: props.background
+                })
+              );
+            },
+            write: function write(_ref8) {
+              var root = _ref8.root, props = _ref8.props, shouldOptimize = _ref8.shouldOptimize;
+              var clip = root.ref.clip;
+              var image = props.image, crop = props.crop, markup = props.markup, resize = props.resize, dirty = props.dirty;
+              clip.crop = crop;
+              clip.markup = markup;
+              clip.resize = resize;
+              clip.dirty = dirty;
+              clip.opacity = shouldOptimize ? 0 : 1;
+              if (shouldOptimize || root.rect.element.hidden) return;
+              var imageAspectRatio = image.height / image.width;
+              var aspectRatio = crop.aspectRatio || imageAspectRatio;
+              var containerWidth = root.rect.inner.width;
+              var containerHeight = root.rect.inner.height;
+              var fixedPreviewHeight = root.query("GET_IMAGE_PREVIEW_HEIGHT");
+              var minPreviewHeight = root.query("GET_IMAGE_PREVIEW_MIN_HEIGHT");
+              var maxPreviewHeight = root.query("GET_IMAGE_PREVIEW_MAX_HEIGHT");
+              var panelAspectRatio = root.query("GET_PANEL_ASPECT_RATIO");
+              var allowMultiple = root.query("GET_ALLOW_MULTIPLE");
+              if (panelAspectRatio && !allowMultiple) {
+                fixedPreviewHeight = containerWidth * panelAspectRatio;
+                aspectRatio = panelAspectRatio;
+              }
+              var clipHeight = fixedPreviewHeight !== null ? fixedPreviewHeight : Math.max(
+                minPreviewHeight,
+                Math.min(containerWidth * aspectRatio, maxPreviewHeight)
+              );
+              var clipWidth = clipHeight / aspectRatio;
+              if (clipWidth > containerWidth) {
+                clipWidth = containerWidth;
+                clipHeight = clipWidth * aspectRatio;
+              }
+              if (clipHeight > containerHeight) {
+                clipHeight = containerHeight;
+                clipWidth = containerHeight / aspectRatio;
+              }
+              clip.width = clipWidth;
+              clip.height = clipHeight;
+            }
+          });
+        };
+        var SVG_MASK = `<svg width="500" height="200" viewBox="0 0 500 200" preserveAspectRatio="none">
+    <defs>
+        <radialGradient id="gradient-__UID__" cx=".5" cy="1.25" r="1.15">
+            <stop offset='50%' stop-color='#000000'/>
+            <stop offset='56%' stop-color='#0a0a0a'/>
+            <stop offset='63%' stop-color='#262626'/>
+            <stop offset='69%' stop-color='#4f4f4f'/>
+            <stop offset='75%' stop-color='#808080'/>
+            <stop offset='81%' stop-color='#b1b1b1'/>
+            <stop offset='88%' stop-color='#dadada'/>
+            <stop offset='94%' stop-color='#f6f6f6'/>
+            <stop offset='100%' stop-color='#ffffff'/>
+        </radialGradient>
+        <mask id="mask-__UID__">
+            <rect x="0" y="0" width="500" height="200" fill="url(#gradient-__UID__)"></rect>
+        </mask>
+    </defs>
+    <rect x="0" width="500" height="200" fill="currentColor" mask="url(#mask-__UID__)"></rect>
+</svg>`;
+        var SVGMaskUniqueId = 0;
+        var createImageOverlayView = function createImageOverlayView2(fpAPI) {
+          return fpAPI.utils.createView({
+            name: "image-preview-overlay",
+            tag: "div",
+            ignoreRect: true,
+            create: function create(_ref) {
+              var root = _ref.root, props = _ref.props;
+              var mask = SVG_MASK;
+              if (document.querySelector("base")) {
+                var url = new URL(
+                  window.location.href.replace(window.location.hash, "")
+                ).href;
+                mask = mask.replace(/url\(\#/g, "url(" + url + "#");
+              }
+              SVGMaskUniqueId++;
+              root.element.classList.add(
+                "filepond--image-preview-overlay-".concat(props.status)
+              );
+              root.element.innerHTML = mask.replace(/__UID__/g, SVGMaskUniqueId);
+            },
+            mixins: {
+              styles: ["opacity"],
+              animations: {
+                opacity: { type: "spring", mass: 25 }
+              }
+            }
+          });
+        };
+        var BitmapWorker = function BitmapWorker2() {
+          self.onmessage = function(e) {
+            createImageBitmap(e.data.message.file).then(function(bitmap) {
+              self.postMessage({ id: e.data.id, message: bitmap }, [bitmap]);
+            });
+          };
+        };
+        var ColorMatrixWorker = function ColorMatrixWorker2() {
+          self.onmessage = function(e) {
+            var imageData = e.data.message.imageData;
+            var matrix = e.data.message.colorMatrix;
+            var data2 = imageData.data;
+            var l = data2.length;
+            var m11 = matrix[0];
+            var m12 = matrix[1];
+            var m13 = matrix[2];
+            var m14 = matrix[3];
+            var m15 = matrix[4];
+            var m21 = matrix[5];
+            var m22 = matrix[6];
+            var m23 = matrix[7];
+            var m24 = matrix[8];
+            var m25 = matrix[9];
+            var m31 = matrix[10];
+            var m32 = matrix[11];
+            var m33 = matrix[12];
+            var m34 = matrix[13];
+            var m35 = matrix[14];
+            var m41 = matrix[15];
+            var m42 = matrix[16];
+            var m43 = matrix[17];
+            var m44 = matrix[18];
+            var m45 = matrix[19];
+            var index = 0, r = 0, g = 0, b = 0, a = 0;
+            for (; index < l; index += 4) {
+              r = data2[index] / 255;
+              g = data2[index + 1] / 255;
+              b = data2[index + 2] / 255;
+              a = data2[index + 3] / 255;
+              data2[index] = Math.max(
+                0,
+                Math.min((r * m11 + g * m12 + b * m13 + a * m14 + m15) * 255, 255)
+              );
+              data2[index + 1] = Math.max(
+                0,
+                Math.min((r * m21 + g * m22 + b * m23 + a * m24 + m25) * 255, 255)
+              );
+              data2[index + 2] = Math.max(
+                0,
+                Math.min((r * m31 + g * m32 + b * m33 + a * m34 + m35) * 255, 255)
+              );
+              data2[index + 3] = Math.max(
+                0,
+                Math.min((r * m41 + g * m42 + b * m43 + a * m44 + m45) * 255, 255)
+              );
+            }
+            self.postMessage({ id: e.data.id, message: imageData }, [
+              imageData.data.buffer
+            ]);
+          };
+        };
+        var getImageSize = function getImageSize2(url, cb) {
+          var image = new Image();
+          image.onload = function() {
+            var width = image.naturalWidth;
+            var height = image.naturalHeight;
+            image = null;
+            cb(width, height);
+          };
+          image.src = url;
+        };
+        var transforms = {
+          1: function _() {
+            return [1, 0, 0, 1, 0, 0];
+          },
+          2: function _(width) {
+            return [-1, 0, 0, 1, width, 0];
+          },
+          3: function _(width, height) {
+            return [-1, 0, 0, -1, width, height];
+          },
+          4: function _(width, height) {
+            return [1, 0, 0, -1, 0, height];
+          },
+          5: function _() {
+            return [0, 1, 1, 0, 0, 0];
+          },
+          6: function _(width, height) {
+            return [0, 1, -1, 0, height, 0];
+          },
+          7: function _(width, height) {
+            return [0, -1, -1, 0, height, width];
+          },
+          8: function _(width) {
+            return [0, -1, 1, 0, 0, width];
+          }
+        };
+        var fixImageOrientation = function fixImageOrientation2(ctx, width, height, orientation) {
+          if (orientation === -1) {
+            return;
+          }
+          ctx.transform.apply(ctx, transforms[orientation](width, height));
+        };
+        var createPreviewImage = function createPreviewImage2(data2, width, height, orientation) {
+          width = Math.round(width);
+          height = Math.round(height);
+          var canvas = document.createElement("canvas");
+          canvas.width = width;
+          canvas.height = height;
+          var ctx = canvas.getContext("2d");
+          if (orientation >= 5 && orientation <= 8) {
+            var _ref = [height, width];
+            width = _ref[0];
+            height = _ref[1];
+          }
+          fixImageOrientation(ctx, width, height, orientation);
+          ctx.drawImage(data2, 0, 0, width, height);
+          return canvas;
+        };
+        var isBitmap = function isBitmap2(file) {
+          return /^image/.test(file.type) && !/svg/.test(file.type);
+        };
+        var MAX_WIDTH = 10;
+        var MAX_HEIGHT = 10;
+        var calculateAverageColor = function calculateAverageColor2(image) {
+          var scalar = Math.min(MAX_WIDTH / image.width, MAX_HEIGHT / image.height);
+          var canvas = document.createElement("canvas");
+          var ctx = canvas.getContext("2d");
+          var width = canvas.width = Math.ceil(image.width * scalar);
+          var height = canvas.height = Math.ceil(image.height * scalar);
+          ctx.drawImage(image, 0, 0, width, height);
+          var data2 = null;
+          try {
+            data2 = ctx.getImageData(0, 0, width, height).data;
+          } catch (e) {
+            return null;
+          }
+          var l = data2.length;
+          var r = 0;
+          var g = 0;
+          var b = 0;
+          var i = 0;
+          for (; i < l; i += 4) {
+            r += data2[i] * data2[i];
+            g += data2[i + 1] * data2[i + 1];
+            b += data2[i + 2] * data2[i + 2];
+          }
+          r = averageColor(r, l);
+          g = averageColor(g, l);
+          b = averageColor(b, l);
+          return { r, g, b };
+        };
+        var averageColor = function averageColor2(c, l) {
+          return Math.floor(Math.sqrt(c / (l / 4)));
+        };
+        var cloneCanvas = function cloneCanvas2(origin, target) {
+          target = target || document.createElement("canvas");
+          target.width = origin.width;
+          target.height = origin.height;
+          var ctx = target.getContext("2d");
+          ctx.drawImage(origin, 0, 0);
+          return target;
+        };
+        var cloneImageData = function cloneImageData2(imageData) {
+          var id2;
+          try {
+            id2 = new ImageData(imageData.width, imageData.height);
+          } catch (e) {
+            var canvas = document.createElement("canvas");
+            var ctx = canvas.getContext("2d");
+            id2 = ctx.createImageData(imageData.width, imageData.height);
+          }
+          id2.data.set(new Uint8ClampedArray(imageData.data));
+          return id2;
+        };
+        var loadImage = function loadImage2(url) {
+          return new Promise(function(resolve, reject) {
+            var img = new Image();
+            img.crossOrigin = "Anonymous";
+            img.onload = function() {
+              resolve(img);
+            };
+            img.onerror = function(e) {
+              reject(e);
+            };
+            img.src = url;
+          });
+        };
+        var createImageWrapperView = function createImageWrapperView2(_) {
+          var OverlayView = createImageOverlayView(_);
+          var ImageView = createImageView(_);
+          var createWorker = _.utils.createWorker;
+          var applyFilter = function applyFilter2(root, filter, target) {
+            return new Promise(function(resolve) {
+              if (!root.ref.imageData) {
+                root.ref.imageData = target.getContext("2d").getImageData(0, 0, target.width, target.height);
+              }
+              var imageData = cloneImageData(root.ref.imageData);
+              if (!filter || filter.length !== 20) {
+                target.getContext("2d").putImageData(imageData, 0, 0);
+                return resolve();
+              }
+              var worker = createWorker(ColorMatrixWorker);
+              worker.post(
+                {
+                  imageData,
+                  colorMatrix: filter
+                },
+                function(response) {
+                  target.getContext("2d").putImageData(response, 0, 0);
+                  worker.terminate();
+                  resolve();
+                },
+                [imageData.data.buffer]
+              );
+            });
+          };
+          var removeImageView = function removeImageView2(root, imageView) {
+            root.removeChildView(imageView);
+            imageView.image.width = 1;
+            imageView.image.height = 1;
+            imageView._destroy();
+          };
+          var shiftImage = function shiftImage2(_ref) {
+            var root = _ref.root;
+            var imageView = root.ref.images.shift();
+            imageView.opacity = 0;
+            imageView.translateY = -15;
+            root.ref.imageViewBin.push(imageView);
+            return imageView;
+          };
+          var pushImage = function pushImage2(_ref2) {
+            var root = _ref2.root, props = _ref2.props, image = _ref2.image;
+            var id2 = props.id;
+            var item = root.query("GET_ITEM", { id: id2 });
+            if (!item) return;
+            var crop = item.getMetadata("crop") || {
+              center: {
+                x: 0.5,
+                y: 0.5
+              },
+              flip: {
+                horizontal: false,
+                vertical: false
+              },
+              zoom: 1,
+              rotation: 0,
+              aspectRatio: null
+            };
+            var background = root.query(
+              "GET_IMAGE_TRANSFORM_CANVAS_BACKGROUND_COLOR"
+            );
+            var markup;
+            var resize;
+            var dirty = false;
+            if (root.query("GET_IMAGE_PREVIEW_MARKUP_SHOW")) {
+              markup = item.getMetadata("markup") || [];
+              resize = item.getMetadata("resize");
+              dirty = true;
+            }
+            var imageView = root.appendChildView(
+              root.createChildView(ImageView, {
+                id: id2,
+                image,
+                crop,
+                resize,
+                markup,
+                dirty,
+                background,
+                opacity: 0,
+                scaleX: 1.15,
+                scaleY: 1.15,
+                translateY: 15
+              }),
+              root.childViews.length
+            );
+            root.ref.images.push(imageView);
+            imageView.opacity = 1;
+            imageView.scaleX = 1;
+            imageView.scaleY = 1;
+            imageView.translateY = 0;
+            setTimeout(function() {
+              root.dispatch("DID_IMAGE_PREVIEW_SHOW", { id: id2 });
+            }, 250);
+          };
+          var updateImage2 = function updateImage3(_ref3) {
+            var root = _ref3.root, props = _ref3.props;
+            var item = root.query("GET_ITEM", { id: props.id });
+            if (!item) return;
+            var imageView = root.ref.images[root.ref.images.length - 1];
+            imageView.crop = item.getMetadata("crop");
+            imageView.background = root.query(
+              "GET_IMAGE_TRANSFORM_CANVAS_BACKGROUND_COLOR"
+            );
+            if (root.query("GET_IMAGE_PREVIEW_MARKUP_SHOW")) {
+              imageView.dirty = true;
+              imageView.resize = item.getMetadata("resize");
+              imageView.markup = item.getMetadata("markup");
+            }
+          };
+          var didUpdateItemMetadata = function didUpdateItemMetadata2(_ref4) {
+            var root = _ref4.root, props = _ref4.props, action = _ref4.action;
+            if (!/crop|filter|markup|resize/.test(action.change.key)) return;
+            if (!root.ref.images.length) return;
+            var item = root.query("GET_ITEM", { id: props.id });
+            if (!item) return;
+            if (/filter/.test(action.change.key)) {
+              var imageView = root.ref.images[root.ref.images.length - 1];
+              applyFilter(root, action.change.value, imageView.image);
+              return;
+            }
+            if (/crop|markup|resize/.test(action.change.key)) {
+              var crop = item.getMetadata("crop");
+              var image = root.ref.images[root.ref.images.length - 1];
+              if (crop && crop.aspectRatio && image.crop && image.crop.aspectRatio && Math.abs(crop.aspectRatio - image.crop.aspectRatio) > 1e-5) {
+                var _imageView = shiftImage({ root });
+                pushImage({
+                  root,
+                  props,
+                  image: cloneCanvas(_imageView.image)
+                });
+              } else {
+                updateImage2({ root, props });
+              }
+            }
+          };
+          var canCreateImageBitmap = function canCreateImageBitmap2(file) {
+            var userAgent = window.navigator.userAgent;
+            var isFirefox = userAgent.match(/Firefox\/([0-9]+)\./);
+            var firefoxVersion = isFirefox ? parseInt(isFirefox[1]) : null;
+            if (firefoxVersion !== null && firefoxVersion <= 58) return false;
+            return "createImageBitmap" in window && isBitmap(file);
+          };
+          var didCreatePreviewContainer = function didCreatePreviewContainer2(_ref5) {
+            var root = _ref5.root, props = _ref5.props;
+            var id2 = props.id;
+            var item = root.query("GET_ITEM", id2);
+            if (!item) return;
+            var fileURL = URL.createObjectURL(item.file);
+            getImageSize(fileURL, function(width, height) {
+              root.dispatch("DID_IMAGE_PREVIEW_CALCULATE_SIZE", {
+                id: id2,
+                width,
+                height
+              });
+            });
+          };
+          var drawPreview = function drawPreview2(_ref6) {
+            var root = _ref6.root, props = _ref6.props;
+            var id2 = props.id;
+            var item = root.query("GET_ITEM", id2);
+            if (!item) return;
+            var fileURL = URL.createObjectURL(item.file);
+            var loadPreviewFallback = function loadPreviewFallback2() {
+              loadImage(fileURL).then(previewImageLoaded);
+            };
+            var previewImageLoaded = function previewImageLoaded2(imageData) {
+              URL.revokeObjectURL(fileURL);
+              var exif = item.getMetadata("exif") || {};
+              var orientation = exif.orientation || -1;
+              var width = imageData.width, height = imageData.height;
+              if (!width || !height) return;
+              if (orientation >= 5 && orientation <= 8) {
+                var _ref7 = [height, width];
+                width = _ref7[0];
+                height = _ref7[1];
+              }
+              var pixelDensityFactor = Math.max(1, window.devicePixelRatio * 0.75);
+              var zoomFactor = root.query("GET_IMAGE_PREVIEW_ZOOM_FACTOR");
+              var scaleFactor = zoomFactor * pixelDensityFactor;
+              var previewImageRatio = height / width;
+              var previewContainerWidth = root.rect.element.width;
+              var previewContainerHeight = root.rect.element.height;
+              var imageWidth = previewContainerWidth;
+              var imageHeight = imageWidth * previewImageRatio;
+              if (previewImageRatio > 1) {
+                imageWidth = Math.min(width, previewContainerWidth * scaleFactor);
+                imageHeight = imageWidth * previewImageRatio;
+              } else {
+                imageHeight = Math.min(height, previewContainerHeight * scaleFactor);
+                imageWidth = imageHeight / previewImageRatio;
+              }
+              var previewImage = createPreviewImage(
+                imageData,
+                imageWidth,
+                imageHeight,
+                orientation
+              );
+              var done = function done2() {
+                var averageColor2 = root.query(
+                  "GET_IMAGE_PREVIEW_CALCULATE_AVERAGE_IMAGE_COLOR"
+                ) ? calculateAverageColor(data) : null;
+                item.setMetadata("color", averageColor2, true);
+                if ("close" in imageData) {
+                  imageData.close();
+                }
+                root.ref.overlayShadow.opacity = 1;
+                pushImage({ root, props, image: previewImage });
+              };
+              var filter = item.getMetadata("filter");
+              if (filter) {
+                applyFilter(root, filter, previewImage).then(done);
+              } else {
+                done();
+              }
+            };
+            if (canCreateImageBitmap(item.file)) {
+              var worker = createWorker(BitmapWorker);
+              worker.post(
+                {
+                  file: item.file
+                },
+                function(imageBitmap) {
+                  worker.terminate();
+                  if (!imageBitmap) {
+                    loadPreviewFallback();
+                    return;
+                  }
+                  previewImageLoaded(imageBitmap);
+                }
+              );
+            } else {
+              loadPreviewFallback();
+            }
+          };
+          var didDrawPreview = function didDrawPreview2(_ref8) {
+            var root = _ref8.root;
+            var image = root.ref.images[root.ref.images.length - 1];
+            image.translateY = 0;
+            image.scaleX = 1;
+            image.scaleY = 1;
+            image.opacity = 1;
+          };
+          var restoreOverlay = function restoreOverlay2(_ref9) {
+            var root = _ref9.root;
+            root.ref.overlayShadow.opacity = 1;
+            root.ref.overlayError.opacity = 0;
+            root.ref.overlaySuccess.opacity = 0;
+          };
+          var didThrowError = function didThrowError2(_ref10) {
+            var root = _ref10.root;
+            root.ref.overlayShadow.opacity = 0.25;
+            root.ref.overlayError.opacity = 1;
+          };
+          var didCompleteProcessing = function didCompleteProcessing2(_ref11) {
+            var root = _ref11.root;
+            root.ref.overlayShadow.opacity = 0.25;
+            root.ref.overlaySuccess.opacity = 1;
+          };
+          var create = function create2(_ref12) {
+            var root = _ref12.root;
+            root.ref.images = [];
+            root.ref.imageData = null;
+            root.ref.imageViewBin = [];
+            root.ref.overlayShadow = root.appendChildView(
+              root.createChildView(OverlayView, {
+                opacity: 0,
+                status: "idle"
+              })
+            );
+            root.ref.overlaySuccess = root.appendChildView(
+              root.createChildView(OverlayView, {
+                opacity: 0,
+                status: "success"
+              })
+            );
+            root.ref.overlayError = root.appendChildView(
+              root.createChildView(OverlayView, {
+                opacity: 0,
+                status: "failure"
+              })
+            );
+          };
+          return _.utils.createView({
+            name: "image-preview-wrapper",
+            create,
+            styles: ["height"],
+            apis: ["height"],
+            destroy: function destroy(_ref13) {
+              var root = _ref13.root;
+              root.ref.images.forEach(function(imageView) {
+                imageView.image.width = 1;
+                imageView.image.height = 1;
+              });
+            },
+            didWriteView: function didWriteView(_ref14) {
+              var root = _ref14.root;
+              root.ref.images.forEach(function(imageView) {
+                imageView.dirty = false;
+              });
+            },
+            write: _.utils.createRoute(
+              {
+                // image preview stated
+                DID_IMAGE_PREVIEW_DRAW: didDrawPreview,
+                DID_IMAGE_PREVIEW_CONTAINER_CREATE: didCreatePreviewContainer,
+                DID_FINISH_CALCULATE_PREVIEWSIZE: drawPreview,
+                DID_UPDATE_ITEM_METADATA: didUpdateItemMetadata,
+                // file states
+                DID_THROW_ITEM_LOAD_ERROR: didThrowError,
+                DID_THROW_ITEM_PROCESSING_ERROR: didThrowError,
+                DID_THROW_ITEM_INVALID: didThrowError,
+                DID_COMPLETE_ITEM_PROCESSING: didCompleteProcessing,
+                DID_START_ITEM_PROCESSING: restoreOverlay,
+                DID_REVERT_ITEM_PROCESSING: restoreOverlay
+              },
+              function(_ref15) {
+                var root = _ref15.root;
+                var viewsToRemove = root.ref.imageViewBin.filter(function(imageView) {
+                  return imageView.opacity === 0;
+                });
+                root.ref.imageViewBin = root.ref.imageViewBin.filter(function(imageView) {
+                  return imageView.opacity > 0;
+                });
+                viewsToRemove.forEach(function(imageView) {
+                  return removeImageView(root, imageView);
+                });
+                viewsToRemove.length = 0;
+              }
+            )
+          });
+        };
+        var plugin = function plugin2(fpAPI) {
+          var addFilter = fpAPI.addFilter, utils = fpAPI.utils;
+          var Type = utils.Type, createRoute = utils.createRoute, isFile = utils.isFile;
+          var imagePreviewView = createImageWrapperView(fpAPI);
+          addFilter("CREATE_VIEW", function(viewAPI) {
+            var is = viewAPI.is, view = viewAPI.view, query = viewAPI.query;
+            if (!is("file") || !query("GET_ALLOW_IMAGE_PREVIEW")) return;
+            var didLoadItem = function didLoadItem2(_ref) {
+              var root = _ref.root, props = _ref.props;
+              var id2 = props.id;
+              var item = query("GET_ITEM", id2);
+              if (!item || !isFile(item.file) || item.archived) return;
+              var file = item.file;
+              if (!isPreviewableImage(file)) return;
+              if (!query("GET_IMAGE_PREVIEW_FILTER_ITEM")(item)) return;
+              var supportsCreateImageBitmap = "createImageBitmap" in (window || {});
+              var maxPreviewFileSize = query("GET_IMAGE_PREVIEW_MAX_FILE_SIZE");
+              if (!supportsCreateImageBitmap && maxPreviewFileSize && file.size > maxPreviewFileSize)
+                return;
+              root.ref.imagePreview = view.appendChildView(
+                view.createChildView(imagePreviewView, { id: id2 })
+              );
+              var fixedPreviewHeight = root.query("GET_IMAGE_PREVIEW_HEIGHT");
+              if (fixedPreviewHeight) {
+                root.dispatch("DID_UPDATE_PANEL_HEIGHT", {
+                  id: item.id,
+                  height: fixedPreviewHeight
+                });
+              }
+              var queue = !supportsCreateImageBitmap && file.size > query("GET_IMAGE_PREVIEW_MAX_INSTANT_PREVIEW_FILE_SIZE");
+              root.dispatch("DID_IMAGE_PREVIEW_CONTAINER_CREATE", { id: id2 }, queue);
+            };
+            var rescaleItem = function rescaleItem2(root, props) {
+              if (!root.ref.imagePreview) return;
+              var id2 = props.id;
+              var item = root.query("GET_ITEM", { id: id2 });
+              if (!item) return;
+              var panelAspectRatio = root.query("GET_PANEL_ASPECT_RATIO");
+              var itemPanelAspectRatio = root.query("GET_ITEM_PANEL_ASPECT_RATIO");
+              var fixedHeight = root.query("GET_IMAGE_PREVIEW_HEIGHT");
+              if (panelAspectRatio || itemPanelAspectRatio || fixedHeight) return;
+              var _root$ref = root.ref, imageWidth = _root$ref.imageWidth, imageHeight = _root$ref.imageHeight;
+              if (!imageWidth || !imageHeight) return;
+              var minPreviewHeight = root.query("GET_IMAGE_PREVIEW_MIN_HEIGHT");
+              var maxPreviewHeight = root.query("GET_IMAGE_PREVIEW_MAX_HEIGHT");
+              var exif = item.getMetadata("exif") || {};
+              var orientation = exif.orientation || -1;
+              if (orientation >= 5 && orientation <= 8) {
+                var _ref2 = [imageHeight, imageWidth];
+                imageWidth = _ref2[0];
+                imageHeight = _ref2[1];
+              }
+              if (!isBitmap(item.file) || root.query("GET_IMAGE_PREVIEW_UPSCALE")) {
+                var scalar = 2048 / imageWidth;
+                imageWidth *= scalar;
+                imageHeight *= scalar;
+              }
+              var imageAspectRatio = imageHeight / imageWidth;
+              var previewAspectRatio = (item.getMetadata("crop") || {}).aspectRatio || imageAspectRatio;
+              var previewHeightMax = Math.max(
+                minPreviewHeight,
+                Math.min(imageHeight, maxPreviewHeight)
+              );
+              var itemWidth = root.rect.element.width;
+              var previewHeight = Math.min(
+                itemWidth * previewAspectRatio,
+                previewHeightMax
+              );
+              root.dispatch("DID_UPDATE_PANEL_HEIGHT", {
+                id: item.id,
+                height: previewHeight
+              });
+            };
+            var didResizeView = function didResizeView2(_ref3) {
+              var root = _ref3.root;
+              root.ref.shouldRescale = true;
+            };
+            var didUpdateItemMetadata = function didUpdateItemMetadata2(_ref4) {
+              var root = _ref4.root, action = _ref4.action;
+              if (action.change.key !== "crop") return;
+              root.ref.shouldRescale = true;
+            };
+            var didCalculatePreviewSize = function didCalculatePreviewSize2(_ref5) {
+              var root = _ref5.root, action = _ref5.action;
+              root.ref.imageWidth = action.width;
+              root.ref.imageHeight = action.height;
+              root.ref.shouldRescale = true;
+              root.ref.shouldDrawPreview = true;
+              root.dispatch("KICK");
+            };
+            view.registerWriter(
+              createRoute(
+                {
+                  DID_RESIZE_ROOT: didResizeView,
+                  DID_STOP_RESIZE: didResizeView,
+                  DID_LOAD_ITEM: didLoadItem,
+                  DID_IMAGE_PREVIEW_CALCULATE_SIZE: didCalculatePreviewSize,
+                  DID_UPDATE_ITEM_METADATA: didUpdateItemMetadata
+                },
+                function(_ref6) {
+                  var root = _ref6.root, props = _ref6.props;
+                  if (!root.ref.imagePreview) return;
+                  if (root.rect.element.hidden) return;
+                  if (root.ref.shouldRescale) {
+                    rescaleItem(root, props);
+                    root.ref.shouldRescale = false;
+                  }
+                  if (root.ref.shouldDrawPreview) {
+                    requestAnimationFrame(function() {
+                      requestAnimationFrame(function() {
+                        root.dispatch("DID_FINISH_CALCULATE_PREVIEWSIZE", {
+                          id: props.id
+                        });
+                      });
+                    });
+                    root.ref.shouldDrawPreview = false;
+                  }
+                }
+              )
+            );
+          });
+          return {
+            options: {
+              // Enable or disable image preview
+              allowImagePreview: [true, Type.BOOLEAN],
+              // filters file items to determine which are shown as preview
+              imagePreviewFilterItem: [
+                function() {
+                  return true;
+                },
+                Type.FUNCTION
+              ],
+              // Fixed preview height
+              imagePreviewHeight: [null, Type.INT],
+              // Min image height
+              imagePreviewMinHeight: [44, Type.INT],
+              // Max image height
+              imagePreviewMaxHeight: [256, Type.INT],
+              // Max size of preview file for when createImageBitmap is not supported
+              imagePreviewMaxFileSize: [null, Type.INT],
+              // The amount of extra pixels added to the image preview to allow comfortable zooming
+              imagePreviewZoomFactor: [2, Type.INT],
+              // Should we upscale small images to fit the max bounding box of the preview area
+              imagePreviewUpscale: [false, Type.BOOLEAN],
+              // Max size of preview file that we allow to try to instant preview if createImageBitmap is not supported, else image is queued for loading
+              imagePreviewMaxInstantPreviewFileSize: [1e6, Type.INT],
+              // Style of the transparancy indicator used behind images
+              imagePreviewTransparencyIndicator: [null, Type.STRING],
+              // Enables or disables reading average image color
+              imagePreviewCalculateAverageImageColor: [false, Type.BOOLEAN],
+              // Enables or disables the previewing of markup
+              imagePreviewMarkupShow: [true, Type.BOOLEAN],
+              // Allows filtering of markup to only show certain shapes
+              imagePreviewMarkupFilter: [
+                function() {
+                  return true;
+                },
+                Type.FUNCTION
+              ]
+            }
+          };
+        };
+        var isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+        if (isBrowser) {
+          document.dispatchEvent(
+            new CustomEvent("FilePond:pluginloaded", { detail: plugin })
+          );
+        }
+        return plugin;
+      });
+    }
+  });
+
   // src/main.jsx
-  var import_react46 = __toESM(require_react(), 1);
+  var import_react47 = __toESM(require_react(), 1);
   var import_client = __toESM(require_client(), 1);
 
   // src/app/App.jsx
-  var import_react45 = __toESM(require_react(), 1);
+  var import_react46 = __toESM(require_react(), 1);
 
   // src/app/i18n.jsx
   var import_react = __toESM(require_react(), 1);
@@ -8287,9 +20271,12 @@
       test: "node --test"
     },
     dependencies: {
+      filepond: "4.32.12",
+      "filepond-plugin-image-preview": "4.6.12",
       "lucide-react": "0.453.0",
       react: "18.3.1",
-      "react-dom": "18.3.1"
+      "react-dom": "18.3.1",
+      "react-filepond": "7.1.3"
     },
     devDependencies: {
       esbuild: "0.24.2"
@@ -11070,7 +23057,7 @@
   }
 
   // src/screens/ChatScreen.jsx
-  var import_react36 = __toESM(require_react(), 1);
+  var import_react37 = __toESM(require_react(), 1);
 
   // src/components/chat/ChatBubble.jsx
   var import_react29 = __toESM(require_react(), 1);
@@ -11472,7 +23459,121 @@
   }
 
   // src/components/chat/Composer.jsx
+  var import_react34 = __toESM(require_react(), 1);
+
+  // src/components/chat/AttachmentPond.jsx
   var import_react33 = __toESM(require_react(), 1);
+  var import_react_filepond = __toESM(require_react_filepond(), 1);
+  var import_filepond_plugin_image_preview = __toESM(require_filepond_plugin_image_preview(), 1);
+
+  // ../shared/chat-attachments.mjs
+  var MAX_ATTACHMENTS_PER_TURN = 32;
+  var MAX_CLIPBOARD_ITEM_BYTES = 256 * 1024 * 1024;
+  var MAX_CLIPBOARD_TURN_BYTES = 512 * 1024 * 1024;
+
+  // src/components/chat/AttachmentPond.jsx
+  var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
+  (0, import_react_filepond.registerPlugin)(import_filepond_plugin_image_preview.default);
+  var DEFAULT_LABELS = {
+    add: "\u6DFB\u52A0\u6587\u4EF6 Add files",
+    drop: "\u62D6\u653E\u3001\u7C98\u8D34\u6216\u9009\u62E9\u6587\u4EF6 Drop, paste, or browse",
+    staging: "\u6B63\u5728\u51C6\u5907 Preparing\u2026",
+    ready: "\u5DF2\u5C31\u7EEA Ready",
+    retry: "\u91CD\u8BD5 Retry",
+    remove: "\u79FB\u9664 Remove"
+  };
+  function formatBytes(value) {
+    const bytes = Number(value) || 0;
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+    if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+    return (bytes / (1024 * 1024 * 1024)).toFixed(1) + " GB";
+  }
+  function findItem(items, fileItem) {
+    return items.find((item) => item.pondId === (fileItem == null ? void 0 : fileItem.id) || item.file === (fileItem == null ? void 0 : fileItem.file));
+  }
+  var AttachmentPond = import_react33.default.forwardRef(function AttachmentPond2({
+    items = [],
+    disabled = false,
+    labels: suppliedLabels,
+    onAddFile,
+    onRemoveAttachment,
+    onRetryAttachment
+  }, forwardedRef) {
+    const pondRef = import_react33.default.useRef(null);
+    const labels = { ...DEFAULT_LABELS, ...suppliedLabels || {} };
+    const pondFiles = items.map((item) => item.file).filter(Boolean);
+    const labelIdle = labels.drop + ' <span class="filepond--label-action">' + labels.add + "</span>";
+    import_react33.default.useImperativeHandle(forwardedRef, () => ({
+      addFiles(files) {
+        var _a;
+        return (_a = pondRef.current) == null ? void 0 : _a.addFiles(Array.from(files || []));
+      }
+    }), []);
+    const handleAdd = (error, fileItem) => {
+      if (error || !(fileItem == null ? void 0 : fileItem.file) || findItem(items, fileItem)) return;
+      onAddFile == null ? void 0 : onAddFile({ pondId: fileItem.id, file: fileItem.file });
+    };
+    const handleRemove = (error, fileItem) => {
+      if (error) return;
+      const item = findItem(items, fileItem);
+      if (item) onRemoveAttachment == null ? void 0 : onRemoveAttachment(item);
+    };
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { className: "ae-attachment-pond", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+        import_react_filepond.FilePond,
+        {
+          ref: pondRef,
+          files: pondFiles,
+          allowMultiple: true,
+          allowPaste: true,
+          allowBrowse: !disabled,
+          allowDrop: !disabled,
+          allowReorder: false,
+          instantUpload: false,
+          maxFiles: MAX_ATTACHMENTS_PER_TURN,
+          credits: false,
+          disabled,
+          labelIdle,
+          onaddfile: handleAdd,
+          onremovefile: handleRemove
+        }
+      ),
+      items.length ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { className: "ae-attachment-status-list", "aria-live": "polite", children: items.map((item) => {
+        var _a, _b, _c, _d, _e, _f;
+        return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+          "div",
+          {
+            className: `ae-attachment-status ae-attachment-status--${item.status}`,
+            children: [
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: "paperclip", size: 12 }),
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { className: "ae-attachment-status__name", children: ((_a = item.file) == null ? void 0 : _a.name) || ((_b = item.ref) == null ? void 0 : _b.name) }),
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { className: "ae-attachment-status__size", children: formatBytes((_e = (_c = item.file) == null ? void 0 : _c.size) != null ? _e : (_d = item.ref) == null ? void 0 : _d.size) }),
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { className: "ae-attachment-status__state", children: item.status === "staging" ? labels.staging : item.status === "error" ? ((_f = item.error) == null ? void 0 : _f.message) || labels.retry : labels.ready }),
+              item.status === "error" ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("button", { type: "button", onClick: () => onRetryAttachment == null ? void 0 : onRetryAttachment(item), children: labels.retry }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("button", { type: "button", onClick: () => onRemoveAttachment == null ? void 0 : onRemoveAttachment(item), children: labels.remove })
+            ]
+          },
+          item.pondId
+        );
+      }) }) : null
+    ] });
+  });
+
+  // src/lib/attachmentDraft.js
+  function readyAttachments(state) {
+    return state.items.filter((item) => item.status === "ready" && item.ref).map((item) => item.ref);
+  }
+  function draftIsBusy(state) {
+    return state.items.some((item) => item.status === "staging");
+  }
+  function isFileTransfer(dataTransfer) {
+    return Array.from((dataTransfer == null ? void 0 : dataTransfer.types) || []).includes("Files");
+  }
+  function attachmentDropFiles(dataTransfer) {
+    if (!isFileTransfer(dataTransfer)) return [];
+    return Array.from((dataTransfer == null ? void 0 : dataTransfer.files) || []);
+  }
 
   // src/lib/composerResize.js
   var COMPOSER_MIN_HEIGHT = 72;
@@ -11570,7 +23671,7 @@
   }
 
   // src/components/chat/Composer.jsx
-  var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
   function ComposerResizeHandle({
     height,
     minHeight,
@@ -11578,10 +23679,10 @@
     onHeightChange,
     onHeightReset
   }) {
-    const [hover, setHover] = import_react33.default.useState(false);
-    const [dragging, setDragging] = import_react33.default.useState(false);
-    const [focused, setFocused] = import_react33.default.useState(false);
-    const dragRef = import_react33.default.useRef(null);
+    const [hover, setHover] = import_react34.default.useState(false);
+    const [dragging, setDragging] = import_react34.default.useState(false);
+    const [focused, setFocused] = import_react34.default.useState(false);
+    const dragRef = import_react34.default.useRef(null);
     const clearDrag = (updateState = true) => {
       const active = dragRef.current;
       if (!active) return;
@@ -11591,7 +23692,7 @@
       dragRef.current = null;
       if (updateState) setDragging(false);
     };
-    import_react33.default.useEffect(() => () => clearDrag(false), []);
+    import_react34.default.useEffect(() => () => clearDrag(false), []);
     const handleMouseDown = (event) => {
       if (event.button !== 0) return;
       event.currentTarget.focus();
@@ -11623,7 +23724,7 @@
       event.preventDefault();
       onHeightChange == null ? void 0 : onHeightChange(nextHeight);
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
       "div",
       {
         style: {
@@ -11640,7 +23741,7 @@
           boxShadow: focused ? "0 0 0 1px var(--focus-ring)" : "none"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
             "input",
             {
               type: "text",
@@ -11674,7 +23775,7 @@
               }
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
             "span",
             {
               role: "separator",
@@ -11708,20 +23809,43 @@
     minHeight = COMPOSER_MIN_HEIGHT,
     maxHeight = FALLBACK_MAX_HEIGHT,
     onHeightChange,
-    onHeightReset
+    onHeightReset,
+    attachmentDraft = { items: [] },
+    onAddFile,
+    onRemoveAttachment,
+    onRetryAttachment,
+    attachmentLabels
   }) {
-    const [focus, setFocus] = import_react33.default.useState(false);
-    const canSend = !disabled && !streaming && value.trim().length > 0;
+    const [focus, setFocus] = import_react34.default.useState(false);
+    const attachmentPondRef = import_react34.default.useRef(null);
+    const readyAttachmentCount = readyAttachments(attachmentDraft).length;
+    const attachmentsBusy = draftIsBusy(attachmentDraft) || attachmentDraft.items.some((item) => item.status === "error");
+    const canSend = !disabled && !streaming && !attachmentsBusy && (value.trim().length > 0 || readyAttachmentCount > 0);
     const handleKey = (e) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         if (canSend && onSend) onSend();
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-15)", ...style }, children: [
+    const handleFileDrag = (event) => {
+      if (disabled || streaming || attachmentDraft.pendingTurnId) return;
+      if (!isFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    const handleFileDrop = (event) => {
+      var _a;
+      if (disabled || streaming || attachmentDraft.pendingTurnId) return;
+      const files = attachmentDropFiles(event.dataTransfer);
+      if (!files.length) return;
+      event.preventDefault();
+      event.stopPropagation();
+      (_a = attachmentPondRef.current) == null ? void 0 : _a.addFiles(files);
+    };
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-15)", ...style }, children: [
       notice,
-      /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { display: "flex", flexDirection: "column", minHeight: 0 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", minHeight: 0 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
           ComposerResizeHandle,
           {
             height,
@@ -11731,16 +23855,16 @@
             onHeightReset
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+        /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
           "div",
           {
             style: {
               height,
               minHeight: 0,
               display: "flex",
-              flexDirection: options ? "column" : "row",
+              flexDirection: "column",
               alignItems: "stretch",
-              gap: options ? 2 : "var(--space-15)",
+              gap: 2,
               padding: "var(--space-15)",
               background: "var(--bg-well)",
               border: `1px solid ${focus && !disabled ? "var(--border-strong)" : "var(--border-default)"}`,
@@ -11749,37 +23873,55 @@
               opacity: disabled ? 0.5 : 1,
               transition: "border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)"
             },
+            onDragEnterCapture: handleFileDrag,
+            onDragOverCapture: handleFileDrag,
+            onDropCapture: handleFileDrop,
             children: [
-              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
-                "textarea",
+              /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+                AttachmentPond,
                 {
-                  rows: 1,
-                  value,
-                  placeholder,
-                  disabled,
-                  onChange: (e) => onChange && onChange(e.target.value),
-                  onFocus: () => setFocus(true),
-                  onBlur: () => setFocus(false),
-                  onKeyDown: handleKey,
-                  style: {
-                    flex: 1,
-                    minWidth: 0,
-                    minHeight: 0,
-                    overflowY: "auto",
-                    resize: "none",
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    padding: "4px 2px 4px 4px",
-                    color: "var(--text-primary)",
-                    font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`
-                  }
+                  ref: attachmentPondRef,
+                  items: attachmentDraft.items,
+                  disabled: disabled || streaming || Boolean(attachmentDraft.pendingTurnId),
+                  labels: attachmentLabels,
+                  onAddFile,
+                  onRemoveAttachment,
+                  onRetryAttachment
                 }
               ),
-              options ? /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { flex: "none", display: "flex", alignItems: "center", gap: 2, minWidth: 0, overflow: "visible" }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 2 }, children: options }),
-                streaming ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
-              ] }) : streaming ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
+              /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { flex: 1, minWidth: 0, minHeight: 0, display: "flex", alignItems: "stretch", gap: "var(--space-15)" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+                  "textarea",
+                  {
+                    rows: 1,
+                    value,
+                    placeholder,
+                    disabled,
+                    onChange: (e) => onChange && onChange(e.target.value),
+                    onFocus: () => setFocus(true),
+                    onBlur: () => setFocus(false),
+                    onKeyDown: handleKey,
+                    style: {
+                      flex: 1,
+                      minWidth: 0,
+                      minHeight: 0,
+                      overflowY: "auto",
+                      resize: "none",
+                      background: "transparent",
+                      border: "none",
+                      outline: "none",
+                      padding: "4px 2px 4px 4px",
+                      color: "var(--text-primary)",
+                      font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`
+                    }
+                  }
+                ),
+                !options ? streaming ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 }) : null
+              ] }),
+              options ? /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { flex: "none", display: "flex", alignItems: "center", gap: 2, minWidth: 0, overflow: "visible" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 2 }, children: options }),
+                streaming ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
+              ] }) : null
             ]
           }
         )
@@ -11787,9 +23929,9 @@
     ] });
   }
   function SendButton({ icon, title, kind, disabled = false, onClick }) {
-    const [hover, setHover] = import_react33.default.useState(false);
+    const [hover, setHover] = import_react34.default.useState(false);
     const active = kind === "send" && !disabled;
-    return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
       "button",
       {
         type: "button",
@@ -11816,19 +23958,19 @@
           cursor: disabled ? "default" : "pointer",
           transition: "background var(--dur-fast) var(--ease-out)"
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: icon, size: 13, strokeWidth: 2.25 })
+        children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: icon, size: 13, strokeWidth: 2.25 })
       }
     );
   }
 
   // src/components/chat/ComposerChip.jsx
-  var import_react35 = __toESM(require_react(), 1);
+  var import_react36 = __toESM(require_react(), 1);
 
   // src/components/core/Menu.jsx
-  var import_react34 = __toESM(require_react(), 1);
-  var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
+  var import_react35 = __toESM(require_react(), 1);
+  var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
   function Keycap({ children }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
       "span",
       {
         style: {
@@ -11849,9 +23991,9 @@
     );
   }
   function MenuRow({ item, onClose }) {
-    const [hover, setHover] = import_react34.default.useState(false);
+    const [hover, setHover] = import_react35.default.useState(false);
     const disabled = !!item.disabled;
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
       "button",
       {
         type: "button",
@@ -11880,15 +24022,15 @@
           transition: "background var(--dur-fast) var(--ease-out)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.label }),
-          item.checked ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.25, color: "var(--text-primary)" }) : null,
-          item.hint ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { flex: "none", font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: item.hint }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.label }),
+          item.checked ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.25, color: "var(--text-primary)" }) : null,
+          item.hint ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { flex: "none", font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: item.hint }) : null
         ]
       }
     );
   }
   function Menu({ header, items = [], footer, onClose, minWidth = 184, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
       "div",
       {
         role: "menu",
@@ -11902,7 +24044,7 @@
           ...style
         },
         children: [
-          header ? /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+          header ? /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
             "div",
             {
               style: {
@@ -11915,15 +24057,15 @@
                 marginBottom: "var(--space-1)"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: header.label }),
-                header.keys && header.keys.length ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { display: "inline-flex", gap: 3 }, children: header.keys.map((k, i) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Keycap, { children: k }, i)) }) : null
+                /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: header.label }),
+                header.keys && header.keys.length ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { display: "inline-flex", gap: 3 }, children: header.keys.map((k, i) => /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Keycap, { children: k }, i)) }) : null
               ]
             }
           ) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { display: "flex", flexDirection: "column" }, children: items.map(
-            (item, i) => item.divider ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { height: 1, background: "var(--border-subtle)", margin: "4px 0" } }, i) : /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(MenuRow, { item, onClose }, i)
+          /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("div", { style: { display: "flex", flexDirection: "column" }, children: items.map(
+            (item, i) => item.divider ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("div", { style: { height: 1, background: "var(--border-subtle)", margin: "4px 0" } }, i) : /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(MenuRow, { item, onClose }, i)
           ) }),
-          footer ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          footer ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
             "div",
             {
               style: {
@@ -11942,7 +24084,7 @@
   }
 
   // src/components/chat/ComposerChip.jsx
-  var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime34 = __toESM(require_jsx_runtime(), 1);
   function ComposerChip({
     icon,
     label,
@@ -11956,11 +24098,11 @@
     title,
     style
   }) {
-    const [hover, setHover] = import_react35.default.useState(false);
-    const [open, setOpen] = import_react35.default.useState(false);
-    const rootRef = import_react35.default.useRef(null);
+    const [hover, setHover] = import_react36.default.useState(false);
+    const [open, setOpen] = import_react36.default.useState(false);
+    const rootRef = import_react36.default.useRef(null);
     const isMenu = Array.isArray(items) && items.length > 0;
-    import_react35.default.useEffect(() => {
+    import_react36.default.useEffect(() => {
       if (!open) return void 0;
       const onDoc = (e) => {
         if (rootRef.current && !rootRef.current.contains(e.target)) setOpen(false);
@@ -11976,8 +24118,8 @@
       };
     }, [open]);
     const lit = active || open;
-    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { ref: rootRef, style: { position: "relative", flex: "none", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { ref: rootRef, style: { position: "relative", flex: "none", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)(
         "button",
         {
           type: "button",
@@ -12010,14 +24152,14 @@
             whiteSpace: "nowrap"
           },
           children: [
-            icon ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: icon, size: 12 }) : null,
-            label ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { overflow: "hidden", textOverflow: "ellipsis", maxWidth: 96 }, children: label }) : null,
-            !isMenu && onToggle && active ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: "check", size: 10, strokeWidth: 2.5 }) : null,
-            isMenu ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: "chevron-down", size: 10, strokeWidth: 2, style: { opacity: 0.7 } }) : null
+            icon ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: icon, size: 12 }) : null,
+            label ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { style: { overflow: "hidden", textOverflow: "ellipsis", maxWidth: 96 }, children: label }) : null,
+            !isMenu && onToggle && active ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: "check", size: 10, strokeWidth: 2.5 }) : null,
+            isMenu ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: "chevron-down", size: 10, strokeWidth: 2, style: { opacity: 0.7 } }) : null
           ]
         }
       ),
-      isMenu && open ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
+      isMenu && open ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
         "div",
         {
           style: {
@@ -12027,7 +24169,7 @@
             zIndex: 30,
             animation: "ds-fade-up var(--dur-base) var(--ease-out)"
           },
-          children: /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Menu, { header: menuHeader, items, footer: menuFooter, onClose: () => setOpen(false) })
+          children: /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Menu, { header: menuHeader, items, footer: menuFooter, onClose: () => setOpen(false) })
         }
       ) : null
     ] });
@@ -12077,7 +24219,7 @@
   }
 
   // src/screens/ChatScreen.jsx
-  var import_jsx_runtime34 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime35 = __toESM(require_jsx_runtime(), 1);
   var C = {
     zh: {
       hello: "\u4F60\u597D\uFF01\u6211\u53EF\u4EE5\u76F4\u63A5\u64CD\u4F5C\u5F53\u524D\u6253\u5F00\u7684 AE \u5DE5\u7A0B\u3002\u8BD5\u8BD5\u8FD9\u4E9B\uFF1A",
@@ -12133,10 +24275,10 @@
     ]
   };
   function Notice({ text, actionLabel, onAction }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, padding: "5px 8px", background: "var(--bg-well)", border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: "plug", size: 12, color: "var(--text-tertiary)" }),
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { style: { flex: 1, minWidth: 0, font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: text }),
-      onAction ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, children: actionLabel }) : null
+    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, padding: "5px 8px", background: "var(--bg-well)", border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Icon2, { name: "plug", size: 12, color: "var(--text-tertiary)" }),
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { style: { flex: 1, minWidth: 0, font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: text }),
+      onAction ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, children: actionLabel }) : null
     ] });
   }
   function statusForTool(state) {
@@ -12157,15 +24299,15 @@
   function Entry({ entry, lang, onApprove }) {
     const t = C[lang] || C.zh;
     if (entry.type === "user-text") {
-      return /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(ChatBubble, { role: "user", children: entry.text });
+      return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ChatBubble, { role: "user", children: entry.text });
     }
     if (entry.type === "ai-text") {
-      return /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(ChatBubble, { role: "ai", children: entry.text });
+      return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ChatBubble, { role: "ai", children: entry.text });
     }
     if (entry.type === "tool-call") {
       const highRisk = entry.risk === "destructive" || entry.risk === "external";
-      return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", gap: 6 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", gap: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
           ToolCallCard,
           {
             verb: titleForTool(entry, lang),
@@ -12175,7 +24317,7 @@
             errorMessage: entry.state === "error" ? entry.text : null
           }
         ),
-        entry.state === "awaiting-approval" ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+        entry.state === "awaiting-approval" ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
           ApprovalCard,
           {
             risk: highRisk ? "high" : "normal",
@@ -12191,7 +24333,7 @@
       ] });
     }
     if (entry.type === "error") {
-      return /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(ToolCallCard, { verb: entry.kind === "model" ? t.modelErrorTitle : t.errorTitle, target: entry.kind, status: "error", errorMessage: entry.message }) });
+      return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ToolCallCard, { verb: entry.kind === "model" ? t.modelErrorTitle : t.errorTitle, target: entry.kind, status: "error", errorMessage: entry.message }) });
     }
     return null;
   }
@@ -12224,22 +24366,22 @@
     onChipApproval
   }) {
     const t = C[lang] || C.zh;
-    const [draft, setDraft] = import_react36.default.useState("");
-    const logRef = import_react36.default.useRef(null);
-    const layoutRef = import_react36.default.useRef(null);
-    const footerRef = import_react36.default.useRef(null);
-    const [composerSize, dispatchComposerSize] = import_react36.default.useReducer(
+    const [draft, setDraft] = import_react37.default.useState("");
+    const logRef = import_react37.default.useRef(null);
+    const layoutRef = import_react37.default.useRef(null);
+    const footerRef = import_react37.default.useRef(null);
+    const [composerSize, dispatchComposerSize] = import_react37.default.useReducer(
       reduceComposerHeight,
       void 0,
       () => createComposerHeightState()
     );
-    const composerHeightRef = import_react36.default.useRef(composerSize.height);
+    const composerHeightRef = import_react37.default.useRef(composerSize.height);
     composerHeightRef.current = composerSize.height;
     const hasEntries = entries.length > 0;
     const prompts = promptCards || DEFAULT_PROMPTS[lang] || DEFAULT_PROMPTS.zh;
     const chips = chipState && chipState.descriptor ? buildComposerChips({ ...chipState, lang }) : null;
-    const composerOptions = chips ? /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)(import_react36.default.Fragment, { children: [
-      chips.model ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+    const composerOptions = chips ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(import_react37.default.Fragment, { children: [
+      chips.model ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         ComposerChip,
         {
           icon: "box",
@@ -12249,7 +24391,7 @@
           items: menuItems(chips.model.items, chipState.modelId, onChipModel)
         }
       ) : null,
-      chips.effort ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+      chips.effort ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         ComposerChip,
         {
           icon: "brain",
@@ -12259,7 +24401,7 @@
           items: menuItems(chips.effort.items, chipState.effort, onChipEffort)
         }
       ) : null,
-      chips.fast ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+      chips.fast ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         ComposerChip,
         {
           icon: "zap",
@@ -12269,7 +24411,7 @@
           onToggle: (next) => onChipFast && onChipFast(next)
         }
       ) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         ComposerChip,
         {
           icon: "shield",
@@ -12280,11 +24422,11 @@
         }
       )
     ] }) : null;
-    import_react36.default.useEffect(() => {
+    import_react37.default.useEffect(() => {
       const el = logRef.current;
       if (el) el.scrollTop = el.scrollHeight;
     }, [entries, streaming, thinking]);
-    import_react36.default.useEffect(() => {
+    import_react37.default.useEffect(() => {
       if (typeof ResizeObserver !== "function") return void 0;
       if (!layoutRef.current || !footerRef.current) return void 0;
       const measureComposerBounds = () => {
@@ -12310,19 +24452,19 @@
       if (onSend) onSend(text);
       setDraft("");
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { ref: layoutRef, style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
-        !hasEntries && composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(import_react36.default.Fragment, { children: /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(AIAvatar, { size: 32 }),
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { style: { font: "600 12px/1.35 var(--font-ui)", color: "var(--text-primary)", maxWidth: 240 }, children: disabledHint || t.keyTitle }),
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { style: { font: "400 11px/1.45 var(--font-ui)", color: "var(--text-tertiary)", maxWidth: 250 }, children: t.keyCaption })
+    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { ref: layoutRef, style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
+        !hasEntries && composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(import_react37.default.Fragment, { children: /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(AIAvatar, { size: 32 }),
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { font: "600 12px/1.35 var(--font-ui)", color: "var(--text-primary)", maxWidth: 240 }, children: disabledHint || t.keyTitle }),
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { font: "400 11px/1.45 var(--font-ui)", color: "var(--text-tertiary)", maxWidth: 250 }, children: t.keyCaption })
         ] }) }) : null,
-        !hasEntries && !composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)(import_react36.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(AIAvatar, { size: 32 }),
-            /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.hello })
+        !hasEntries && !composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(import_react37.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(AIAvatar, { size: 32 }),
+            /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.hello })
           ] }),
-          prompts.map((card) => /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+          prompts.map((card) => /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
             PromptCard,
             {
               icon: card.icon,
@@ -12336,13 +24478,13 @@
             card.id || card.title
           ))
         ] }) : null,
-        entries.map((entry) => /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Entry, { entry, lang, onApprove }, entry.id)),
-        streaming && thinking ? /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { style: { paddingLeft: 28, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Spinner, { size: 12 }),
-          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { children: t.thinking })
+        entries.map((entry) => /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Entry, { entry, lang, onApprove }, entry.id)),
+        streaming && thinking ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { paddingLeft: 28, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Spinner, { size: 12 }),
+          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { children: t.thinking })
         ] }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { ref: footerRef, style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { ref: footerRef, style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         Composer,
         {
           value: draft,
@@ -12353,7 +24495,7 @@
           disabled: composerDisabled,
           placeholder: t.placeholder,
           options: composerOptions,
-          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || onNewSession }) : null,
+          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || onNewSession }) : null,
           height: composerSize.height,
           minHeight: COMPOSER_MIN_HEIGHT,
           maxHeight: composerSize.maxHeight,
@@ -12365,11 +24507,11 @@
   }
 
   // src/screens/ToolsScreen.jsx
-  var import_react40 = __toESM(require_react(), 1);
+  var import_react41 = __toESM(require_react(), 1);
 
   // src/components/forms/Textarea.jsx
-  var import_react37 = __toESM(require_react(), 1);
-  var import_jsx_runtime35 = __toESM(require_jsx_runtime(), 1);
+  var import_react38 = __toESM(require_react(), 1);
+  var import_jsx_runtime36 = __toESM(require_jsx_runtime(), 1);
   function Textarea({
     value,
     onChange,
@@ -12380,8 +24522,8 @@
     rows = 5,
     style
   }) {
-    const [focused, setFocused] = import_react37.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+    const [focused, setFocused] = import_react38.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
       "textarea",
       {
         className: "ds-focusable",
@@ -12415,7 +24557,7 @@
   }
 
   // src/components/tools/ToolArtifactEditor.jsx
-  var import_react38 = __toESM(require_react(), 1);
+  var import_react39 = __toESM(require_react(), 1);
 
   // src/lib/toolsState.js
   var EMPTY_SUMMARIES = Object.freeze([]);
@@ -12710,7 +24852,7 @@
   }
 
   // src/components/tools/ToolArtifactEditor.jsx
-  var import_jsx_runtime36 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
   var COPY = {
     zh: {
       titleNew: "\u65B0\u5EFA\u5DE5\u5177",
@@ -12779,9 +24921,9 @@
     const isLegacy = Boolean(
       artifact && (artifact.sourceType || artifact.source && artifact.source.type) === "legacy"
     );
-    const [draft, setDraft] = import_react38.default.useState(() => initialDraft(artifact));
-    const [error, setError] = import_react38.default.useState("");
-    import_react38.default.useEffect(() => {
+    const [draft, setDraft] = import_react39.default.useState(() => initialDraft(artifact));
+    const [error, setError] = import_react39.default.useState("");
+    import_react39.default.useEffect(() => {
       setDraft(initialDraft(artifact));
       setError("");
     }, [artifact]);
@@ -12836,10 +24978,10 @@
         await onSave({ ...editable, status: "saved" });
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { className: "tools-editor", role: "dialog", "aria-label": artifact ? t.titleEdit : t.titleNew, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("div", { className: "tools-editor__title", children: artifact ? t.titleEdit : t.titleNew }),
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { className: "tools-editor__grid", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.name, caption: isLegacy ? t.legacyName : "", children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("div", { className: "tools-editor", role: "dialog", "aria-label": artifact ? t.titleEdit : t.titleNew, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("div", { className: "tools-editor__title", children: artifact ? t.titleEdit : t.titleNew }),
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("div", { className: "tools-editor__grid", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.name, caption: isLegacy ? t.legacyName : "", children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
           Input,
           {
             value: draft.name,
@@ -12847,25 +24989,25 @@
             disabled: isLegacy
           }
         ) }),
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.category, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Input, { value: draft.category, onChange: (value) => update("category", value) }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.kind, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Select, { value: draft.kind, onChange: (value) => update("kind", value), options: KIND_OPTIONS }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.risk, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Select, { value: draft.declaredRisk, onChange: (value) => update("declaredRisk", value), options: RISK_OPTIONS }) })
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.category, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Input, { value: draft.category, onChange: (value) => update("category", value) }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.kind, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Select, { value: draft.kind, onChange: (value) => update("kind", value), options: KIND_OPTIONS }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.risk, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Select, { value: draft.declaredRisk, onChange: (value) => update("declaredRisk", value), options: RISK_OPTIONS }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.description, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Textarea, { value: draft.description, onChange: (value) => update("description", value), rows: 2 }) }),
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.tags, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Input, { value: draft.tags, onChange: (value) => update("tags", value), placeholder: "animation, utility" }) }),
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.content, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Textarea, { mono: true, value: draft.content, onChange: (value) => update("content", value), rows: 9 }) }),
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Field, { label: t.args, children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Textarea, { mono: true, value: draft.argsSchema, onChange: (value) => update("argsSchema", value), rows: 6, error: Boolean(error) }) }),
-      error ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("div", { className: "tools-inline-error", role: "alert", children: error }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { className: "tools-editor__actions", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Button, { variant: "ghost", onClick: onCancel, disabled: busy, children: t.cancel }),
-        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Button, { variant: "primary", onClick: save, disabled: busy || !draft.name.trim(), children: t.save })
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.description, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Textarea, { value: draft.description, onChange: (value) => update("description", value), rows: 2 }) }),
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.tags, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Input, { value: draft.tags, onChange: (value) => update("tags", value), placeholder: "animation, utility" }) }),
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.content, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Textarea, { mono: true, value: draft.content, onChange: (value) => update("content", value), rows: 9 }) }),
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Field, { label: t.args, children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Textarea, { mono: true, value: draft.argsSchema, onChange: (value) => update("argsSchema", value), rows: 6, error: Boolean(error) }) }),
+      error ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("div", { className: "tools-inline-error", role: "alert", children: error }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("div", { className: "tools-editor__actions", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Button, { variant: "ghost", onClick: onCancel, disabled: busy, children: t.cancel }),
+        /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Button, { variant: "primary", onClick: save, disabled: busy || !draft.name.trim(), children: t.save })
       ] })
     ] });
   }
 
   // src/components/tools/ToolArtifactRow.jsx
-  var import_react39 = __toESM(require_react(), 1);
-  var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
+  var import_react40 = __toESM(require_react(), 1);
+  var import_jsx_runtime38 = __toESM(require_jsx_runtime(), 1);
   var L2 = {
     zh: { never: "\u672A\u4F7F\u7528", verified: "\u5DF2\u9A8C\u8BC1", run: "\u8FD0\u884C" },
     en: { never: "Never used", verified: "Verified", run: "Run" }
@@ -12895,12 +25037,12 @@
     const directRun = Boolean(
       artifact && artifact.executionCapabilities && artifact.executionCapabilities.directRun && artifact.executionCapabilities.directRun.available
     );
-    return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(
       "div",
       {
         className: `tools-artifact-row ds-focusable${selected ? " is-selected" : ""}`,
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
+          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(
             "button",
             {
               type: "button",
@@ -12908,24 +25050,24 @@
               "aria-current": selected || void 0,
               onClick: () => onSelect && onSelect(artifact.id),
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__top", children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { className: "tools-artifact-row__name", children: artifact.name }),
-                  artifact.verified ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: "ok", icon: "check", children: t.verified }) : null
+                /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { className: "tools-artifact-row__top", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { className: "tools-artifact-row__name", children: artifact.name }),
+                  artifact.verified ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: "ok", icon: "check", children: t.verified }) : null
                 ] }),
-                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__badges", children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.kind }),
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { children: artifact.category }),
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: riskStatus(artifact.declaredRisk), children: artifact.declaredRisk }),
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Badge, { status: artifact.status === "candidate" ? "warn" : artifact.status === "pinned" ? "accent" : "neutral", children: artifact.status })
+                /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { className: "tools-artifact-row__badges", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { children: artifact.kind }),
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { children: artifact.category }),
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: riskStatus(artifact.declaredRisk), children: artifact.declaredRisk }),
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: artifact.status === "candidate" ? "warn" : artifact.status === "pinned" ? "accent" : "neutral", children: artifact.status })
                 ] }),
-                /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("span", { className: "tools-artifact-row__meta", children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: artifact.sourceType }),
-                  /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { children: lastUsed(artifact.lastUsedAt, t) })
+                /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { className: "tools-artifact-row__meta", children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: artifact.sourceType }),
+                  /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: lastUsed(artifact.lastUsedAt, t) })
                 ] })
               ]
             }
           ),
-          directRun ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
+          directRun ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
             "button",
             {
               type: "button",
@@ -12945,9 +25087,9 @@
   var SYSTEM_COMMAND_SUFFIXES = [".ps1", ".psm1", ".bat", ".cmd", ".sh", ".command"];
   function selectedValue(result) {
     if (!result || Number(result.err || 0) !== 0) return null;
-    const data = result.data;
-    if (Array.isArray(data)) return data.length === 1 ? data[0] : null;
-    return data || null;
+    const data2 = result.data;
+    if (Array.isArray(data2)) return data2.length === 1 ? data2[0] : null;
+    return data2 || null;
   }
   function normalizeFileUrl(value) {
     let path = String(value || "").trim();
@@ -13222,7 +25364,7 @@
   }
 
   // src/screens/ToolsScreen.jsx
-  var import_jsx_runtime38 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime39 = __toESM(require_jsx_runtime(), 1);
   var TEXT = {
     zh: {
       library: "\u5DE5\u5177\u5E93",
@@ -13381,38 +25523,38 @@
     const t = TEXT[lang] || TEXT.zh;
     const conflicts = preview.conflicts || [];
     const complete = conflicts.every((conflict) => ["keep", "duplicate"].includes(resolutions[conflict.conflictId]));
-    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-modal__scrim" }),
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import", role: "dialog", "aria-label": t.importTitle, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__heading", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: t.importTitle }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: preview.highestRisk === "external" || preview.highestRisk === "destructive" ? "error" : "warn", children: preview.highestRisk })
+    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-modal__scrim" }),
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import", role: "dialog", "aria-label": t.importTitle, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__heading", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: t.importTitle }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Badge, { status: preview.highestRisk === "external" || preview.highestRisk === "destructive" ? "error" : "warn", children: preview.highestRisk })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__body", children: [
-          (preview.artifacts || []).map((item, index) => /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__item", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("strong", { children: item.summary && item.summary.name }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__body", children: [
+          (preview.artifacts || []).map((item, index) => /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__item", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("strong", { children: item.summary && item.summary.name }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("span", { children: [
               item.summary && item.summary.kind,
               " \xB7 ",
               item.calculatedRisk
             ] }),
-            item.contentChanged ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: "warn", children: t.contentChanged }) : null,
-            item.metadataChanges && Object.keys(item.metadataChanges).length ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("details", { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("summary", { children: t.importChanges }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { children: JSON.stringify(item.metadataChanges, null, 2) })
+            item.contentChanged ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Badge, { status: "warn", children: t.contentChanged }) : null,
+            item.metadataChanges && Object.keys(item.metadataChanges).length ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("details", { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("summary", { children: t.importChanges }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { children: JSON.stringify(item.metadataChanges, null, 2) })
             ] }) : null
           ] }, `${item.summary && item.summary.id || "artifact"}:${index}`)),
-          conflicts.map((conflict) => /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__conflict", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("strong", { children: t.importConflict }),
+          conflicts.map((conflict) => /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__conflict", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("strong", { children: t.importConflict }),
               " \xB7 ",
               conflict.incomingName
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__hashes", children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: conflict.existingContentHash }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: conflict.incomingContentHash })
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__hashes", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: conflict.existingContentHash }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: conflict.incomingContentHash })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
               Select,
               {
                 value: resolutions[conflict.conflictId] || "",
@@ -13426,9 +25568,9 @@
             )
           ] }, conflict.conflictId))
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-import__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "ghost", onClick: onCancel, disabled: busy, children: t.cancel }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: onCommit, disabled: busy || !complete, children: t.commit })
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-import__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "ghost", onClick: onCancel, disabled: busy, children: t.cancel }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "primary", onClick: onCommit, disabled: busy || !complete, children: t.commit })
         ] })
       ] })
     ] });
@@ -13440,24 +25582,24 @@
     initialPath = ""
   }) {
     const t = TEXT[lang] || TEXT.zh;
-    const [state, dispatch] = import_react40.default.useReducer(reduceToolsState, INITIAL_TOOLS_STATE);
-    const [busy, setBusy] = import_react40.default.useState(false);
-    const initialRunInputs = import_react40.default.useMemo(() => emptyToolRunInputs(), []);
-    const [runArgs, setRunArgs] = import_react40.default.useState(initialRunInputs.args);
-    const [runForm, setRunForm] = import_react40.default.useState({});
-    const [advancedJson, setAdvancedJson] = import_react40.default.useState(false);
-    const [target, setTarget] = import_react40.default.useState(initialRunInputs.target);
-    const [runResult, setRunResult] = import_react40.default.useState(null);
-    const [runJob, setRunJob] = import_react40.default.useState(null);
-    const [runHistory, setRunHistory] = import_react40.default.useState([]);
-    const [developerMode, setDeveloperMode] = import_react40.default.useState(false);
-    const loadSequence = import_react40.default.useRef(0);
-    const inspectSequence = import_react40.default.useRef(0);
-    const rowRunLock = import_react40.default.useRef(false);
+    const [state, dispatch] = import_react41.default.useReducer(reduceToolsState, INITIAL_TOOLS_STATE);
+    const [busy, setBusy] = import_react41.default.useState(false);
+    const initialRunInputs = import_react41.default.useMemo(() => emptyToolRunInputs(), []);
+    const [runArgs, setRunArgs] = import_react41.default.useState(initialRunInputs.args);
+    const [runForm, setRunForm] = import_react41.default.useState({});
+    const [advancedJson, setAdvancedJson] = import_react41.default.useState(false);
+    const [target, setTarget] = import_react41.default.useState(initialRunInputs.target);
+    const [runResult, setRunResult] = import_react41.default.useState(null);
+    const [runJob, setRunJob] = import_react41.default.useState(null);
+    const [runHistory, setRunHistory] = import_react41.default.useState([]);
+    const [developerMode, setDeveloperMode] = import_react41.default.useState(false);
+    const loadSequence = import_react41.default.useRef(0);
+    const inspectSequence = import_react41.default.useRef(0);
+    const rowRunLock = import_react41.default.useRef(false);
     const selectedSummary = state.summaries.find((row) => row.id === state.selectedId) || null;
     const artifact = state.inspected && state.inspected.artifact || null;
     const runPending = Boolean(runJob && !runJob.terminal);
-    const load = import_react40.default.useCallback(async () => {
+    const load = import_react41.default.useCallback(async () => {
       if (!api) return;
       const sequence = loadSequence.current + 1;
       loadSequence.current = sequence;
@@ -13477,7 +25619,7 @@
         if (sequence === loadSequence.current) dispatch({ type: "load-error", error });
       }
     }, [api, state.query, state.kinds, state.category, state.risk, state.statuses, state.sourceType, developerMode]);
-    import_react40.default.useEffect(() => {
+    import_react41.default.useEffect(() => {
       const timer = setTimeout(load, 120);
       return () => clearTimeout(timer);
     }, [load]);
@@ -13786,24 +25928,24 @@
     const execution = toolExecutionCapabilities(artifact);
     const executable = execution.render || execution.directRun;
     const argFields = toolArgFields(artifact && artifact.argsSchema);
-    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-screen", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("header", { className: "tools-header", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-header__title", children: t.library }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-header__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "primary", icon: "plus", onClick: () => dispatch({ type: "edit-start", editor: { mode: "create", artifact: null } }), children: t.new }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "download", onClick: previewImport, disabled: busy, children: t.import }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", icon: "external-link", onClick: exportPackage, disabled: busy || !state.summaries.length, children: t.export }),
-          runPending ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: resumeExecution, disabled: busy, children: t.resumeRun }) : null,
-          runPending ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "danger", onClick: cancelExecution, disabled: busy, children: t.cancelRun }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: developerMode ? "danger" : "ghost", onClick: () => setDeveloperMode((value) => !value), disabled: busy, children: t.developerTools })
+    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-screen", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("header", { className: "tools-header", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-header__title", children: t.library }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-header__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "primary", icon: "plus", onClick: () => dispatch({ type: "edit-start", editor: { mode: "create", artifact: null } }), children: t.new }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", icon: "download", onClick: previewImport, disabled: busy, children: t.import }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", icon: "external-link", onClick: exportPackage, disabled: busy || !state.summaries.length, children: t.export }),
+          runPending ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: resumeExecution, disabled: busy, children: t.resumeRun }) : null,
+          runPending ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "danger", onClick: cancelExecution, disabled: busy, children: t.cancelRun }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: developerMode ? "danger" : "ghost", onClick: () => setDeveloperMode((value) => !value), disabled: busy, children: t.developerTools })
         ] })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-filters", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: state.query, onChange: (value) => dispatch({ type: "set-query", value }), placeholder: t.search }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.kinds[0] || "", onChange: (value) => dispatch({ type: "set-filter", key: "kinds", value: value ? [value] : [] }), options: KIND_OPTIONS2.filter((value) => developerMode || value !== "system-command").map((value) => ({ value, label: value || t.allKinds })) }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: state.category, onChange: (value) => dispatch({ type: "set-filter", key: "category", value }), placeholder: t.category }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.risk, onChange: (value) => dispatch({ type: "set-filter", key: "risk", value }), options: RISK_OPTIONS2.map((value) => ({ value, label: value || t.allRisk })) }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: statusValue, onChange: (value) => dispatch({ type: "set-filter", key: "statuses", value: value.split(",").filter(Boolean) }), options: [
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-filters", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Input, { value: state.query, onChange: (value) => dispatch({ type: "set-query", value }), placeholder: t.search }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Select, { value: state.kinds[0] || "", onChange: (value) => dispatch({ type: "set-filter", key: "kinds", value: value ? [value] : [] }), options: KIND_OPTIONS2.filter((value) => developerMode || value !== "system-command").map((value) => ({ value, label: value || t.allKinds })) }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Input, { value: state.category, onChange: (value) => dispatch({ type: "set-filter", key: "category", value }), placeholder: t.category }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Select, { value: state.risk, onChange: (value) => dispatch({ type: "set-filter", key: "risk", value }), options: RISK_OPTIONS2.map((value) => ({ value, label: value || t.allRisk })) }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Select, { value: statusValue, onChange: (value) => dispatch({ type: "set-filter", key: "statuses", value: value.split(",").filter(Boolean) }), options: [
           { value: "saved,pinned", label: t.active },
           { value: "candidate", label: t.candidates },
           { value: "saved", label: t.saved },
@@ -13812,15 +25954,15 @@
           { value: "deprecated", label: t.deprecated },
           { value: "candidate,saved,pinned,archived,deprecated", label: t.allStatuses }
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Select, { value: state.sourceType, onChange: (value) => dispatch({ type: "set-filter", key: "sourceType", value }), options: SOURCE_OPTIONS.map((value) => ({ value, label: value || t.allSource })) })
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Select, { value: state.sourceType, onChange: (value) => dispatch({ type: "set-filter", key: "sourceType", value }), options: SOURCE_OPTIONS.map((value) => ({ value, label: value || t.allSource })) })
       ] }),
-      state.error ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-error", role: "alert", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: state.error }),
-        state.refreshRequired ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "ghost", onClick: load, children: t.refresh }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("button", { type: "button", "aria-label": "Dismiss", onClick: () => dispatch({ type: "clear-error" }), children: "\xD7" })
+      state.error ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-error", role: "alert", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: state.error }),
+        state.refreshRequired ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "ghost", onClick: load, children: t.refresh }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("button", { type: "button", "aria-label": "Dismiss", onClick: () => dispatch({ type: "clear-error" }), children: "\xD7" })
       ] }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-split", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("section", { className: "tools-list", "aria-label": "Tool summaries", children: state.summaries.length ? state.summaries.map((row) => /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-split", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("section", { className: "tools-list", "aria-label": "Tool summaries", children: state.summaries.length ? state.summaries.map((row) => /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
           ToolArtifactRow,
           {
             artifact: row,
@@ -13831,63 +25973,63 @@
             lang
           },
           row.id
-        )) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(EmptyState, { icon: "box", title: t.empty, caption: t.emptyCap, compact: true }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("section", { className: "tools-detail", children: !selectedSummary ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : !artifact ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(EmptyState, { icon: "rotate-cw", title: state.phase === "error" ? state.error : t.select, compact: true }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-detail__heading", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h2", { children: artifact.name }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("p", { children: artifact.description })
+        )) : /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(EmptyState, { icon: "box", title: t.empty, caption: t.emptyCap, compact: true }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("section", { className: "tools-detail", children: !selectedSummary ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : !artifact ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(EmptyState, { icon: "rotate-cw", title: state.phase === "error" ? state.error : t.select, compact: true }) : /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_react41.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-detail__heading", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h2", { children: artifact.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("p", { children: artifact.description })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Badge, { status: state.inspected.trust === "signed-bundled" ? "ok" : "warn", children: state.inspected.trust === "signed-bundled" ? t.signed : t.untrusted })
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Badge, { status: state.inspected.trust === "signed-bundled" ? "ok" : "warn", children: state.inspected.trust === "signed-bundled" ? t.signed : t.untrusted })
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-detail__actions", children: [
-            editable ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => dispatch({ type: "edit-start", editor: { mode: "edit", artifact } }), children: t.edit }) : null,
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: duplicate, disabled: busy, children: t.duplicate }),
-            editable && ["saved", "pinned"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => editStatus(artifact.status === "pinned" ? "saved" : "pinned"), disabled: busy, children: artifact.status === "pinned" ? t.unpin : t.pin }) : null,
-            editable && !artifact.verified && ["saved", "pinned"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: verify, disabled: busy, children: t.verify }) : null,
-            canPromoteArtifact(artifact) ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "accent", onClick: promote, disabled: busy, children: t.promote }) : null,
-            editable && !["archived", "deprecated"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "ghost", onClick: archive, disabled: busy, children: t.archive }) : null,
-            source !== "bundled" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "danger", onClick: remove, disabled: busy, children: t.delete }) : null,
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "ghost", icon: "copy", onClick: () => copyText(displayArtifactContent(artifact)), children: t.copy })
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-detail__actions", children: [
+            editable ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => dispatch({ type: "edit-start", editor: { mode: "edit", artifact } }), children: t.edit }) : null,
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: duplicate, disabled: busy, children: t.duplicate }),
+            editable && ["saved", "pinned"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => editStatus(artifact.status === "pinned" ? "saved" : "pinned"), disabled: busy, children: artifact.status === "pinned" ? t.unpin : t.pin }) : null,
+            editable && !artifact.verified && ["saved", "pinned"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: verify, disabled: busy, children: t.verify }) : null,
+            canPromoteArtifact(artifact) ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "accent", onClick: promote, disabled: busy, children: t.promote }) : null,
+            editable && !["archived", "deprecated"].includes(artifact.status) ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "ghost", onClick: archive, disabled: busy, children: t.archive }) : null,
+            source !== "bundled" ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "danger", onClick: remove, disabled: busy, children: t.delete }) : null,
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "ghost", icon: "copy", onClick: () => copyText(displayArtifactContent(artifact)), children: t.copy })
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.metadata }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("dl", { className: "tools-kv", children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "ID" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.id }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Kind" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.kind }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Category" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.category }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Risk" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.declaredRisk }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Status" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.status }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Source" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: source }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Runtime" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: execution.runtime || "\u2014" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dt", { children: "Hash" }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("dd", { children: artifact.contentHash })
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("section", { className: "tools-detail__section", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.metadata }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("dl", { className: "tools-kv", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "ID" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.id }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Kind" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.kind }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Category" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.category }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Risk" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.declaredRisk }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Status" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.status }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Source" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: source }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Runtime" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: execution.runtime || "\u2014" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: "Hash" }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: artifact.contentHash })
             ] })
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.content }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { className: "tools-content", children: displayArtifactContent(artifact) })
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("section", { className: "tools-detail__section", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.content }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { className: "tools-content", children: displayArtifactContent(artifact) })
           ] }),
-          executable ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section tools-runner", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.args }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-runner__actions", children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setAdvancedJson((value) => !value), disabled: busy, children: advancedJson ? t.formView : t.advancedJson }) }),
-            advancedJson ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Textarea, { mono: true, value: runArgs, onChange: setRunArgs, rows: 4 }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-runner__form", children: argFields.length ? argFields.map((field) => {
+          executable ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("section", { className: "tools-detail__section tools-runner", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.args }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-runner__actions", children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setAdvancedJson((value) => !value), disabled: busy, children: advancedJson ? t.formView : t.advancedJson }) }),
+            advancedJson ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Textarea, { mono: true, value: runArgs, onChange: setRunArgs, rows: 4 }) : /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-runner__form", children: argFields.length ? argFields.map((field) => {
               var _a;
-              return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: `${field.name}${field.required ? " *" : ""}`, children: field.type === "boolean" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+              return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Field, { label: `${field.name}${field.required ? " *" : ""}`, children: field.type === "boolean" ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
                 Select,
                 {
                   value: String(Boolean(runForm[field.name])),
                   onChange: (value) => setRunForm((current) => ({ ...current, [field.name]: value === "true" })),
                   options: [{ value: "false", label: "false" }, { value: "true", label: "true" }]
                 }
-              ) : field.enum ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+              ) : field.enum ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
                 Select,
                 {
                   value: runForm[field.name] === "" ? "" : JSON.stringify(runForm[field.name]),
@@ -13897,7 +26039,7 @@
                     ...field.enum.map((value) => ({ value: JSON.stringify(value), label: String(value) }))
                   ]
                 }
-              ) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+              ) : /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
                 Input,
                 {
                   value: (_a = runForm[field.name]) != null ? _a : "",
@@ -13906,40 +26048,40 @@
                   onChange: (value) => setRunForm((current) => ({ ...current, [field.name]: value }))
                 }
               ) }, field.name);
-            }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: "{}" }) }),
-            artifact.kind === "expression" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-runner__target", children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: t.compId, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: target.compId, onChange: (value) => setTarget((current) => ({ ...current, compId: value })) }) }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: t.layerId, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: target.layerId, onChange: (value) => setTarget((current) => ({ ...current, layerId: value })) }) }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Field, { label: t.propertyPath, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Input, { value: target.path, onChange: (value) => setTarget((current) => ({ ...current, path: value })) }) })
+            }) : /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: "{}" }) }),
+            artifact.kind === "expression" ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-runner__target", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Field, { label: t.compId, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Input, { value: target.compId, onChange: (value) => setTarget((current) => ({ ...current, compId: value })) }) }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Field, { label: t.layerId, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Input, { value: target.layerId, onChange: (value) => setTarget((current) => ({ ...current, layerId: value })) }) }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Field, { label: t.propertyPath, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Input, { value: target.path, onChange: (value) => setTarget((current) => ({ ...current, path: value })) }) })
             ] }) : null,
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-runner__actions", children: [
-              execution.render ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "secondary", onClick: renderAndCopy, disabled: busy, children: t.renderCopy }) : null,
-              execution.directRun ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy || runPending, children: t.run }) : null
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-runner__actions", children: [
+              execution.render ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "secondary", onClick: renderAndCopy, disabled: busy, children: t.renderCopy }) : null,
+              execution.directRun ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "primary", onClick: execute, disabled: busy || runPending, children: t.run }) : null
             ] }),
-            runJob ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { children: [
+            runJob ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { children: [
               t.progress,
               ": ",
               runJob.progress,
               "% \xB7 ",
               runJob.status
             ] }) : null,
-            runResult ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.result }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { className: "tools-content", children: JSON.stringify(runResult, null, 2) })
+            runResult ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_react41.default.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.result }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { className: "tools-content", children: JSON.stringify(runResult, null, 2) })
             ] }) : null,
-            runHistory.length ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.history }),
-              /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("pre", { className: "tools-content", children: JSON.stringify(runHistory, null, 2) })
+            runHistory.length ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_react41.default.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.history }),
+              /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { className: "tools-content", children: JSON.stringify(runHistory, null, 2) })
             ] }) : null
-          ] }) : execution.disabledReason ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("section", { className: "tools-detail__section", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("h3", { children: t.incompatible }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("p", { children: execution.disabledReason.message })
+          ] }) : execution.disabledReason ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("section", { className: "tools-detail__section", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("h3", { children: t.incompatible }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("p", { children: execution.disabledReason.message })
           ] }) : null
         ] }) })
       ] }),
-      state.editor ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { className: "tools-modal__scrim", onClick: () => !busy && dispatch({ type: "edit-cancel" }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      state.editor ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-modal__scrim", onClick: () => !busy && dispatch({ type: "edit-cancel" }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
           ToolArtifactEditor,
           {
             artifact: state.editor.artifact,
@@ -13950,7 +26092,7 @@
           }
         )
       ] }) : null,
-      state.importPreview ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      state.importPreview ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ImportPreview,
         {
           preview: state.importPreview,
@@ -13966,8 +26108,8 @@
   }
 
   // src/components/tools/ToolApprovalDialog.jsx
-  var import_react41 = __toESM(require_react(), 1);
-  var import_jsx_runtime39 = __toESM(require_jsx_runtime(), 1);
+  var import_react42 = __toESM(require_react(), 1);
+  var import_jsx_runtime40 = __toESM(require_jsx_runtime(), 1);
   var L3 = {
     zh: {
       title: "\u6279\u51C6\u5DE5\u5177\u6267\u884C\uFF1F",
@@ -13997,29 +26139,29 @@
     const t = L3[lang] || L3.zh;
     const plan = record.plan || {};
     const resolve = (decision) => onResolve && onResolve({ id: record.id, decision });
-    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve("deny") }),
-      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-approval", role: "alertdialog", "aria-label": t.title, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-approval__heading", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: t.title }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Badge, { status: plan.risk === "destructive" || plan.risk === "external" ? "error" : "warn", children: plan.risk })
+    return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve("deny") }),
+      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-approval", role: "alertdialog", "aria-label": t.title, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-approval__heading", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { children: t.title }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: plan.risk === "destructive" || plan.risk === "external" ? "error" : "warn", children: plan.risk })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("dl", { className: "tools-kv", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: t.artifact }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: plan.artifactId || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: t.operation }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: plan.operation || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: t.risk }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: plan.risk || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: t.args }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { children: JSON.stringify(plan.normalizedArgs || {}, null, 2) }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dt", { children: t.target }),
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("pre", { children: JSON.stringify(plan.target || {}, null, 2) }) })
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("dl", { className: "tools-kv", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dt", { children: t.artifact }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dd", { children: plan.artifactId || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dt", { children: t.operation }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dd", { children: plan.operation || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dt", { children: t.risk }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dd", { children: plan.risk || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dt", { children: t.args }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { children: JSON.stringify(plan.normalizedArgs || {}, null, 2) }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dt", { children: t.target }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { children: JSON.stringify(plan.target || {}, null, 2) }) })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { className: "tools-approval__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "ghost", onClick: () => resolve("deny"), children: t.deny }),
-          record.policy && record.policy.allowSession ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "secondary", onClick: () => resolve("session"), children: t.session }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "primary", onClick: () => resolve("once"), children: t.once })
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-approval__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", onClick: () => resolve("deny"), children: t.deny }),
+          record.policy && record.policy.allowSession ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "secondary", onClick: () => resolve("session"), children: t.session }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "primary", onClick: () => resolve("once"), children: t.once })
         ] })
       ] })
     ] });
@@ -14030,16 +26172,16 @@
     let buffer = "";
     function parseFrame(frame) {
       let event = "";
-      let data = "";
+      let data2 = "";
       const lines = frame.replace(/\r\n/g, "\n").split("\n");
       for (const line of lines) {
         if (line.startsWith("event:")) {
           event = line.slice(6).trim();
         } else if (line.startsWith("data:")) {
-          data += line.slice(5).trimStart();
+          data2 += line.slice(5).trimStart();
         }
       }
-      const trimmed = data.trim();
+      const trimmed = data2.trim();
       if (!trimmed || trimmed === "[DONE]") return;
       try {
         onEvent({ event, data: JSON.parse(trimmed) });
@@ -15116,13 +27258,13 @@
     error.kind = kind;
     return error;
   }
-  function parseAnthropicEvent(data, state, onTextDelta) {
-    if (data.type === "content_block_start") {
-      const block = data.content_block || {};
+  function parseAnthropicEvent(data2, state, onTextDelta) {
+    if (data2.type === "content_block_start") {
+      const block = data2.content_block || {};
       if (block.type === "text") {
-        state.blocks.set(data.index, { type: "text", text: block.text || "" });
+        state.blocks.set(data2.index, { type: "text", text: block.text || "" });
       } else if (block.type === "tool_use") {
-        state.blocks.set(data.index, {
+        state.blocks.set(data2.index, {
           type: "tool_use",
           id: block.id,
           name: block.name,
@@ -15130,18 +27272,18 @@
           startInput: block.input || {}
         });
       }
-    } else if (data.type === "content_block_delta") {
-      const block = state.blocks.get(data.index);
-      if (!block || !data.delta) return;
-      if (data.delta.type === "text_delta") {
-        const text = data.delta.text || "";
+    } else if (data2.type === "content_block_delta") {
+      const block = state.blocks.get(data2.index);
+      if (!block || !data2.delta) return;
+      if (data2.delta.type === "text_delta") {
+        const text = data2.delta.text || "";
         block.text += text;
         if (text) onTextDelta(text);
-      } else if (data.delta.type === "input_json_delta") {
-        block.inputJson += data.delta.partial_json || "";
+      } else if (data2.delta.type === "input_json_delta") {
+        block.inputJson += data2.delta.partial_json || "";
       }
-    } else if (data.type === "message_delta" && data.delta) {
-      state.stopReason = data.delta.stop_reason || state.stopReason;
+    } else if (data2.type === "message_delta" && data2.delta) {
+      state.stopReason = data2.delta.stop_reason || state.stopReason;
     }
   }
   function finishBlocks(blocks) {
@@ -15237,7 +27379,7 @@
     if (!reader) throw toError("network", "Anthropic response body is not streamable.");
     const decoder = new TextDecoder();
     const state = { blocks: /* @__PURE__ */ new Map(), stopReason: "end_turn" };
-    const parser = createSseParser(({ data }) => parseAnthropicEvent(data, state, onTextDelta));
+    const parser = createSseParser(({ data: data2 }) => parseAnthropicEvent(data2, state, onTextDelta));
     while (true) {
       const chunk = await reader.read();
       if (chunk.done) break;
@@ -17447,19 +29589,59 @@
 
   // src/cep/backends/index.js
   var BACKENDS = {
-    subscription: { id: "subscription", baseDescriptor: claudeSubDescriptor },
-    byok: { id: "byok", baseDescriptor: byokStaticDescriptor },
-    "claude-api": { id: "claude-api", baseDescriptor: byokStaticDescriptor },
-    codex: { id: "codex", baseDescriptor: codexStaticDescriptor },
-    opencode: { id: "opencode", baseDescriptor: openCodeStaticDescriptor },
+    subscription: {
+      id: "subscription",
+      baseDescriptor: claudeSubDescriptor,
+      attachmentTransport: "agent-sdk"
+    },
+    byok: {
+      id: "byok",
+      baseDescriptor: byokStaticDescriptor,
+      attachmentTransport: "reject"
+    },
+    "claude-api": {
+      id: "claude-api",
+      baseDescriptor: byokStaticDescriptor,
+      attachmentTransport: "agent-sdk"
+    },
+    codex: {
+      id: "codex",
+      baseDescriptor: codexStaticDescriptor,
+      attachmentTransport: "native"
+    },
+    opencode: {
+      id: "opencode",
+      baseDescriptor: openCodeStaticDescriptor,
+      attachmentTransport: "native"
+    },
     // zcode's baseDescriptor is intentionally NOT zcodeStaticDescriptor here:
     // baseDescriptorFor() special-cases 'zcode' below to build a live,
     // CLI-config-aware descriptor. zcodeStaticDescriptor remains the ultimate
     // fallback (used by zcodeDynamicDescriptor itself, and by
     // zcodeDescriptorFromModels once a session exists) when no CLI config is
     // readable at all.
-    zcode: { id: "zcode", baseDescriptor: zcodeStaticDescriptor }
+    zcode: {
+      id: "zcode",
+      baseDescriptor: zcodeStaticDescriptor,
+      attachmentTransport: "manifest"
+    }
   };
+  var ATTACHMENT_TRANSPORTS = /* @__PURE__ */ new Set(["agent-sdk", "native", "manifest", "reject"]);
+  function assertAttachmentBackendRegistry(registry) {
+    for (const [id, entry] of Object.entries(registry)) {
+      if (!ATTACHMENT_TRANSPORTS.has(entry == null ? void 0 : entry.attachmentTransport)) {
+        throw new TypeError(id + " is missing a valid attachment transport");
+      }
+      if (entry.attachmentTransport === "reject" && id !== "byok") {
+        throw new TypeError(id + " must not reject attachments");
+      }
+      if (id === "byok" && entry.attachmentTransport !== "reject") {
+        throw new TypeError("byok must reject attachments");
+      }
+    }
+    return true;
+  }
+  assertAttachmentBackendRegistry(BACKENDS);
   var REAL_BACKENDS = Object.keys(BACKENDS);
   function baseDescriptorFor(backendId, env) {
     if (backendId === "zcode") return zcodeDynamicDescriptor({ env });
@@ -20577,8 +32759,8 @@
         unsupportedMessages
       );
       if (!IMAGE_MEDIA_TYPES.has(source.media_type)) throw invalidMessages(`${path}.source.media_type`);
-      const data = nonemptyString(source.data, `${path}.source.data`, invalidMessages);
-      return { kind: "image", url: `data:${source.media_type};base64,${data}` };
+      const data2 = nonemptyString(source.data, `${path}.source.data`, invalidMessages);
+      return { kind: "image", url: `data:${source.media_type};base64,${data2}` };
     }
     if (image.source.type === "url") {
       const source = exactRequest(
@@ -21056,11 +33238,11 @@ ${output}` : output
       consumed.add(`${path}.detail`);
     }
     const url = nonemptyString(image.image_url, `${path}.image_url`, invalidResponses);
-    const data = url.match(/^data:(image\/(?:jpeg|png|gif|webp));base64,([A-Za-z0-9+/=]+)$/);
-    if (data) {
+    const data2 = url.match(/^data:(image\/(?:jpeg|png|gif|webp));base64,([A-Za-z0-9+/=]+)$/);
+    if (data2) {
       return {
         type: "image",
-        source: { type: "base64", media_type: data[1], data: data[2] }
+        source: { type: "base64", media_type: data2[1], data: data2[2] }
       };
     }
     return { type: "image", source: { type: "url", url } };
@@ -22018,7 +34200,7 @@ ${output}` : output
     function processFrame(frame) {
       if (byteLength2(frame) > maxFrameBytes) throw streamError("upstream_sse_frame_too_large", "sse");
       let event = "";
-      const data = [];
+      const data2 = [];
       for (const rawLine of frame.split(/\r?\n/)) {
         if (!rawLine || rawLine.startsWith(":")) continue;
         if (rawLine.startsWith("event:")) {
@@ -22027,13 +34209,13 @@ ${output}` : output
           continue;
         }
         if (rawLine.startsWith("data:")) {
-          data.push(rawLine.slice(5).replace(/^ /, ""));
+          data2.push(rawLine.slice(5).replace(/^ /, ""));
           continue;
         }
         throw streamError("upstream_sse_malformed", "sse");
       }
-      if (data.length === 0) return;
-      const rawData = data.join("\n");
+      if (data2.length === 0) return;
+      const rawData = data2.join("\n");
       if (rawData === "[DONE]") {
         onFrame({ event, done: true, data: null });
         return;
@@ -22088,24 +34270,24 @@ ${output}` : output
     let sawDone = false;
     const parser = strictParser({
       maxFrameBytes,
-      onFrame({ event, done, data }) {
+      onFrame({ event, done, data: data2 }) {
         if (done) {
           if (!terminal || sawDone) throw streamError("upstream_sse_malformed", "sse.done");
           sawDone = true;
           return;
         }
-        if (!isObject2(data) || typeof data.type !== "string") {
+        if (!isObject2(data2) || typeof data2.type !== "string") {
           throw streamError("upstream_sse_malformed", "sse.data.type");
         }
-        if (event && event !== data.type) throw streamError("upstream_sse_malformed", "sse.event");
+        if (event && event !== data2.type) throw streamError("upstream_sse_malformed", "sse.event");
         if (terminal) throw streamError("upstream_sse_malformed", "sse.after_terminal");
-        if (["response.completed", "response.incomplete", "response.failed"].includes(data.type)) {
-          if (!isObject2(data.response)) throw streamError("upstream_sse_malformed", "sse.data.response");
-          const expected = data.type.slice("response.".length);
-          if (data.response.status !== expected) {
+        if (["response.completed", "response.incomplete", "response.failed"].includes(data2.type)) {
+          if (!isObject2(data2.response)) throw streamError("upstream_sse_malformed", "sse.data.response");
+          const expected = data2.type.slice("response.".length);
+          if (data2.response.status !== expected) {
             throw streamError("upstream_sse_malformed", "sse.data.response.status");
           }
-          terminal = data.response;
+          terminal = data2.response;
         }
       }
     });
@@ -22150,13 +34332,13 @@ ${output}` : output
     const tools = /* @__PURE__ */ new Map();
     const parser = strictParser({
       maxFrameBytes,
-      onFrame({ done, data }) {
+      onFrame({ done, data: data2 }) {
         if (done) {
           if (doneMarker || !finishReason) throw streamError("upstream_sse_malformed", "sse.done");
           doneMarker = true;
           return;
         }
-        const chunk = exactStream(data, CHAT_CHUNK_FIELDS, "data");
+        const chunk = exactStream(data2, CHAT_CHUNK_FIELDS, "data");
         if (chunk.object !== "chat.completion.chunk") throw streamError("upstream_sse_malformed", "data.object");
         if (typeof chunk.id === "string" && chunk.id) {
           if (id && id !== chunk.id) throw streamError("upstream_sse_malformed", "data.id");
@@ -22380,58 +34562,58 @@ ${output}` : output
     const blocks = /* @__PURE__ */ new Map();
     const parser = strictParser({
       maxFrameBytes,
-      onFrame({ event, done, data }) {
+      onFrame({ event, done, data: data2 }) {
         var _a;
         if (done) {
           if (doneMarker) throw streamError("upstream_sse_malformed", "sse.done");
           doneMarker = true;
           return;
         }
-        if (!isObject2(data) || typeof data.type !== "string") {
+        if (!isObject2(data2) || typeof data2.type !== "string") {
           throw streamError("upstream_sse_malformed", "sse.data.type");
         }
-        if (event && event !== data.type) throw streamError("upstream_sse_malformed", "sse.event");
+        if (event && event !== data2.type) throw streamError("upstream_sse_malformed", "sse.event");
         if (messageStop) throw streamError("upstream_sse_malformed", "sse.after_terminal");
-        if (data.type === "ping") return;
-        if (data.type === "error") throw streamError("upstream_stream_error", "sse.data.error");
-        if (data.type === "message_start") {
-          if (start || !isObject2(data.message)) throw streamError("upstream_sse_malformed", "message_start.message");
-          start = data.message;
+        if (data2.type === "ping") return;
+        if (data2.type === "error") throw streamError("upstream_stream_error", "sse.data.error");
+        if (data2.type === "message_start") {
+          if (start || !isObject2(data2.message)) throw streamError("upstream_sse_malformed", "message_start.message");
+          start = data2.message;
           usage = isObject2(start.usage) ? { ...start.usage } : {};
           return;
         }
-        if (data.type === "content_block_start") {
-          if (!Number.isInteger(data.index) || data.index < 0 || blocks.has(data.index)) {
+        if (data2.type === "content_block_start") {
+          if (!Number.isInteger(data2.index) || data2.index < 0 || blocks.has(data2.index)) {
             throw streamError("upstream_sse_malformed", "content_block_start.index");
           }
-          blocks.set(data.index, messageBlockStart(data.content_block, data.index));
+          blocks.set(data2.index, messageBlockStart(data2.content_block, data2.index));
           return;
         }
-        if (data.type === "content_block_delta") {
-          const block = blocks.get(data.index);
+        if (data2.type === "content_block_delta") {
+          const block = blocks.get(data2.index);
           if (!block || block.stopped) throw streamError("upstream_sse_malformed", "content_block_delta.index");
-          applyMessageDelta(block, data.delta);
+          applyMessageDelta(block, data2.delta);
           return;
         }
-        if (data.type === "content_block_stop") {
-          const block = blocks.get(data.index);
+        if (data2.type === "content_block_stop") {
+          const block = blocks.get(data2.index);
           if (!block || block.stopped) throw streamError("upstream_sse_malformed", "content_block_stop.index");
           block.stopped = true;
           return;
         }
-        if (data.type === "message_delta") {
-          if (!isObject2(data.delta) || typeof data.delta.stop_reason !== "string") {
+        if (data2.type === "message_delta") {
+          if (!isObject2(data2.delta) || typeof data2.delta.stop_reason !== "string") {
             throw streamError("upstream_sse_malformed", "message_delta.delta.stop_reason");
           }
-          stopReason = data.delta.stop_reason;
-          stopSequence = (_a = data.delta.stop_sequence) != null ? _a : null;
-          if (data.usage !== void 0) {
-            if (!isObject2(data.usage)) throw streamError("upstream_sse_malformed", "message_delta.usage");
-            usage = { ...usage || {}, ...data.usage };
+          stopReason = data2.delta.stop_reason;
+          stopSequence = (_a = data2.delta.stop_sequence) != null ? _a : null;
+          if (data2.usage !== void 0) {
+            if (!isObject2(data2.usage)) throw streamError("upstream_sse_malformed", "message_delta.usage");
+            usage = { ...usage || {}, ...data2.usage };
           }
           return;
         }
-        if (data.type === "message_stop") {
+        if (data2.type === "message_stop") {
           if (!start || !stopReason) throw streamError("upstream_sse_malformed", "message_stop");
           messageStop = true;
           return;
@@ -23568,8 +35750,8 @@ ${output}` : output
       buffer = "";
       fail(error);
     }
-    function emit(event, data) {
-      writeEvent(event, { type: event, ...data });
+    function emit(event, data2) {
+      writeEvent(event, { type: event, ...data2 });
     }
     function ensureStarted() {
       if (started) return;
@@ -23867,22 +36049,22 @@ ${output}` : output
       for (const rawLine of frame.split(/\r?\n/)) {
         if (rawLine.startsWith(":")) continue;
         if (rawLine.startsWith("data:")) {
-          const data2 = rawLine.slice(5);
-          dataLines.push(data2.startsWith(" ") ? data2.slice(1) : data2);
+          const data3 = rawLine.slice(5);
+          dataLines.push(data3.startsWith(" ") ? data3.slice(1) : data3);
           continue;
         }
         if (rawLine.trim().length !== 0) throw invalidChatSse("sse");
       }
       if (dataLines.length === 0) return;
-      const data = dataLines.join("\n");
-      if (data === "[DONE]") {
+      const data2 = dataLines.join("\n");
+      if (data2 === "[DONE]") {
         complete();
         return;
       }
       if (done) throw invalidChatSse("sse");
       let chunk;
       try {
-        chunk = JSON.parse(data);
+        chunk = JSON.parse(data2);
       } catch {
         throw invalidChatSse("data");
       }
@@ -24192,11 +36374,11 @@ ${output}` : output
       collectStreamingStrings(item, identity, streams, [...path, key]);
     }
   }
-  function requireCredentialFreeSse(data, secrets = [], {
+  function requireCredentialFreeSse(data2, secrets = [], {
     maxFrameBytes = 1024 * 1024,
     seedValues = []
   } = {}) {
-    const bytes = Buffer.isBuffer(data) ? Buffer.from(data) : Buffer.from(data || "");
+    const bytes = Buffer.isBuffer(data2) ? Buffer.from(data2) : Buffer.from(data2 || "");
     if (bytes.length > MAX_STREAM_AGGREGATE_CHARS) {
       throw invalidSse("provider_stream_too_large", "Provider stream was too large.");
     }
@@ -25461,9 +37643,9 @@ data: ${JSON.stringify(payload)}
     res.writeHead(status, { ...headers, "content-type": "application/json; charset=utf-8" });
     res.end(JSON.stringify(body));
   }
-  function writeSse2(res, event, data) {
+  function writeSse2(res, event, data2) {
     res.write("event: " + event + "\n");
-    res.write("data: " + JSON.stringify(data) + "\n\n");
+    res.write("data: " + JSON.stringify(data2) + "\n\n");
   }
   function parseLocalUrl2(rawUrl) {
     const raw = String(rawUrl || "/");
@@ -25836,7 +38018,7 @@ data: ${JSON.stringify(payload)}
         "content-type": "text/event-stream; charset=utf-8",
         "cache-control": safeHeaders["cache-control"] || "no-cache"
       });
-      for (const [event, data] of events) writeSse2(context.res, event, data);
+      for (const [event, data2] of events) writeSse2(context.res, event, data2);
       context.res.end();
     };
     const readConvertedResponse = ({
@@ -26423,12 +38605,12 @@ data: ${JSON.stringify(payload)}
       });
     };
     const handleModels = (res) => {
-      const data = (getModels() || []).map((entry) => ({
+      const data2 = (getModels() || []).map((entry) => ({
         id: String((entry == null ? void 0 : entry.id) || "").trim(),
         object: "model",
         owned_by: "custom-provider"
       })).filter((entry) => entry.id);
-      sendJson2(res, 200, { object: "list", data });
+      sendJson2(res, 200, { object: "list", data: data2 });
     };
     const handleLocalRequest = (req, res) => {
       const candidate = parseRouteToken(req.rawHeaders || []);
@@ -28702,7 +40884,7 @@ data: ${JSON.stringify(payload)}
     function startSse() {
       if (sseStarted) return;
       sseStarted = true;
-      const parser = createSseParser(({ data }) => handleOpenCodeEvent(data));
+      const parser = createSseParser(({ data: data2 }) => handleOpenCodeEvent(data2));
       request("/event").then((response) => readSseBody(response.body, parser)).catch((e) => {
         if (!sseClosed && activeRun) {
           emit({ type: "error", kind: "mcp", message: e && e.message ? e.message : "OpenCode event stream failed." });
@@ -32083,11 +44265,11 @@ data: ${JSON.stringify(payload)}
         if (line.startsWith("event:")) event = line.slice(6).trim();
         if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart());
       }
-      const data = dataLines.join("\n").trim();
-      if (protocol === "chat" && data === "[DONE]") return true;
+      const data2 = dataLines.join("\n").trim();
+      if (protocol === "chat" && data2 === "[DONE]") return true;
       let parsed = null;
       try {
-        parsed = data ? JSON.parse(data) : null;
+        parsed = data2 ? JSON.parse(data2) : null;
       } catch {
       }
       const type = String((parsed == null ? void 0 : parsed.type) || event || "");
@@ -33726,7 +45908,7 @@ data: ${JSON.stringify(payload)}
   }
 
   // src/components/settings/ProviderManagerSection.jsx
-  var import_react42 = __toESM(require_react(), 1);
+  var import_react43 = __toESM(require_react(), 1);
 
   // src/lib/providerManagerState.js
   function defaultProviderModelAuthKind(protocol) {
@@ -33875,7 +46057,7 @@ data: ${JSON.stringify(payload)}
   }
 
   // src/components/settings/ProviderManagerSection.jsx
-  var import_jsx_runtime40 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime41 = __toESM(require_jsx_runtime(), 1);
   var L4 = {
     zh: {
       title: "Provider \u7BA1\u7406",
@@ -33951,7 +46133,7 @@ data: ${JSON.stringify(payload)}
     }
   };
   function SecretInput({ name, disabled = false }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
       "input",
       {
         name,
@@ -33999,8 +46181,8 @@ data: ${JSON.stringify(payload)}
     disabled = false
   }) {
     const t = L4[lang] || L4.zh;
-    const [draft, setDraft] = import_react42.default.useState(null);
-    const [error, setError] = import_react42.default.useState("");
+    const [draft, setDraft] = import_react43.default.useState(null);
+    const [error, setError] = import_react43.default.useState("");
     const currentModelId = String(activeModelId || "").trim();
     const save = async (event) => {
       var _a;
@@ -34021,98 +46203,98 @@ data: ${JSON.stringify(payload)}
         (_a = formElement == null ? void 0 : formElement.reset) == null ? void 0 : _a.call(formElement);
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("details", { style: { border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", padding: "7px 8px" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("summary", { style: { cursor: "pointer", listStyle: "none", display: "flex", alignItems: "center", gap: 8 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { style: { flex: 1, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.title }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "secondary", size: "sm", icon: "plus", onClick: (event) => {
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("details", { style: { border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", padding: "7px 8px" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("summary", { style: { cursor: "pointer", listStyle: "none", display: "flex", alignItems: "center", gap: 8 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { style: { flex: 1, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: t.title }),
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "secondary", size: "sm", icon: "plus", onClick: (event) => {
           event.preventDefault();
           setDraft(emptyDraft());
         }, children: t.add })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
-        ccSwitch && onImportCcSwitch ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "secondary", size: "sm", icon: "download", disabled, onClick: onImportCcSwitch, children: t.importCc }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
+        ccSwitch && onImportCcSwitch ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "secondary", size: "sm", icon: "download", disabled, onClick: onImportCcSwitch, children: t.importCc }) : null,
         providers.map((provider) => {
           const modelCount = providerModelCount(provider);
           const selected = provider.id === activeProviderId;
           const routeBadges = ["codex", "claude-code"].map((client) => providerClientRouteBadge(provider, { client, modelId: currentModelId, lang })).filter(Boolean);
           const canRedetectCurrentModel = Boolean(currentModelId && Array.isArray(provider.modelCapabilities));
-          return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { "data-provider-id": provider.id, style: { display: "flex", flexDirection: "column", gap: 4, padding: "6px 8px", border: `1px solid ${selected ? "var(--accent-border)" : "var(--border-default)"}`, borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { style: { flex: 1, minWidth: 120, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: provider.name }),
-              selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: "accent", children: t.selected }) : null,
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: "neutral", children: t.perModel }),
-              modelCount ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: "ok", children: t.models(modelCount) }) : null
+          return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { "data-provider-id": provider.id, style: { display: "flex", flexDirection: "column", gap: 4, padding: "6px 8px", border: `1px solid ${selected ? "var(--accent-border)" : "var(--border-default)"}`, borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { style: { flex: 1, minWidth: 120, font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: provider.name }),
+              selected ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: "accent", children: t.selected }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: "neutral", children: t.perModel }),
+              modelCount ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: "ok", children: t.models(modelCount) }) : null
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { display: "flex", gap: 5, alignItems: "center", flexWrap: "wrap" }, children: routeBadges.map((badge) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { title: badge.title, children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: badge.status, children: badge.label }) }, badge.label)) }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: provider.baseUrl }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", disabled: disabled || probing === provider.id, onClick: () => onProbe(provider), children: probing === provider.id ? t.probing : t.probe }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", disabled: disabled || probing === provider.id || !canRedetectCurrentModel, onClick: () => onProbe(provider, { forceDetect: true, modelId: currentModelId }), children: t.redetect }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", disabled, onClick: () => {
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { style: { display: "flex", gap: 5, alignItems: "center", flexWrap: "wrap" }, children: routeBadges.map((badge) => /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { title: badge.title, children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: badge.status, children: badge.label }) }, badge.label)) }),
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: provider.baseUrl }),
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", disabled: disabled || probing === provider.id, onClick: () => onProbe(provider), children: probing === provider.id ? t.probing : t.probe }),
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", disabled: disabled || probing === provider.id || !canRedetectCurrentModel, onClick: () => onProbe(provider, { forceDetect: true, modelId: currentModelId }), children: t.redetect }),
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", disabled, onClick: () => {
                 setDraft(draftFromEntry(provider));
                 setError("");
               }, children: t.edit }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", disabled, onClick: () => onRemove(provider), children: t.del })
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", disabled, onClick: () => onRemove(provider), children: t.del })
             ] }),
-            probeErrors[provider.id] ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: [
+            probeErrors[provider.id] ? /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: [
               t.probeFailed,
               probeErrors[provider.id]
             ] }) : null
           ] }, provider.id);
         }),
-        draft ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("form", { onSubmit: save, style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px", border: "1px solid var(--border-strong)", borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Field, { label: t.name, children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Input, { value: draft.name, onChange: (value) => setDraft({ ...draft, name: value }) }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Field, { label: t.baseUrl, children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Input, { mono: true, value: draft.baseUrl, onChange: (value) => setDraft({ ...draft, baseUrl: value }), placeholder: "https://api.example.com/v1" }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { style: { display: "flex", gap: 6, alignItems: "center", font: "400 11px/1.35 var(--font-ui)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("input", { type: "checkbox", checked: draft.allowInsecureHttp, onChange: (event) => setDraft({ ...draft, allowInsecureHttp: event.target.checked }) }),
+        draft ? /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("form", { onSubmit: save, style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px", border: "1px solid var(--border-strong)", borderRadius: "var(--radius-sm)", background: "var(--bg-panel)" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Field, { label: t.name, children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Input, { value: draft.name, onChange: (value) => setDraft({ ...draft, name: value }) }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Field, { label: t.baseUrl, children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Input, { mono: true, value: draft.baseUrl, onChange: (value) => setDraft({ ...draft, baseUrl: value }), placeholder: "https://api.example.com/v1" }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("label", { style: { display: "flex", gap: 6, alignItems: "center", font: "400 11px/1.35 var(--font-ui)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("input", { type: "checkbox", checked: draft.allowInsecureHttp, onChange: (event) => setDraft({ ...draft, allowInsecureHttp: event.target.checked }) }),
             t.insecure
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Field, { label: t.apiKey, caption: draft.modelAuthKind === "auto" ? t.autoAuthCap : t.overrideAuthCap, children: draft.modelAuthKind !== "none" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.noApiKey }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("details", { "data-provider-advanced-auth": true, style: { border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)", padding: "5px 6px" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("summary", { style: { cursor: "pointer", font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: t.advancedAuth }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(Field, { label: t.authType, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Select, { value: draft.modelAuthKind, onChange: (value) => setDraft({ ...draft, modelAuthKind: value, modelAuthAutomatic: false }), options: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Field, { label: t.apiKey, caption: draft.modelAuthKind === "auto" ? t.autoAuthCap : t.overrideAuthCap, children: draft.modelAuthKind !== "none" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) : /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.noApiKey }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("details", { "data-provider-advanced-auth": true, style: { border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)", padding: "5px 6px" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("summary", { style: { cursor: "pointer", font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: t.advancedAuth }),
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(Field, { label: t.authType, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Select, { value: draft.modelAuthKind, onChange: (value) => setDraft({ ...draft, modelAuthKind: value, modelAuthAutomatic: false }), options: [
                   { value: "auto", label: t.auto },
                   { value: "bearer", label: "Authorization: Bearer" },
                   { value: "x-api-key", label: "x-api-key" },
                   { value: "custom", label: "Custom header" },
                   { value: "none", label: "None" }
                 ] }),
-                draft.modelAuthKind === "custom" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Input, { mono: true, value: draft.modelAuthHeaderName, onChange: (value) => setDraft({ ...draft, modelAuthHeaderName: value }), placeholder: "x-provider-token" }) : null
+                draft.modelAuthKind === "custom" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Input, { mono: true, value: draft.modelAuthHeaderName, onChange: (value) => setDraft({ ...draft, modelAuthHeaderName: value }), placeholder: "x-provider-token" }) : null
               ] }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Field, { label: t.probePreference, caption: t.probePreferenceCap, children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Select, { value: draft.probePreference, onChange: (value) => setDraft({ ...draft, probePreference: value }), options: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Field, { label: t.probePreference, caption: t.probePreferenceCap, children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Select, { value: draft.probePreference, onChange: (value) => setDraft({ ...draft, probePreference: value }), options: [
                 { value: "", label: t.auto },
                 { value: "responses", label: "Responses" },
                 { value: "chat", label: "Chat Completions" },
                 { value: "messages", label: "Messages" }
               ] }) }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Field, { label: t.extraHeaders, children: /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Field, { label: t.extraHeaders, children: /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
                 draft.headers.map((header, index) => {
                   const sensitiveName = isSensitiveProviderHeaderName(header.name);
                   const valueKind = sensitiveName ? "secret" : header.valueKind;
-                  return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4, padding: 6, border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)" }, children: [
-                    /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Input, { mono: true, value: header.name, onChange: (value) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, name: value, ...isSensitiveProviderHeaderName(value) ? { valueKind: "secret", value: "" } : {} } : item) }), placeholder: t.headerName }),
-                    /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Select, { value: valueKind, onChange: (nextValueKind) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, valueKind: nextValueKind, value: nextValueKind === "literal" ? item.value || "" : "" } : item) }), options: sensitiveName ? [{ value: "secret", label: t.secretValue }] : [{ value: "literal", label: t.literal }, { value: "secret", label: t.secretValue }] }),
-                    valueKind === "secret" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(SecretInput, { name: `headerSecret:${header.id}`, disabled }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Input, { mono: true, value: header.value || "", onChange: (value) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, value } : item) }) }),
-                    /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { display: "flex", gap: 10 }, children: ["probe", "model"].map((scope) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { style: { display: "flex", alignItems: "center", gap: 4, font: "400 10px/1.35 var(--font-ui)" }, children: [
-                      /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("input", { type: "checkbox", checked: header.scopes.includes(scope), onChange: (event) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, scopes: event.target.checked ? [.../* @__PURE__ */ new Set([...item.scopes, scope])] : item.scopes.filter((value) => value !== scope) } : item) }) }),
+                  return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4, padding: 6, border: "1px solid var(--border-default)", borderRadius: "var(--radius-sm)" }, children: [
+                    /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Input, { mono: true, value: header.name, onChange: (value) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, name: value, ...isSensitiveProviderHeaderName(value) ? { valueKind: "secret", value: "" } : {} } : item) }), placeholder: t.headerName }),
+                    /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Select, { value: valueKind, onChange: (nextValueKind) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, valueKind: nextValueKind, value: nextValueKind === "literal" ? item.value || "" : "" } : item) }), options: sensitiveName ? [{ value: "secret", label: t.secretValue }] : [{ value: "literal", label: t.literal }, { value: "secret", label: t.secretValue }] }),
+                    valueKind === "secret" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(SecretInput, { name: `headerSecret:${header.id}`, disabled }) : /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Input, { mono: true, value: header.value || "", onChange: (value) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, value } : item) }) }),
+                    /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { style: { display: "flex", gap: 10 }, children: ["probe", "model"].map((scope) => /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("label", { style: { display: "flex", alignItems: "center", gap: 4, font: "400 10px/1.35 var(--font-ui)" }, children: [
+                      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("input", { type: "checkbox", checked: header.scopes.includes(scope), onChange: (event) => setDraft({ ...draft, headers: draft.headers.map((item, itemIndex) => itemIndex === index ? { ...item, scopes: event.target.checked ? [.../* @__PURE__ */ new Set([...item.scopes, scope])] : item.scopes.filter((value) => value !== scope) } : item) }) }),
                       scope === "probe" ? t.scopeProbe : t.scopeModel
                     ] }, scope)) }),
-                    /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => setDraft({ ...draft, headers: draft.headers.filter((_, itemIndex) => itemIndex !== index) }), children: t.removeHeader })
+                    /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => setDraft({ ...draft, headers: draft.headers.filter((_, itemIndex) => itemIndex !== index) }), children: t.removeHeader })
                   ] }, header.id);
                 }),
-                /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "secondary", size: "sm", icon: "plus", onClick: () => setDraft({ ...draft, headers: [...draft.headers, { id: nextHeaderId(draft.headers), name: "", scopes: ["model"], valueKind: "secret", value: "" }] }), children: t.addHeader })
+                /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "secondary", size: "sm", icon: "plus", onClick: () => setDraft({ ...draft, headers: [...draft.headers, { id: nextHeaderId(draft.headers), name: "", scopes: ["model"], valueKind: "secret", value: "" }] }), children: t.addHeader })
               ] }) })
             ] })
           ] }),
-          error ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: error }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", gap: 6, justifyContent: "flex-end" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
+          error ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--warn)" }, children: error }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { display: "flex", gap: 6, justifyContent: "flex-end" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
               setDraft(null);
               setError("");
             }, children: t.cancel }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "primary", size: "sm", disabled, onClick: (event) => {
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "primary", size: "sm", disabled, onClick: (event) => {
               var _a;
               return (_a = event.currentTarget.closest("form")) == null ? void 0 : _a.requestSubmit();
             }, children: t.save })
@@ -34757,10 +46939,10 @@ data: ${JSON.stringify(payload)}
   var ZCODE_PROBED_MODELS_CACHE_MS = 60 * 60 * 1e3;
 
   // src/cep/useActivity.js
-  var import_react43 = __toESM(require_react(), 1);
+  var import_react44 = __toESM(require_react(), 1);
   function useActivity(getHost) {
-    const [events, setEvents] = import_react43.default.useState([]);
-    import_react43.default.useEffect(() => {
+    const [events, setEvents] = import_react44.default.useState([]);
+    import_react44.default.useEffect(() => {
       let unsub = null;
       let retry = null;
       let disposed = false;
@@ -34782,7 +46964,7 @@ data: ${JSON.stringify(payload)}
         if (retry) clearTimeout(retry);
       };
     }, [getHost]);
-    const clear = import_react43.default.useCallback(() => setEvents([]), []);
+    const clear = import_react44.default.useCallback(() => setEvents([]), []);
     return { events, clear };
   }
 
@@ -34809,7 +46991,7 @@ data: ${JSON.stringify(payload)}
   }
 
   // src/app/wizardWiring.js
-  var import_react44 = __toESM(require_react(), 1);
+  var import_react45 = __toESM(require_react(), 1);
 
   // src/cep/wizardActions.js
   var OUTPUT_TAIL = 8192;
@@ -34913,36 +47095,36 @@ data: ${JSON.stringify(payload)}
     return text.includes("winget") && (text.includes("not recognized") || text.includes("not found") || text.includes("enoent") || text.includes("cannot find"));
   }
   function useWizardWiring({ extRoot, lang, claudeStatus, recheckLogin, platform, runtimeManager, onRuntimeReady } = {}) {
-    const [stepStates, dispatch] = import_react44.default.useReducer(stepReducer, null, initialStepStates);
-    const [useUvFallback, setUseUvFallback] = import_react44.default.useState(false);
-    const repoRoot = import_react44.default.useMemo(() => {
+    const [stepStates, dispatch] = import_react45.default.useReducer(stepReducer, null, initialStepStates);
+    const [useUvFallback, setUseUvFallback] = import_react45.default.useState(false);
+    const repoRoot = import_react45.default.useMemo(() => {
       try {
         return detectRepoRoot({ extRoot });
       } catch (e) {
         return "";
       }
     }, [extRoot]);
-    const cmds = import_react44.default.useMemo(() => buildInstallCommands({
+    const cmds = import_react45.default.useMemo(() => buildInstallCommands({
       panelVersion: PANEL_VERSION,
       repoRoot,
       platform
     }), [platform, repoRoot]);
-    const localSteps = import_react44.default.useMemo(
+    const localSteps = import_react45.default.useMemo(
       () => (platform == null ? void 0 : platform.id) === "macos-arm64" && runtimeManager ? ["aeMcp"] : LOCAL_STEPS,
       [platform, runtimeManager]
     );
-    const activeCmds = import_react44.default.useMemo(() => ({
+    const activeCmds = import_react45.default.useMemo(() => ({
       ...cmds,
       uv: useUvFallback ? cmds.uvFallback : cmds.uv
     }), [cmds, useUvFallback]);
-    const commandPreviews = import_react44.default.useMemo(() => ({
+    const commandPreviews = import_react45.default.useMemo(() => ({
       uv: commandPreview(activeCmds.uv),
       aeMcp: (platform == null ? void 0 : platform.id) === "macos-arm64" && runtimeManager ? lang === "zh" ? "\u9A8C\u8BC1\u5E76\u6FC0\u6D3B\u63D2\u4EF6\u5185\u7F6E\u79BB\u7EBF\u8FD0\u884C\u65F6" : "Verify and activate the bundled offline runtime" : commandPreview(activeCmds.aeMcp),
       node: (platform == null ? void 0 : platform.id) === "macos-arm64" && runtimeManager ? lang === "zh" ? "\u4FEE\u590D\u63D2\u4EF6\u5185\u7F6E\u79BB\u7EBF Node \u8FD0\u884C\u65F6" : "Repair the bundled offline Node runtime" : commandPreview(activeCmds.node),
       claude: commandPreview(activeCmds.claude),
       login: "claude"
     }), [activeCmds, lang, platform, runtimeManager]);
-    const detect = import_react44.default.useCallback(async (id) => {
+    const detect = import_react45.default.useCallback(async (id) => {
       dispatch({ type: "detect-start", id });
       if (id === "login") {
         if (recheckLogin) {
@@ -34958,7 +47140,7 @@ data: ${JSON.stringify(payload)}
       dispatch({ type: "detect-result", id, ok: result.ok, version: result.version || "" });
       return result;
     }, [claudeStatus, extRoot, onRuntimeReady, platform, recheckLogin, runtimeManager]);
-    const install = import_react44.default.useCallback(async (id) => {
+    const install = import_react45.default.useCallback(async (id) => {
       if (["aeMcp", "node"].includes(id) && (platform == null ? void 0 : platform.id) === "macos-arm64" && runtimeManager) {
         dispatch({ type: "run-start", id });
         try {
@@ -35001,19 +47183,19 @@ data: ${JSON.stringify(payload)}
       await detect(id);
       return result;
     }, [activeCmds, detect, lang, onRuntimeReady, platform, runtimeManager, useUvFallback]);
-    const openLogin = import_react44.default.useCallback(() => {
+    const openLogin = import_react45.default.useCallback(() => {
       openLoginTerminal({ tool: "claude" });
       dispatch({ type: "detect-result", id: "login", ok: false });
     }, []);
-    const bootDetectRef = import_react44.default.useRef(false);
-    import_react44.default.useEffect(() => {
+    const bootDetectRef = import_react45.default.useRef(false);
+    import_react45.default.useEffect(() => {
       if (bootDetectRef.current) return;
       bootDetectRef.current = true;
       [...localSteps, ...SUBSCRIPTION_STEPS].forEach((id) => {
         detect(id);
       });
     }, [detect, localSteps]);
-    import_react44.default.useEffect(() => {
+    import_react45.default.useEffect(() => {
       if (!claudeStatus) return;
       if (claudeStatus.state === "checking") {
         dispatch({ type: "detect-start", id: "login" });
@@ -36091,7 +48273,7 @@ data: ${JSON.stringify(payload)}
   }
 
   // src/app/App.jsx
-  var import_jsx_runtime41 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime42 = __toESM(require_jsx_runtime(), 1);
   var T = {
     zh: {
       connected: "\u670D\u52A1\u8FD0\u884C\u4E2D",
@@ -36294,142 +48476,142 @@ data: ${JSON.stringify(payload)}
   function Shell({ cs: cs2 }) {
     const { lang, setLang } = useLang();
     const t = T[lang];
-    const [tab, setTab] = import_react45.default.useState("chat");
-    const [status, setStatus] = import_react45.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
-    const [paused, setPaused] = import_react45.default.useState(false);
-    const [logs, setLogs] = import_react45.default.useState([]);
-    const ctrl = import_react45.default.useRef(null);
-    const getHost = import_react45.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
-    const [wizardDone, setWizardDone] = import_react45.default.useState(() => isWizardDone(window.localStorage));
-    const [wizStep, setWizStep] = import_react45.default.useState(1);
-    const [wizClient, setWizClient] = import_react45.default.useState("claude-desktop");
-    const [drawerOpen, setDrawerOpen] = import_react45.default.useState(false);
-    const [connInfo, setConnInfo] = import_react45.default.useState(null);
-    const [diagnostics, setDiagnostics] = import_react45.default.useState(null);
+    const [tab, setTab] = import_react46.default.useState("chat");
+    const [status, setStatus] = import_react46.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
+    const [paused, setPaused] = import_react46.default.useState(false);
+    const [logs, setLogs] = import_react46.default.useState([]);
+    const ctrl = import_react46.default.useRef(null);
+    const getHost = import_react46.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
+    const [wizardDone, setWizardDone] = import_react46.default.useState(() => isWizardDone(window.localStorage));
+    const [wizStep, setWizStep] = import_react46.default.useState(1);
+    const [wizClient, setWizClient] = import_react46.default.useState("claude-desktop");
+    const [drawerOpen, setDrawerOpen] = import_react46.default.useState(false);
+    const [connInfo, setConnInfo] = import_react46.default.useState(null);
+    const [diagnostics, setDiagnostics] = import_react46.default.useState(null);
     const { events, clear } = useActivity(getHost);
-    const [clients, setClients] = import_react45.default.useState([]);
-    const [confirmRegen, setConfirmRegen] = import_react45.default.useState(false);
-    const [tokenEpoch, setTokenEpoch] = import_react45.default.useState(0);
-    const platform = import_react45.default.useMemo(() => createPlatformAdapter(), []);
-    const legacyKeyStore = import_react45.default.useMemo(() => {
+    const [clients, setClients] = import_react46.default.useState([]);
+    const [confirmRegen, setConfirmRegen] = import_react46.default.useState(false);
+    const [tokenEpoch, setTokenEpoch] = import_react46.default.useState(0);
+    const platform = import_react46.default.useMemo(() => createPlatformAdapter(), []);
+    const legacyKeyStore = import_react46.default.useMemo(() => {
       try {
         return createLegacyApiKeyStore();
       } catch (e) {
         return null;
       }
     }, []);
-    const [customModel, setCustomModel] = import_react45.default.useState(() => readPref("ae_mcp_custom_model", ""));
-    const [model, setModel] = import_react45.default.useState(() => readPref("ae_mcp_model", DEFAULT_MODEL));
-    const [logLevel, setLogLevel] = import_react45.default.useState(() => readPref("ae_mcp_log_level", "info"));
-    const logLevelRef = import_react45.default.useRef(logLevel);
+    const [customModel, setCustomModel] = import_react46.default.useState(() => readPref("ae_mcp_custom_model", ""));
+    const [model, setModel] = import_react46.default.useState(() => readPref("ae_mcp_model", DEFAULT_MODEL));
+    const [logLevel, setLogLevel] = import_react46.default.useState(() => readPref("ae_mcp_log_level", "info"));
+    const logLevelRef = import_react46.default.useRef(logLevel);
     logLevelRef.current = logLevel;
-    const [sessionModel, setSessionModel] = import_react45.default.useState(null);
-    const [sessionEffort, setSessionEffort] = import_react45.default.useState(null);
-    const [sessionFast, setSessionFast] = import_react45.default.useState(null);
-    const [permissionMode, setPermissionMode] = import_react45.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
-    const permissionModeRef = import_react45.default.useRef(permissionMode);
+    const [sessionModel, setSessionModel] = import_react46.default.useState(null);
+    const [sessionEffort, setSessionEffort] = import_react46.default.useState(null);
+    const [sessionFast, setSessionFast] = import_react46.default.useState(null);
+    const [permissionMode, setPermissionMode] = import_react46.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
+    const permissionModeRef = import_react46.default.useRef(permissionMode);
     permissionModeRef.current = permissionMode;
-    const approvalTierFile = import_react45.default.useMemo(() => createApprovalTierFile({
+    const approvalTierFile = import_react46.default.useMemo(() => createApprovalTierFile({
       fs: platform.fs,
       paths: platform.paths,
       platformId: platform.id,
       pid: window.cep_node && window.cep_node.process && window.cep_node.process.pid || 0
     }), [platform]);
-    const elicitationCoordinator = import_react45.default.useMemo(() => createElicitationCoordinator({
+    const elicitationCoordinator = import_react46.default.useMemo(() => createElicitationCoordinator({
       resolveApproval: (_request, { plan }) => decideToolPlan({
         tier: permissionModeRef.current,
         plan
       }),
       presentGenericForm: () => ({ action: "decline", content: {} })
     }), []);
-    const [toolApproval, setToolApproval] = import_react45.default.useState(() => elicitationCoordinator.snapshot());
-    import_react45.default.useEffect(() => elicitationCoordinator.subscribe(setToolApproval), [elicitationCoordinator]);
-    import_react45.default.useEffect(() => {
+    const [toolApproval, setToolApproval] = import_react46.default.useState(() => elicitationCoordinator.snapshot());
+    import_react46.default.useEffect(() => elicitationCoordinator.subscribe(setToolApproval), [elicitationCoordinator]);
+    import_react46.default.useEffect(() => {
       approvalTierFile.write(permissionMode);
     }, [approvalTierFile, permissionMode]);
-    import_react45.default.useEffect(() => () => {
+    import_react46.default.useEffect(() => () => {
       elicitationCoordinator.dispose();
       try {
         approvalTierFile.dispose();
       } catch (error) {
       }
     }, [approvalTierFile, elicitationCoordinator]);
-    const backendMigration = import_react45.default.useMemo(() => migrateBackendPref(window.localStorage), []);
-    const [backendPref, setBackendPref] = import_react45.default.useState(() => backendMigration.pref);
-    const [channelLock, setChannelLock] = import_react45.default.useState(() => codexProviderChannelLock(
+    const backendMigration = import_react46.default.useMemo(() => migrateBackendPref(window.localStorage), []);
+    const [backendPref, setBackendPref] = import_react46.default.useState(() => backendMigration.pref);
+    const [channelLock, setChannelLock] = import_react46.default.useState(() => codexProviderChannelLock(
       backendMigration.lockedChannel,
       readPref("ae_mcp_codex_provider", "")
     ));
-    const providerStore = import_react45.default.useMemo(() => {
+    const providerStore = import_react46.default.useMemo(() => {
       try {
         return createProviderStore();
       } catch (e) {
         return null;
       }
     }, []);
-    const providerSecretService = import_react45.default.useMemo(() => createProviderSecretService({
+    const providerSecretService = import_react46.default.useMemo(() => createProviderSecretService({
       getHost,
       randomBytes: (size) => cepRequire4("crypto").randomBytes(size)
     }), [getHost]);
-    const zcodeCredentialManager = import_react45.default.useMemo(() => createZcodeCredentialManager({
+    const zcodeCredentialManager = import_react46.default.useMemo(() => createZcodeCredentialManager({
       storage: window.localStorage,
       secretService: providerSecretService,
       legacyKeyStore
     }), [legacyKeyStore, providerSecretService]);
-    const zcodeStoredKeyRef = import_react45.default.useRef("");
-    const [zcodeCredentialEpoch, setZcodeCredentialEpoch] = import_react45.default.useState(0);
-    const [providerInit, setProviderInit] = import_react45.default.useState({ state: "checking", error: "" });
-    const [providers, setProviders] = import_react45.default.useState([]);
-    const [claudeProviderId, setClaudeProviderId] = import_react45.default.useState(() => readPref("ae_mcp_claude_provider", ""));
-    const [codexProviderId, setCodexProviderId] = import_react45.default.useState(() => readPref("ae_mcp_codex_provider", ""));
-    const syncCodexProviderChannelLock = import_react45.default.useCallback((providerId) => {
+    const zcodeStoredKeyRef = import_react46.default.useRef("");
+    const [zcodeCredentialEpoch, setZcodeCredentialEpoch] = import_react46.default.useState(0);
+    const [providerInit, setProviderInit] = import_react46.default.useState({ state: "checking", error: "" });
+    const [providers, setProviders] = import_react46.default.useState([]);
+    const [claudeProviderId, setClaudeProviderId] = import_react46.default.useState(() => readPref("ae_mcp_claude_provider", ""));
+    const [codexProviderId, setCodexProviderId] = import_react46.default.useState(() => readPref("ae_mcp_codex_provider", ""));
+    const syncCodexProviderChannelLock = import_react46.default.useCallback((providerId) => {
       setChannelLock((current) => {
         const next = codexProviderChannelLock(current, providerId);
         writePref("ae_mcp_channel_lock", next);
         return next;
       });
     }, []);
-    const [expertGuidance, setExpertGuidance] = import_react45.default.useState(() => loadExpertGuidance(window.localStorage));
-    const [probe, setProbe] = import_react45.default.useState(null);
-    const [codexProbe, setCodexProbe] = import_react45.default.useState(null);
-    const [codexModels, setCodexModels] = import_react45.default.useState(null);
-    const [zcodeProbe, setZcodeProbe] = import_react45.default.useState(null);
-    const [zcodeSessionModels, setZcodeSessionModels] = import_react45.default.useState(null);
-    const [zcodeProbedModels, setZcodeProbedModels] = import_react45.default.useState(null);
-    import_react45.default.useEffect(() => {
+    const [expertGuidance, setExpertGuidance] = import_react46.default.useState(() => loadExpertGuidance(window.localStorage));
+    const [probe, setProbe] = import_react46.default.useState(null);
+    const [codexProbe, setCodexProbe] = import_react46.default.useState(null);
+    const [codexModels, setCodexModels] = import_react46.default.useState(null);
+    const [zcodeProbe, setZcodeProbe] = import_react46.default.useState(null);
+    const [zcodeSessionModels, setZcodeSessionModels] = import_react46.default.useState(null);
+    const [zcodeProbedModels, setZcodeProbedModels] = import_react46.default.useState(null);
+    import_react46.default.useEffect(() => {
       try {
         window.localStorage.removeItem(CODEX_MODELS_CACHE_KEY);
         window.localStorage.removeItem(ZCODE_PROBED_MODELS_CACHE_KEY);
       } catch {
       }
     }, []);
-    const [chatEntries, setChatEntries] = import_react45.default.useState([]);
-    const [chatStreaming, setChatStreaming] = import_react45.default.useState(false);
-    const [thinkingActive, setThinkingActive] = import_react45.default.useState(false);
+    const [chatEntries, setChatEntries] = import_react46.default.useState([]);
+    const [chatStreaming, setChatStreaming] = import_react46.default.useState(false);
+    const [thinkingActive, setThinkingActive] = import_react46.default.useState(false);
     const customModelForBackend = backendPref === "codex" ? customModel : "";
-    const baseDescriptor = import_react45.default.useMemo(() => descriptorWithCustomModel(baseDescriptorFor(backendPref, window.cep_node && window.cep_node.process && window.cep_node.process.env || {}), customModelForBackend), [backendPref, customModelForBackend]);
-    const [descriptor, setDescriptor] = import_react45.default.useState(() => baseDescriptor);
+    const baseDescriptor = import_react46.default.useMemo(() => descriptorWithCustomModel(baseDescriptorFor(backendPref, window.cep_node && window.cep_node.process && window.cep_node.process.env || {}), customModelForBackend), [backendPref, customModelForBackend]);
+    const [descriptor, setDescriptor] = import_react46.default.useState(() => baseDescriptor);
     const requestedModel = sessionModel || model;
     const effectiveModel = descriptor.models.some((m) => m.id === requestedModel) ? requestedModel : descriptor.defaultModelId || descriptor.models[0] && descriptor.models[0].id || requestedModel;
     const modelMeta = descriptor.models.find((m) => m.id === effectiveModel) || descriptor.models[0] || {};
     const effectiveEffort = sessionEffort || (modelMeta.effortLevels && modelMeta.effortLevels.length ? descriptor.defaultEffort : null);
     const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
-    const claudeApiProvider = import_react45.default.useMemo(() => {
+    const claudeApiProvider = import_react46.default.useMemo(() => {
       return providers.find((provider) => provider.id === claudeProviderId) || null;
     }, [providers, claudeProviderId]);
-    const codexCustomProvider = import_react45.default.useMemo(() => {
+    const codexCustomProvider = import_react46.default.useMemo(() => {
       return providers.find((provider) => provider.id === codexProviderId) || null;
     }, [providers, codexProviderId]);
-    const [providerProbing, setProviderProbing] = import_react45.default.useState("");
-    const [providerProbeErrors, setProviderProbeErrors] = import_react45.default.useState({});
-    const ccSwitchFound = import_react45.default.useMemo(() => {
+    const [providerProbing, setProviderProbing] = import_react46.default.useState("");
+    const [providerProbeErrors, setProviderProbeErrors] = import_react46.default.useState({});
+    const ccSwitchFound = import_react46.default.useMemo(() => {
       try {
         return detectCcSwitch({ platform, fsImpl: platform.fs });
       } catch (e) {
         return null;
       }
     }, [platform]);
-    const providerManager = /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+    const providerManager = /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
       ProviderManagerSection,
       {
         lang,
@@ -36543,15 +48725,15 @@ ${baseUrl}`),
         }
       }
     );
-    const zcodeConfigSummary = import_react45.default.useMemo(() => {
+    const zcodeConfigSummary = import_react46.default.useMemo(() => {
       try {
         return summarizeZcodeConfig({ env: window.cep_node && window.cep_node.process && window.cep_node.process.env || {}, storedKey: zcodeStoredKeyRef.current });
       } catch (e) {
         return null;
       }
     }, [zcodeCredentialEpoch, zcodeProbe]);
-    const codexCliConfigStableRef = import_react45.default.useRef(null);
-    const codexCliConfig = import_react45.default.useMemo(() => {
+    const codexCliConfigStableRef = import_react46.default.useRef(null);
+    const codexCliConfig = import_react46.default.useMemo(() => {
       let next;
       try {
         next = readCodexCliConfig({ env: window.cep_node && window.cep_node.process && window.cep_node.process.env || {} });
@@ -36561,54 +48743,54 @@ ${baseUrl}`),
       codexCliConfigStableRef.current = reconcileStableJsonValue(codexCliConfigStableRef.current, next);
       return codexCliConfigStableRef.current.value;
     }, [codexProbe]);
-    const codexCliCredentialReady = import_react45.default.useMemo(() => {
+    const codexCliCredentialReady = import_react46.default.useMemo(() => {
       const env = window.cep_node && window.cep_node.process && window.cep_node.process.env || {};
       return codexCliCredentialAvailable({ provider: codexCliConfig && codexCliConfig.provider, env, storedValueRef: null });
     }, [codexCliConfig]);
     const codexProviderCredentialResolverReady = providerInit.state === "ready";
-    const channels = import_react45.default.useMemo(() => ({
+    const channels = import_react46.default.useMemo(() => ({
       claude: claudeChannels({ probe, apiProvider: claudeApiProvider, apiProviderSelected: Boolean(claudeProviderId), providerAvailable: providerInit.state === "ready" && Boolean(claudeApiProvider), providerCredentialResolverReady: codexProviderCredentialResolverReady, providerChecking: providerInit.state === "checking" }),
       codex: codexChannels({ codexProbe, customProvider: codexCustomProvider, customProviderSelected: Boolean(codexProviderId), customProviderAvailable: providerInit.state === "ready" && Boolean(codexCustomProvider), customProviderCredentialResolverReady: codexProviderCredentialResolverReady, providerChecking: providerInit.state === "checking", cliConfig: codexCliConfig, cliCredentialAvailable: codexCliCredentialReady }),
       zcode: zcodeChannels({ zcodeProbe, configSummary: zcodeConfigSummary })
     }), [probe, claudeApiProvider, claudeProviderId, codexProbe, codexCustomProvider, codexProviderCredentialResolverReady, codexProviderId, zcodeProbe, zcodeConfigSummary, codexCliConfig, codexCliCredentialReady, providerInit.state]);
     const nodeOk = !(probe && probe.nodeOk === false);
     const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk });
-    const claudeSettingsHint = import_react45.default.useMemo(() => {
+    const claudeSettingsHint = import_react46.default.useMemo(() => {
       try {
         return inspectClaudeSettingsEnv({ platform, fsImpl: platform.fs });
       } catch (e) {
         return null;
       }
     }, [platform]);
-    const providerProfile = import_react45.default.useMemo(() => codexRuntimeProviderProfile({
+    const providerProfile = import_react46.default.useMemo(() => codexRuntimeProviderProfile({
       effectiveChannel: effective.channel,
       customProvider: codexCustomProvider,
       customProviderCredentialResolverReady: codexProviderCredentialResolverReady,
       modelId: effectiveModel
     }), [effective.channel, codexCustomProvider, codexProviderCredentialResolverReady, effectiveModel]);
-    const runtimeRef = import_react45.default.useRef({ providerProfile, providerCandidate: null, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: "subscription", claudeApiProvider: null });
-    const previousCodexProviderProfileRef = import_react45.default.useRef(providerProfile);
-    const extRoot = import_react45.default.useMemo(() => readCepSystemPath({ cs: cs2, platform }), [cs2, platform]);
-    const developmentRuntimeFallback = import_react45.default.useMemo(() => {
+    const runtimeRef = import_react46.default.useRef({ providerProfile, providerCandidate: null, model: effectiveModel, permissionMode, effort: effectiveEffort, thinking: null, fast: effectiveFast, claudeChannel: "subscription", claudeApiProvider: null });
+    const previousCodexProviderProfileRef = import_react46.default.useRef(providerProfile);
+    const extRoot = import_react46.default.useMemo(() => readCepSystemPath({ cs: cs2, platform }), [cs2, platform]);
+    const developmentRuntimeFallback = import_react46.default.useMemo(() => {
       if (platform.id !== "macos-arm64") return false;
       const debugMarker = platform.paths.join([extRoot, ".debug"]);
       const bundleManifest = platform.paths.join([extRoot, "bundle-manifest.json"]);
       return platform.fs.existsSync(debugMarker) && !platform.fs.existsSync(bundleManifest);
     }, [extRoot, platform]);
-    const developmentRuntimeOverride = import_react45.default.useMemo(
+    const developmentRuntimeOverride = import_react46.default.useMemo(
       () => hasDevelopmentRuntimeOverride(platform.env),
       [platform]
     );
-    const runtimeManager = import_react45.default.useMemo(() => platform.id === "macos-arm64" && (!developmentRuntimeFallback || developmentRuntimeOverride) ? createRuntimeManager({ platform, extensionRoot: extRoot }) : null, [developmentRuntimeFallback, developmentRuntimeOverride, extRoot, platform]);
-    const [runtimeActivation, setRuntimeActivation] = import_react45.default.useState(() => ({
+    const runtimeManager = import_react46.default.useMemo(() => platform.id === "macos-arm64" && (!developmentRuntimeFallback || developmentRuntimeOverride) ? createRuntimeManager({ platform, extensionRoot: extRoot }) : null, [developmentRuntimeFallback, developmentRuntimeOverride, extRoot, platform]);
+    const [runtimeActivation, setRuntimeActivation] = import_react46.default.useState(() => ({
       state: runtimeManager ? "starting" : "ready",
       result: null,
       error: null
     }));
-    const markRuntimeReady = import_react45.default.useCallback((result) => {
+    const markRuntimeReady = import_react46.default.useCallback((result) => {
       setRuntimeActivation({ state: "ready", result: result || null, error: null });
     }, []);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (!runtimeManager) {
         setRuntimeActivation({ state: "ready", result: null, error: null });
         return void 0;
@@ -36635,12 +48817,12 @@ ${baseUrl}`),
     }, [markRuntimeReady, runtimeManager]);
     const runtimeReady = runtimeActivation.state === "ready";
     const mcpCommand = runtimeManager ? platform.paths.launcher : "ae-mcp";
-    const resolvePanelNode = import_react45.default.useCallback(
+    const resolvePanelNode = import_react46.default.useCallback(
       ({ platform: requestedPlatform } = {}) => runtimeManager ? runtimeManager.resolveNode() : resolveSystemNode({ platform: requestedPlatform || platform }),
       [platform, runtimeManager]
     );
-    const sidecarPath = import_react45.default.useMemo(() => resolveSidecarPath({ extRoot, platform }), [extRoot, platform]);
-    const getMcpSpec = import_react45.default.useCallback(async () => {
+    const sidecarPath = import_react46.default.useMemo(() => resolveSidecarPath({ extRoot, platform }), [extRoot, platform]);
+    const getMcpSpec = import_react46.default.useCallback(async () => {
       try {
         const spec = await resolveMcpCommand({ extRoot, platform, runtimeManager });
         if (runtimeManager && spec.runtime) markRuntimeReady(spec.runtime);
@@ -36650,7 +48832,7 @@ ${baseUrl}`),
         throw error;
       }
     }, [approvalTierFile, extRoot, markRuntimeReady, platform, runtimeManager]);
-    const mcp = import_react45.default.useMemo(() => createMcpClient({
+    const mcp = import_react46.default.useMemo(() => createMcpClient({
       platform,
       extRoot,
       resolveCommand: getMcpSpec,
@@ -36659,10 +48841,10 @@ ${baseUrl}`),
       getExpertGuidance: () => loadExpertGuidance(window.localStorage),
       randomBytes: (size) => cepRequire4("crypto").randomBytes(size)
     }), [approvalTierFile, elicitationCoordinator, extRoot, getMcpSpec, platform]);
-    const toolsApi = import_react45.default.useMemo(() => createToolsApi(mcp), [mcp]);
-    import_react45.default.useEffect(() => () => mcp.stop(), [mcp]);
-    const providerAcceptanceEventsRef = import_react45.default.useRef([]);
-    const handleChatEvent = import_react45.default.useCallback((evt) => {
+    const toolsApi = import_react46.default.useMemo(() => createToolsApi(mcp), [mcp]);
+    import_react46.default.useEffect(() => () => mcp.stop(), [mcp]);
+    const providerAcceptanceEventsRef = import_react46.default.useRef([]);
+    const handleChatEvent = import_react46.default.useCallback((evt) => {
       if (evt && typeof evt.type === "string") {
         providerAcceptanceEventsRef.current.push({
           type: evt.type,
@@ -36680,7 +48862,7 @@ ${baseUrl}`),
       if (evt.type === "zcode-session-created") setZcodeSessionModels(evt.result || null);
       setChatEntries((entries) => reduceEvent(entries, evt));
     }, []);
-    const recoverRuntimeProvider = import_react45.default.useCallback(async (provider, _failureFacts, requestedModelId) => {
+    const recoverRuntimeProvider = import_react46.default.useCallback(async (provider, _failureFacts, requestedModelId) => {
       if (!providerStore) return null;
       const modelId = String(requestedModelId || "").trim();
       if (!modelId) return null;
@@ -36701,10 +48883,10 @@ ${baseUrl}`),
       }
       return { provider: result.entry, modelId };
     }, [providerSecretService, providerStore]);
-    const refreshRuntimeProviders = import_react45.default.useCallback(() => {
+    const refreshRuntimeProviders = import_react46.default.useCallback(() => {
       if (providerStore) setProviders(providerStore.list());
     }, [providerStore]);
-    const byokLoop = import_react45.default.useMemo(() => {
+    const byokLoop = import_react46.default.useMemo(() => {
       return createAgentLoop({
         resolveRequestProfile: () => {
           const provider = runtimeRef.current.claudeApiProvider;
@@ -36720,7 +48902,7 @@ ${baseUrl}`),
         onEvent: handleChatEvent
       });
     }, [mcp, handleChatEvent, providerSecretService]);
-    const claudeBackend = import_react45.default.useMemo(() => createClaudeAgentBackend({
+    const claudeBackend = import_react46.default.useMemo(() => createClaudeAgentBackend({
       platform,
       resolveNode: resolvePanelNode,
       sidecarPath,
@@ -36746,7 +48928,7 @@ ${baseUrl}`),
       lang,
       onEvent: handleChatEvent
     }), [getMcpSpec, sidecarPath, mcp, handleChatEvent, platform, providerSecretService, recoverRuntimeProvider, refreshRuntimeProviders, resolvePanelNode]);
-    const codexBackend = import_react45.default.useMemo(() => createCodexBackend({
+    const codexBackend = import_react46.default.useMemo(() => createCodexBackend({
       platform,
       getMcpSpec,
       getModel: () => runtimeRef.current.model,
@@ -36770,7 +48952,7 @@ ${baseUrl}`),
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
     }), [extRoot, getMcpSpec, mcp, handleChatEvent, platform, providerSecretService, recoverRuntimeProvider, refreshRuntimeProviders]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (providerInit.state !== "ready" || !providerStore) return void 0;
       let debugMarker = false;
       try {
@@ -36875,16 +49057,16 @@ ${baseUrl}`),
         });
       };
     }, [claudeBackend, codexBackend, extRoot, platform, providerInit.state, providerSecretService, providerStore, refreshRuntimeProviders]);
-    import_react45.default.useEffect(
+    import_react46.default.useEffect(
       () => installBeforeUnloadReset(window, codexBackend),
       [codexBackend]
     );
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (previousCodexProviderProfileRef.current === providerProfile) return;
       previousCodexProviderProfileRef.current = providerProfile;
       codexBackend.reset();
     }, [codexBackend, providerProfile]);
-    const openCodeBackend = import_react45.default.useMemo(() => createOpenCodeBackend({
+    const openCodeBackend = import_react46.default.useMemo(() => createOpenCodeBackend({
       platform,
       getMcpSpec,
       getModel: () => runtimeRef.current.model,
@@ -36894,7 +49076,7 @@ ${baseUrl}`),
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
     }), [extRoot, getMcpSpec, mcp, handleChatEvent, platform]);
-    const zcodeBackend = import_react45.default.useMemo(() => createZcodeBackend({
+    const zcodeBackend = import_react46.default.useMemo(() => createZcodeBackend({
       platform,
       getMcpSpec,
       getModel: () => runtimeRef.current.model,
@@ -36907,7 +49089,7 @@ ${baseUrl}`),
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
     }), [extRoot, getMcpSpec, mcp, handleChatEvent, platform]);
-    import_react45.default.useEffect(() => () => {
+    import_react46.default.useEffect(() => () => {
       zcodeStoredKeyRef.current = "";
       zcodeBackend.reset();
     }, [zcodeBackend]);
@@ -36924,7 +49106,7 @@ ${baseUrl}`),
     };
     const backendInstances = { subscription: claudeBackend, "claude-api": claudeBackend, byok: byokLoop, codex: codexBackend, opencode: openCodeBackend, zcode: zcodeBackend };
     const activeBackend = backendInstances[effective.backend] || byokLoop;
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       const facts = {
         effectiveBackend: effective.backend,
         effectiveChannel: effective.channel,
@@ -36952,8 +49134,8 @@ ${baseUrl}`),
         writePref("ae_mcp_model", reconciled);
       }
     }, [effective.backend, effective.channel, backendPref, baseDescriptor, customModel, claudeApiProvider, codexCustomProvider, codexModels, zcodeSessionModels, zcodeProbedModels, providerSecretService, codexProviderCredentialResolverReady, codexProviderId, providerInit.state]);
-    const activeBackendRef = import_react45.default.useRef(null);
-    import_react45.default.useEffect(() => {
+    const activeBackendRef = import_react46.default.useRef(null);
+    import_react46.default.useEffect(() => {
       if (backendPref !== "zcode") return void 0;
       const sessionAvailable = zcodeSessionModels && zcodeSessionModels.settings && zcodeSessionModels.settings.model && Array.isArray(zcodeSessionModels.settings.model.available) ? zcodeSessionModels.settings.model.available : [];
       if (sessionAvailable.length > 1) return void 0;
@@ -36978,7 +49160,7 @@ ${baseUrl}`),
         alive = false;
       };
     }, [backendPref, zcodeCredentialEpoch, zcodeSessionModels, zcodeConfigSummary]);
-    const runClaudeProbe = import_react45.default.useCallback(() => {
+    const runClaudeProbe = import_react46.default.useCallback(() => {
       let alive = true;
       setProbe(null);
       probeClaudeLogin({
@@ -36994,11 +49176,11 @@ ${baseUrl}`),
         alive = false;
       };
     }, [platform, resolvePanelNode, sidecarPath]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (backendPref !== "subscription") return void 0;
       return runClaudeProbe();
     }, [backendPref, runClaudeProbe]);
-    const runCodexProbe = import_react45.default.useCallback(() => {
+    const runCodexProbe = import_react46.default.useCallback(() => {
       let alive = true;
       setCodexProbe(null);
       codexBackend.probeAccount().then((result) => {
@@ -37020,11 +49202,11 @@ ${baseUrl}`),
         alive = false;
       };
     }, [codexBackend, providerSecretService]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (backendPref !== "codex") return void 0;
       return runCodexProbe();
     }, [backendPref, runCodexProbe]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (backendPref !== "codex") return void 0;
       if (!codexCliConfig || !codexCliConfig.provider || !codexCliCredentialReady) return void 0;
       if (effective.channel === "custom" && codexCustomProvider && codexCustomProvider.baseUrl) return void 0;
@@ -37058,7 +49240,7 @@ ${baseUrl}`),
         alive = false;
       };
     }, [backendPref, effective.channel, codexCliConfig, codexCliCredentialReady, codexCustomProvider, codexModels, providerSecretService]);
-    const runZcodeProbe = import_react45.default.useCallback(() => {
+    const runZcodeProbe = import_react46.default.useCallback(() => {
       let alive = true;
       setZcodeProbe(null);
       zcodeBackend.probeAccount().then((result) => {
@@ -37070,15 +49252,15 @@ ${baseUrl}`),
         alive = false;
       };
     }, [zcodeBackend]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (backendPref !== "zcode") return void 0;
       return runZcodeProbe();
     }, [backendPref, runZcodeProbe]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (effective.backend !== "zcode" || !effectiveEffort) return;
       zcodeBackend.setThoughtLevel(effectiveEffort);
     }, [effective.backend, effectiveEffort, zcodeBackend]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       const decision = shouldResetOnBackendChange(activeBackendRef.current, effective.backend);
       activeBackendRef.current = decision.nextReal;
       if (!decision.reset) return;
@@ -37105,11 +49287,11 @@ ${baseUrl}`),
       setChatStreaming(false);
       setChatEntries([]);
     };
-    const pushLog = import_react45.default.useCallback((m) => {
+    const pushLog = import_react46.default.useCallback((m) => {
       if (!keepLogLine(logLevelRef.current, m)) return;
       setLogs((xs) => [...xs.slice(-199), `[${(/* @__PURE__ */ new Date()).toLocaleTimeString()}] ${m}`]);
     }, []);
-    const exportLogs = import_react45.default.useCallback(() => {
+    const exportLogs = import_react46.default.useCallback(() => {
       try {
         const exactSecrets = providerSecretService.getRedactionValues();
         if (zcodeStoredKeyRef.current) exactSecrets.push(zcodeStoredKeyRef.current);
@@ -37127,7 +49309,7 @@ ${baseUrl}`),
         pushLog("Log export failed: " + (e && e.message ? e.message : String(e)));
       }
     }, [logs, connInfo, claudeBackend, providerSecretService, pushLog]);
-    const undoToPreviousCheckpoint = import_react45.default.useCallback(async () => {
+    const undoToPreviousCheckpoint = import_react46.default.useCallback(async () => {
       try {
         await revertToPreviousCheckpoint(mcp);
         pushLog("Reverted to previous checkpoint");
@@ -37135,7 +49317,7 @@ ${baseUrl}`),
         pushLog("Checkpoint revert failed: " + (e && e.message ? e.message : String(e)));
       }
     }, [mcp, pushLog]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       const port = loadSavedPort(window.localStorage) || DEFAULT_PORT;
       ctrl.current = createHostController({
         cs: cs2,
@@ -37153,7 +49335,7 @@ ${baseUrl}`),
       });
       ctrl.current.start(port);
     }, [cs2, extRoot, platform, pushLog]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (status.state !== "ok") return void 0;
       let alive = true;
       setProviderInit({ state: "checking", error: "" });
@@ -37241,7 +49423,7 @@ ${baseUrl}`),
         alive = false;
       };
     }, [status.state, providerStore, providerSecretService, getHost, legacyKeyStore, platform, pushLog, zcodeCredentialManager]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (!drawerOpen) return void 0;
       const update = () => {
         const h = getHost();
@@ -37251,7 +49433,7 @@ ${baseUrl}`),
       const i = setInterval(update, 3e3);
       return () => clearInterval(i);
     }, [drawerOpen, getHost]);
-    import_react45.default.useEffect(() => {
+    import_react46.default.useEffect(() => {
       if (tab !== "settings") return void 0;
       const update = () => {
         const h = getHost();
@@ -37262,7 +49444,7 @@ ${baseUrl}`),
       const i = setInterval(update, 4e3);
       return () => clearInterval(i);
     }, [tab, getHost]);
-    const runDiag = import_react45.default.useCallback(async () => {
+    const runDiag = import_react46.default.useCallback(async () => {
       var _a;
       setDiagnostics("running");
       try {
@@ -37322,7 +49504,7 @@ ${baseUrl}`),
       onRuntimeReady: markRuntimeReady
     });
     if (!wizardDone) {
-      return /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
         WizardScreen,
         {
           step: wizStep,
@@ -37357,8 +49539,8 @@ ${baseUrl}`),
     const backendDisabledHint = effective.fixHint && (effective.fixHint[lang] || effective.fixHint.zh) || (effective.reason && effective.reason.endsWith("-probing") ? lang === "zh" ? "\u6B63\u5728\u68C0\u6D4B\u51ED\u636E\u901A\u9053\u2026" : "Checking credential channels\u2026" : "");
     const composerDisabled = paused || effective.backend === "none";
     const modelOptions = descriptor.models.map((m) => ({ value: m.id, label: `${m.label} ${costBadge(m.cost)}` }));
-    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react45.default.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)(import_react46.default.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
         StatusBar,
         {
           status: statusForBar,
@@ -37373,8 +49555,8 @@ ${baseUrl}`),
           settingsTitle: t.settings
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
-        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
+        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
           ChatScreen,
           {
             lang,
@@ -37405,7 +49587,7 @@ ${baseUrl}`),
             }
           }
         ) : null,
-        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
           ActivityScreen,
           {
             events,
@@ -37416,7 +49598,7 @@ ${baseUrl}`),
             emptyCaption: t.actEmptyB
           }
         ) : null,
-        tab === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+        tab === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
           ToolsScreen,
           {
             api: toolsApi,
@@ -37425,7 +49607,7 @@ ${baseUrl}`),
             initialPath: extRoot
           }
         ) : null,
-        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
           SettingsScreen,
           {
             lang,
@@ -37557,8 +49739,8 @@ ${baseUrl}`),
           tokenEpoch
         ) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
         ConnectionDrawer,
         {
           open: drawerOpen,
@@ -37572,7 +49754,7 @@ ${baseUrl}`),
           onRestart: () => applyPort(status.port)
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
         ConfirmDialog,
         {
           open: confirmRegen,
@@ -37594,7 +49776,7 @@ ${baseUrl}`),
           }
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
         ToolApprovalDialog,
         {
           record: toolApproval && toolApproval.plan ? toolApproval : null,
@@ -37605,13 +49787,13 @@ ${baseUrl}`),
     ] });
   }
   function App({ cs: cs2 }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Shell, { cs: cs2 }) });
+    return /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Shell, { cs: cs2 }) });
   }
 
   // src/main.jsx
-  var import_jsx_runtime42 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime43 = __toESM(require_jsx_runtime(), 1);
   var cs = new window.CSInterface();
-  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime42.jsx)(App, { cs }));
+  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime43.jsx)(App, { cs }));
 })();
 /*! Bundled license information:
 
@@ -37657,6 +49839,31 @@ react/cjs/react-jsx-runtime.production.min.js:
    *
    * This source code is licensed under the MIT license found in the
    * LICENSE file in the root directory of this source tree.
+   *)
+
+filepond/dist/filepond.js:
+  (*!
+   * FilePond 4.32.12
+   * Licensed under MIT, https://opensource.org/licenses/MIT/
+   * Please visit https://pqina.nl/filepond/ for details.
+   *)
+
+react-filepond/dist/react-filepond.js:
+  (*!
+   * react-filepond v7.1.3
+   * A handy FilePond adapter component for React
+   * 
+   * Copyright (c) 2024 PQINA
+   * https://pqina.nl/filepond
+   * 
+   * Licensed under the MIT license.
+   *)
+
+filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js:
+  (*!
+   * FilePondPluginImagePreview 4.6.12
+   * Licensed under MIT, https://opensource.org/licenses/MIT/
+   * Please visit https://pqina.nl/filepond/ for details.
    *)
 
 lucide-react/dist/esm/shared/src/utils.js:

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -38241,6 +38241,26 @@ data: ${JSON.stringify(payload)}
     else delete next["anthropic-beta"];
     return next;
   }
+  function payloadWithoutRejectedContextManagement(payload, buffer) {
+    let errorBody;
+    let requestBody2;
+    try {
+      errorBody = JSON.parse(buffer.toString("utf8"));
+      requestBody2 = JSON.parse(payload.toString("utf8"));
+    } catch {
+      return null;
+    }
+    const source = (errorBody == null ? void 0 : errorBody.error) && typeof errorBody.error === "object" ? errorBody.error : errorBody;
+    const message = typeof (source == null ? void 0 : source.message) === "string" ? source.message : "";
+    if (!/\bcontext_management\b/.test(message) || requestBody2 === null || typeof requestBody2 !== "object" || Array.isArray(requestBody2)) return null;
+    const context = requestBody2.context_management;
+    if (context === null || typeof context !== "object" || Array.isArray(context) || JSON.stringify(Object.keys(context).sort()) !== '["edits"]' || !Array.isArray(context.edits) || context.edits.length !== 1) return null;
+    const edit = context.edits[0];
+    if (edit === null || typeof edit !== "object" || Array.isArray(edit) || JSON.stringify(Object.keys(edit).sort()) !== '["keep","type"]' || edit.type !== "clear_thinking_20251015" || edit.keep !== "all") return null;
+    const next = { ...requestBody2 };
+    delete next.context_management;
+    return Buffer.from(JSON.stringify(next), "utf8");
+  }
   function createGate2(maximum) {
     let active = 0;
     return {
@@ -38568,7 +38588,7 @@ data: ${JSON.stringify(payload)}
         method: "POST"
       };
       if (lookupImpl) requestOptions.lookup = lookupImpl;
-      const sendAttempt = (attemptHeaders, allowBetaRetry) => {
+      const sendAttempt = (attemptHeaders, attemptPayload, compatibility2) => {
         let connected = false;
         let requestSettled = false;
         let request = null;
@@ -38617,8 +38637,9 @@ data: ${JSON.stringify(payload)}
                 if (responseSettled || context.finished) return;
                 responseSettled = true;
                 const rawErrorBody = Buffer.concat(chunks2);
-                const retryHeaders = allowBetaRetry && status === 400 ? headersWithoutRejectedAnthropicBetas(attemptHeaders, rawErrorBody) : null;
+                const retryHeaders = compatibility2.beta && status === 400 ? headersWithoutRejectedAnthropicBetas(attemptHeaders, rawErrorBody) : null;
                 if (retryHeaders) {
+                  retryHeaders["content-length"] = String(attemptPayload.length);
                   onAudit({
                     event: "provider_route_compat_retry",
                     modelId,
@@ -38627,7 +38648,33 @@ data: ${JSON.stringify(payload)}
                     compatibility: "anthropic-beta-rejected-values",
                     outcome: "retry"
                   });
-                  sendAttempt(retryHeaders, false);
+                  sendAttempt(retryHeaders, attemptPayload, {
+                    beta: false,
+                    contextManagement: compatibility2.contextManagement
+                  });
+                  return;
+                }
+                const retryPayload = compatibility2.contextManagement && status === 400 ? payloadWithoutRejectedContextManagement(attemptPayload, rawErrorBody) : null;
+                if (retryPayload) {
+                  onAudit({
+                    event: "provider_route_compat_retry",
+                    modelId,
+                    clientProtocol,
+                    upstreamProtocol: capability.upstreamProtocol,
+                    compatibility: "context-management-rejected",
+                    outcome: "retry"
+                  });
+                  sendAttempt(
+                    {
+                      ...attemptHeaders,
+                      "content-length": String(retryPayload.length)
+                    },
+                    retryPayload,
+                    {
+                      beta: compatibility2.beta,
+                      contextManagement: false
+                    }
+                  );
                   return;
                 }
                 let errorHeaders = responseHeaders;
@@ -38812,7 +38859,7 @@ data: ${JSON.stringify(payload)}
               "Provider request failed."
             ));
           });
-          request.end(payload);
+          request.end(attemptPayload);
         } catch {
           clearTimeout(connectTimer);
           if (!context.finish()) return;
@@ -38823,7 +38870,10 @@ data: ${JSON.stringify(payload)}
           ));
         }
       };
-      sendAttempt(headers, true);
+      sendAttempt(headers, payload, {
+        beta: true,
+        contextManagement: true
+      });
     };
     const forwardChatFacade = ({ context, payload, modelId }) => {
       const endpoint = new URL("responses", chatRouteInfo.baseUrl.replace(/\/+$/, "") + "/");
@@ -42831,6 +42881,7 @@ data: ${JSON.stringify(payload)}
       PROVIDER_ACCEPTANCE_BRIDGE_DISPOSED: "Provider acceptance bridge is disposed.",
       PROVIDER_ACCEPTANCE_CALLBACK_FAILED: "Provider acceptance state refresh failed.",
       PROVIDER_ACCEPTANCE_INVALID_MODELS: "Provider acceptance model list is invalid.",
+      PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN: "Provider acceptance panel turn is invalid.",
       PROVIDER_ACCEPTANCE_PROVIDER_NOT_FOUND: "Provider was not found.",
       PROVIDER_ACCEPTANCE_PROBE_FAILED: "Provider acceptance probe failed.",
       PROVIDER_ACCEPTANCE_ROUTE_CLOSE_FAILED: "Provider acceptance route did not close cleanly.",
@@ -42841,6 +42892,52 @@ data: ${JSON.stringify(payload)}
     const error = new Error(messages[code] || messages.PROVIDER_ACCEPTANCE_STORE_UNAVAILABLE);
     error.code = messages[code] ? code : "PROVIDER_ACCEPTANCE_STORE_UNAVAILABLE";
     return error;
+  }
+  function absoluteAttachmentPath(value) {
+    return typeof value === "string" && value.length > 0 && value.length <= 4096 && !/[\0\r\n]/.test(value) && (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\[^\\]+\\[^\\]+/.test(value));
+  }
+  function normalizePanelAcceptanceTurns(input = {}) {
+    const hasPrompts = Array.isArray(input.prompts);
+    const hasTurns = Array.isArray(input.turns);
+    if (hasPrompts === hasTurns) {
+      throw bridgeError("PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN");
+    }
+    const source = hasTurns ? input.turns : input.prompts.map((value) => ({
+      text: String(value || "").trim(),
+      attachments: []
+    }));
+    if (source.length < 1 || source.length > 4) {
+      throw bridgeError("PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN");
+    }
+    try {
+      return Object.freeze(source.map((value, index) => {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          throw new TypeError("turn must be an object");
+        }
+        const turn = normalizeTurnInput({
+          ...value,
+          turnId: `provider-acceptance-${index + 1}`
+        });
+        if (turn.text.length > 2e3 || turn.attachments.some((attachment) => !absoluteAttachmentPath(
+          attachment.localPath
+        ))) {
+          throw new TypeError("turn is outside the acceptance boundary");
+        }
+        return turn;
+      }));
+    } catch {
+      throw bridgeError("PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN");
+    }
+  }
+  function countMentionedPanelAttachments(transcript, attachments) {
+    const assistantText = Array.isArray(transcript) ? transcript.filter((message) => (message == null ? void 0 : message.role) === "assistant" && typeof message.text === "string").map((message) => message.text).join("\n") : "";
+    if (!assistantText || !Array.isArray(attachments)) return 0;
+    const names = new Set(attachments.flatMap((attachment) => typeof (attachment == null ? void 0 : attachment.name) === "string" && attachment.name ? [attachment.name] : []));
+    let count = 0;
+    for (const name of names) {
+      if (assistantText.includes(name)) count += 1;
+    }
+    return count;
   }
   function dependency(name, value, predicate) {
     if (!predicate(value)) throw new TypeError(`${name} is required`);
@@ -49928,9 +50025,14 @@ ${baseUrl}`),
           const client = input.client === "claude" ? "claude" : input.client === "codex" ? "codex" : "";
           const providerId = typeof input.providerId === "string" ? input.providerId.trim() : "";
           const modelId = typeof input.modelId === "string" ? input.modelId.trim() : "";
-          const prompts = Array.isArray(input.prompts) ? input.prompts.map((value) => String(value || "").trim()) : [];
+          let plannedTurns;
+          try {
+            plannedTurns = normalizePanelAcceptanceTurns(input);
+          } catch {
+            return { ok: false, errorCode: "PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN", turns: [] };
+          }
           const graceMs = Number.isInteger(input.graceMs) && input.graceMs >= 0 && input.graceMs <= 1e4 ? input.graceMs : 3e3;
-          if (!client || !providerId || !modelId || prompts.length < 1 || prompts.length > 4 || prompts.some((value) => !value || value.length > 2e3)) {
+          if (!client || !providerId || !modelId) {
             return { ok: false, errorCode: "PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN", turns: [] };
           }
           let provider = null;
@@ -49957,13 +50059,14 @@ ${baseUrl}`),
           };
           backend.reset();
           try {
-            for (const prompt of prompts) {
+            for (const plannedTurn of plannedTurns) {
               const eventStart = providerAcceptanceEventsRef.current.length;
               const startedAt = Date.now();
-              await backend.sendUser(prompt);
+              await backend.sendUser(plannedTurn);
               await new Promise((resolve) => setTimeout(resolve, graceMs));
               const events2 = providerAcceptanceEventsRef.current.slice(eventStart);
               const error = events2.find((event) => event.type === "error");
+              const accepted = events2.some((event) => event.type === "turn-accepted");
               const terminal = events2.some((event) => event.type === "turn-end");
               const transcript = backend.getMessages();
               const hasAssistant = transcript.some((message) => (message == null ? void 0 : message.role) === "assistant" && typeof message.text === "string" && message.text.trim());
@@ -49971,12 +50074,18 @@ ${baseUrl}`),
                 ok: !error && terminal && hasAssistant,
                 terminal: terminal ? "turn-end" : null,
                 durationMs: Date.now() - startedAt,
-                errorCode: (error == null ? void 0 : error.code) || (error == null ? void 0 : error.kind) || null
+                errorCode: (error == null ? void 0 : error.code) || (error == null ? void 0 : error.kind) || null,
+                attachmentCount: plannedTurn.attachments.length,
+                mentionedAttachmentCount: countMentionedPanelAttachments(
+                  transcript,
+                  plannedTurn.attachments
+                ),
+                accepted
               });
               if (!turns.at(-1).ok) break;
             }
             return {
-              ok: turns.length === prompts.length && turns.every((turn) => turn.ok),
+              ok: turns.length === plannedTurns.length && turns.every((turn) => turn.ok),
               client,
               modelId,
               turns

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -30009,7 +30009,7 @@
     codex: {
       id: "codex",
       baseDescriptor: codexStaticDescriptor,
-      attachmentTransport: "native"
+      attachmentTransport: "native+manifest"
     },
     opencode: {
       id: "opencode",
@@ -30028,7 +30028,13 @@
       attachmentTransport: "manifest"
     }
   };
-  var ATTACHMENT_TRANSPORTS = /* @__PURE__ */ new Set(["agent-sdk", "native", "manifest", "reject"]);
+  var ATTACHMENT_TRANSPORTS = /* @__PURE__ */ new Set([
+    "agent-sdk",
+    "native",
+    "native+manifest",
+    "manifest",
+    "reject"
+  ]);
   function assertAttachmentBackendRegistry(registry) {
     for (const [id, entry] of Object.entries(registry)) {
       if (!ATTACHMENT_TRANSPORTS.has(entry == null ? void 0 : entry.attachmentTransport)) {
@@ -40775,14 +40781,13 @@ data: ${JSON.stringify(payload)}
     }
     function turnInput(turn, text) {
       const input = [];
-      if (text) input.push({ type: "text", text });
+      const modelText = withAttachmentManifest(text, turn.attachments);
+      if (modelText) input.push({ type: "text", text: modelText });
       for (const attachment of turn.attachments) {
         if (attachment.mediaType.startsWith("image/")) {
           input.push({ type: "localImage", path: attachment.localPath });
         } else if (attachment.mediaType.startsWith("audio/")) {
           input.push({ type: "localAudio", path: attachment.localPath });
-        } else {
-          input.push({ type: "mention", name: attachment.name, path: attachment.localPath });
         }
       }
       return input;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -7289,10 +7289,10 @@
         var isNode = function isNode2(value) {
           return value instanceof HTMLElement;
         };
-        var createStore = function createStore2(initialState) {
+        var createStore = function createStore2(initialState2) {
           var queries2 = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : [];
           var actions2 = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : [];
-          var state2 = Object.assign({}, initialState);
+          var state2 = Object.assign({}, initialState2);
           var actionQueue = [];
           var dispatchQueue = [];
           var getState = function getState2() {
@@ -23062,9 +23062,23 @@
   // src/components/chat/ChatBubble.jsx
   var import_react29 = __toESM(require_react(), 1);
   var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
-  function ChatBubble({ role = "ai", children, streaming = false, avatar = true, style }) {
+  function formatAttachmentBytes(value) {
+    const bytes = Number(value) || 0;
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+    if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+    return (bytes / (1024 * 1024 * 1024)).toFixed(1) + " GB";
+  }
+  function ChatBubble({
+    role = "ai",
+    children,
+    attachments = [],
+    streaming = false,
+    avatar = true,
+    style
+  }) {
     if (role === "user") {
-      return /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { display: "flex", justifyContent: "flex-end", ...style }, children: /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { display: "flex", justifyContent: "flex-end", ...style }, children: /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(
         "div",
         {
           style: {
@@ -23078,7 +23092,27 @@
             color: "var(--text-primary)",
             overflowWrap: "break-word"
           },
-          children
+          children: [
+            children ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { children }) : null,
+            attachments.length ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 3, marginTop: children ? 5 : 0 }, children: attachments.map((attachment) => /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(
+              "div",
+              {
+                style: {
+                  minWidth: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  color: "var(--text-secondary)",
+                  font: "var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)"
+                },
+                children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: attachment.name }),
+                  /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { flex: "none", color: "var(--text-tertiary)" }, children: formatAttachmentBytes(attachment.size) })
+                ]
+              },
+              attachment.id
+            )) }) : null
+          ]
         }
       ) });
     }
@@ -23470,6 +23504,65 @@
   var MAX_ATTACHMENTS_PER_TURN = 32;
   var MAX_CLIPBOARD_ITEM_BYTES = 256 * 1024 * 1024;
   var MAX_CLIPBOARD_TURN_BYTES = 512 * 1024 * 1024;
+  function requireString(value, field, { allowEmpty = false } = {}) {
+    if (typeof value !== "string" || !allowEmpty && !value) {
+      throw new TypeError(field + " must be " + (allowEmpty ? "a string" : "a non-empty string"));
+    }
+    return value;
+  }
+  function normalizeAttachment(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new TypeError("attachment must be an object");
+    }
+    if (!Number.isSafeInteger(value.size) || value.size < 0) {
+      throw new TypeError("attachment.size must be a non-negative safe integer");
+    }
+    if (typeof value.temporary !== "boolean") {
+      throw new TypeError("attachment.temporary must be a boolean");
+    }
+    const attachment = {
+      id: requireString(value.id, "attachment.id"),
+      name: requireString(value.name, "attachment.name"),
+      localPath: requireString(value.localPath, "attachment.localPath"),
+      size: value.size,
+      mediaType: value.mediaType === void 0 ? "" : requireString(value.mediaType, "attachment.mediaType", { allowEmpty: true }),
+      temporary: value.temporary
+    };
+    return Object.freeze(attachment);
+  }
+  function normalizeTurnInput(input) {
+    const source = typeof input === "string" ? { turnId: "", text: input, attachments: [] } : input;
+    if (!source || typeof source !== "object" || Array.isArray(source)) {
+      throw new TypeError("turn input must be a string or object");
+    }
+    const attachments = source.attachments;
+    if (!Array.isArray(attachments)) {
+      throw new TypeError("turn.attachments must be an array");
+    }
+    if (attachments.length > MAX_ATTACHMENTS_PER_TURN) {
+      throw new TypeError("turn.attachments exceeds the per-turn limit");
+    }
+    const normalized = {
+      turnId: requireString(source.turnId, "turn.turnId", { allowEmpty: true }),
+      text: requireString(source.text, "turn.text", { allowEmpty: true }),
+      attachments: Object.freeze(attachments.map(normalizeAttachment))
+    };
+    if (!normalized.text.trim() && !normalized.attachments.length) {
+      throw new TypeError("turn requires text or attachments");
+    }
+    return Object.freeze(normalized);
+  }
+  function displayAttachments(attachments) {
+    return attachments.map((value) => {
+      const { id, name, size, mediaType } = normalizeAttachment(value);
+      return Object.freeze({
+        id,
+        name,
+        size,
+        ...mediaType ? { mediaType } : {}
+      });
+    });
+  }
 
   // src/components/chat/AttachmentPond.jsx
   var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
@@ -23561,11 +23654,29 @@
   });
 
   // src/lib/attachmentDraft.js
+  function initialState() {
+    return {
+      text: "",
+      items: [],
+      pendingTurnId: null,
+      pendingSnapshot: null,
+      dispatchState: null,
+      sendError: null
+    };
+  }
+  function createAttachmentDraftState() {
+    return initialState();
+  }
   function readyAttachments(state) {
     return state.items.filter((item) => item.status === "ready" && item.ref).map((item) => item.ref);
   }
   function draftIsBusy(state) {
     return state.items.some((item) => item.status === "staging");
+  }
+  function draftCanSend(state) {
+    if (state.pendingTurnId || draftIsBusy(state)) return false;
+    if (state.items.some((item) => item.status === "error")) return false;
+    return state.text.trim().length > 0 || readyAttachments(state).length > 0;
   }
   function isFileTransfer(dataTransfer) {
     return Array.from((dataTransfer == null ? void 0 : dataTransfer.types) || []).includes("Files");
@@ -23573,6 +23684,107 @@
   function attachmentDropFiles(dataTransfer) {
     if (!isFileTransfer(dataTransfer)) return [];
     return Array.from((dataTransfer == null ? void 0 : dataTransfer.files) || []);
+  }
+  function replaceItem(items, pondId, update) {
+    const index = items.findIndex((item) => item.pondId === pondId);
+    if (index < 0) return items;
+    const next = items.slice();
+    next[index] = update(items[index]);
+    return next;
+  }
+  function freezeSnapshot(turn, fallbackState, turnId) {
+    const source = turn || {
+      turnId,
+      text: fallbackState.text,
+      attachments: readyAttachments(fallbackState)
+    };
+    return Object.freeze({
+      turnId: source.turnId,
+      text: source.text,
+      attachments: Object.freeze([...source.attachments])
+    });
+  }
+  function reduceAttachmentDraft(state, action) {
+    var _a;
+    if (!state || !action) return state;
+    if (action.type === "accepted") {
+      return action.turnId === state.pendingTurnId ? initialState() : state;
+    }
+    if (action.type === "rejected") {
+      if (action.turnId !== state.pendingTurnId) return state;
+      return {
+        ...state,
+        pendingTurnId: null,
+        pendingSnapshot: null,
+        dispatchState: "not-started",
+        sendError: action.error || null
+      };
+    }
+    if (action.type === "uncertain") {
+      if (action.turnId !== state.pendingTurnId) return state;
+      return {
+        ...state,
+        dispatchState: "uncertain",
+        sendError: action.error || null
+      };
+    }
+    if (action.type === "reset") return initialState();
+    if (state.pendingTurnId) return state;
+    if (action.type === "text") {
+      return {
+        ...state,
+        text: String((_a = action.value) != null ? _a : ""),
+        sendError: null,
+        dispatchState: null
+      };
+    }
+    if (action.type === "staging") {
+      const replacement = {
+        pondId: action.pondId,
+        file: action.file,
+        status: "staging",
+        ref: null,
+        error: null
+      };
+      const existing = state.items.findIndex((item) => item.pondId === action.pondId);
+      return {
+        ...state,
+        items: existing < 0 ? [...state.items, replacement] : state.items.map((item, index) => index === existing ? replacement : item),
+        sendError: null
+      };
+    }
+    if (action.type === "ready") {
+      const items = replaceItem(state.items, action.pondId, (item) => ({
+        ...item,
+        status: "ready",
+        ref: action.ref,
+        error: null
+      }));
+      return items === state.items ? state : { ...state, items };
+    }
+    if (action.type === "error") {
+      const items = replaceItem(state.items, action.pondId, (item) => ({
+        ...item,
+        status: "error",
+        ref: null,
+        error: action.error || null
+      }));
+      return items === state.items ? state : { ...state, items };
+    }
+    if (action.type === "remove") {
+      const items = state.items.filter((item) => item.pondId !== action.pondId);
+      return items.length === state.items.length ? state : { ...state, items };
+    }
+    if (action.type === "sending") {
+      return {
+        ...state,
+        pendingTurnId: action.turnId,
+        pendingSnapshot: freezeSnapshot(action.turn, state, action.turnId),
+        dispatchState: "pending",
+        sendError: null
+      };
+    }
+    return state;
   }
 
   // src/lib/composerResize.js
@@ -24239,7 +24451,14 @@
       ok: "\u5B8C\u6210",
       failed: "\u5931\u8D25",
       awaiting: "\u7B49\u5F85\u6279\u51C6",
-      thinking: "\u601D\u8003\u4E2D\u2026"
+      thinking: "\u601D\u8003\u4E2D\u2026",
+      attachmentAdd: "\u6DFB\u52A0\u6587\u4EF6",
+      attachmentDrop: "\u62D6\u653E\u6216\u7C98\u8D34\u6587\u4EF6",
+      attachmentStaging: "\u6B63\u5728\u51C6\u5907\u2026",
+      attachmentReady: "\u5DF2\u5C31\u7EEA",
+      attachmentRetry: "\u91CD\u8BD5",
+      attachmentRemove: "\u79FB\u9664",
+      uncertainTurn: "\u53D1\u9001\u7ED3\u679C\u4E0D\u786E\u5B9A\u3002\u8BF7\u65B0\u5EFA\u4F1A\u8BDD\u6838\u5BF9\u540E\u518D\u8BD5\u3002"
     },
     en: {
       hello: "Hi! I can operate the open AE project directly. Try one of these:",
@@ -24259,7 +24478,14 @@
       ok: "Done",
       failed: "Failed",
       awaiting: "Awaiting approval",
-      thinking: "Thinking\u2026"
+      thinking: "Thinking\u2026",
+      attachmentAdd: "Add files",
+      attachmentDrop: "Drop or paste files",
+      attachmentStaging: "Preparing\u2026",
+      attachmentReady: "Ready",
+      attachmentRetry: "Retry",
+      attachmentRemove: "Remove",
+      uncertainTurn: "Send outcome is uncertain. Start a new session before retrying."
     }
   };
   var DEFAULT_PROMPTS = {
@@ -24299,7 +24525,7 @@
   function Entry({ entry, lang, onApprove }) {
     const t = C[lang] || C.zh;
     if (entry.type === "user-text") {
-      return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ChatBubble, { role: "user", children: entry.text });
+      return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ChatBubble, { role: "user", attachments: entry.attachments, children: entry.text });
     }
     if (entry.type === "ai-text") {
       return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(ChatBubble, { role: "ai", children: entry.text });
@@ -24363,10 +24589,15 @@
     onChipModel,
     onChipEffort,
     onChipFast,
-    onChipApproval
+    onChipApproval,
+    attachmentDraft = createAttachmentDraftState(),
+    dispatchAttachmentDraft,
+    createTurnId,
+    onAddFile,
+    onRemoveAttachment,
+    onRetryAttachment
   }) {
     const t = C[lang] || C.zh;
-    const [draft, setDraft] = import_react37.default.useState("");
     const logRef = import_react37.default.useRef(null);
     const layoutRef = import_react37.default.useRef(null);
     const footerRef = import_react37.default.useRef(null);
@@ -24446,11 +24677,31 @@
       observer.observe(footerRef.current);
       return () => observer.disconnect();
     }, []);
-    const send = () => {
-      const text = draft.trim();
-      if (!text || composerDisabled || streaming) return;
-      if (onSend) onSend(text);
-      setDraft("");
+    const sendTurn = (textOverride) => {
+      const text = String(textOverride === void 0 ? attachmentDraft.text : textOverride).trim();
+      const candidate = textOverride === void 0 ? attachmentDraft : { ...attachmentDraft, text };
+      if (!draftCanSend(candidate) || composerDisabled || streaming || !createTurnId) return;
+      if (textOverride !== void 0) {
+        dispatchAttachmentDraft == null ? void 0 : dispatchAttachmentDraft({ type: "text", value: text });
+      }
+      const turnId = createTurnId();
+      const turn = {
+        turnId,
+        text,
+        attachments: readyAttachments(attachmentDraft)
+      };
+      dispatchAttachmentDraft == null ? void 0 : dispatchAttachmentDraft({ type: "sending", turnId, turn });
+      onSend == null ? void 0 : onSend(turn);
+    };
+    const send = () => sendTurn();
+    const sendError = attachmentDraft.sendError;
+    const attachmentLabels = {
+      add: t.attachmentAdd,
+      drop: t.attachmentDrop,
+      staging: t.attachmentStaging,
+      ready: t.attachmentReady,
+      retry: t.attachmentRetry,
+      remove: t.attachmentRemove
     };
     return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { ref: layoutRef, style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
       /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
@@ -24472,7 +24723,7 @@
               caption: card.caption,
               onClick: () => {
                 if (card.onClick) card.onClick(card);
-                else if (onSend) onSend(card.prompt || card.title);
+                else sendTurn(card.prompt || card.title);
               }
             },
             card.id || card.title
@@ -24487,20 +24738,32 @@
       /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { ref: footerRef, style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         Composer,
         {
-          value: draft,
-          onChange: setDraft,
+          value: attachmentDraft.text,
+          onChange: (value) => dispatchAttachmentDraft == null ? void 0 : dispatchAttachmentDraft({ type: "text", value }),
           onSend: send,
           onStop,
           streaming,
           disabled: composerDisabled,
           placeholder: t.placeholder,
           options: composerOptions,
-          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || onNewSession }) : null,
+          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || onNewSession }) : sendError ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+            Notice,
+            {
+              text: attachmentDraft.dispatchState === "uncertain" ? t.uncertainTurn : sendError.message,
+              actionLabel: attachmentDraft.dispatchState === "uncertain" ? t.newSession : null,
+              onAction: attachmentDraft.dispatchState === "uncertain" ? onNewSession : null
+            }
+          ) : null,
           height: composerSize.height,
           minHeight: COMPOSER_MIN_HEIGHT,
           maxHeight: composerSize.maxHeight,
           onHeightChange: (height) => dispatchComposerSize({ type: "request", height }),
-          onHeightReset: () => dispatchComposerSize({ type: "reset" })
+          onHeightReset: () => dispatchComposerSize({ type: "reset" }),
+          attachmentDraft,
+          onAddFile,
+          onRemoveAttachment,
+          onRetryAttachment,
+          attachmentLabels
         }
       ) })
     ] });
@@ -46773,11 +47036,20 @@ data: ${JSON.stringify(payload)}
       return updater(entry);
     });
   }
+  function userTurnEntry(turn) {
+    return {
+      id: `user-${turn.turnId}`,
+      type: "user-text",
+      text: turn.text,
+      attachments: displayAttachments(turn.attachments)
+    };
+  }
   function reduceEvent(entries, evt) {
     const current = Array.isArray(entries) ? entries : [];
     if (!evt || !evt.type) return current;
     switch (evt.type) {
       case "turn-start":
+      case "turn-accepted":
         return current;
       case "text-delta": {
         const text = String(evt.text || "");
@@ -46858,6 +47130,239 @@ data: ${JSON.stringify(payload)}
       default:
         return current;
     }
+  }
+
+  // src/cep/attachmentStore.js
+  function attachmentError(code, message, cause) {
+    const error = new Error(message);
+    error.code = code;
+    if (cause) error.cause = cause;
+    return error;
+  }
+  function browserBlobChunk(slice) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error || new Error("FileReader failed"));
+      reader.onload = () => resolve(reader.result);
+      reader.readAsArrayBuffer(slice);
+    });
+  }
+  function requireSegment(value, field) {
+    const text = String(value || "");
+    if (!/^[A-Za-z0-9_-]+$/.test(text)) {
+      throw attachmentError("ATTACHMENT_INVALID", field + " must be a safe path segment");
+    }
+    return text;
+  }
+  function safeBasename(value, fallback = "attachment") {
+    const normalized = String(value || "").replace(/\\/g, "/");
+    const name = normalized.split("/").filter(Boolean).pop() || fallback;
+    return name === "." || name === ".." ? fallback : name;
+  }
+  function mediaTypeOf(file) {
+    return typeof (file == null ? void 0 : file.type) === "string" ? file.type : "";
+  }
+  function writeAll(fs, descriptor, bytes) {
+    const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    let offset = 0;
+    while (offset < view.byteLength) {
+      const written = fs.writeSync(descriptor, view, offset, view.byteLength - offset);
+      if (!written) throw new Error("attachment write made no progress");
+      offset += written;
+    }
+  }
+  function removeEmptyDirectory(fs, directory) {
+    try {
+      fs.rmdirSync(directory);
+    } catch (error) {
+      if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error == null ? void 0 : error.code)) throw error;
+    }
+  }
+  function createAttachmentStore({
+    platform,
+    randomUUID,
+    readBlobChunk = browserBlobChunk,
+    chunkBytes = 1024 * 1024,
+    now = Date.now
+  }) {
+    if (!(platform == null ? void 0 : platform.paths) || !(platform == null ? void 0 : platform.fs)) throw new TypeError("attachment store requires a platform adapter");
+    if (typeof randomUUID !== "function") throw new TypeError("attachment store requires randomUUID");
+    if (typeof readBlobChunk !== "function") throw new TypeError("attachment store requires readBlobChunk");
+    if (!Number.isSafeInteger(chunkBytes) || chunkBytes <= 0) throw new TypeError("chunkBytes must be positive");
+    const { fs } = platform;
+    const root = platform.paths.join([
+      platform.paths.tempRoot,
+      "ae-mcp-panel-attachments"
+    ]);
+    const records = /* @__PURE__ */ new Map();
+    let disposed = false;
+    function sessionRecords(sessionId) {
+      return [...records.values()].filter((record) => record.sessionId === sessionId);
+    }
+    function reserve({ sessionId, pondId, size, temporary }) {
+      if (disposed) throw attachmentError("ATTACHMENT_STORE_DISPOSED", "Attachment store is disposed");
+      const safeSessionId = requireSegment(sessionId, "sessionId");
+      requireSegment(pondId, "pondId");
+      const existing = sessionRecords(safeSessionId);
+      if (existing.length >= MAX_ATTACHMENTS_PER_TURN) {
+        throw attachmentError("ATTACHMENT_COUNT_LIMIT", "Attachment count exceeds the per-turn limit");
+      }
+      if (temporary && size > MAX_CLIPBOARD_ITEM_BYTES) {
+        throw attachmentError("ATTACHMENT_ITEM_TOO_LARGE", "Clipboard attachment exceeds the per-item limit");
+      }
+      const reservedBytes = existing.reduce(
+        (total, record2) => total + (record2.temporary ? record2.size : 0),
+        0
+      );
+      if (temporary && reservedBytes + size > MAX_CLIPBOARD_TURN_BYTES) {
+        throw attachmentError("ATTACHMENT_TURN_TOO_LARGE", "Clipboard attachments exceed the per-turn limit");
+      }
+      const id = requireSegment(randomUUID(), "attachment id");
+      if (records.has(id)) throw attachmentError("ATTACHMENT_ID_COLLISION", "Attachment id already exists");
+      const record = {
+        id,
+        pondId,
+        sessionId: safeSessionId,
+        size,
+        temporary,
+        createdAt: Number(now()),
+        ref: null
+      };
+      records.set(id, record);
+      return record;
+    }
+    function protectDirectory(directory) {
+      fs.mkdirSync(directory, { recursive: true, mode: 448 });
+      try {
+        fs.chmodSync(directory, 448);
+      } catch (error) {
+        if (platform.id !== "windows-x64") throw error;
+      }
+      if (fs.lstatSync(directory).isSymbolicLink()) {
+        throw attachmentError("ATTACHMENT_STAGING_FAILED", "Attachment directory must not be a symbolic link");
+      }
+    }
+    function cleanupTemporary(record, candidate = ((_a) => (_a = record == null ? void 0 : record.ref) == null ? void 0 : _a.localPath)()) {
+      if (!(record == null ? void 0 : record.temporary) || !candidate || !platform.paths.contains(root, candidate)) return;
+      try {
+        fs.unlinkSync(candidate);
+      } catch (error) {
+        if ((error == null ? void 0 : error.code) !== "ENOENT") throw error;
+      }
+      const sessionDirectory = platform.paths.join([root, record.sessionId]);
+      if (platform.paths.contains(root, sessionDirectory)) removeEmptyDirectory(fs, sessionDirectory);
+      removeEmptyDirectory(fs, root);
+    }
+    async function preparePathless(file, context) {
+      var _a, _b;
+      if (!Number.isSafeInteger(file == null ? void 0 : file.size) || file.size < 0 || typeof (file == null ? void 0 : file.slice) !== "function") {
+        throw attachmentError("ATTACHMENT_INVALID", "Pathless attachment must be a Blob-like file");
+      }
+      const record = reserve({
+        ...context,
+        size: file.size,
+        temporary: true
+      });
+      const name = safeBasename(file.name);
+      const sessionDirectory = platform.paths.join([root, record.sessionId]);
+      const partPath = platform.paths.join([sessionDirectory, record.id + ".part"]);
+      const finalPath = platform.paths.join([sessionDirectory, record.id + "-" + name]);
+      let descriptor = null;
+      try {
+        protectDirectory(root);
+        protectDirectory(sessionDirectory);
+        if (!platform.paths.contains(root, partPath) || !platform.paths.contains(root, finalPath)) {
+          throw attachmentError("ATTACHMENT_STAGING_FAILED", "Attachment staging path escaped the managed root");
+        }
+        descriptor = fs.openSync(partPath, "wx", 384);
+        for (let offset = 0; offset < file.size; offset += chunkBytes) {
+          const slice = file.slice(offset, Math.min(file.size, offset + chunkBytes));
+          const chunk = await readBlobChunk(slice);
+          writeAll(fs, descriptor, chunk);
+        }
+        fs.fsyncSync(descriptor);
+        fs.closeSync(descriptor);
+        descriptor = null;
+        fs.renameSync(partPath, finalPath);
+        const ref = Object.freeze({
+          id: record.id,
+          name,
+          localPath: finalPath,
+          size: file.size,
+          mediaType: mediaTypeOf(file),
+          temporary: true
+        });
+        record.ref = ref;
+        return ref;
+      } catch (cause) {
+        if (descriptor !== null) {
+          try {
+            fs.closeSync(descriptor);
+          } catch {
+          }
+        }
+        cleanupTemporary(record, partPath);
+        records.delete(record.id);
+        if ((_b = (_a = cause == null ? void 0 : cause.code) == null ? void 0 : _a.startsWith) == null ? void 0 : _b.call(_a, "ATTACHMENT_")) throw cause;
+        throw attachmentError("ATTACHMENT_STAGING_FAILED", "Failed to stage local attachment", cause);
+      }
+    }
+    async function preparePathBacked(file, context) {
+      if (!platform.paths.isAbsolute(file.path)) {
+        throw attachmentError("ATTACHMENT_INVALID", "Attachment path must be absolute");
+      }
+      const localPath = platform.paths.resolve([file.path]);
+      let stat;
+      try {
+        stat = fs.statSync(localPath);
+        if (!stat.isFile()) throw new Error("not a regular file");
+        fs.accessSync(localPath, fs.constants.R_OK);
+      } catch (cause) {
+        throw attachmentError("ATTACHMENT_UNREADABLE", "Attachment path is not a readable file", cause);
+      }
+      const record = reserve({
+        ...context,
+        size: stat.size,
+        temporary: false
+      });
+      const name = safeBasename(file.name || platform.paths.basename(localPath));
+      const ref = Object.freeze({
+        id: record.id,
+        name,
+        localPath,
+        size: stat.size,
+        mediaType: mediaTypeOf(file),
+        temporary: false
+      });
+      record.ref = ref;
+      return ref;
+    }
+    return Object.freeze({
+      prepare(file, context = {}) {
+        if (file == null ? void 0 : file.path) return preparePathBacked(file, context);
+        return preparePathless(file, context);
+      },
+      release(attachmentId) {
+        const record = records.get(attachmentId);
+        if (!record) return;
+        cleanupTemporary(record);
+        records.delete(attachmentId);
+      },
+      releaseSession(sessionId) {
+        for (const record of sessionRecords(String(sessionId || ""))) {
+          cleanupTemporary(record);
+          records.delete(record.id);
+        }
+      },
+      dispose() {
+        if (disposed) return;
+        for (const record of [...records.values()]) {
+          cleanupTemporary(record);
+          records.delete(record.id);
+        }
+        disposed = true;
+      }
+    });
   }
 
   // src/lib/descriptorSelect.js
@@ -48493,6 +48998,22 @@ data: ${JSON.stringify(payload)}
     const [confirmRegen, setConfirmRegen] = import_react46.default.useState(false);
     const [tokenEpoch, setTokenEpoch] = import_react46.default.useState(0);
     const platform = import_react46.default.useMemo(() => createPlatformAdapter(), []);
+    const attachmentStore = import_react46.default.useMemo(() => createAttachmentStore({
+      platform,
+      randomUUID: randomProviderCredentialId
+    }), [platform]);
+    const [attachmentDraft, dispatchAttachmentDraft] = import_react46.default.useReducer(
+      reduceAttachmentDraft,
+      void 0,
+      createAttachmentDraftState
+    );
+    const [chatSessionId, setChatSessionId] = import_react46.default.useState("chat-0");
+    const chatSessionIdRef = import_react46.default.useRef(chatSessionId);
+    chatSessionIdRef.current = chatSessionId;
+    const attachmentOperationsRef = import_react46.default.useRef(/* @__PURE__ */ new Map());
+    const pendingTurnRef = import_react46.default.useRef(null);
+    const acceptedTurnRef = import_react46.default.useRef(null);
+    import_react46.default.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
     const legacyKeyStore = import_react46.default.useMemo(() => {
       try {
         return createLegacyApiKeyStore();
@@ -48843,6 +49364,55 @@ ${baseUrl}`),
     }), [approvalTierFile, elicitationCoordinator, extRoot, getMcpSpec, platform]);
     const toolsApi = import_react46.default.useMemo(() => createToolsApi(mcp), [mcp]);
     import_react46.default.useEffect(() => () => mcp.stop(), [mcp]);
+    const releaseTurnAttachments = import_react46.default.useCallback((turn) => {
+      for (const attachment of (turn == null ? void 0 : turn.attachments) || []) {
+        attachmentStore.release(attachment.id);
+      }
+    }, [attachmentStore]);
+    const resetAttachmentDraftSession = import_react46.default.useCallback(() => {
+      attachmentStore.releaseSession(chatSessionIdRef.current);
+      attachmentOperationsRef.current.clear();
+      pendingTurnRef.current = null;
+      acceptedTurnRef.current = null;
+      dispatchAttachmentDraft({ type: "reset" });
+      const nextSessionId = "chat-" + randomProviderCredentialId();
+      chatSessionIdRef.current = nextSessionId;
+      setChatSessionId(nextSessionId);
+    }, [attachmentStore]);
+    const addAttachment = import_react46.default.useCallback(async ({ pondId, file }) => {
+      const operation = {};
+      const sessionId = chatSessionId;
+      attachmentOperationsRef.current.set(pondId, operation);
+      dispatchAttachmentDraft({ type: "staging", pondId, file });
+      try {
+        const ref = await attachmentStore.prepare(file, { sessionId, pondId });
+        if (attachmentOperationsRef.current.get(pondId) !== operation || chatSessionIdRef.current !== sessionId) {
+          attachmentStore.release(ref.id);
+          return;
+        }
+        attachmentOperationsRef.current.delete(pondId);
+        dispatchAttachmentDraft({ type: "ready", pondId, ref });
+      } catch (error) {
+        if (attachmentOperationsRef.current.get(pondId) !== operation || chatSessionIdRef.current !== sessionId) return;
+        attachmentOperationsRef.current.delete(pondId);
+        dispatchAttachmentDraft({
+          type: "error",
+          pondId,
+          error: {
+            code: (error == null ? void 0 : error.code) || "ATTACHMENT_STAGING_FAILED",
+            message: (error == null ? void 0 : error.message) || "Attachment staging failed"
+          }
+        });
+      }
+    }, [attachmentStore, chatSessionId]);
+    const removeAttachment = import_react46.default.useCallback((item) => {
+      attachmentOperationsRef.current.delete(item.pondId);
+      if (item.ref) attachmentStore.release(item.ref.id);
+      dispatchAttachmentDraft({ type: "remove", pondId: item.pondId });
+    }, [attachmentStore]);
+    const retryAttachment = import_react46.default.useCallback((item) => {
+      addAttachment({ pondId: item.pondId, file: item.file });
+    }, [addAttachment]);
     const providerAcceptanceEventsRef = import_react46.default.useRef([]);
     const handleChatEvent = import_react46.default.useCallback((evt) => {
       if (evt && typeof evt.type === "string") {
@@ -48853,15 +49423,48 @@ ${baseUrl}`),
         });
         if (providerAcceptanceEventsRef.current.length > 256) providerAcceptanceEventsRef.current.shift();
       }
-      if (evt.type === "turn-start") setChatStreaming(true);
+      const pending = pendingTurnRef.current;
+      if (evt.type === "turn-accepted") {
+        if (!pending || evt.turnId !== pending.turnId) return;
+        acceptedTurnRef.current = pending.turnId;
+        setChatEntries((entries) => entries.concat(userTurnEntry(pending)));
+        dispatchAttachmentDraft({ type: "accepted", turnId: pending.turnId });
+        setChatStreaming(true);
+        return;
+      }
+      if (evt.type === "error" && pending && acceptedTurnRef.current !== pending.turnId) {
+        if (evt.turnId !== pending.turnId) return;
+        setChatStreaming(false);
+        setThinkingActive(false);
+        if (evt.dispatchState === "not-started") {
+          dispatchAttachmentDraft({
+            type: "rejected",
+            turnId: pending.turnId,
+            error: { code: evt.code || "BACKEND_ERROR", message: evt.message || "Backend unavailable" }
+          });
+          pendingTurnRef.current = null;
+        } else {
+          dispatchAttachmentDraft({
+            type: "uncertain",
+            turnId: pending.turnId,
+            error: { code: evt.code || "TRANSPORT_UNCERTAIN", message: evt.message || "Send outcome is uncertain" }
+          });
+        }
+        return;
+      }
       if (evt.type === "thinking") setThinkingActive(!!evt.active);
       if (evt.type === "turn-end" || evt.type === "error") {
+        if (pending && acceptedTurnRef.current === pending.turnId) {
+          releaseTurnAttachments(pending);
+          pendingTurnRef.current = null;
+          acceptedTurnRef.current = null;
+        }
         setChatStreaming(false);
         setThinkingActive(false);
       }
       if (evt.type === "zcode-session-created") setZcodeSessionModels(evt.result || null);
       setChatEntries((entries) => reduceEvent(entries, evt));
-    }, []);
+    }, [releaseTurnAttachments]);
     const recoverRuntimeProvider = import_react46.default.useCallback(async (provider, _failureFacts, requestedModelId) => {
       if (!providerStore) return null;
       const modelId = String(requestedModelId || "").trim();
@@ -49269,22 +49872,60 @@ ${baseUrl}`),
       codexBackend.reset();
       openCodeBackend.reset();
       zcodeBackend.reset();
+      resetAttachmentDraftSession();
       setChatEntries([]);
       setChatStreaming(false);
       setSessionModel(null);
       setSessionEffort(null);
       setSessionFast(null);
       if (decision.nextReal !== "zcode") setZcodeSessionModels(null);
-    }, [effective.backend, byokLoop, claudeBackend, codexBackend, openCodeBackend, zcodeBackend]);
-    const sendChat = (text) => {
-      const trimmed = String(text || "").trim();
-      if (!trimmed) return;
-      setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: "user-text", text: trimmed }));
-      activeBackend.sendUser(trimmed);
+    }, [effective.backend, byokLoop, claudeBackend, codexBackend, openCodeBackend, resetAttachmentDraftSession, zcodeBackend]);
+    const sendChat = (input) => {
+      if (pendingTurnRef.current) return;
+      let turn;
+      try {
+        turn = normalizeTurnInput(input);
+      } catch (error) {
+        const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
+        dispatchAttachmentDraft({
+          type: "rejected",
+          turnId,
+          error: { code: "TURN_INPUT_INVALID", message: error.message }
+        });
+        return;
+      }
+      pendingTurnRef.current = turn;
+      acceptedTurnRef.current = null;
+      try {
+        const result = activeBackend.sendUser(turn);
+        Promise.resolve(result).catch((error) => {
+          var _a;
+          if (((_a = pendingTurnRef.current) == null ? void 0 : _a.turnId) !== turn.turnId) return;
+          handleChatEvent({
+            type: "error",
+            kind: (error == null ? void 0 : error.kind) || "backend",
+            code: (error == null ? void 0 : error.code) || "BACKEND_ERROR",
+            message: (error == null ? void 0 : error.message) || String(error),
+            turnId: turn.turnId,
+            dispatchState: (error == null ? void 0 : error.dispatchState) || "uncertain"
+          });
+        });
+      } catch (error) {
+        handleChatEvent({
+          type: "error",
+          kind: (error == null ? void 0 : error.kind) || "backend",
+          code: (error == null ? void 0 : error.code) || "BACKEND_ERROR",
+          message: (error == null ? void 0 : error.message) || String(error),
+          turnId: turn.turnId,
+          dispatchState: (error == null ? void 0 : error.dispatchState) || "not-started"
+        });
+      }
     };
     const newChatSession = () => {
       activeBackend.reset();
+      resetAttachmentDraftSession();
       setChatStreaming(false);
+      setThinkingActive(false);
       setChatEntries([]);
     };
     const pushLog = import_react46.default.useCallback((m) => {
@@ -49584,7 +50225,13 @@ ${baseUrl}`),
             onChipApproval: (m) => {
               setPermissionMode(m);
               writePref("ae_mcp_perm_mode", m);
-            }
+            },
+            attachmentDraft,
+            dispatchAttachmentDraft,
+            createTurnId: randomProviderCredentialId,
+            onAddFile: addAttachment,
+            onRemoveAttachment: removeAttachment,
+            onRetryAttachment: retryAttachment
           }
         ) : null,
         tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(

--- a/plugin/host/platform-helper-registration.js
+++ b/plugin/host/platform-helper-registration.js
@@ -1,0 +1,313 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const HELPER_ID = 'com.junkdoge.ae-mcp.platform-helper';
+const HELPER_ENTRYPOINT = 'bin/ae-mcp-platform-helper';
+const LAUNCHER_ENTRYPOINT = 'bin/ae-mcp';
+const LAUNCHD_TEMPLATE = `launchd/${HELPER_ID}.plist`;
+const LAUNCHD_TOKEN = '__AE_MCP_HELPER_EXECUTABLE__';
+const MACOS_PAYLOAD = Object.freeze([
+    Object.freeze({ path: HELPER_ENTRYPOINT, architecture: 'macho-arm64' }),
+    Object.freeze({ path: LAUNCHER_ENTRYPOINT, architecture: 'script' }),
+    Object.freeze({
+        path: 'lib/ae-mcp-platform-helper-transport.node',
+        architecture: 'macho-arm64',
+    }),
+    Object.freeze({
+        path: `xpc/${HELPER_ID}.xpc/Contents/MacOS/ae-mcp-platform-helper`,
+        architecture: 'macho-arm64',
+    }),
+    Object.freeze({
+        path: `xpc/${HELPER_ID}.xpc/Contents/Info.plist`,
+        architecture: 'data',
+    }),
+    Object.freeze({
+        path: 'metadata/PlatformHelper.entitlements',
+        architecture: 'data',
+    }),
+    Object.freeze({ path: LAUNCHD_TEMPLATE, architecture: 'data' }),
+]);
+const LAUNCHCTL = '/bin/launchctl';
+const MAX_LAUNCHCTL_OUTPUT_BYTES = 65536;
+
+function helperError(code, message, retryable, cause) {
+    const error = new Error(message);
+    error.code = code;
+    error.retryable = Boolean(retryable);
+    if (cause !== undefined) error.cause = cause;
+    return error;
+}
+
+function repairRequired(message, cause) {
+    return helperError('PLATFORM_HELPER_REPAIR_REQUIRED', message, false, cause);
+}
+
+function startFailed(message, cause) {
+    return helperError('HELPER_START_FAILED', message, true, cause);
+}
+
+function regularFile(filePath, fsImpl) {
+    let metadata;
+    try {
+        metadata = fsImpl.lstatSync(filePath);
+    } catch (cause) {
+        throw repairRequired('platform helper payload is incomplete', cause);
+    }
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw repairRequired('platform helper payload contains an invalid file');
+    }
+}
+
+function resolvePayloadFile(helperRoot, relative) {
+    const absolute = path.resolve(helperRoot, ...relative.split('/'));
+    if (!absolute.startsWith(helperRoot + path.sep)) {
+        throw repairRequired('platform helper payload path is invalid');
+    }
+    return absolute;
+}
+
+function readManifest(helperRoot, fsImpl) {
+    const manifestPath = path.join(helperRoot, 'helper-manifest.json');
+    regularFile(manifestPath, fsImpl);
+    try {
+        return JSON.parse(fsImpl.readFileSync(manifestPath, 'utf8'));
+    } catch (cause) {
+        throw repairRequired('platform helper manifest is invalid', cause);
+    }
+}
+
+function verifyMacosPayload(addonPath, input) {
+    const fsImpl = input.fsImpl;
+    const createHash = input.createHash;
+    const helperRoot = path.resolve(path.dirname(addonPath), '..');
+    const expectedAddonPath = resolvePayloadFile(
+        helperRoot,
+        'lib/ae-mcp-platform-helper-transport.node',
+    );
+    if (path.resolve(addonPath) !== expectedAddonPath) {
+        throw repairRequired('platform helper addon path is invalid');
+    }
+
+    const manifest = readManifest(helperRoot, fsImpl);
+    if (manifest === null
+        || typeof manifest !== 'object'
+        || Array.isArray(manifest)
+        || manifest.schemaVersion !== 1
+        || manifest.platform !== 'macos-arm64'
+        || manifest.helperId !== HELPER_ID
+        || manifest.entrypoints === null
+        || typeof manifest.entrypoints !== 'object'
+        || Array.isArray(manifest.entrypoints)
+        || manifest.entrypoints.helper !== HELPER_ENTRYPOINT
+        || manifest.entrypoints.launcher !== LAUNCHER_ENTRYPOINT
+        || !Array.isArray(manifest.files)
+        || manifest.files.length !== MACOS_PAYLOAD.length) {
+        throw repairRequired('platform helper manifest identity is invalid');
+    }
+
+    for (let index = 0; index < MACOS_PAYLOAD.length; index += 1) {
+        const expected = MACOS_PAYLOAD[index];
+        const record = manifest.files[index];
+        if (record === null
+            || typeof record !== 'object'
+            || Array.isArray(record)
+            || record.path !== expected.path
+            || record.architecture !== expected.architecture
+            || typeof record.sha256 !== 'string'
+            || !/^[0-9a-f]{64}$/i.test(record.sha256)) {
+            throw repairRequired('platform helper manifest inventory is invalid');
+        }
+        const filePath = resolvePayloadFile(helperRoot, record.path);
+        regularFile(filePath, fsImpl);
+        let digest;
+        try {
+            digest = createHash('sha256')
+                .update(fsImpl.readFileSync(filePath))
+                .digest('hex');
+        } catch (cause) {
+            throw repairRequired('platform helper payload could not be verified', cause);
+        }
+        if (digest.toLowerCase() !== record.sha256.toLowerCase()) {
+            throw repairRequired('platform helper payload verification failed');
+        }
+    }
+
+    return Object.freeze({
+        helperRoot,
+        helperPath: resolvePayloadFile(helperRoot, HELPER_ENTRYPOINT),
+        templatePath: resolvePayloadFile(helperRoot, LAUNCHD_TEMPLATE),
+    });
+}
+
+function xmlEscape(value) {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;');
+}
+
+function privateStateRoot(input) {
+    return path.join(
+        input.homedir(),
+        'Library',
+        'Application Support',
+        'AfterEffectsMCP',
+        'platform-helper-v1',
+    );
+}
+
+function ensurePrivateDirectory(stateRoot, fsImpl) {
+    try {
+        if (!fsImpl.existsSync(stateRoot)) {
+            fsImpl.mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
+        }
+        const metadata = fsImpl.lstatSync(stateRoot);
+        if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+            throw new Error('state root is not a private directory');
+        }
+        fsImpl.chmodSync(stateRoot, 0o700);
+    } catch (cause) {
+        if (cause && cause.code === 'PLATFORM_HELPER_REPAIR_REQUIRED') throw cause;
+        throw repairRequired('platform helper registration state is invalid', cause);
+    }
+}
+
+function materializePrivatePlist(payload, input) {
+    const fsImpl = input.fsImpl;
+    const stateRoot = privateStateRoot(input);
+    ensurePrivateDirectory(stateRoot, fsImpl);
+
+    let template;
+    try {
+        template = fsImpl.readFileSync(payload.templatePath, 'utf8');
+    } catch (cause) {
+        throw repairRequired('platform helper launchd template is unavailable', cause);
+    }
+    const pieces = template.split(LAUNCHD_TOKEN);
+    if (pieces.length !== 2) {
+        throw repairRequired('platform helper launchd template is invalid');
+    }
+    const rendered = pieces[0] + xmlEscape(payload.helperPath) + pieces[1];
+    const destination = path.join(stateRoot, `${HELPER_ID}.plist`);
+    const nonce = crypto.randomBytes(8).toString('hex');
+    const temporary = `${destination}.tmp.${input.processId}.${nonce}`;
+    try {
+        fsImpl.writeFileSync(temporary, rendered, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+        fsImpl.renameSync(temporary, destination);
+        fsImpl.chmodSync(destination, 0o600);
+    } catch (cause) {
+        try {
+            if (fsImpl.existsSync(temporary)) fsImpl.unlinkSync(temporary);
+        } catch (_) {}
+        throw repairRequired('platform helper registration could not be written', cause);
+    }
+    return destination;
+}
+
+function launchctlRunner(input) {
+    return function launchctl(args, options) {
+        const allowMissing = Boolean(options && options.allowMissing);
+        return new Promise(function (resolve, reject) {
+            let settled = false;
+            function finish(error, stdout) {
+                if (settled) return;
+                settled = true;
+                if (error) {
+                    if (allowMissing) {
+                        resolve(Object.freeze({ found: false, stdout: '' }));
+                        return;
+                    }
+                    reject(startFailed('platform helper registration command failed', error));
+                    return;
+                }
+                resolve(Object.freeze({ found: true, stdout: String(stdout || '') }));
+            }
+            try {
+                input.execFile(LAUNCHCTL, args, {
+                    encoding: 'utf8',
+                    timeout: 5000,
+                    windowsHide: true,
+                    maxBuffer: MAX_LAUNCHCTL_OUTPUT_BYTES,
+                }, finish);
+            } catch (cause) {
+                finish(cause, '');
+            }
+        });
+    };
+}
+
+function requireExactProgram(stdout, helperPath) {
+    const exact = `program = ${helperPath}`;
+    const lines = String(stdout).split(/\r?\n/).map(function (line) { return line.trim(); });
+    if (!lines.includes(exact)) {
+        throw repairRequired('registered platform helper identity is invalid');
+    }
+}
+
+function prepareMacosHelperRegistration(options) {
+    const input = options || {};
+    if (typeof input.addonPath !== 'string' || !path.isAbsolute(input.addonPath)) {
+        throw new TypeError('addonPath must be absolute');
+    }
+    const dependencies = {
+        fsImpl: input.fsImpl || fs,
+        createHash: input.createHash || crypto.createHash,
+        execFile: input.execFile || require('child_process').execFile,
+        homedir: input.homedir || os.homedir,
+        getuid: input.getuid || process.getuid,
+        processId: input.processId === undefined ? process.pid : input.processId,
+    };
+    if (typeof dependencies.execFile !== 'function'
+        || typeof dependencies.homedir !== 'function'
+        || typeof dependencies.getuid !== 'function'
+        || !Number.isSafeInteger(dependencies.processId)
+        || dependencies.processId <= 0) {
+        throw new TypeError('macOS helper registration dependencies are invalid');
+    }
+    const userIdentifier = dependencies.getuid();
+    if (!Number.isSafeInteger(userIdentifier) || userIdentifier < 0) {
+        throw new TypeError('current user identifier is invalid');
+    }
+    const payload = verifyMacosPayload(path.resolve(input.addonPath), dependencies);
+    const launchctl = launchctlRunner(dependencies);
+    const domain = `gui/${userIdentifier}`;
+    const service = `${domain}/${HELPER_ID}`;
+    let registrationPromise = null;
+
+    async function register() {
+        const current = await launchctl(['print', service], { allowMissing: true });
+        if (current.found) {
+            requireExactProgram(current.stdout, payload.helperPath);
+            return;
+        }
+        const plistPath = materializePrivatePlist(payload, dependencies);
+        await launchctl(['bootstrap', domain, plistPath]);
+        const registered = await launchctl(['print', service]);
+        requireExactProgram(registered.stdout, payload.helperPath);
+    }
+
+    function ensureRegistered() {
+        if (!registrationPromise) {
+            const pending = Promise.resolve().then(register).catch(function (error) {
+                if (registrationPromise === pending) registrationPromise = null;
+                throw error;
+            });
+            registrationPromise = pending;
+            pending.catch(function () {});
+        }
+        return registrationPromise;
+    }
+
+    return Object.freeze({
+        helperPath: payload.helperPath,
+        ensureRegistered,
+    });
+}
+
+module.exports = { prepareMacosHelperRegistration };

--- a/plugin/host/platform-helper-registration.test.js
+++ b/plugin/host/platform-helper-registration.test.js
@@ -99,9 +99,27 @@ function registrationFor(fixture, execFile, overrides) {
 test('macOS registration verifies the payload and bootstraps the exact helper before use', async (t) => {
     const fixture = writeMacosFixture(t);
     const calls = [];
+    const mkdirCalls = [];
+    const writeFileCalls = [];
+    const chmodCalls = [];
     let generatedPlist = null;
     let generatedContents = null;
     const service = `gui/501/${HELPER_ID}`;
+    const fsImpl = {
+        ...fs,
+        mkdirSync(target, options) {
+            mkdirCalls.push([target, options]);
+            return fs.mkdirSync(target, options);
+        },
+        writeFileSync(target, contents, options) {
+            writeFileCalls.push([target, options]);
+            return fs.writeFileSync(target, contents, options);
+        },
+        chmodSync(target, mode) {
+            chmodCalls.push([target, mode]);
+            return fs.chmodSync(target, mode);
+        },
+    };
 
     function execFile(file, args, options, callback) {
         calls.push([file, [...args]]);
@@ -127,7 +145,7 @@ test('macOS registration verifies the payload and bootstraps the exact helper be
         ));
     }
 
-    const registration = registrationFor(fixture, execFile);
+    const registration = registrationFor(fixture, execFile, { fsImpl });
     await registration.ensureRegistered();
 
     assert.equal(registration.helperPath, fixture.helperPath);
@@ -138,8 +156,26 @@ test('macOS registration verifies the payload and bootstraps the exact helper be
     ]);
     assert.equal(generatedContents.includes('__AE_MCP_HELPER_EXECUTABLE__'), false);
     assert.equal(generatedContents.includes(fixture.helperPath), true);
-    assert.equal(fs.statSync(fixture.stateRoot).mode & 0o077, 0);
-    assert.equal(fs.statSync(generatedPlist).mode & 0o177, 0);
+    assert.deepEqual(
+        mkdirCalls.find(([target]) => target === fixture.stateRoot),
+        [fixture.stateRoot, { recursive: true, mode: 0o700 }],
+    );
+    const temporaryWrite = writeFileCalls.find(
+        ([target]) => target.startsWith(generatedPlist + '.tmp.'),
+    );
+    assert.ok(temporaryWrite);
+    assert.deepEqual(
+        temporaryWrite[1],
+        { encoding: 'utf8', mode: 0o600, flag: 'wx' },
+    );
+    assert.deepEqual(chmodCalls, [
+        [fixture.stateRoot, 0o700],
+        [generatedPlist, 0o600],
+    ]);
+    if (process.platform !== 'win32') {
+        assert.equal(fs.statSync(fixture.stateRoot).mode & 0o077, 0);
+        assert.equal(fs.statSync(generatedPlist).mode & 0o177, 0);
+    }
 });
 
 test('macOS registration rejects a tampered payload before launchctl', (t) => {

--- a/plugin/host/platform-helper-registration.test.js
+++ b/plugin/host/platform-helper-registration.test.js
@@ -1,0 +1,280 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    prepareMacosHelperRegistration,
+} = require('./platform-helper-registration');
+
+const HELPER_ID = 'com.junkdoge.ae-mcp.platform-helper';
+const MACOS_FILES = Object.freeze([
+    ['bin/ae-mcp-platform-helper', 'macho-arm64'],
+    ['bin/ae-mcp', 'script'],
+    ['lib/ae-mcp-platform-helper-transport.node', 'macho-arm64'],
+    ['xpc/com.junkdoge.ae-mcp.platform-helper.xpc/Contents/MacOS/ae-mcp-platform-helper', 'macho-arm64'],
+    ['xpc/com.junkdoge.ae-mcp.platform-helper.xpc/Contents/Info.plist', 'data'],
+    ['metadata/PlatformHelper.entitlements', 'data'],
+    ['launchd/com.junkdoge.ae-mcp.platform-helper.plist', 'data'],
+]);
+
+function sha256(contents) {
+    return crypto.createHash('sha256').update(contents).digest('hex');
+}
+
+function writeMacosFixture(t) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-helper-registration-'));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const helperRoot = path.join(root, 'platform', 'macos-arm64');
+    const home = path.join(root, 'home');
+    fs.mkdirSync(home, { recursive: true });
+
+    const records = MACOS_FILES.map(function ([relative, architecture], index) {
+        const target = path.join(helperRoot, ...relative.split('/'));
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        const contents = relative.startsWith('launchd/')
+            ? [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<plist version="1.0"><dict>',
+                '<key>Label</key><string>com.junkdoge.ae-mcp.platform-helper</string>',
+                '<key>ProgramArguments</key><array>',
+                '<string>__AE_MCP_HELPER_EXECUTABLE__</string>',
+                '</array></dict></plist>',
+                '',
+            ].join('\n')
+            : `fixture-${index}-${relative}\n`;
+        fs.writeFileSync(target, contents);
+        return {
+            path: relative,
+            architecture,
+            sha256: sha256(contents),
+        };
+    });
+    fs.writeFileSync(path.join(helperRoot, 'helper-manifest.json'), JSON.stringify({
+        schemaVersion: 1,
+        platform: 'macos-arm64',
+        helperId: HELPER_ID,
+        entrypoints: {
+            helper: 'bin/ae-mcp-platform-helper',
+            launcher: 'bin/ae-mcp',
+        },
+        files: records,
+    }));
+    return {
+        addonPath: path.join(
+            helperRoot,
+            'lib',
+            'ae-mcp-platform-helper-transport.node',
+        ),
+        helperPath: path.join(helperRoot, 'bin', 'ae-mcp-platform-helper'),
+        helperRoot,
+        home,
+        stateRoot: path.join(
+            home,
+            'Library',
+            'Application Support',
+            'AfterEffectsMCP',
+            'platform-helper-v1',
+        ),
+    };
+}
+
+function manifestPath(fixture) {
+    return path.join(fixture.helperRoot, 'helper-manifest.json');
+}
+
+function registrationFor(fixture, execFile, overrides) {
+    return prepareMacosHelperRegistration({
+        addonPath: fixture.addonPath,
+        execFile,
+        homedir: function () { return fixture.home; },
+        getuid: function () { return 501; },
+        processId: 42,
+        ...overrides,
+    });
+}
+
+test('macOS registration verifies the payload and bootstraps the exact helper before use', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    let generatedPlist = null;
+    let generatedContents = null;
+    const service = `gui/501/${HELPER_ID}`;
+
+    function execFile(file, args, options, callback) {
+        calls.push([file, [...args]]);
+        assert.equal(options.encoding, 'utf8');
+        assert.equal(options.timeout, 5000);
+        assert.equal(options.windowsHide, true);
+        assert.equal(options.maxBuffer, 65536);
+        if (args[0] === 'print' && calls.length === 1) {
+            const error = Object.assign(new Error('service absent'), { code: 113 });
+            queueMicrotask(() => callback(error, '', 'service absent'));
+            return;
+        }
+        if (args[0] === 'bootstrap') {
+            generatedPlist = args[2];
+            generatedContents = fs.readFileSync(generatedPlist, 'utf8');
+            queueMicrotask(() => callback(null, '', ''));
+            return;
+        }
+        queueMicrotask(() => callback(
+            null,
+            `${service} = {\n\tprogram = ${fixture.helperPath}\n}\n`,
+            '',
+        ));
+    }
+
+    const registration = registrationFor(fixture, execFile);
+    await registration.ensureRegistered();
+
+    assert.equal(registration.helperPath, fixture.helperPath);
+    assert.deepEqual(calls, [
+        ['/bin/launchctl', ['print', service]],
+        ['/bin/launchctl', ['bootstrap', 'gui/501', generatedPlist]],
+        ['/bin/launchctl', ['print', service]],
+    ]);
+    assert.equal(generatedContents.includes('__AE_MCP_HELPER_EXECUTABLE__'), false);
+    assert.equal(generatedContents.includes(fixture.helperPath), true);
+    assert.equal(fs.statSync(fixture.stateRoot).mode & 0o077, 0);
+    assert.equal(fs.statSync(generatedPlist).mode & 0o177, 0);
+});
+
+test('macOS registration rejects a tampered payload before launchctl', (t) => {
+    const fixture = writeMacosFixture(t);
+    fs.appendFileSync(fixture.helperPath, 'tampered');
+    let launchctlCalls = 0;
+    assert.throws(() => registrationFor(fixture, function () {
+        launchctlCalls += 1;
+    }), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED', retryable: false });
+    assert.equal(launchctlCalls, 0);
+});
+
+test('macOS registration rejects an expanded manifest before launchctl', (t) => {
+    const fixture = writeMacosFixture(t);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath(fixture), 'utf8'));
+    manifest.files.push({
+        path: 'unexpected',
+        architecture: 'data',
+        sha256: 'a'.repeat(64),
+    });
+    fs.writeFileSync(manifestPath(fixture), JSON.stringify(manifest));
+    let launchctlCalls = 0;
+    assert.throws(() => registrationFor(fixture, function () {
+        launchctlCalls += 1;
+    }), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED', retryable: false });
+    assert.equal(launchctlCalls, 0);
+});
+
+test('macOS registration rejects a symbolic state root before bootstrap', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const outside = path.join(path.dirname(fixture.home), 'outside-state');
+    fs.mkdirSync(outside);
+    fs.mkdirSync(path.dirname(fixture.stateRoot), { recursive: true });
+    fs.symlinkSync(outside, fixture.stateRoot);
+    const calls = [];
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        queueMicrotask(() => callback(Object.assign(new Error('absent'), { code: 113 }), '', ''));
+    });
+
+    await assert.rejects(registration.ensureRegistered(), {
+        code: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+        retryable: false,
+    });
+    assert.deepEqual(calls, [
+        ['/bin/launchctl', ['print', `gui/501/${HELPER_ID}`]],
+    ]);
+});
+
+test('macOS registration reuses only an already-loaded exact helper', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        queueMicrotask(() => callback(
+            null,
+            `gui/501/${HELPER_ID} = {\n\tprogram = ${fixture.helperPath}\n}\n`,
+            '',
+        ));
+    });
+
+    await registration.ensureRegistered();
+    assert.deepEqual(calls, [
+        ['/bin/launchctl', ['print', `gui/501/${HELPER_ID}`]],
+    ]);
+    assert.equal(fs.existsSync(fixture.stateRoot), false);
+});
+
+test('macOS registration rejects an already-loaded different helper', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        queueMicrotask(() => callback(
+            null,
+            `gui/501/${HELPER_ID} = {\n\tprogram = /tmp/untrusted-helper\n}\n`,
+            '',
+        ));
+    });
+
+    await assert.rejects(registration.ensureRegistered(), {
+        code: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+        retryable: false,
+    });
+});
+
+test('macOS registration sanitizes bootstrap failures without fallback', async (t) => {
+    const fixture = writeMacosFixture(t);
+    let calls = 0;
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls += 1;
+        if (args[0] === 'print') {
+            queueMicrotask(() => callback(Object.assign(new Error('absent'), { code: 113 }), '', ''));
+            return;
+        }
+        const sensitive = `${fixture.home}/secret stderr`;
+        queueMicrotask(() => callback(Object.assign(new Error(sensitive), { code: 5 }), '', sensitive));
+    });
+
+    await assert.rejects(registration.ensureRegistered(), function (error) {
+        assert.equal(error.code, 'HELPER_START_FAILED');
+        assert.equal(error.retryable, true);
+        assert.equal(error.message.includes(fixture.home), false);
+        assert.equal(error.message.includes('stderr'), false);
+        return true;
+    });
+    assert.equal(calls, 2);
+});
+
+test('macOS registration is single-flight for concurrent callers', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = `gui/501/${HELPER_ID}`;
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        if (args[0] === 'print' && calls.length === 1) {
+            setImmediate(() => callback(Object.assign(new Error('absent'), { code: 113 }), '', ''));
+            return;
+        }
+        if (args[0] === 'bootstrap') {
+            setImmediate(() => callback(null, '', ''));
+            return;
+        }
+        setImmediate(() => callback(
+            null,
+            `${service} = {\n\tprogram = ${fixture.helperPath}\n}\n`,
+            '',
+        ));
+    });
+
+    const first = registration.ensureRegistered();
+    const second = registration.ensureRegistered();
+    assert.equal(first, second);
+    await Promise.all([first, second]);
+    assert.deepEqual(calls.map(function (call) { return call[1][0]; }), [
+        'print',
+        'bootstrap',
+        'print',
+    ]);
+});

--- a/plugin/host/platform-helper-stdio-transport.js
+++ b/plugin/host/platform-helper-stdio-transport.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const MAX_MESSAGE_BYTES = 65536;
+
+function helperError(code, message, retryable, cause) {
+    const error = new Error(message);
+    error.code = code;
+    error.retryable = Boolean(retryable);
+    if (cause !== undefined) error.cause = cause;
+    return error;
+}
+
+function unavailable(message, cause) {
+    return helperError('HELPER_UNAVAILABLE', message, true, cause);
+}
+
+function startFailed(cause) {
+    return helperError(
+        'HELPER_START_FAILED',
+        'platform helper broker could not be started',
+        true,
+        cause,
+    );
+}
+
+function createPlatformHelperStdioTransport(options) {
+    const input = options || {};
+    if (typeof input.helperPath !== 'string' || input.helperPath.length === 0) {
+        throw new TypeError('helperPath must be a non-empty string');
+    }
+    const maxMessageBytes = input.maxMessageBytes === undefined
+        ? MAX_MESSAGE_BYTES
+        : input.maxMessageBytes;
+    if (!Number.isSafeInteger(maxMessageBytes) || maxMessageBytes < 1) {
+        throw new TypeError('maxMessageBytes must be a positive safe integer');
+    }
+    const spawnImpl = input.spawnImpl
+        || function (file, args, spawnOptions) {
+            return require('child_process').spawn(file, args, spawnOptions);
+        };
+
+    let child = null;
+    let startupError = null;
+    let terminalError = null;
+    let closed = false;
+    let stdoutBuffer = Buffer.alloc(0);
+    const pending = [];
+
+    function rejectPending(error) {
+        while (pending.length > 0) pending.shift().reject(error);
+    }
+
+    function fail(error) {
+        if (terminalError || closed) return;
+        terminalError = error;
+        rejectPending(error);
+    }
+
+    try {
+        child = spawnImpl(input.helperPath, ['--client-stdio'], {
+            windowsHide: true,
+            shell: false,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        if (!child
+            || !child.stdin
+            || typeof child.stdin.write !== 'function'
+            || typeof child.stdin.end !== 'function'
+            || !child.stdout
+            || typeof child.stdout.on !== 'function'
+            || !child.stderr
+            || typeof child.stderr.on !== 'function'
+            || typeof child.on !== 'function') {
+            throw new TypeError('platform helper broker process is invalid');
+        }
+    } catch (cause) {
+        startupError = startFailed(cause);
+    }
+
+    if (child) {
+        child.stdout.on('data', function (chunk) {
+            if (terminalError || closed) return;
+            const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            stdoutBuffer = Buffer.concat([stdoutBuffer, bytes]);
+            if (stdoutBuffer.length > maxMessageBytes && stdoutBuffer.indexOf(0x0a) === -1) {
+                fail(unavailable('platform helper broker returned an oversized response'));
+                return;
+            }
+            let newline = stdoutBuffer.indexOf(0x0a);
+            while (newline !== -1 && !terminalError) {
+                let frame = stdoutBuffer.subarray(0, newline);
+                stdoutBuffer = stdoutBuffer.subarray(newline + 1);
+                if (frame.length > 0 && frame[frame.length - 1] === 0x0d) {
+                    frame = frame.subarray(0, frame.length - 1);
+                }
+                if (frame.length === 0 || frame.length > maxMessageBytes || pending.length === 0) {
+                    fail(unavailable('platform helper broker returned an invalid response'));
+                    return;
+                }
+                pending.shift().resolve(frame.toString('utf8'));
+                newline = stdoutBuffer.indexOf(0x0a);
+            }
+            if (stdoutBuffer.length > maxMessageBytes) {
+                fail(unavailable('platform helper broker returned an oversized response'));
+            }
+        });
+        child.stdout.on('error', function (cause) {
+            fail(unavailable('platform helper broker output failed', cause));
+        });
+        child.stderr.on('data', function () {
+            // Deliberately discard bounded public diagnostics. Native stderr may
+            // contain local paths and never crosses the host error boundary.
+        });
+        child.stderr.on('error', function () {});
+        child.stdin.on('error', function (cause) {
+            fail(unavailable('platform helper broker input failed', cause));
+        });
+        child.on('error', function (cause) {
+            fail(startFailed(cause));
+        });
+        child.on('exit', function () {
+            if (!closed) fail(startFailed());
+        });
+    }
+
+    return Object.freeze({
+        request: function (jsonUtf8) {
+            if (closed) {
+                return Promise.reject(unavailable('platform helper broker transport is closed'));
+            }
+            if (startupError) return Promise.reject(startupError);
+            if (terminalError) return Promise.reject(terminalError);
+            if (typeof jsonUtf8 !== 'string'
+                || jsonUtf8.length === 0
+                || jsonUtf8.includes('\n')
+                || jsonUtf8.includes('\r')
+                || Buffer.byteLength(jsonUtf8, 'utf8') > maxMessageBytes) {
+                return Promise.reject(unavailable('platform helper request is invalid'));
+            }
+            return new Promise(function (resolve, reject) {
+                pending.push({ resolve, reject });
+                try {
+                    child.stdin.write(jsonUtf8 + '\n');
+                } catch (cause) {
+                    fail(unavailable('platform helper broker input failed', cause));
+                }
+            });
+        },
+        close: function () {
+            if (closed) return Promise.resolve();
+            closed = true;
+            rejectPending(unavailable('platform helper broker transport is closed'));
+            if (child && child.stdin && child.stdin.writable !== false) {
+                try { child.stdin.end(); } catch (_) {}
+            }
+            return Promise.resolve();
+        },
+    });
+}
+
+module.exports = { createPlatformHelperStdioTransport };

--- a/plugin/host/platform-helper-stdio-transport.test.js
+++ b/plugin/host/platform-helper-stdio-transport.test.js
@@ -1,0 +1,133 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+
+const {
+    createPlatformHelperStdioTransport,
+} = require('./platform-helper-stdio-transport');
+
+function fakeChild() {
+    const child = new EventEmitter();
+    child.stdin = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin.writable = true;
+    child.stdin.writes = [];
+    child.stdin.write = function (value) {
+        child.stdin.writes.push(value);
+        return true;
+    };
+    child.stdin.end = function () {
+        child.stdin.writable = false;
+        child.stdin.emit('finish');
+    };
+    return child;
+}
+
+test('stdio transport spawns only the verified Helper broker with private pipes', async () => {
+    const child = fakeChild();
+    const calls = [];
+    const transport = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        spawnImpl: function (file, args, options) {
+            calls.push({ file, args, options });
+            return child;
+        },
+    });
+
+    const response = transport.request('{"protocolVersion":1,"id":1,"method":"capabilities","params":{}}');
+    assert.deepEqual(calls, [{
+        file: '/verified/ae-mcp-platform-helper',
+        args: ['--client-stdio'],
+        options: {
+            windowsHide: true,
+            shell: false,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        },
+    }]);
+    assert.deepEqual(child.stdin.writes, [
+        '{"protocolVersion":1,"id":1,"method":"capabilities","params":{}}\n',
+    ]);
+    child.stdout.emit('data', Buffer.from('{"protocolVersion":1,"id":1,"ok":true,"result":{}}\n'));
+    assert.equal(
+        await response,
+        '{"protocolVersion":1,"id":1,"ok":true,"result":{}}',
+    );
+    await transport.close();
+    assert.equal(child.stdin.writable, false);
+});
+
+test('stdio transport preserves FIFO framing across concurrent requests', async () => {
+    const child = fakeChild();
+    const transport = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        spawnImpl: function () { return child; },
+    });
+
+    const first = transport.request('one');
+    const second = transport.request('two');
+    child.stdout.emit('data', Buffer.from('first\nsec'));
+    child.stdout.emit('data', Buffer.from('ond\n'));
+
+    assert.deepEqual(await Promise.all([first, second]), ['first', 'second']);
+    assert.deepEqual(child.stdin.writes, ['one\n', 'two\n']);
+    await transport.close();
+});
+
+test('stdio transport fails closed on oversized output and rejects every pending request', async () => {
+    const child = fakeChild();
+    const transport = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        maxMessageBytes: 8,
+        spawnImpl: function () { return child; },
+    });
+    const first = transport.request('one');
+    const second = transport.request('two');
+    child.stdout.emit('data', Buffer.from('123456789'));
+
+    await assert.rejects(first, { code: 'HELPER_UNAVAILABLE', retryable: true });
+    await assert.rejects(second, { code: 'HELPER_UNAVAILABLE', retryable: true });
+    await transport.close();
+});
+
+test('stdio transport classifies spawn and premature-exit failures without stderr leakage', async () => {
+    const spawnFailure = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        spawnImpl: function () { throw new Error('/private/path secret detail'); },
+    });
+    await assert.rejects(spawnFailure.request('{}'), function (error) {
+        assert.equal(error.code, 'HELPER_START_FAILED');
+        assert.equal(error.retryable, true);
+        assert.equal(error.message.includes('/private/path'), false);
+        return true;
+    });
+
+    const child = fakeChild();
+    const exited = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        spawnImpl: function () { return child; },
+    });
+    const request = exited.request('{}');
+    child.stderr.emit('data', Buffer.from('credential-shaped private detail'));
+    child.emit('exit', 78, null);
+    await assert.rejects(request, function (error) {
+        assert.equal(error.code, 'HELPER_START_FAILED');
+        assert.equal(error.message.includes('credential-shaped'), false);
+        return true;
+    });
+    await exited.close();
+});
+
+test('stdio transport rejects newline requests before writing to the broker', async () => {
+    const child = fakeChild();
+    const transport = createPlatformHelperStdioTransport({
+        helperPath: '/verified/ae-mcp-platform-helper',
+        spawnImpl: function () { return child; },
+    });
+    await assert.rejects(transport.request('one\ntwo'), {
+        code: 'HELPER_UNAVAILABLE',
+        retryable: true,
+    });
+    assert.deepEqual(child.stdin.writes, []);
+    await transport.close();
+});

--- a/plugin/host/platform-helper-transport.js
+++ b/plugin/host/platform-helper-transport.js
@@ -6,6 +6,9 @@ const path = require('path');
 const {
     prepareMacosHelperRegistration,
 } = require('./platform-helper-registration');
+const {
+    createPlatformHelperStdioTransport,
+} = require('./platform-helper-stdio-transport');
 
 const WINDOWS_PAYLOAD_FILES = Object.freeze([
     'bin/ae-mcp-platform-helper.exe',
@@ -199,14 +202,16 @@ function createPlatformHelperTransport(options) {
         }
     }
 
-    let addon;
-    try {
-        addon = loadAddon(addonPath);
-    } catch (cause) {
-        throw repairRequired('failed to load the platform helper transport addon', cause);
-    }
-    if (!addon || typeof addon.createTransport !== 'function') {
-        throw repairRequired('platform helper addon does not export createTransport');
+    let addon = null;
+    if (platformId === 'windows-x64') {
+        try {
+            addon = loadAddon(addonPath);
+        } catch (cause) {
+            throw repairRequired('failed to load the platform helper transport addon', cause);
+        }
+        if (!addon || typeof addon.createTransport !== 'function') {
+            throw repairRequired('platform helper addon does not export createTransport');
+        }
     }
 
     let nativeTransport = null;
@@ -215,12 +220,10 @@ function createPlatformHelperTransport(options) {
     let closed = false;
 
     function openNativeTransport() {
-        const opened = platformId === 'windows-x64'
-            ? addon.createTransport({
-                expectedServerPath: helperIdentity.path,
-                expectedServerSha256: helperIdentity.sha256,
-            })
-            : addon.createTransport();
+        const opened = addon.createTransport({
+            expectedServerPath: helperIdentity.path,
+            expectedServerSha256: helperIdentity.sha256,
+        });
         if (!validNativeTransport(opened)) {
             try {
                 if (opened && typeof opened.close === 'function') opened.close();
@@ -288,7 +291,18 @@ function createPlatformHelperTransport(options) {
         } else {
             try {
                 await macosRegistration.ensureRegistered();
-                opened = openNativeTransport();
+                const createBrokerTransport = input.createMacosBrokerTransport
+                    || createPlatformHelperStdioTransport;
+                opened = createBrokerTransport({
+                    helperPath: macosRegistration.helperPath,
+                    spawnImpl: input.spawnMacosBroker,
+                });
+                if (!validNativeTransport(opened)) {
+                    try {
+                        if (opened && typeof opened.close === 'function') opened.close();
+                    } catch (_) {}
+                    throw repairRequired('platform helper broker returned an invalid transport');
+                }
             } catch (cause) {
                 if (cause
                     && (cause.code === 'PLATFORM_HELPER_REPAIR_REQUIRED'

--- a/plugin/host/platform-helper-transport.js
+++ b/plugin/host/platform-helper-transport.js
@@ -3,6 +3,9 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const {
+    prepareMacosHelperRegistration,
+} = require('./platform-helper-registration');
 
 const WINDOWS_PAYLOAD_FILES = Object.freeze([
     'bin/ae-mcp-platform-helper.exe',
@@ -139,6 +142,13 @@ function validNativeTransport(value) {
         && typeof value.close === 'function';
 }
 
+function validMacosRegistration(value) {
+    return value
+        && typeof value.helperPath === 'string'
+        && value.helperPath.length > 0
+        && typeof value.ensureRegistered === 'function';
+}
+
 function createPlatformHelperTransport(options) {
     const input = options || {};
     const runtime = input.runtime || { platform: process.platform, arch: process.arch };
@@ -161,6 +171,7 @@ function createPlatformHelperTransport(options) {
     };
 
     let helperIdentity = null;
+    let macosRegistration = null;
     if (platformId === 'windows-x64') {
         const verifyPayload = input.verifyWindowsPayload || verifyWindowsPayload;
         helperIdentity = verifyPayload(addonPath, input);
@@ -170,6 +181,21 @@ function createPlatformHelperTransport(options) {
             || typeof helperIdentity.sha256 !== 'string'
             || !/^[0-9a-f]{64}$/i.test(helperIdentity.sha256)) {
             throw repairRequired('platform helper payload verifier returned an invalid entrypoint');
+        }
+    } else {
+        const prepareRegistration = input.prepareMacosHelperRegistration
+            || prepareMacosHelperRegistration;
+        macosRegistration = prepareRegistration({
+            addonPath,
+            fsImpl: input.fsImpl,
+            createHash: input.createHash,
+            execFile: input.execFile,
+            homedir: input.homedir,
+            getuid: input.getuid,
+            processId: input.processId,
+        });
+        if (!validMacosRegistration(macosRegistration)) {
+            throw repairRequired('platform helper registrar returned an invalid registration');
         }
     }
 
@@ -261,9 +287,12 @@ function createPlatformHelperTransport(options) {
             opened = await connectWindows();
         } else {
             try {
+                await macosRegistration.ensureRegistered();
                 opened = openNativeTransport();
             } catch (cause) {
-                if (cause && cause.code === 'PLATFORM_HELPER_REPAIR_REQUIRED') throw cause;
+                if (cause
+                    && (cause.code === 'PLATFORM_HELPER_REPAIR_REQUIRED'
+                        || cause.code === 'HELPER_START_FAILED')) throw cause;
                 throw unavailable('failed to open the authenticated platform helper transport', cause);
             }
         }

--- a/plugin/host/platform-helper-transport.test.js
+++ b/plugin/host/platform-helper-transport.test.js
@@ -51,39 +51,21 @@ function windowsOptions(overrides) {
     };
 }
 
-test('transport loads the in-process N-API addon for only the two supported targets', async () => {
-    for (const fixture of [
-        { platform: 'darwin', arch: 'arm64', platformId: 'macos-arm64' },
-        { platform: 'win32', arch: 'x64', platformId: 'windows-x64' },
-    ]) {
-        const loaded = [];
-        const native = fakeNativeTransport();
-        const options = {
-            runtime: { platform: fixture.platform, arch: fixture.arch },
-            verifyWindowsPayload: function () {
-                return {
-                    path: 'C:\\verified\\ae-mcp-platform-helper.exe',
-                    sha256: 'a'.repeat(64),
-                };
-            },
-            loadAddon: function (addonPath) {
-                loaded.push(addonPath);
-                return { createTransport: function () { return native; } };
-            },
-        };
-        if (fixture.platform === 'darwin') {
-            options.prepareMacosHelperRegistration = macOptions()
-                .prepareMacosHelperRegistration;
-        }
-        const transport = createPlatformHelperTransport(options);
-        assert.equal(loaded.length, 1);
-        assert.match(
-            loaded[0],
-            new RegExp(`platform[\\\\/]${fixture.platformId}[\\\\/]lib[\\\\/]ae-mcp-platform-helper-transport\\.node$`),
-        );
-        assert.equal(await transport.request('{"ok":true}'), '{"ok":true}');
-        await transport.close();
-    }
+test('only Windows loads the in-process N-API addon', async () => {
+    const loaded = [];
+    const transport = createPlatformHelperTransport(windowsOptions({
+        loadAddon: function (addonPath) {
+            loaded.push(addonPath);
+            return { createTransport: function () { return fakeNativeTransport(); } };
+        },
+    }));
+    assert.equal(loaded.length, 1);
+    assert.match(
+        loaded[0],
+        /platform[\\/]windows-x64[\\/]lib[\\/]ae-mcp-platform-helper-transport\.node$/,
+    );
+    assert.equal(await transport.request('{"ok":true}'), '{"ok":true}');
+    await transport.close();
 });
 
 test('transport rejects unsupported OS/architecture pairs before loading native code', () => {
@@ -101,14 +83,16 @@ test('transport rejects unsupported OS/architecture pairs before loading native 
     }
 });
 
-test('transport fails closed when the addon or N-API result violates the contract', async () => {
-    const runtime = { platform: 'darwin', arch: 'arm64' };
+test('Windows transport fails closed when the addon or N-API result violates the contract', async () => {
+    const runtime = { platform: 'win32', arch: 'x64' };
     assert.throws(() => createPlatformHelperTransport(macOptions({
         runtime,
+        verifyWindowsPayload: windowsOptions().verifyWindowsPayload,
         loadAddon: function () { return {}; },
     })), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' });
     const transport = createPlatformHelperTransport(macOptions({
         runtime,
+        verifyWindowsPayload: windowsOptions().verifyWindowsPayload,
         loadAddon: function () {
             return { createTransport: function () { return { request: async function () {} }; } };
         },
@@ -184,20 +168,23 @@ test('Windows transport reports a bounded startup failure without falling back',
     await transport.close();
 });
 
-test('macOS relies on XPC activation and never invokes the Windows launcher', async () => {
-    let spawns = 0;
+test('macOS uses the verified stdio broker and never loads the addon', async () => {
+    const events = [];
     const transport = createPlatformHelperTransport(macOptions({
         loadAddon: function () {
-            return { createTransport: function () { return fakeNativeTransport(); } };
+            throw new Error('macOS must not load the addon');
         },
-        spawnHelper: function () { spawns += 1; return fakeChild(); },
+        createMacosBrokerTransport: function ({ helperPath }) {
+            events.push(`broker:${helperPath}`);
+            return fakeNativeTransport();
+        },
     }));
-    assert.equal(await transport.request('xpc'), 'xpc');
-    assert.equal(spawns, 0);
+    assert.equal(await transport.request('stdio'), 'stdio');
+    assert.deepEqual(events, ['broker:/verified/ae-mcp-platform-helper']);
     await transport.close();
 });
 
-test('macOS registration completes before the addon opens XPC or sends a request', async () => {
+test('macOS registration completes before the stdio broker starts or sends a request', async () => {
     const events = [];
     let releaseRegistration;
     const registrationGate = new Promise(function (resolve) {
@@ -216,17 +203,16 @@ test('macOS registration completes before the addon opens XPC or sends a request
             };
         },
         loadAddon: function () {
+            throw new Error('macOS must not load the addon');
+        },
+        createMacosBrokerTransport: function () {
+            events.push('broker:createTransport');
             return {
-                createTransport: function () {
-                    events.push('addon:createTransport');
-                    return {
-                        request: async function (jsonUtf8) {
-                            events.push('native:request');
-                            return jsonUtf8;
-                        },
-                        close: async function () {},
-                    };
+                request: async function (jsonUtf8) {
+                    events.push('broker:request');
+                    return jsonUtf8;
                 },
+                close: async function () {},
             };
         },
     });
@@ -242,8 +228,8 @@ test('macOS registration completes before the addon opens XPC or sends a request
     assert.deepEqual(events, [
         'register:start',
         'register:done',
-        'addon:createTransport',
-        'native:request',
+        'broker:createTransport',
+        'broker:request',
     ]);
     await transport.close();
 });
@@ -261,13 +247,9 @@ test('concurrent macOS requests share one registration and one native transport'
                 },
             };
         },
-        loadAddon: function () {
-            return {
-                createTransport: function () {
-                    nativeTransports += 1;
-                    return fakeNativeTransport();
-                },
-            };
+        createMacosBrokerTransport: function () {
+            nativeTransports += 1;
+            return fakeNativeTransport();
         },
     }));
 
@@ -295,13 +277,9 @@ test('macOS registration lifecycle errors remain bounded and block native XPC', 
                     },
                 };
             },
-            loadAddon: function () {
-                return {
-                    createTransport: function () {
-                        nativeTransports += 1;
-                        return fakeNativeTransport();
-                    },
-                };
+            createMacosBrokerTransport: function () {
+                nativeTransports += 1;
+                return fakeNativeTransport();
             },
         }));
         await assert.rejects(transport.request('{}'), fixture);
@@ -377,7 +355,7 @@ test('Windows payload is hashed before native code is loaded or Helper is starte
     assert.equal(loads, 1);
 });
 
-test('process launch is isolated to the verified Windows JS boundary', () => {
+test('process launch is isolated to the verified platform Helper JS boundaries', () => {
     const hostSource = fs.readFileSync(path.join(__dirname, 'platform-helper-transport.js'), 'utf8');
     assert.match(hostSource, /require\('child_process'\)\.spawn/);
     assert.match(hostSource, /windowsHide:\s*true/);
@@ -395,6 +373,7 @@ test('process launch is isolated to the verified Windows JS boundary', () => {
     const processBoundaryFiles = new Set([
         'platform-helper-transport.js',
         'platform-helper-registration.js',
+        'platform-helper-stdio-transport.js',
     ]);
     for (const name of productionHostFiles) {
         const source = fs.readFileSync(path.join(__dirname, name), 'utf8');
@@ -411,6 +390,17 @@ test('process launch is isolated to the verified Windows JS boundary', () => {
     assert.doesNotMatch(
         registrationSource,
         /shell:\s*true|\bexec\s*\(|\bspawn\s*\(|\bbootout\b|\bkill\b|stdio:\s*'inherit'/i,
+    );
+    const stdioSource = fs.readFileSync(
+        path.join(__dirname, 'platform-helper-stdio-transport.js'),
+        'utf8',
+    );
+    assert.match(stdioSource, /\['--client-stdio'\]/);
+    assert.match(stdioSource, /shell:\s*false/);
+    assert.match(stdioSource, /stdio:\s*\['pipe',\s*'pipe',\s*'pipe'\]/);
+    assert.doesNotMatch(
+        stdioSource,
+        /shell:\s*true|\bexec\s*\(|\bexecFile\s*\(|\bkill\s*\(|stdio:\s*'inherit'/i,
     );
 
     const addonRoot = path.resolve(__dirname, '../../native/platform-helper/client-addon');

--- a/plugin/host/platform-helper-transport.test.js
+++ b/plugin/host/platform-helper-transport.test.js
@@ -21,6 +21,23 @@ function fakeChild() {
     return child;
 }
 
+function nextTurn() {
+    return new Promise(function (resolve) { setImmediate(resolve); });
+}
+
+function macOptions(overrides) {
+    return {
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        prepareMacosHelperRegistration: function () {
+            return {
+                helperPath: '/verified/ae-mcp-platform-helper',
+                ensureRegistered: async function () {},
+            };
+        },
+        ...overrides,
+    };
+}
+
 function windowsOptions(overrides) {
     return {
         runtime: { platform: 'win32', arch: 'x64' },
@@ -41,7 +58,7 @@ test('transport loads the in-process N-API addon for only the two supported targ
     ]) {
         const loaded = [];
         const native = fakeNativeTransport();
-        const transport = createPlatformHelperTransport({
+        const options = {
             runtime: { platform: fixture.platform, arch: fixture.arch },
             verifyWindowsPayload: function () {
                 return {
@@ -53,7 +70,12 @@ test('transport loads the in-process N-API addon for only the two supported targ
                 loaded.push(addonPath);
                 return { createTransport: function () { return native; } };
             },
-        });
+        };
+        if (fixture.platform === 'darwin') {
+            options.prepareMacosHelperRegistration = macOptions()
+                .prepareMacosHelperRegistration;
+        }
+        const transport = createPlatformHelperTransport(options);
         assert.equal(loaded.length, 1);
         assert.match(
             loaded[0],
@@ -81,16 +103,16 @@ test('transport rejects unsupported OS/architecture pairs before loading native 
 
 test('transport fails closed when the addon or N-API result violates the contract', async () => {
     const runtime = { platform: 'darwin', arch: 'arm64' };
-    assert.throws(() => createPlatformHelperTransport({
+    assert.throws(() => createPlatformHelperTransport(macOptions({
         runtime,
         loadAddon: function () { return {}; },
-    }), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' });
-    const transport = createPlatformHelperTransport({
+    })), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' });
+    const transport = createPlatformHelperTransport(macOptions({
         runtime,
         loadAddon: function () {
             return { createTransport: function () { return { request: async function () {} }; } };
         },
-    });
+    }));
     await assert.rejects(transport.request('{}'), { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' });
     await transport.close();
 });
@@ -164,15 +186,143 @@ test('Windows transport reports a bounded startup failure without falling back',
 
 test('macOS relies on XPC activation and never invokes the Windows launcher', async () => {
     let spawns = 0;
-    const transport = createPlatformHelperTransport({
-        runtime: { platform: 'darwin', arch: 'arm64' },
+    const transport = createPlatformHelperTransport(macOptions({
         loadAddon: function () {
             return { createTransport: function () { return fakeNativeTransport(); } };
         },
         spawnHelper: function () { spawns += 1; return fakeChild(); },
-    });
+    }));
     assert.equal(await transport.request('xpc'), 'xpc');
     assert.equal(spawns, 0);
+    await transport.close();
+});
+
+test('macOS registration completes before the addon opens XPC or sends a request', async () => {
+    const events = [];
+    let releaseRegistration;
+    const registrationGate = new Promise(function (resolve) {
+        releaseRegistration = resolve;
+    });
+    const transport = createPlatformHelperTransport({
+        runtime: { platform: 'darwin', arch: 'arm64' },
+        prepareMacosHelperRegistration: function () {
+            return {
+                helperPath: '/verified/ae-mcp-platform-helper',
+                ensureRegistered: async function () {
+                    events.push('register:start');
+                    await registrationGate;
+                    events.push('register:done');
+                },
+            };
+        },
+        loadAddon: function () {
+            return {
+                createTransport: function () {
+                    events.push('addon:createTransport');
+                    return {
+                        request: async function (jsonUtf8) {
+                            events.push('native:request');
+                            return jsonUtf8;
+                        },
+                        close: async function () {},
+                    };
+                },
+            };
+        },
+    });
+
+    const request = transport.request('xpc');
+    try {
+        await nextTurn();
+        assert.deepEqual(events, ['register:start']);
+    } finally {
+        releaseRegistration();
+    }
+    assert.equal(await request, 'xpc');
+    assert.deepEqual(events, [
+        'register:start',
+        'register:done',
+        'addon:createTransport',
+        'native:request',
+    ]);
+    await transport.close();
+});
+
+test('concurrent macOS requests share one registration and one native transport', async () => {
+    let registrations = 0;
+    let nativeTransports = 0;
+    const transport = createPlatformHelperTransport(macOptions({
+        prepareMacosHelperRegistration: function () {
+            return {
+                helperPath: '/verified/ae-mcp-platform-helper',
+                ensureRegistered: async function () {
+                    registrations += 1;
+                    await nextTurn();
+                },
+            };
+        },
+        loadAddon: function () {
+            return {
+                createTransport: function () {
+                    nativeTransports += 1;
+                    return fakeNativeTransport();
+                },
+            };
+        },
+    }));
+
+    assert.deepEqual(await Promise.all([
+        transport.request('one'),
+        transport.request('two'),
+    ]), ['one', 'two']);
+    assert.equal(registrations, 1);
+    assert.equal(nativeTransports, 1);
+    await transport.close();
+});
+
+test('macOS registration lifecycle errors remain bounded and block native XPC', async () => {
+    for (const fixture of [
+        { code: 'HELPER_START_FAILED', retryable: true },
+        { code: 'PLATFORM_HELPER_REPAIR_REQUIRED', retryable: false },
+    ]) {
+        let nativeTransports = 0;
+        const transport = createPlatformHelperTransport(macOptions({
+            prepareMacosHelperRegistration: function () {
+                return {
+                    helperPath: '/verified/ae-mcp-platform-helper',
+                    ensureRegistered: async function () {
+                        throw Object.assign(new Error('sensitive local detail'), fixture);
+                    },
+                };
+            },
+            loadAddon: function () {
+                return {
+                    createTransport: function () {
+                        nativeTransports += 1;
+                        return fakeNativeTransport();
+                    },
+                };
+            },
+        }));
+        await assert.rejects(transport.request('{}'), fixture);
+        assert.equal(nativeTransports, 0);
+        await transport.close();
+    }
+});
+
+test('Windows never constructs the macOS registrar', async () => {
+    let macosRegistrars = 0;
+    const transport = createPlatformHelperTransport(windowsOptions({
+        prepareMacosHelperRegistration: function () {
+            macosRegistrars += 1;
+            throw new Error('must not run');
+        },
+        loadAddon: function () {
+            return { createTransport: function () { return fakeNativeTransport(); } };
+        },
+    }));
+    assert.equal(await transport.request('windows'), 'windows');
+    assert.equal(macosRegistrars, 0);
     await transport.close();
 });
 
@@ -235,16 +385,33 @@ test('process launch is isolated to the verified Windows JS boundary', () => {
     assert.match(hostSource, /detached:\s*true/);
     assert.match(hostSource, /shell:\s*false/);
     assert.match(hostSource, /stdio:\s*'ignore'/);
-    assert.doesNotMatch(hostSource, /execFile|\bexec\s*\(|ShellExecute|stdio:\s*'inherit'/i);
+    assert.doesNotMatch(
+        hostSource,
+        /require\('child_process'\)\.execFile|\bexec\s*\(|ShellExecute|stdio:\s*'inherit'/i,
+    );
 
     const productionHostFiles = fs.readdirSync(__dirname)
         .filter((name) => name.endsWith('.js') && !name.endsWith('.test.js'));
+    const processBoundaryFiles = new Set([
+        'platform-helper-transport.js',
+        'platform-helper-registration.js',
+    ]);
     for (const name of productionHostFiles) {
         const source = fs.readFileSync(path.join(__dirname, name), 'utf8');
-        if (name === 'platform-helper-transport.js') continue;
+        if (processBoundaryFiles.has(name)) continue;
         assert.doesNotMatch(source, /process\.(?:platform|arch)/, name);
         assert.doesNotMatch(source, /child_process|execFile|spawn\s*\(/i, name);
     }
+    const registrationSource = fs.readFileSync(
+        path.join(__dirname, 'platform-helper-registration.js'),
+        'utf8',
+    );
+    assert.match(registrationSource, /\/bin\/launchctl/);
+    assert.match(registrationSource, /require\('child_process'\)\.execFile/);
+    assert.doesNotMatch(
+        registrationSource,
+        /shell:\s*true|\bexec\s*\(|\bspawn\s*\(|\bbootout\b|\bkill\b|stdio:\s*'inherit'/i,
+    );
 
     const addonRoot = path.resolve(__dirname, '../../native/platform-helper/client-addon');
     const cmake = fs.readFileSync(path.join(addonRoot, 'CMakeLists.txt'), 'utf8');

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -8,9 +8,12 @@
       "name": "ae-mcp-panel",
       "version": "0.9.2",
       "dependencies": {
+        "filepond": "4.32.12",
+        "filepond-plugin-image-preview": "4.6.12",
         "lucide-react": "0.453.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-filepond": "7.1.3"
       },
       "devDependencies": {
         "esbuild": "0.24.2"
@@ -482,6 +485,21 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
+    "node_modules/filepond": {
+      "version": "4.32.12",
+      "resolved": "https://registry.npmmirror.com/filepond/-/filepond-4.32.12.tgz",
+      "integrity": "sha512-wro0/deLwua9CkL7HJygOlDaPo1c7Ov8kfzbZjH7m4hdi56gdHGDeRWnYa+qXnRm3Lty69gUGVFb3JZy/9vT8g==",
+      "license": "MIT"
+    },
+    "node_modules/filepond-plugin-image-preview": {
+      "version": "4.6.12",
+      "resolved": "https://registry.npmmirror.com/filepond-plugin-image-preview/-/filepond-plugin-image-preview-4.6.12.tgz",
+      "integrity": "sha512-Y8ETX5QVV0mbPB0586UH8AUmG9tZg8PuN5bdEAIlZVJFTct5ebViJ7+Am94/VhTPjLqZjBf1zmDq5JU6XRsZKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "filepond": ">=4.x <5.x"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -532,6 +550,17 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-filepond": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmmirror.com/react-filepond/-/react-filepond-7.1.3.tgz",
+      "integrity": "sha512-uQOCZt+YXnBfYn6OxK6vsgSoUROkBu/ZahcfIJnK94c1ZeSAS84L/XKDADq/8Adx/Lz88VtVWvUpTXnNpmjHFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "filepond": ">=3.7.x < 5.x",
+        "react": "16 - 19",
+        "react-dom": "16 - 19"
       }
     },
     "node_modules/scheduler": {

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -9,9 +9,12 @@
     "test": "node --test"
   },
   "dependencies": {
+    "filepond": "4.32.12",
+    "filepond-plugin-image-preview": "4.6.12",
     "lucide-react": "0.453.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-filepond": "7.1.3"
   },
   "devDependencies": {
     "esbuild": "0.24.2"

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -65,7 +65,7 @@ import { copyWizardConfig } from '../lib/wizardCopy.js';
 import { createHostController, loadSavedPort, savePort, DEFAULT_PORT, buildMcpConfig, isValidPort } from '../cep/hostBridge';
 import { loadExpertGuidance, saveExpertGuidance } from '../lib/expertGuidance.js';
 import pkg from '../../package.json';
-import { buildLogExport, exportFileName, keepLogLine } from '../lib/logExport.js';
+import { attachmentPathSecrets, buildLogExport, exportFileName, keepLogLine } from '../lib/logExport.js';
 import { writeLogExport, revealInExplorer } from '../cep/logExportFs.js';
 import { reconcileStableJsonValue } from '../lib/stableValue.js';
 import { createPlatformAdapter } from '../cep/platform/index.js';
@@ -1287,6 +1287,11 @@ function Shell({ cs }) {
     try {
       const exactSecrets = providerSecretService.getRedactionValues();
       if (zcodeStoredKeyRef.current) exactSecrets.push(zcodeStoredKeyRef.current);
+      const attachmentSecrets = attachmentPathSecrets({
+        draft: attachmentDraft,
+        pendingTurn: pendingTurnRef.current,
+      });
+      exactSecrets.push(...attachmentSecrets);
       const text = buildLogExport({
         panelLogs: logs,
         hostInfo: { hostVersion: (connInfo && connInfo.hostVersion) || '-', pythonVersion: (connInfo && connInfo.pythonVersion) || '-' },
@@ -1300,7 +1305,7 @@ function Shell({ cs }) {
     } catch (e) {
       pushLog('Log export failed: ' + (e && e.message ? e.message : String(e)));
     }
-  }, [logs, connInfo, claudeBackend, providerSecretService, pushLog]);
+  }, [logs, connInfo, claudeBackend, providerSecretService, pushLog, attachmentDraft]);
 
   const undoToPreviousCheckpoint = React.useCallback(async () => {
     try {

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -29,7 +29,11 @@ import { createZcodeBackend, summarizeZcodeConfig } from '../cep/zcodeBackend';
 import { claudeChannels, codexChannels, zcodeChannels, migrateBackendPref, codexProviderChannelLock } from '../lib/channels.js';
 import { createProviderStore } from '../cep/providerStore';
 import { createProviderSecretService, resolveProviderRequestProfile } from '../cep/providerSecrets';
-import { createProviderAcceptanceBridge } from '../cep/providerAcceptanceBridge.js';
+import {
+  countMentionedPanelAttachments,
+  createProviderAcceptanceBridge,
+  normalizePanelAcceptanceTurns,
+} from '../cep/providerAcceptanceBridge.js';
 import { createUniversalProviderRoute } from '../cep/universalProviderRoute.js';
 import { migrateProviderStoreSecrets } from '../cep/providerMigration';
 import { migrateProviderStoreV2ToV3 } from '../cep/providerSchemaMigration';
@@ -901,14 +905,16 @@ function Shell({ cs }) {
         const client = input.client === 'claude' ? 'claude' : input.client === 'codex' ? 'codex' : '';
         const providerId = typeof input.providerId === 'string' ? input.providerId.trim() : '';
         const modelId = typeof input.modelId === 'string' ? input.modelId.trim() : '';
-        const prompts = Array.isArray(input.prompts)
-          ? input.prompts.map((value) => String(value || '').trim())
-          : [];
+        let plannedTurns;
+        try {
+          plannedTurns = normalizePanelAcceptanceTurns(input);
+        } catch {
+          return { ok: false, errorCode: 'PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN', turns: [] };
+        }
         const graceMs = Number.isInteger(input.graceMs) && input.graceMs >= 0 && input.graceMs <= 10000
           ? input.graceMs
           : 3000;
-        if (!client || !providerId || !modelId || prompts.length < 1 || prompts.length > 4
-          || prompts.some((value) => !value || value.length > 2000)) {
+        if (!client || !providerId || !modelId) {
           return { ok: false, errorCode: 'PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN', turns: [] };
         }
         let provider = null;
@@ -932,13 +938,14 @@ function Shell({ cs }) {
         };
         backend.reset();
         try {
-          for (const prompt of prompts) {
+          for (const plannedTurn of plannedTurns) {
             const eventStart = providerAcceptanceEventsRef.current.length;
             const startedAt = Date.now();
-            await backend.sendUser(prompt);
+            await backend.sendUser(plannedTurn);
             await new Promise((resolve) => setTimeout(resolve, graceMs));
             const events = providerAcceptanceEventsRef.current.slice(eventStart);
             const error = events.find((event) => event.type === 'error');
+            const accepted = events.some((event) => event.type === 'turn-accepted');
             const terminal = events.some((event) => event.type === 'turn-end');
             const transcript = backend.getMessages();
             const hasAssistant = transcript.some((message) => message?.role === 'assistant'
@@ -948,11 +955,17 @@ function Shell({ cs }) {
               terminal: terminal ? 'turn-end' : null,
               durationMs: Date.now() - startedAt,
               errorCode: error?.code || error?.kind || null,
+              attachmentCount: plannedTurn.attachments.length,
+              mentionedAttachmentCount: countMentionedPanelAttachments(
+                transcript,
+                plannedTurn.attachments,
+              ),
+              accepted,
             });
             if (!turns.at(-1).ok) break;
           }
           return {
-            ok: turns.length === prompts.length && turns.every((turn) => turn.ok),
+            ok: turns.length === plannedTurns.length && turns.every((turn) => turn.ok),
             client,
             modelId,
             turns,

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -573,8 +573,7 @@ function Shell({ cs }) {
     codex: codexChannels({ codexProbe, customProvider: codexCustomProvider, customProviderSelected: Boolean(codexProviderId), customProviderAvailable: providerInit.state === 'ready' && Boolean(codexCustomProvider), customProviderCredentialResolverReady: codexProviderCredentialResolverReady, providerChecking: providerInit.state === 'checking', cliConfig: codexCliConfig, cliCredentialAvailable: codexCliCredentialReady }),
     zcode: zcodeChannels({ zcodeProbe, configSummary: zcodeConfigSummary }),
   }), [probe, claudeApiProvider, claudeProviderId, codexProbe, codexCustomProvider, codexProviderCredentialResolverReady, codexProviderId, zcodeProbe, zcodeConfigSummary, codexCliConfig, codexCliCredentialReady, providerInit.state]);
-  const nodeOk = !(probe && probe.nodeOk === false);
-  const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock, nodeOk });
+  const effective = pickBackend({ pref: backendPref, channels, lockedChannel: channelLock });
   const claudeSettingsHint = React.useMemo(() => {
     try { return inspectClaudeSettingsEnv({ platform, fsImpl: platform.fs }); } catch (e) { return null; }
   }, [platform]);
@@ -1042,8 +1041,8 @@ function Shell({ cs }) {
   const activeBackend = backendInstances[effective.backend] || byokLoop;
 
   // Descriptor selection is keyed on the EFFECTIVE backend from pickBackend,
-  // not backendPref: 'byok' never appears as a pref (migrateBackendPref maps
-  // it away), only as an effective backend when Node is broken.
+  // not backendPref. `byok` remains only for legacy state compatibility;
+  // live custom Claude Provider selection resolves to `claude-api`.
   React.useEffect(() => {
     const facts = {
       effectiveBackend: effective.backend,

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -42,7 +42,12 @@ import { probeProviderModels } from '../cep/modelProbe';
 import { detectCcSwitch, readCcSwitchProviderDrafts } from '../cep/ccSwitch';
 import { inspectClaudeSettingsEnv, readClaudeSettingsProviderDraft } from '../cep/claudeSettingsImport';
 import { codexCliCredentialAvailable, readCodexCliConfig, resolveCodexCliCredential } from '../cep/codexConfig';
-import { reduceEvent } from '../lib/chatEntries';
+import { reduceEvent, userTurnEntry } from '../lib/chatEntries';
+import {
+  createAttachmentDraftState,
+  reduceAttachmentDraft,
+} from '../lib/attachmentDraft.js';
+import { createAttachmentStore } from '../cep/attachmentStore.js';
 import { DEFAULT_MODEL } from '../lib/anthropic';
 import { descriptorWithCustomModel } from '../lib/backendCapabilities';
 import { selectDescriptor, reconcileModelPref } from '../lib/descriptorSelect';
@@ -68,6 +73,7 @@ import { readCepSystemPath } from '../cep/platform/paths.js';
 import { createRuntimeManager, hasDevelopmentRuntimeOverride } from '../cep/runtimeManager.js';
 import { createElicitationCoordinator } from '../lib/elicitationCoordinator.js';
 import { decideToolPlan } from '../../../shared/tool-approval.mjs';
+import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 // Re-export so app code has a single import surface; the helpers themselves live
 // in lib/ so the test suite (node --test, which cannot parse JSX) can import them.
@@ -314,6 +320,22 @@ function Shell({ cs }) {
   // Embedded chat: provider references, model/permission prefs, entry feed.
   // Resolved provider values exist only inside a request/probe/spawn call.
   const platform = React.useMemo(() => createPlatformAdapter(), []);
+  const attachmentStore = React.useMemo(() => createAttachmentStore({
+    platform,
+    randomUUID: randomProviderCredentialId,
+  }), [platform]);
+  const [attachmentDraft, dispatchAttachmentDraft] = React.useReducer(
+    reduceAttachmentDraft,
+    undefined,
+    createAttachmentDraftState,
+  );
+  const [chatSessionId, setChatSessionId] = React.useState('chat-0');
+  const chatSessionIdRef = React.useRef(chatSessionId);
+  chatSessionIdRef.current = chatSessionId;
+  const attachmentOperationsRef = React.useRef(new Map());
+  const pendingTurnRef = React.useRef(null);
+  const acceptedTurnRef = React.useRef(null);
+  React.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
   const legacyKeyStore = React.useMemo(() => {
     try { return createLegacyApiKeyStore(); } catch (e) { return null; }
   }, []);
@@ -646,6 +668,61 @@ function Shell({ cs }) {
   }), [approvalTierFile, elicitationCoordinator, extRoot, getMcpSpec, platform]);
   const toolsApi = React.useMemo(() => createToolsApi(mcp), [mcp]);
   React.useEffect(() => () => mcp.stop(), [mcp]);
+  const releaseTurnAttachments = React.useCallback((turn) => {
+    for (const attachment of turn?.attachments || []) {
+      attachmentStore.release(attachment.id);
+    }
+  }, [attachmentStore]);
+  const resetAttachmentDraftSession = React.useCallback(() => {
+    attachmentStore.releaseSession(chatSessionIdRef.current);
+    attachmentOperationsRef.current.clear();
+    pendingTurnRef.current = null;
+    acceptedTurnRef.current = null;
+    dispatchAttachmentDraft({ type: 'reset' });
+    const nextSessionId = 'chat-' + randomProviderCredentialId();
+    chatSessionIdRef.current = nextSessionId;
+    setChatSessionId(nextSessionId);
+  }, [attachmentStore]);
+  const addAttachment = React.useCallback(async ({ pondId, file }) => {
+    const operation = {};
+    const sessionId = chatSessionId;
+    attachmentOperationsRef.current.set(pondId, operation);
+    dispatchAttachmentDraft({ type: 'staging', pondId, file });
+    try {
+      const ref = await attachmentStore.prepare(file, { sessionId, pondId });
+      if (
+        attachmentOperationsRef.current.get(pondId) !== operation
+        || chatSessionIdRef.current !== sessionId
+      ) {
+        attachmentStore.release(ref.id);
+        return;
+      }
+      attachmentOperationsRef.current.delete(pondId);
+      dispatchAttachmentDraft({ type: 'ready', pondId, ref });
+    } catch (error) {
+      if (
+        attachmentOperationsRef.current.get(pondId) !== operation
+        || chatSessionIdRef.current !== sessionId
+      ) return;
+      attachmentOperationsRef.current.delete(pondId);
+      dispatchAttachmentDraft({
+        type: 'error',
+        pondId,
+        error: {
+          code: error?.code || 'ATTACHMENT_STAGING_FAILED',
+          message: error?.message || 'Attachment staging failed',
+        },
+      });
+    }
+  }, [attachmentStore, chatSessionId]);
+  const removeAttachment = React.useCallback((item) => {
+    attachmentOperationsRef.current.delete(item.pondId);
+    if (item.ref) attachmentStore.release(item.ref.id);
+    dispatchAttachmentDraft({ type: 'remove', pondId: item.pondId });
+  }, [attachmentStore]);
+  const retryAttachment = React.useCallback((item) => {
+    addAttachment({ pondId: item.pondId, file: item.file });
+  }, [addAttachment]);
   const providerAcceptanceEventsRef = React.useRef([]);
   const handleChatEvent = React.useCallback((evt) => {
     if (evt && typeof evt.type === 'string') {
@@ -656,15 +733,48 @@ function Shell({ cs }) {
       });
       if (providerAcceptanceEventsRef.current.length > 256) providerAcceptanceEventsRef.current.shift();
     }
-    if (evt.type === 'turn-start') setChatStreaming(true);
+    const pending = pendingTurnRef.current;
+    if (evt.type === 'turn-accepted') {
+      if (!pending || evt.turnId !== pending.turnId) return;
+      acceptedTurnRef.current = pending.turnId;
+      setChatEntries((entries) => entries.concat(userTurnEntry(pending)));
+      dispatchAttachmentDraft({ type: 'accepted', turnId: pending.turnId });
+      setChatStreaming(true);
+      return;
+    }
+    if (evt.type === 'error' && pending && acceptedTurnRef.current !== pending.turnId) {
+      if (evt.turnId !== pending.turnId) return;
+      setChatStreaming(false);
+      setThinkingActive(false);
+      if (evt.dispatchState === 'not-started') {
+        dispatchAttachmentDraft({
+          type: 'rejected',
+          turnId: pending.turnId,
+          error: { code: evt.code || 'BACKEND_ERROR', message: evt.message || 'Backend unavailable' },
+        });
+        pendingTurnRef.current = null;
+      } else {
+        dispatchAttachmentDraft({
+          type: 'uncertain',
+          turnId: pending.turnId,
+          error: { code: evt.code || 'TRANSPORT_UNCERTAIN', message: evt.message || 'Send outcome is uncertain' },
+        });
+      }
+      return;
+    }
     if (evt.type === 'thinking') setThinkingActive(!!evt.active);
     if (evt.type === 'turn-end' || evt.type === 'error') {
+      if (pending && acceptedTurnRef.current === pending.turnId) {
+        releaseTurnAttachments(pending);
+        pendingTurnRef.current = null;
+        acceptedTurnRef.current = null;
+      }
       setChatStreaming(false);
       setThinkingActive(false);
     }
     if (evt.type === 'zcode-session-created') setZcodeSessionModels(evt.result || null);
     setChatEntries((entries) => reduceEvent(entries, evt));
-  }, []);
+  }, [releaseTurnAttachments]);
 
   const recoverRuntimeProvider = React.useCallback(async (provider, _failureFacts, requestedModelId) => {
     if (!providerStore) return null;
@@ -1109,24 +1219,61 @@ function Shell({ cs }) {
     codexBackend.reset();
     openCodeBackend.reset();
     zcodeBackend.reset();
+    resetAttachmentDraftSession();
     setChatEntries([]);
     setChatStreaming(false);
     setSessionModel(null);
     setSessionEffort(null);
     setSessionFast(null);
     if (decision.nextReal !== 'zcode') setZcodeSessionModels(null);
-  }, [effective.backend, byokLoop, claudeBackend, codexBackend, openCodeBackend, zcodeBackend]);
+  }, [effective.backend, byokLoop, claudeBackend, codexBackend, openCodeBackend, resetAttachmentDraftSession, zcodeBackend]);
 
-  const sendChat = (text) => {
-    const trimmed = String(text || '').trim();
-    if (!trimmed) return;
-    setChatEntries((entries) => entries.concat({ id: `user-${Date.now()}`, type: 'user-text', text: trimmed }));
-    activeBackend.sendUser(trimmed);
+  const sendChat = (input) => {
+    if (pendingTurnRef.current) return;
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      dispatchAttachmentDraft({
+        type: 'rejected',
+        turnId,
+        error: { code: 'TURN_INPUT_INVALID', message: error.message },
+      });
+      return;
+    }
+    pendingTurnRef.current = turn;
+    acceptedTurnRef.current = null;
+    try {
+      const result = activeBackend.sendUser(turn);
+      Promise.resolve(result).catch((error) => {
+        if (pendingTurnRef.current?.turnId !== turn.turnId) return;
+        handleChatEvent({
+          type: 'error',
+          kind: error?.kind || 'backend',
+          code: error?.code || 'BACKEND_ERROR',
+          message: error?.message || String(error),
+          turnId: turn.turnId,
+          dispatchState: error?.dispatchState || 'uncertain',
+        });
+      });
+    } catch (error) {
+      handleChatEvent({
+        type: 'error',
+        kind: error?.kind || 'backend',
+        code: error?.code || 'BACKEND_ERROR',
+        message: error?.message || String(error),
+        turnId: turn.turnId,
+        dispatchState: error?.dispatchState || 'not-started',
+      });
+    }
   };
 
   const newChatSession = () => {
     activeBackend.reset();
+    resetAttachmentDraftSession();
     setChatStreaming(false);
+    setThinkingActive(false);
     setChatEntries([]);
   };
 
@@ -1433,6 +1580,12 @@ function Shell({ cs }) {
             onChipEffort={setSessionEffort}
             onChipFast={(v) => setSessionFast(Boolean(v))}
             onChipApproval={(m) => { setPermissionMode(m); writePref('ae_mcp_perm_mode', m); }}
+            attachmentDraft={attachmentDraft}
+            dispatchAttachmentDraft={dispatchAttachmentDraft}
+            createTurnId={randomProviderCredentialId}
+            onAddFile={addAttachment}
+            onRemoveAttachment={removeAttachment}
+            onRetryAttachment={retryAttachment}
           />
         ) : null}
         {tab === 'activity' ? (

--- a/plugin/panel/src/cep/attachmentStore.js
+++ b/plugin/panel/src/cep/attachmentStore.js
@@ -1,0 +1,253 @@
+import {
+  MAX_ATTACHMENTS_PER_TURN,
+  MAX_CLIPBOARD_ITEM_BYTES,
+  MAX_CLIPBOARD_TURN_BYTES,
+} from '../../../shared/chat-attachments.mjs';
+
+function attachmentError(code, message, cause) {
+  const error = new Error(message);
+  error.code = code;
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function browserBlobChunk(slice) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error || new Error('FileReader failed'));
+    reader.onload = () => resolve(reader.result);
+    reader.readAsArrayBuffer(slice);
+  });
+}
+
+function requireSegment(value, field) {
+  const text = String(value || '');
+  if (!/^[A-Za-z0-9_-]+$/.test(text)) {
+    throw attachmentError('ATTACHMENT_INVALID', field + ' must be a safe path segment');
+  }
+  return text;
+}
+
+function safeBasename(value, fallback = 'attachment') {
+  const normalized = String(value || '').replaceAll('\\', '/');
+  const name = normalized.split('/').filter(Boolean).pop() || fallback;
+  return name === '.' || name === '..' ? fallback : name;
+}
+
+function mediaTypeOf(file) {
+  return typeof file?.type === 'string' ? file.type : '';
+}
+
+function writeAll(fs, descriptor, bytes) {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let offset = 0;
+  while (offset < view.byteLength) {
+    const written = fs.writeSync(descriptor, view, offset, view.byteLength - offset);
+    if (!written) throw new Error('attachment write made no progress');
+    offset += written;
+  }
+}
+
+function removeEmptyDirectory(fs, directory) {
+  try {
+    fs.rmdirSync(directory);
+  } catch (error) {
+    if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error?.code)) throw error;
+  }
+}
+
+export function createAttachmentStore({
+  platform,
+  randomUUID,
+  readBlobChunk = browserBlobChunk,
+  chunkBytes = 1024 * 1024,
+  now = Date.now,
+}) {
+  if (!platform?.paths || !platform?.fs) throw new TypeError('attachment store requires a platform adapter');
+  if (typeof randomUUID !== 'function') throw new TypeError('attachment store requires randomUUID');
+  if (typeof readBlobChunk !== 'function') throw new TypeError('attachment store requires readBlobChunk');
+  if (!Number.isSafeInteger(chunkBytes) || chunkBytes <= 0) throw new TypeError('chunkBytes must be positive');
+
+  const { fs } = platform;
+  const root = platform.paths.join([
+    platform.paths.tempRoot,
+    'ae-mcp-panel-attachments',
+  ]);
+  const records = new Map();
+  let disposed = false;
+
+  function sessionRecords(sessionId) {
+    return [...records.values()].filter((record) => record.sessionId === sessionId);
+  }
+
+  function reserve({ sessionId, pondId, size, temporary }) {
+    if (disposed) throw attachmentError('ATTACHMENT_STORE_DISPOSED', 'Attachment store is disposed');
+    const safeSessionId = requireSegment(sessionId, 'sessionId');
+    requireSegment(pondId, 'pondId');
+    const existing = sessionRecords(safeSessionId);
+    if (existing.length >= MAX_ATTACHMENTS_PER_TURN) {
+      throw attachmentError('ATTACHMENT_COUNT_LIMIT', 'Attachment count exceeds the per-turn limit');
+    }
+    if (temporary && size > MAX_CLIPBOARD_ITEM_BYTES) {
+      throw attachmentError('ATTACHMENT_ITEM_TOO_LARGE', 'Clipboard attachment exceeds the per-item limit');
+    }
+    const reservedBytes = existing.reduce(
+      (total, record) => total + (record.temporary ? record.size : 0),
+      0,
+    );
+    if (temporary && reservedBytes + size > MAX_CLIPBOARD_TURN_BYTES) {
+      throw attachmentError('ATTACHMENT_TURN_TOO_LARGE', 'Clipboard attachments exceed the per-turn limit');
+    }
+    const id = requireSegment(randomUUID(), 'attachment id');
+    if (records.has(id)) throw attachmentError('ATTACHMENT_ID_COLLISION', 'Attachment id already exists');
+    const record = {
+      id,
+      pondId,
+      sessionId: safeSessionId,
+      size,
+      temporary,
+      ref: null,
+    };
+    records.set(id, record);
+    return record;
+  }
+
+  function protectDirectory(directory) {
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    try {
+      fs.chmodSync(directory, 0o700);
+    } catch (error) {
+      if (platform.id !== 'windows-x64') throw error;
+    }
+    if (fs.lstatSync(directory).isSymbolicLink()) {
+      throw attachmentError('ATTACHMENT_STAGING_FAILED', 'Attachment directory must not be a symbolic link');
+    }
+  }
+
+  function cleanupTemporary(record, candidate = record?.ref?.localPath) {
+    if (!record?.temporary || !candidate || !platform.paths.contains(root, candidate)) return;
+    try {
+      fs.unlinkSync(candidate);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+    const sessionDirectory = platform.paths.join([root, record.sessionId]);
+    if (platform.paths.contains(root, sessionDirectory)) removeEmptyDirectory(fs, sessionDirectory);
+    removeEmptyDirectory(fs, root);
+  }
+
+  async function preparePathless(file, context) {
+    if (!Number.isSafeInteger(file?.size) || file.size < 0 || typeof file?.slice !== 'function') {
+      throw attachmentError('ATTACHMENT_INVALID', 'Pathless attachment must be a Blob-like file');
+    }
+    const record = reserve({
+      ...context,
+      size: file.size,
+      temporary: true,
+    });
+    const name = safeBasename(file.name);
+    const sessionDirectory = platform.paths.join([root, record.sessionId]);
+    const partPath = platform.paths.join([sessionDirectory, record.id + '.part']);
+    const finalPath = platform.paths.join([sessionDirectory, record.id + '-' + name]);
+    let descriptor = null;
+    try {
+      protectDirectory(root);
+      protectDirectory(sessionDirectory);
+      if (!platform.paths.contains(root, partPath) || !platform.paths.contains(root, finalPath)) {
+        throw attachmentError('ATTACHMENT_STAGING_FAILED', 'Attachment staging path escaped the managed root');
+      }
+      descriptor = fs.openSync(partPath, 'wx', 0o600);
+      for (let offset = 0; offset < file.size; offset += chunkBytes) {
+        const slice = file.slice(offset, Math.min(file.size, offset + chunkBytes));
+        const chunk = await readBlobChunk(slice);
+        writeAll(fs, descriptor, chunk);
+      }
+      fs.fsyncSync(descriptor);
+      fs.closeSync(descriptor);
+      descriptor = null;
+      fs.renameSync(partPath, finalPath);
+      const ref = Object.freeze({
+        id: record.id,
+        name,
+        localPath: finalPath,
+        size: file.size,
+        mediaType: mediaTypeOf(file),
+        temporary: true,
+        createdAt: Number(now()),
+      });
+      record.ref = ref;
+      return ref;
+    } catch (cause) {
+      if (descriptor !== null) {
+        try {
+          fs.closeSync(descriptor);
+        } catch {
+          // The staging error remains primary.
+        }
+      }
+      cleanupTemporary(record, partPath);
+      records.delete(record.id);
+      if (cause?.code?.startsWith?.('ATTACHMENT_')) throw cause;
+      throw attachmentError('ATTACHMENT_STAGING_FAILED', 'Failed to stage local attachment', cause);
+    }
+  }
+
+  async function preparePathBacked(file, context) {
+    const localPath = platform.paths.resolve([file.path]);
+    if (!platform.paths.isAbsolute(localPath)) {
+      throw attachmentError('ATTACHMENT_INVALID', 'Attachment path must be absolute');
+    }
+    let stat;
+    try {
+      stat = fs.statSync(localPath);
+      if (!stat.isFile()) throw new Error('not a regular file');
+      fs.accessSync(localPath, fs.constants.R_OK);
+    } catch (cause) {
+      throw attachmentError('ATTACHMENT_UNREADABLE', 'Attachment path is not a readable file', cause);
+    }
+    const record = reserve({
+      ...context,
+      size: stat.size,
+      temporary: false,
+    });
+    const name = safeBasename(file.name || platform.paths.basename(localPath));
+    const ref = Object.freeze({
+      id: record.id,
+      name,
+      localPath,
+      size: stat.size,
+      mediaType: mediaTypeOf(file),
+      temporary: false,
+      createdAt: Number(now()),
+    });
+    record.ref = ref;
+    return ref;
+  }
+
+  return Object.freeze({
+    prepare(file, context = {}) {
+      if (file?.path) return preparePathBacked(file, context);
+      return preparePathless(file, context);
+    },
+    release(attachmentId) {
+      const record = records.get(attachmentId);
+      if (!record) return;
+      cleanupTemporary(record);
+      records.delete(attachmentId);
+    },
+    releaseSession(sessionId) {
+      for (const record of sessionRecords(String(sessionId || ''))) {
+        cleanupTemporary(record);
+        records.delete(record.id);
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      for (const record of [...records.values()]) {
+        cleanupTemporary(record);
+        records.delete(record.id);
+      }
+      disposed = true;
+    },
+  });
+}

--- a/plugin/panel/src/cep/attachmentStore.js
+++ b/plugin/panel/src/cep/attachmentStore.js
@@ -29,7 +29,7 @@ function requireSegment(value, field) {
 }
 
 function safeBasename(value, fallback = 'attachment') {
-  const normalized = String(value || '').replaceAll('\\', '/');
+  const normalized = String(value || '').replace(/\\/g, '/');
   const name = normalized.split('/').filter(Boolean).pop() || fallback;
   return name === '.' || name === '..' ? fallback : name;
 }
@@ -106,6 +106,7 @@ export function createAttachmentStore({
       sessionId: safeSessionId,
       size,
       temporary,
+      createdAt: Number(now()),
       ref: null,
     };
     records.set(id, record);
@@ -173,7 +174,6 @@ export function createAttachmentStore({
         size: file.size,
         mediaType: mediaTypeOf(file),
         temporary: true,
-        createdAt: Number(now()),
       });
       record.ref = ref;
       return ref;
@@ -193,10 +193,10 @@ export function createAttachmentStore({
   }
 
   async function preparePathBacked(file, context) {
-    const localPath = platform.paths.resolve([file.path]);
-    if (!platform.paths.isAbsolute(localPath)) {
+    if (!platform.paths.isAbsolute(file.path)) {
       throw attachmentError('ATTACHMENT_INVALID', 'Attachment path must be absolute');
     }
+    const localPath = platform.paths.resolve([file.path]);
     let stat;
     try {
       stat = fs.statSync(localPath);
@@ -218,7 +218,6 @@ export function createAttachmentStore({
       size: stat.size,
       mediaType: mediaTypeOf(file),
       temporary: false,
-      createdAt: Number(now()),
     });
     record.ref = ref;
     return ref;

--- a/plugin/panel/src/cep/backends/contract.js
+++ b/plugin/panel/src/cep/backends/contract.js
@@ -14,6 +14,7 @@
 //
 // onEvent emission contract (order within a turn):
 //   turn-start
+//   turn-accepted{turnId,transport}
 //   ( text-delta{text,phase?}
 //   | tool-start{toolUseId,name,input}
 //   | tool-result{toolUseId,ok,text,durationMs}
@@ -23,12 +24,19 @@
 //   | thinking{active} )*
 //   turn-end{stopReason} | error{kind,message}
 //
+// An error before a model-turn request is sent includes the matching turnId
+// and dispatchState:'not-started'. A transport failure after request dispatch
+// but before turn-accepted includes the matching turnId and
+// dispatchState:'uncertain'. Backends never retry an uncertain turn
+// automatically.
+//
 // stop(): drains every pending approval (deny + tool-denied) and emits
 //   exactly one error{kind:'aborted'}.
 //
 // New backends are validated against this in backends-contract.test.js.
 export const BACKEND_EVENTS = Object.freeze([
   'turn-start',
+  'turn-accepted',
   'text-delta',
   'tool-start',
   'tool-result',

--- a/plugin/panel/src/cep/backends/index.js
+++ b/plugin/panel/src/cep/backends/index.js
@@ -30,7 +30,7 @@ export const BACKENDS = {
   codex: {
     id: 'codex',
     baseDescriptor: codexStaticDescriptor,
-    attachmentTransport: 'native',
+    attachmentTransport: 'native+manifest',
   },
   opencode: {
     id: 'opencode',
@@ -50,7 +50,13 @@ export const BACKENDS = {
   },
 };
 
-const ATTACHMENT_TRANSPORTS = new Set(['agent-sdk', 'native', 'manifest', 'reject']);
+const ATTACHMENT_TRANSPORTS = new Set([
+  'agent-sdk',
+  'native',
+  'native+manifest',
+  'manifest',
+  'reject',
+]);
 
 export function assertAttachmentBackendRegistry(registry) {
   for (const [id, entry] of Object.entries(registry)) {

--- a/plugin/panel/src/cep/backends/index.js
+++ b/plugin/panel/src/cep/backends/index.js
@@ -12,19 +12,62 @@ import {
 } from '../../lib/backendCapabilities.js';
 
 export const BACKENDS = {
-  subscription: { id: 'subscription', baseDescriptor: claudeSubDescriptor },
-  byok: { id: 'byok', baseDescriptor: byokStaticDescriptor },
-  'claude-api': { id: 'claude-api', baseDescriptor: byokStaticDescriptor },
-  codex: { id: 'codex', baseDescriptor: codexStaticDescriptor },
-  opencode: { id: 'opencode', baseDescriptor: openCodeStaticDescriptor },
+  subscription: {
+    id: 'subscription',
+    baseDescriptor: claudeSubDescriptor,
+    attachmentTransport: 'agent-sdk',
+  },
+  byok: {
+    id: 'byok',
+    baseDescriptor: byokStaticDescriptor,
+    attachmentTransport: 'reject',
+  },
+  'claude-api': {
+    id: 'claude-api',
+    baseDescriptor: byokStaticDescriptor,
+    attachmentTransport: 'agent-sdk',
+  },
+  codex: {
+    id: 'codex',
+    baseDescriptor: codexStaticDescriptor,
+    attachmentTransport: 'native',
+  },
+  opencode: {
+    id: 'opencode',
+    baseDescriptor: openCodeStaticDescriptor,
+    attachmentTransport: 'native',
+  },
   // zcode's baseDescriptor is intentionally NOT zcodeStaticDescriptor here:
   // baseDescriptorFor() special-cases 'zcode' below to build a live,
   // CLI-config-aware descriptor. zcodeStaticDescriptor remains the ultimate
   // fallback (used by zcodeDynamicDescriptor itself, and by
   // zcodeDescriptorFromModels once a session exists) when no CLI config is
   // readable at all.
-  zcode: { id: 'zcode', baseDescriptor: zcodeStaticDescriptor },
+  zcode: {
+    id: 'zcode',
+    baseDescriptor: zcodeStaticDescriptor,
+    attachmentTransport: 'manifest',
+  },
 };
+
+const ATTACHMENT_TRANSPORTS = new Set(['agent-sdk', 'native', 'manifest', 'reject']);
+
+export function assertAttachmentBackendRegistry(registry) {
+  for (const [id, entry] of Object.entries(registry)) {
+    if (!ATTACHMENT_TRANSPORTS.has(entry?.attachmentTransport)) {
+      throw new TypeError(id + ' is missing a valid attachment transport');
+    }
+    if (entry.attachmentTransport === 'reject' && id !== 'byok') {
+      throw new TypeError(id + ' must not reject attachments');
+    }
+    if (id === 'byok' && entry.attachmentTransport !== 'reject') {
+      throw new TypeError('byok must reject attachments');
+    }
+  }
+  return true;
+}
+
+assertAttachmentBackendRegistry(BACKENDS);
 
 // Real (conversation-bearing) backend ids — drives shouldResetOnBackendChange.
 export const REAL_BACKENDS = Object.keys(BACKENDS);

--- a/plugin/panel/src/cep/claudeAgentBackend.js
+++ b/plugin/panel/src/cep/claudeAgentBackend.js
@@ -4,6 +4,7 @@ import { createDeltaRedactor, redactValue } from '../lib/exactSecretRedaction.js
 import { selectProviderRoute } from '../lib/providerRouteSelection.js';
 import { createPlatformAdapter } from './platform/index.js';
 import { createUniversalProviderRoute } from './universalProviderRoute.js';
+import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 const READY_TIMEOUT_MS = 15000;
 const STDERR_TAIL_LIMIT = 4096;
@@ -111,17 +112,35 @@ export function createClaudeAgentBackend({
   let routeClosePromise = Promise.resolve();
   let runtimeGeneration = 0;
   let providerSensitiveValues = [];
+  let activeAttachmentPaths = [];
   let providerDeltaPhase = undefined;
   let providerDeltaRedactor = createDeltaRedactor([], () => {});
+  let activeTurn = null;
+  let activeTurnAccepted = false;
+  let activeTurnDispatched = false;
 
   function emit(evt) {
-    if (onEvent) onEvent(redactValue(evt, providerSensitiveValues));
+    let event = evt;
+    if (
+      event?.type === 'error'
+      && activeTurn?.turnId
+      && !event.turnId
+    ) {
+      event = {
+        ...event,
+        turnId: activeTurn.turnId,
+        ...(!activeTurnAccepted ? {
+          dispatchState: activeTurnDispatched ? 'uncertain' : 'not-started',
+        } : {}),
+      };
+    }
+    if (onEvent) onEvent(redactValue(event, [...providerSensitiveValues, ...activeAttachmentPaths]));
   }
 
   function resetProviderDeltaRedactor() {
     providerDeltaRedactor.discard();
     providerDeltaPhase = undefined;
-    providerDeltaRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
+    providerDeltaRedactor = createDeltaRedactor([...providerSensitiveValues, ...activeAttachmentPaths], (text) => {
       activeAssistantText += text;
       emit({ type: 'text-delta', text, ...(providerDeltaPhase ? { phase: providerDeltaPhase } : {}) });
     });
@@ -134,11 +153,21 @@ export function createClaudeAgentBackend({
     resetProviderDeltaRedactor();
   }
 
+  function setActiveAttachmentPaths(values) {
+    activeAttachmentPaths = Array.from(new Set((values || [])
+      .filter((value) => typeof value === 'string' && value)))
+      .sort((left, right) => right.length - left.length);
+    if (stderrTail) {
+      stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+    }
+    resetProviderDeltaRedactor();
+  }
+
   function clearProviderSensitiveValues() {
     providerDeltaRedactor.discard();
     providerSensitiveValues = [];
     providerDeltaPhase = undefined;
-    providerDeltaRedactor = createDeltaRedactor([], () => {});
+    providerDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, () => {});
   }
 
   function writeMessage(message) {
@@ -147,16 +176,15 @@ export function createClaudeAgentBackend({
   }
 
   function finishActive() {
-    if (!activeResolve) {
-      activeRun = null;
-      activeAssistantText = '';
-      return;
-    }
     const resolve = activeResolve;
     activeResolve = null;
     activeRun = null;
     activeAssistantText = '';
-    resolve();
+    activeTurn = null;
+    activeTurnAccepted = false;
+    activeTurnDispatched = false;
+    setActiveAttachmentPaths([]);
+    if (resolve) resolve();
   }
 
   function handleSidecarMessage(message) {
@@ -176,6 +204,9 @@ export function createClaudeAgentBackend({
       return;
     }
     providerDeltaRedactor.flush();
+    if (event.type === 'turn-accepted' && activeTurn && event.turnId === activeTurn.turnId) {
+      activeTurnAccepted = true;
+    }
     emit(event);
     if (event.type === 'turn-end') {
       transcript.push({ role: 'assistant', text: activeAssistantText });
@@ -532,7 +563,10 @@ export function createClaudeAgentBackend({
       if (spawnedProc.stdout && spawnedProc.stdout.on) spawnedProc.stdout.on('data', reader);
       if (spawnedProc.stderr && spawnedProc.stderr.on) spawnedProc.stderr.on('data', (chunk) => {
         if (startGeneration !== runtimeGeneration || proc !== spawnedProc) return;
-        stderrTail = appendTail(stderrTail, processChannel === 'api' ? '[provider-sidecar-stderr-redacted]\n' : chunk);
+        const detail = processChannel === 'api'
+          ? '[provider-sidecar-stderr-redacted]\n'
+          : redactValue(String(chunk), [...providerSensitiveValues, ...activeAttachmentPaths]);
+        stderrTail = appendTail(stderrTail, detail);
       });
       spawnedProc.on('exit', (code, signal) => handleExit(spawnedProc, startGeneration, code, signal));
       spawnedProc.on('error', (error) => {
@@ -607,10 +641,29 @@ export function createClaudeAgentBackend({
     }
   }
 
-  async function sendUser(text) {
+  async function sendUser(input) {
     if (activeRun) return activeRun;
 
+    const structuredInput = input !== null && typeof input === 'object' && !Array.isArray(input);
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'TURN_INPUT_INVALID',
+        message: error.message,
+        ...(turnId ? { turnId, dispatchState: 'not-started' } : {}),
+      });
+      return;
+    }
     activeAssistantText = '';
+    activeTurn = turn;
+    activeTurnAccepted = false;
+    activeTurnDispatched = false;
+    setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
     resetProviderDeltaRedactor();
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
@@ -623,11 +676,14 @@ export function createClaudeAgentBackend({
       return run;
     }
 
-    const userText = String(text || '');
+    const userText = turn.text;
     transcript.push({ role: 'user', text: userText });
+    activeTurnDispatched = true;
     writeMessage({
       t: 'user',
+      ...(turn.turnId ? { turnId: turn.turnId } : {}),
       text: userText,
+      ...(structuredInput ? { attachments: turn.attachments } : {}),
       permissionMode: getPermissionMode(),
       model: processModel,
       effort: getEffort ? getEffort() : undefined,

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -23,6 +23,7 @@ import {
   isCoreAuthorizedDynamicCall,
   planSessionKey,
 } from '../../../shared/tool-approval.mjs';
+import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 const RPC_TIMEOUT_MS = 30000;
 const STDERR_TAIL_LIMIT = 4096;
@@ -310,6 +311,9 @@ export function createCodexBackend({
   let turnFailureInFlight = false;
   let providerRecoverySequence = 0;
   let providerRefreshPending = false;
+  let activeTurn = null;
+  let activeTurnAccepted = false;
+  let activeTurnDispatched = false;
   let activeUserText = '';
   let activeUserRecorded = false;
   const pendingApprovals = new Map();
@@ -368,12 +372,25 @@ export function createCodexBackend({
     return adapter.completeSpawnEnv(env || {});
   }
 
+  function activeTurnFailureFields() {
+    if (!activeTurn?.turnId) return {};
+    return {
+      turnId: activeTurn.turnId,
+      ...(!activeTurnAccepted ? {
+        dispatchState: activeTurnDispatched ? 'uncertain' : 'not-started',
+      } : {}),
+    };
+  }
+
   function finishActive() {
     const resolve = activeResolve;
     const refreshProvider = providerRefreshPending;
     activeResolve = null;
     activeRun = null;
     activeAssistantText = '';
+    activeTurn = null;
+    activeTurnAccepted = false;
+    activeTurnDispatched = false;
     activeUserText = '';
     activeUserRecorded = false;
     providerRecoveryAttempted = false;
@@ -422,6 +439,10 @@ export function createCodexBackend({
     if (message.method === 'turn/started') {
       currentTurnId = (params.turn && params.turn.id) || params.turnId || null;
       resetProviderDeltaRedactor();
+      if (activeTurn && activeTurn.turnId && !activeTurnAccepted) {
+        activeTurnAccepted = true;
+        emit({ type: 'turn-accepted', turnId: activeTurn.turnId, transport: 'codex-app-server' });
+      }
       emit({ type: 'turn-start' });
       return;
     }
@@ -603,7 +624,12 @@ export function createCodexBackend({
       return;
     }
     if (activeRun) {
-      emit({ type: 'error', kind: 'mcp', message: 'codex app-server exited: ' + detail });
+      emit({
+        type: 'error',
+        kind: 'mcp',
+        message: 'codex app-server exited: ' + detail,
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
     clearProviderSensitiveValues();
@@ -621,7 +647,7 @@ export function createCodexBackend({
     preambleSent = false;
     closeProviderRoute();
     if (activeRun) {
-      emit({ type: 'error', kind: 'mcp', message: err.message });
+      emit({ type: 'error', kind: 'mcp', message: err.message, ...activeTurnFailureFields() });
       finishActive();
     }
     clearProviderSensitiveValues();
@@ -958,10 +984,25 @@ export function createCodexBackend({
     return threadId;
   }
 
-  function turnParams(text) {
+  function turnInput(turn, text) {
+    const input = [];
+    if (text) input.push({ type: 'text', text });
+    for (const attachment of turn.attachments) {
+      if (attachment.mediaType.startsWith('image/')) {
+        input.push({ type: 'localImage', path: attachment.localPath });
+      } else if (attachment.mediaType.startsWith('audio/')) {
+        input.push({ type: 'localAudio', path: attachment.localPath });
+      } else {
+        input.push({ type: 'mention', name: attachment.name, path: attachment.localPath });
+      }
+    }
+    return input;
+  }
+
+  function turnParams(turn, text) {
     const params = {
       threadId,
-      input: [{ type: 'text', text }],
+      input: turnInput(turn, text),
       model: getModel(),
       effort: getEffort ? getEffort() : undefined,
       approvalPolicy: APPROVAL_POLICY,
@@ -985,7 +1026,8 @@ export function createCodexBackend({
       if (instructions) turnText = instructions + '\n\n---\n\n' + activeUserText;
       preambleSent = true;
     }
-    rpc.request('turn/start', turnParams(turnText), 180000).catch((error) => {
+    activeTurnDispatched = true;
+    rpc.request('turn/start', turnParams(activeTurn, turnText), 180000).catch((error) => {
       void handleTurnFailure(error);
     });
   }
@@ -1047,7 +1089,7 @@ export function createCodexBackend({
         message: redactValue(error?.message || 'Failed to start Codex turn.', providerSensitiveValues),
       };
       try {
-        if (await attemptProviderRecovery(error)) return;
+        if (!activeTurnDispatched && await attemptProviderRecovery(error)) return;
       } catch (recoveryError) {
         failure = {
           kind: recoveryError?.kind,
@@ -1063,6 +1105,7 @@ export function createCodexBackend({
         kind: failure?.kind || (providerHttpFailure || /model/i.test(message) ? 'model' : 'mcp'),
         ...(failure?.code ? { code: failure.code } : {}),
         message,
+        ...activeTurnFailureFields(),
       });
       finishActive();
     } finally {
@@ -1070,10 +1113,27 @@ export function createCodexBackend({
     }
   }
 
-  async function sendUser(text) {
+  async function sendUser(input) {
     if (activeRun) return activeRun;
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'TURN_INPUT_INVALID',
+        message: error.message,
+        ...(turnId ? { turnId, dispatchState: 'not-started' } : {}),
+      });
+      return;
+    }
     activeAssistantText = '';
-    activeUserText = String(text || '');
+    activeTurn = turn;
+    activeTurnAccepted = false;
+    activeTurnDispatched = false;
+    activeUserText = turn.text;
     activeUserRecorded = false;
     providerRecoveryAttempted = false;
     providerRecoveryInFlight = false;
@@ -1126,7 +1186,7 @@ export function createCodexBackend({
     drainApprovals();
     providerDeltaRedactor.discard();
     if (activeRun) {
-      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.' });
+      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.', ...activeTurnFailureFields() });
       finishActive();
     }
   }

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -23,7 +23,10 @@ import {
   isCoreAuthorizedDynamicCall,
   planSessionKey,
 } from '../../../shared/tool-approval.mjs';
-import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
+import {
+  normalizeTurnInput,
+  withAttachmentManifest,
+} from '../../../shared/chat-attachments.mjs';
 
 const RPC_TIMEOUT_MS = 30000;
 const STDERR_TAIL_LIMIT = 4096;
@@ -986,14 +989,13 @@ export function createCodexBackend({
 
   function turnInput(turn, text) {
     const input = [];
-    if (text) input.push({ type: 'text', text });
+    const modelText = withAttachmentManifest(text, turn.attachments);
+    if (modelText) input.push({ type: 'text', text: modelText });
     for (const attachment of turn.attachments) {
       if (attachment.mediaType.startsWith('image/')) {
         input.push({ type: 'localImage', path: attachment.localPath });
       } else if (attachment.mediaType.startsWith('audio/')) {
         input.push({ type: 'localAudio', path: attachment.localPath });
-      } else {
-        input.push({ type: 'mention', name: attachment.name, path: attachment.localPath });
       }
     }
     return input;

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -304,6 +304,8 @@ export function createCodexBackend({
   let lastCliInfo = null;
   let providerRoute = null;
   let providerSensitiveValues = [];
+  let activeAttachmentPaths = [];
+  let processStderrAttachmentPaths = [];
   let providerDeltaPhase = undefined;
   let providerDeltaRedactor = createDeltaRedactor([], () => {});
   let providerStderrRedactor = createDeltaRedactor([], () => {});
@@ -330,29 +332,56 @@ export function createCodexBackend({
   }
 
   function emit(evt) {
-    if (onEvent) onEvent(redactValue(evt, providerSensitiveValues));
+    if (onEvent) onEvent(redactValue(evt, [...providerSensitiveValues, ...activeAttachmentPaths]));
   }
 
   function resetProviderDeltaRedactor() {
     providerDeltaRedactor.discard();
     providerDeltaPhase = undefined;
-    providerDeltaRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
-      activeAssistantText += text;
-      emit({ type: 'text-delta', text, phase: providerDeltaPhase });
-    });
+    providerDeltaRedactor = createDeltaRedactor(
+      [...providerSensitiveValues, ...activeAttachmentPaths],
+      (text) => {
+        activeAssistantText += text;
+        emit({ type: 'text-delta', text, phase: providerDeltaPhase });
+      },
+    );
   }
 
   function resetProviderStderrRedactor() {
     providerStderrRedactor.discard();
-    providerStderrRedactor = createDeltaRedactor(providerSensitiveValues, (text) => {
-      stderrTail = appendTail(stderrTail, text);
-    });
+    providerStderrRedactor = createDeltaRedactor(
+      [...providerSensitiveValues, ...processStderrAttachmentPaths],
+      (text) => {
+        stderrTail = appendTail(stderrTail, text);
+      },
+    );
   }
 
   function setProviderSensitiveValues(values) {
     providerSensitiveValues = Array.from(new Set((values || []).filter((value) => typeof value === 'string' && value)))
       .sort((left, right) => right.length - left.length);
     resetProviderDeltaRedactor();
+    resetProviderStderrRedactor();
+  }
+
+  function setActiveAttachmentPaths(values) {
+    activeAttachmentPaths = Array.from(new Set((values || [])
+      .filter((value) => typeof value === 'string' && value)))
+      .sort((left, right) => right.length - left.length);
+    if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+    const previousProcessPathCount = processStderrAttachmentPaths.length;
+    processStderrAttachmentPaths = Array.from(new Set([
+      ...processStderrAttachmentPaths,
+      ...activeAttachmentPaths,
+    ])).sort((left, right) => right.length - left.length);
+    resetProviderDeltaRedactor();
+    if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+      resetProviderStderrRedactor();
+    }
+  }
+
+  function clearProcessStderrAttachmentPaths({ preserveActive = false } = {}) {
+    processStderrAttachmentPaths = preserveActive ? activeAttachmentPaths.slice() : [];
     resetProviderStderrRedactor();
   }
 
@@ -367,8 +396,8 @@ export function createCodexBackend({
     providerStderrRedactor.discard();
     providerSensitiveValues = [];
     providerDeltaPhase = undefined;
-    providerDeltaRedactor = createDeltaRedactor([], () => {});
-    providerStderrRedactor = createDeltaRedactor([], () => {});
+    providerDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, () => {});
+    providerStderrRedactor = createDeltaRedactor(processStderrAttachmentPaths, () => {});
   }
 
   function currentEnv() {
@@ -400,6 +429,7 @@ export function createCodexBackend({
     providerRecoveryInFlight = false;
     turnFailureInFlight = false;
     providerRefreshPending = false;
+    setActiveAttachmentPaths([]);
     if (resolve) resolve();
     if (refreshProvider) {
       Promise.resolve().then(() => onProviderProfileRecovered()).catch(() => {});
@@ -432,6 +462,7 @@ export function createCodexBackend({
     activeAssistantText = '';
     stderrTail = '';
     clearProviderSensitiveValues();
+    clearProcessStderrAttachmentPaths({ preserveActive: true });
     if (previousProc) {
       try { previousProc.kill(); } catch { /* best effort */ }
     }
@@ -624,6 +655,7 @@ export function createCodexBackend({
     closeProviderRoute();
     if (wasStopping) {
       clearProviderSensitiveValues();
+      clearProcessStderrAttachmentPaths();
       return;
     }
     if (activeRun) {
@@ -636,6 +668,7 @@ export function createCodexBackend({
       finishActive();
     }
     clearProviderSensitiveValues();
+    clearProcessStderrAttachmentPaths();
   }
 
   function handleError(error) {
@@ -654,6 +687,7 @@ export function createCodexBackend({
       finishActive();
     }
     clearProviderSensitiveValues();
+    clearProcessStderrAttachmentPaths();
   }
 
   function clearSpawnCredentialCopies(runtimeConfig, spawnEnvironment, extraNames = []) {
@@ -1088,7 +1122,10 @@ export function createCodexBackend({
       let failure = {
         kind: error?.kind,
         code: error?.code,
-        message: redactValue(error?.message || 'Failed to start Codex turn.', providerSensitiveValues),
+        message: redactValue(
+          error?.message || 'Failed to start Codex turn.',
+          [...providerSensitiveValues, ...activeAttachmentPaths],
+        ),
       };
       try {
         if (!activeTurnDispatched && await attemptProviderRecovery(error)) return;
@@ -1096,7 +1133,10 @@ export function createCodexBackend({
         failure = {
           kind: recoveryError?.kind,
           code: recoveryError?.code,
-          message: redactValue(recoveryError?.message || 'Failed to start Codex turn.', providerSensitiveValues),
+          message: redactValue(
+            recoveryError?.message || 'Failed to start Codex turn.',
+            [...providerSensitiveValues, ...activeAttachmentPaths],
+          ),
         };
       }
       providerDeltaRedactor.discard();
@@ -1135,6 +1175,7 @@ export function createCodexBackend({
     activeTurn = turn;
     activeTurnAccepted = false;
     activeTurnDispatched = false;
+    setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
     activeUserText = turn.text;
     activeUserRecorded = false;
     providerRecoveryAttempted = false;
@@ -1220,6 +1261,7 @@ export function createCodexBackend({
     finishActive();
     stderrTail = '';
     clearProviderSensitiveValues();
+    clearProcessStderrAttachmentPaths();
     stopping = false;
   }
 

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -1,6 +1,7 @@
 import { createSseParser } from '../lib/sse.js';
 import { expertGuidanceEnv } from './externalClients.js';
 import { createPlatformAdapter } from './platform/index.js';
+import { createDeltaRedactor, redactValue } from '../lib/exactSecretRedaction.js';
 import { attachmentFileUrl, normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 const MCP_TIMEOUT_MS = 120000;
@@ -173,6 +174,10 @@ export function createOpenCodeBackend({
   let activeRun = null;
   let activeResolve = null;
   let activeAssistantText = '';
+  let activeAttachmentPaths = [];
+  let processStderrAttachmentPaths = [];
+  let assistantDeltaRedactor = createDeltaRedactor([], () => {});
+  let stderrRedactor = createDeltaRedactor([], () => {});
   let activeTurn = null;
   let activeTurnAccepted = false;
   let messageDispatched = false;
@@ -184,7 +189,43 @@ export function createOpenCodeBackend({
   const transcript = [];
 
   function emit(evt) {
-    if (onEvent) onEvent(evt);
+    if (onEvent) onEvent(redactValue(evt, activeAttachmentPaths));
+  }
+
+  function resetAssistantDeltaRedactor() {
+    assistantDeltaRedactor.discard();
+    assistantDeltaRedactor = createDeltaRedactor(activeAttachmentPaths, (text) => {
+      activeAssistantText += text;
+      emit({ type: 'text-delta', text });
+    });
+  }
+
+  function resetStderrRedactor() {
+    stderrRedactor.discard();
+    stderrRedactor = createDeltaRedactor(processStderrAttachmentPaths, (text) => {
+      stderrTail = appendTail(stderrTail, text);
+    });
+  }
+
+  function setActiveAttachmentPaths(values) {
+    activeAttachmentPaths = Array.from(new Set((values || [])
+      .filter((value) => typeof value === 'string' && value)))
+      .sort((left, right) => right.length - left.length);
+    if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+    const previousProcessPathCount = processStderrAttachmentPaths.length;
+    processStderrAttachmentPaths = Array.from(new Set([
+      ...processStderrAttachmentPaths,
+      ...activeAttachmentPaths,
+    ])).sort((left, right) => right.length - left.length);
+    resetAssistantDeltaRedactor();
+    if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+      resetStderrRedactor();
+    }
+  }
+
+  function clearProcessStderrAttachmentPaths() {
+    processStderrAttachmentPaths = [];
+    resetStderrRedactor();
   }
 
   function fetcher() {
@@ -204,6 +245,7 @@ export function createOpenCodeBackend({
       messageDispatched = false;
       turnStarted = false;
       startedTools.clear();
+      setActiveAttachmentPaths([]);
       return;
     }
     const resolve = activeResolve;
@@ -215,6 +257,7 @@ export function createOpenCodeBackend({
     messageDispatched = false;
     turnStarted = false;
     startedTools.clear();
+    setActiveAttachmentPaths([]);
     resolve();
   }
 
@@ -290,13 +333,17 @@ export function createOpenCodeBackend({
 
   function handleExit(code, signal) {
     const wasStopping = stopping;
+    stderrRedactor.flush();
     proc = null;
     serverPromise = null;
     sessionPromise = null;
     sessionId = null;
     sseClosed = true;
     sseStarted = false;
-    if (wasStopping) return;
+    if (wasStopping) {
+      clearProcessStderrAttachmentPaths();
+      return;
+    }
     if (activeRun) {
       const detail = stderrTail ? String(code) + (signal ? ' ' + signal : '') + ' ' + stderrTail : String(code) + (signal ? ' ' + signal : '');
       emit({
@@ -307,6 +354,7 @@ export function createOpenCodeBackend({
       });
       finishActive();
     }
+    clearProcessStderrAttachmentPaths();
   }
 
   function handleError(error) {
@@ -325,6 +373,7 @@ export function createOpenCodeBackend({
       });
       finishActive();
     }
+    clearProcessStderrAttachmentPaths();
   }
 
   async function startServer() {
@@ -348,7 +397,7 @@ export function createOpenCodeBackend({
         env: spawnEnv,
       });
       if (proc.stderr && proc.stderr.on) proc.stderr.on('data', (chunk) => {
-        stderrTail = appendTail(stderrTail, chunk);
+        stderrRedactor.feed(chunk);
       });
       if (proc.on) {
         proc.on('exit', (code, signal) => handleExit(code, signal));
@@ -508,6 +557,7 @@ export function createOpenCodeBackend({
       if (st === 'busy') {
         if (!turnStarted) { turnStarted = true; emit({ type: 'turn-start' }); }
       } else if (st === 'idle') {
+        assistantDeltaRedactor.flush();
         drainApprovals();
         emit({ type: 'turn-end', stopReason: 'end_turn' });
         transcript.push({ role: 'assistant', text: activeAssistantText });
@@ -519,7 +569,7 @@ export function createOpenCodeBackend({
       if (p.field === 'text') {
         emit({ type: 'thinking', active: false });
         const text = p.delta;
-        if (text) { activeAssistantText += String(text); emit({ type: 'text-delta', text: String(text) }); }
+        if (text) assistantDeltaRedactor.feed(String(text));
       } else if (p.field === 'reasoning') {
         emit({ type: 'thinking', active: true });
       }
@@ -532,6 +582,7 @@ export function createOpenCodeBackend({
       return;
     }
     if (type === 'session.error') {
+      assistantDeltaRedactor.discard();
       const error = p.error || p;
       emit({
         type: 'error',
@@ -591,6 +642,10 @@ export function createOpenCodeBackend({
     activeTurn = turn;
     activeTurnAccepted = false;
     messageDispatched = false;
+    setActiveAttachmentPaths(turn.attachments.flatMap((attachment) => [
+      attachment.localPath,
+      attachmentFileUrl(attachment.localPath, adapter.id),
+    ]));
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
     });
@@ -660,6 +715,8 @@ export function createOpenCodeBackend({
     if (proc && proc.kill) proc.kill();
     proc = null;
     serverPromise = null;
+    stderrTail = '';
+    clearProcessStderrAttachmentPaths();
     try {
       if (configHome) {
         const fs = fsImpl || adapter.fs;

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -1,6 +1,7 @@
 import { createSseParser } from '../lib/sse.js';
 import { expertGuidanceEnv } from './externalClients.js';
 import { createPlatformAdapter } from './platform/index.js';
+import { attachmentFileUrl, normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 const MCP_TIMEOUT_MS = 120000;
 const READY_TIMEOUT_MS = 30000;
@@ -172,6 +173,9 @@ export function createOpenCodeBackend({
   let activeRun = null;
   let activeResolve = null;
   let activeAssistantText = '';
+  let activeTurn = null;
+  let activeTurnAccepted = false;
+  let messageDispatched = false;
   let turnStarted = false;
   let toolMeta = { annotations: {} };
   const pendingApprovals = new Map();
@@ -195,6 +199,9 @@ export function createOpenCodeBackend({
     if (!activeResolve) {
       activeRun = null;
       activeAssistantText = '';
+      activeTurn = null;
+      activeTurnAccepted = false;
+      messageDispatched = false;
       turnStarted = false;
       startedTools.clear();
       return;
@@ -203,6 +210,9 @@ export function createOpenCodeBackend({
     activeResolve = null;
     activeRun = null;
     activeAssistantText = '';
+    activeTurn = null;
+    activeTurnAccepted = false;
+    messageDispatched = false;
     turnStarted = false;
     startedTools.clear();
     resolve();
@@ -215,6 +225,16 @@ export function createOpenCodeBackend({
       throw new Error('OpenCode HTTP ' + (response ? response.status : 'error') + (text ? ': ' + text : ''));
     }
     return response;
+  }
+
+  function activeTurnFailureFields() {
+    if (!activeTurn?.turnId) return {};
+    return {
+      turnId: activeTurn.turnId,
+      ...(!activeTurnAccepted ? {
+        dispatchState: messageDispatched ? 'uncertain' : 'not-started',
+      } : {}),
+    };
   }
 
   async function requestJson(path, options = {}) {
@@ -279,7 +299,12 @@ export function createOpenCodeBackend({
     if (wasStopping) return;
     if (activeRun) {
       const detail = stderrTail ? String(code) + (signal ? ' ' + signal : '') + ' ' + stderrTail : String(code) + (signal ? ' ' + signal : '');
-      emit({ type: 'error', kind: 'mcp', message: 'opencode serve exited: ' + detail });
+      emit({
+        type: 'error',
+        kind: 'mcp',
+        message: 'opencode serve exited: ' + detail,
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
   }
@@ -292,7 +317,12 @@ export function createOpenCodeBackend({
     sseClosed = true;
     sseStarted = false;
     if (activeRun) {
-      emit({ type: 'error', kind: 'mcp', message: error && error.message ? error.message : 'opencode serve error' });
+      emit({
+        type: 'error',
+        kind: 'mcp',
+        message: error && error.message ? error.message : 'opencode serve error',
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
   }
@@ -360,7 +390,12 @@ export function createOpenCodeBackend({
     const parser = createSseParser(({ data }) => handleOpenCodeEvent(data));
     request('/event').then((response) => readSseBody(response.body, parser)).catch((e) => {
       if (!sseClosed && activeRun) {
-        emit({ type: 'error', kind: 'mcp', message: e && e.message ? e.message : 'OpenCode event stream failed.' });
+        emit({
+          type: 'error',
+          kind: 'mcp',
+          message: e && e.message ? e.message : 'OpenCode event stream failed.',
+          ...activeTurnFailureFields(),
+        });
         finishActive();
       }
     });
@@ -498,7 +533,12 @@ export function createOpenCodeBackend({
     }
     if (type === 'session.error') {
       const error = p.error || p;
-      emit({ type: 'error', kind: error.kind || 'mcp', message: error.message || String(error || 'OpenCode session error') });
+      emit({
+        type: 'error',
+        kind: error.kind || 'mcp',
+        message: error.message || String(error || 'OpenCode session error'),
+        ...activeTurnFailureFields(),
+      });
       finishActive();
       return;
     }
@@ -519,21 +559,60 @@ export function createOpenCodeBackend({
     return Promise.allSettled(replies);
   }
 
-  async function sendUser(text) {
+  function openCodeParts(turn) {
+    return [
+      ...(turn.text ? [{ type: 'text', text: turn.text }] : []),
+      ...turn.attachments.map((file) => ({
+        type: 'file',
+        mime: file.mediaType || 'application/octet-stream',
+        filename: file.name,
+        url: attachmentFileUrl(file.localPath, adapter.id),
+      })),
+    ];
+  }
+
+  async function sendUser(input) {
     if (activeRun) return activeRun;
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'TURN_INPUT_INVALID',
+        message: error.message,
+        ...(turnId ? { turnId, dispatchState: 'not-started' } : {}),
+      });
+      return;
+    }
     activeAssistantText = '';
+    activeTurn = turn;
+    activeTurnAccepted = false;
+    messageDispatched = false;
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
     });
     try {
       const id = await ensureSession();
-      const userText = String(text || '');
+      const userText = turn.text;
       transcript.push({ role: 'user', text: userText });
+      messageDispatched = true;
       await postJson('/session/' + encodeURIComponent(id) + '/message', {
-        parts: [{ type: 'text', text: userText }],
+        parts: openCodeParts(turn),
       });
+      if (turn.turnId) {
+        activeTurnAccepted = true;
+        emit({ type: 'turn-accepted', turnId: turn.turnId, transport: 'opencode-file-part' });
+      }
     } catch (e) {
-      emit({ type: 'error', kind: 'mcp', message: e && e.message ? e.message : 'Failed to start OpenCode turn.' });
+      emit({
+        type: 'error',
+        kind: 'mcp',
+        message: e && e.message ? e.message : 'Failed to start OpenCode turn.',
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
     return activeRun;
@@ -556,7 +635,7 @@ export function createOpenCodeBackend({
     }
     await drainApprovals();
     if (activeRun) {
-      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.' });
+      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.', ...activeTurnFailureFields() });
       finishActive();
     }
   }
@@ -572,6 +651,9 @@ export function createOpenCodeBackend({
     activeResolve = null;
     activeRun = null;
     activeAssistantText = '';
+    activeTurn = null;
+    activeTurnAccepted = false;
+    messageDispatched = false;
     turnStarted = false;
     startedTools.clear();
     transcript.length = 0;

--- a/plugin/panel/src/cep/providerAcceptanceBridge.js
+++ b/plugin/panel/src/cep/providerAcceptanceBridge.js
@@ -1,3 +1,5 @@
+import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
+
 const PROTOCOLS = new Set(['responses', 'chat', 'messages']);
 const CAPABILITY_STATUSES = new Set(['unknown', 'supported', 'unsupported']);
 const AGENT_FEATURES = Object.freeze([
@@ -55,6 +57,7 @@ function bridgeError(code) {
     PROVIDER_ACCEPTANCE_BRIDGE_DISPOSED: 'Provider acceptance bridge is disposed.',
     PROVIDER_ACCEPTANCE_CALLBACK_FAILED: 'Provider acceptance state refresh failed.',
     PROVIDER_ACCEPTANCE_INVALID_MODELS: 'Provider acceptance model list is invalid.',
+    PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN: 'Provider acceptance panel turn is invalid.',
     PROVIDER_ACCEPTANCE_PROVIDER_NOT_FOUND: 'Provider was not found.',
     PROVIDER_ACCEPTANCE_PROBE_FAILED: 'Provider acceptance probe failed.',
     PROVIDER_ACCEPTANCE_ROUTE_CLOSE_FAILED: 'Provider acceptance route did not close cleanly.',
@@ -65,6 +68,75 @@ function bridgeError(code) {
   const error = new Error(messages[code] || messages.PROVIDER_ACCEPTANCE_STORE_UNAVAILABLE);
   error.code = messages[code] ? code : 'PROVIDER_ACCEPTANCE_STORE_UNAVAILABLE';
   return error;
+}
+
+function absoluteAttachmentPath(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= 4096
+    && !/[\0\r\n]/.test(value)
+    && (
+      value.startsWith('/')
+      || /^[A-Za-z]:[\\/]/.test(value)
+      || /^\\\\[^\\]+\\[^\\]+/.test(value)
+    );
+}
+
+export function normalizePanelAcceptanceTurns(input = {}) {
+  const hasPrompts = Array.isArray(input.prompts);
+  const hasTurns = Array.isArray(input.turns);
+  if (hasPrompts === hasTurns) {
+    throw bridgeError('PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN');
+  }
+  const source = hasTurns
+    ? input.turns
+    : input.prompts.map((value) => ({
+      text: String(value || '').trim(),
+      attachments: [],
+    }));
+  if (source.length < 1 || source.length > 4) {
+    throw bridgeError('PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN');
+  }
+  try {
+    return Object.freeze(source.map((value, index) => {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError('turn must be an object');
+      }
+      const turn = normalizeTurnInput({
+        ...value,
+        turnId: `provider-acceptance-${index + 1}`,
+      });
+      if (turn.text.length > 2000
+          || turn.attachments.some((attachment) => !absoluteAttachmentPath(
+            attachment.localPath,
+          ))) {
+        throw new TypeError('turn is outside the acceptance boundary');
+      }
+      return turn;
+    }));
+  } catch {
+    throw bridgeError('PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN');
+  }
+}
+
+export function countMentionedPanelAttachments(transcript, attachments) {
+  const assistantText = Array.isArray(transcript)
+    ? transcript
+      .filter((message) => message?.role === 'assistant' && typeof message.text === 'string')
+      .map((message) => message.text)
+      .join('\n')
+    : '';
+  if (!assistantText || !Array.isArray(attachments)) return 0;
+  const names = new Set(attachments.flatMap((attachment) => (
+    typeof attachment?.name === 'string' && attachment.name
+      ? [attachment.name]
+      : []
+  )));
+  let count = 0;
+  for (const name of names) {
+    if (assistantText.includes(name)) count += 1;
+  }
+  return count;
 }
 
 function dependency(name, value, predicate) {

--- a/plugin/panel/src/cep/universalProviderRoute.js
+++ b/plugin/panel/src/cep/universalProviderRoute.js
@@ -270,6 +270,42 @@ function headersWithoutRejectedAnthropicBetas(headers, buffer) {
   return next;
 }
 
+function payloadWithoutRejectedContextManagement(payload, buffer) {
+  let errorBody;
+  let requestBody;
+  try {
+    errorBody = JSON.parse(buffer.toString('utf8'));
+    requestBody = JSON.parse(payload.toString('utf8'));
+  } catch {
+    return null;
+  }
+  const source = errorBody?.error && typeof errorBody.error === 'object'
+    ? errorBody.error
+    : errorBody;
+  const message = typeof source?.message === 'string' ? source.message : '';
+  if (!/\bcontext_management\b/.test(message)
+      || requestBody === null
+      || typeof requestBody !== 'object'
+      || Array.isArray(requestBody)) return null;
+  const context = requestBody.context_management;
+  if (context === null
+      || typeof context !== 'object'
+      || Array.isArray(context)
+      || JSON.stringify(Object.keys(context).sort()) !== '["edits"]'
+      || !Array.isArray(context.edits)
+      || context.edits.length !== 1) return null;
+  const edit = context.edits[0];
+  if (edit === null
+      || typeof edit !== 'object'
+      || Array.isArray(edit)
+      || JSON.stringify(Object.keys(edit).sort()) !== '["keep","type"]'
+      || edit.type !== 'clear_thinking_20251015'
+      || edit.keep !== 'all') return null;
+  const next = { ...requestBody };
+  delete next.context_management;
+  return Buffer.from(JSON.stringify(next), 'utf8');
+}
+
 function createGate(maximum) {
   let active = 0;
   return {
@@ -588,7 +624,7 @@ export function createUniversalProviderRoute({
       method: 'POST',
     };
     if (lookupImpl) requestOptions.lookup = lookupImpl;
-    const sendAttempt = (attemptHeaders, allowBetaRetry) => {
+    const sendAttempt = (attemptHeaders, attemptPayload, compatibility) => {
       let connected = false;
       let requestSettled = false;
       let request = null;
@@ -637,10 +673,11 @@ export function createUniversalProviderRoute({
               if (responseSettled || context.finished) return;
               responseSettled = true;
               const rawErrorBody = Buffer.concat(chunks);
-              const retryHeaders = allowBetaRetry && status === 400
+              const retryHeaders = compatibility.beta && status === 400
                 ? headersWithoutRejectedAnthropicBetas(attemptHeaders, rawErrorBody)
                 : null;
               if (retryHeaders) {
+                retryHeaders['content-length'] = String(attemptPayload.length);
                 onAudit({
                   event: 'provider_route_compat_retry',
                   modelId,
@@ -649,7 +686,35 @@ export function createUniversalProviderRoute({
                   compatibility: 'anthropic-beta-rejected-values',
                   outcome: 'retry',
                 });
-                sendAttempt(retryHeaders, false);
+                sendAttempt(retryHeaders, attemptPayload, {
+                  beta: false,
+                  contextManagement: compatibility.contextManagement,
+                });
+                return;
+              }
+              const retryPayload = compatibility.contextManagement && status === 400
+                ? payloadWithoutRejectedContextManagement(attemptPayload, rawErrorBody)
+                : null;
+              if (retryPayload) {
+                onAudit({
+                  event: 'provider_route_compat_retry',
+                  modelId,
+                  clientProtocol,
+                  upstreamProtocol: capability.upstreamProtocol,
+                  compatibility: 'context-management-rejected',
+                  outcome: 'retry',
+                });
+                sendAttempt(
+                  {
+                    ...attemptHeaders,
+                    'content-length': String(retryPayload.length),
+                  },
+                  retryPayload,
+                  {
+                    beta: compatibility.beta,
+                    contextManagement: false,
+                  },
+                );
                 return;
               }
               let errorHeaders = responseHeaders;
@@ -828,7 +893,7 @@ export function createUniversalProviderRoute({
             'Provider request failed.',
           ));
         });
-        request.end(payload);
+        request.end(attemptPayload);
       } catch {
         clearTimeout(connectTimer);
         if (!context.finish()) return;
@@ -839,7 +904,10 @@ export function createUniversalProviderRoute({
         ));
       }
     };
-    sendAttempt(headers, true);
+    sendAttempt(headers, payload, {
+      beta: true,
+      contextManagement: true,
+    });
   };
 
   const forwardChatFacade = ({ context, payload, modelId }) => {

--- a/plugin/panel/src/cep/universalProviderRoute.js
+++ b/plugin/panel/src/cep/universalProviderRoute.js
@@ -247,7 +247,12 @@ function headersWithoutRejectedAnthropicBetas(headers, buffer) {
   const match = message.match(
     /^Unexpected value\(s\)\s+(.+?)\s+for the `anthropic-beta` header(?:\.|$)/,
   );
-  if (!match) return null;
+  if (!match) {
+    if (!/\bbeta\b/i.test(message) || !/\binvalid\b/i.test(message)) return null;
+    const next = { ...headers };
+    delete next['anthropic-beta'];
+    return next;
+  }
   const token = '[A-Za-z0-9][A-Za-z0-9._:-]{0,127}';
   const listPattern = new RegExp('^`' + token + '`(?:\\s*(?:,|and)\\s*`' + token + '`)*$');
   if (!listPattern.test(match[1])) return null;

--- a/plugin/panel/src/cep/zcodeBackend.js
+++ b/plugin/panel/src/cep/zcodeBackend.js
@@ -24,7 +24,7 @@
 import { createNdjsonReader } from '../lib/ndjson.js';
 import { expertGuidanceEnv } from './externalClients.js';
 import { localizeZcodeError } from '../lib/zcodeErrors.js';
-import { redactText, redactValue } from '../lib/exactSecretRedaction.js';
+import { createDeltaRedactor, redactText, redactValue } from '../lib/exactSecretRedaction.js';
 import { isSensitiveProviderHeaderName } from '../lib/providerHeaderPolicy.js';
 import { createPlatformAdapter } from './platform/index.js';
 import {
@@ -524,6 +524,10 @@ export function createZcodeBackend({
   let environmentSecretValues = [];
   let runtimeSecretValues = [];
   let activeSecretValues = [];
+  let activeAttachmentPaths = [];
+  let processStderrAttachmentPaths = [];
+  let assistantDeltaRedactor = createDeltaRedactor([], () => {});
+  let stderrRedactor = createDeltaRedactor([], () => {});
   let secretEpoch = 0;
   let toolMeta = { allowedTools: [], annotations: {} };
   const pendingApprovals = new Map();
@@ -532,20 +536,74 @@ export function createZcodeBackend({
   const sessionAllowedTools = new Set();
   const sessionAllowedPlans = new Set();
 
+  function activeRedactionValues() {
+    return [...activeSecretValues, ...activeAttachmentPaths];
+  }
+
+  function stderrRedactionValues() {
+    return [...activeSecretValues, ...processStderrAttachmentPaths];
+  }
+
   function emit(evt) {
-    if (onEvent) onEvent(redactValue(evt, activeSecretValues));
+    if (onEvent) onEvent(redactValue(evt, activeRedactionValues()));
   }
 
   function safeText(value) {
-    return redactText(value, activeSecretValues);
+    return redactText(value, activeRedactionValues());
+  }
+
+  function resetAssistantDeltaRedactor() {
+    assistantDeltaRedactor.discard();
+    assistantDeltaRedactor = createDeltaRedactor(activeRedactionValues(), (text) => {
+      activeAssistantText += text;
+      emit({ type: 'text-delta', text });
+    });
+  }
+
+  function resetStderrRedactor() {
+    stderrRedactor.discard();
+    stderrRedactor = createDeltaRedactor(stderrRedactionValues(), (text) => {
+      stderrTail = appendTail(stderrTail, text);
+    });
+  }
+
+  function resetOutputRedactors() {
+    resetAssistantDeltaRedactor();
+    resetStderrRedactor();
+  }
+
+  function setActiveAttachmentPaths(values) {
+    activeAttachmentPaths = Array.from(new Set((values || [])
+      .filter((value) => typeof value === 'string' && value)))
+      .sort((left, right) => right.length - left.length);
+    if (stderrTail) stderrTail = redactValue(stderrTail, activeAttachmentPaths);
+    const previousProcessPathCount = processStderrAttachmentPaths.length;
+    processStderrAttachmentPaths = Array.from(new Set([
+      ...processStderrAttachmentPaths,
+      ...activeAttachmentPaths,
+    ])).sort((left, right) => right.length - left.length);
+    resetAssistantDeltaRedactor();
+    if (processStderrAttachmentPaths.length !== previousProcessPathCount) {
+      resetStderrRedactor();
+    }
+  }
+
+  function clearProcessStderrAttachmentPaths() {
+    processStderrAttachmentPaths = [];
+    resetStderrRedactor();
   }
 
   function refreshActiveSecretValues() {
-    activeSecretValues = Array.from(new Set([
+    const nextSecretValues = Array.from(new Set([
       ...environmentSecretValues,
       ...runtimeSecretValues,
     ])).sort((left, right) => right.length - left.length);
+    const stderrInventoryChanged = nextSecretValues.length !== activeSecretValues.length
+      || nextSecretValues.some((value, index) => value !== activeSecretValues[index]);
+    activeSecretValues = nextSecretValues;
     secretEpoch += 1;
+    resetAssistantDeltaRedactor();
+    if (stderrInventoryChanged) resetStderrRedactor();
   }
 
   function clearActiveSecretValues() {
@@ -553,6 +611,7 @@ export function createZcodeBackend({
     runtimeSecretValues = [];
     activeSecretValues = [];
     secretEpoch += 1;
+    resetOutputRedactors();
   }
 
   function scheduleSecretCleanup() {
@@ -621,6 +680,7 @@ export function createZcodeBackend({
       activeTurn = null;
       activeTurnAccepted = false;
       sendDispatched = false;
+      setActiveAttachmentPaths([]);
       return;
     }
     const resolve = activeResolve;
@@ -630,6 +690,7 @@ export function createZcodeBackend({
     activeTurn = null;
     activeTurnAccepted = false;
     sendDispatched = false;
+    setActiveAttachmentPaths([]);
     resolve();
   }
 
@@ -838,6 +899,7 @@ export function createZcodeBackend({
     if (type === 'state.updated') {
       const patch = params.patch || params.payload || {};
       if (patch.status === 'idle' && activeRun) {
+        assistantDeltaRedactor.flush();
         drainApprovals();
         emit({ type: 'turn-end', stopReason: 'end_turn' });
         transcript.push({ role: 'assistant', text: activeAssistantText });
@@ -853,9 +915,7 @@ export function createZcodeBackend({
     if (type === 'model.streaming') {
       const payload = params.payload || {};
       if (payload.kind === 'text_delta' && payload.delta) {
-        const delta = safeText(String(payload.delta));
-        activeAssistantText += delta;
-        emit({ type: 'text-delta', text: delta });
+        assistantDeltaRedactor.feed(String(payload.delta));
       }
       return;
     }
@@ -877,6 +937,7 @@ export function createZcodeBackend({
       return;
     }
     if (type === 'turn.completed') {
+      assistantDeltaRedactor.flush();
       drainApprovals();
       const payload = params.payload || {};
       emit({ type: 'turn-end', stopReason: 'end_turn' });
@@ -885,6 +946,7 @@ export function createZcodeBackend({
       return;
     }
     if (type === 'turn.failed') {
+      assistantDeltaRedactor.discard();
       const payload = params.payload || {};
       const message = zcodePlanRuntimeFailureHint(zcodeErrorMessage(payload.error || payload.message, 'ZCode turn failed', lang), activeRuntimeModel);
       emit({ type: 'error', kind: zcodeErrorKind(message), message, ...activeTurnFailureFields() });
@@ -937,6 +999,7 @@ export function createZcodeBackend({
 
   function handleExit(code, signal) {
     const wasStopping = stopping;
+    stderrRedactor.flush();
     const detail = stderrTail ? String(code) + (signal ? ' ' + signal : '') + ' ' + stderrTail : String(code) + (signal ? ' ' + signal : '');
     if (rpc) rpc.close(new Error('ZCode app-server exited: ' + detail));
     proc = null;
@@ -948,6 +1011,7 @@ export function createZcodeBackend({
     subscribed = false;
     activeRuntimeModel = null;
     if (wasStopping) {
+      clearProcessStderrAttachmentPaths();
       scheduleSecretCleanup();
       return;
     }
@@ -960,6 +1024,7 @@ export function createZcodeBackend({
       });
       finishActive();
     }
+    clearProcessStderrAttachmentPaths();
     scheduleSecretCleanup();
   }
 
@@ -978,6 +1043,7 @@ export function createZcodeBackend({
       emit({ type: 'error', kind: 'mcp', message: err.message, ...activeTurnFailureFields() });
       finishActive();
     }
+    clearProcessStderrAttachmentPaths();
     scheduleSecretCleanup();
   }
 
@@ -1007,7 +1073,7 @@ export function createZcodeBackend({
       const reader = createNdjsonReader((message) => rpc && rpc.handleMessage(message));
       if (proc.stdout && proc.stdout.on) proc.stdout.on('data', reader);
       if (proc.stderr && proc.stderr.on) proc.stderr.on('data', (chunk) => {
-        stderrTail = appendTail(stderrTail, chunk);
+        stderrRedactor.feed(chunk);
       });
       proc.on('exit', (code, signal) => handleExit(code, signal));
       proc.on('error', (error) => handleError(error));
@@ -1149,6 +1215,7 @@ export function createZcodeBackend({
     activeTurn = turn;
     activeTurnAccepted = false;
     sendDispatched = false;
+    setActiveAttachmentPaths(turn.attachments.map((attachment) => attachment.localPath));
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
     });
@@ -1163,7 +1230,7 @@ export function createZcodeBackend({
       let turnText = withAttachmentManifest(userText, turn.attachments);
       if (transcript.filter((m) => m.role === 'user').length === 1) {
         const instr = (getServerInstructions() || '').trim();
-        if (instr) turnText = instr + '\n\n---\n\n' + userText;
+        if (instr) turnText = instr + '\n\n---\n\n' + turnText;
       }
 
       // session/send resolves on acceptance, long before turn.completed.
@@ -1302,6 +1369,7 @@ export function createZcodeBackend({
     toolMeta = { allowedTools: [], annotations: {} };
     finishActive();
     stderrTail = '';
+    clearProcessStderrAttachmentPaths();
     clearActiveSecretValues();
     stopping = false;
   }

--- a/plugin/panel/src/cep/zcodeBackend.js
+++ b/plugin/panel/src/cep/zcodeBackend.js
@@ -35,6 +35,7 @@ import {
   isCoreAuthorizedDynamicCall,
   planSessionKey,
 } from '../../../shared/tool-approval.mjs';
+import { normalizeTurnInput, withAttachmentManifest } from '../../../shared/chat-attachments.mjs';
 
 const RPC_TIMEOUT_MS = 30000;
 const STDERR_TAIL_LIMIT = 4096;
@@ -517,6 +518,9 @@ export function createZcodeBackend({
   let activeRun = null;
   let activeResolve = null;
   let activeAssistantText = '';
+  let activeTurn = null;
+  let activeTurnAccepted = false;
+  let sendDispatched = false;
   let environmentSecretValues = [];
   let runtimeSecretValues = [];
   let activeSecretValues = [];
@@ -614,13 +618,29 @@ export function createZcodeBackend({
     if (!activeResolve) {
       activeRun = null;
       activeAssistantText = '';
+      activeTurn = null;
+      activeTurnAccepted = false;
+      sendDispatched = false;
       return;
     }
     const resolve = activeResolve;
     activeResolve = null;
     activeRun = null;
     activeAssistantText = '';
+    activeTurn = null;
+    activeTurnAccepted = false;
+    sendDispatched = false;
     resolve();
+  }
+
+  function activeTurnFailureFields() {
+    if (!activeTurn?.turnId) return {};
+    return {
+      turnId: activeTurn.turnId,
+      ...(!activeTurnAccepted ? {
+        dispatchState: sendDispatched ? 'uncertain' : 'not-started',
+      } : {}),
+    };
   }
 
   function drainApprovals() {
@@ -867,7 +887,7 @@ export function createZcodeBackend({
     if (type === 'turn.failed') {
       const payload = params.payload || {};
       const message = zcodePlanRuntimeFailureHint(zcodeErrorMessage(payload.error || payload.message, 'ZCode turn failed', lang), activeRuntimeModel);
-      emit({ type: 'error', kind: zcodeErrorKind(message), message });
+      emit({ type: 'error', kind: zcodeErrorKind(message), message, ...activeTurnFailureFields() });
       finishActive();
       return;
     }
@@ -932,7 +952,12 @@ export function createZcodeBackend({
       return;
     }
     if (activeRun) {
-      emit({ type: 'error', kind: 'mcp', message: 'ZCode app-server exited: ' + detail });
+      emit({
+        type: 'error',
+        kind: 'mcp',
+        message: 'ZCode app-server exited: ' + detail,
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
     scheduleSecretCleanup();
@@ -950,7 +975,7 @@ export function createZcodeBackend({
     subscribed = false;
     activeRuntimeModel = null;
     if (activeRun) {
-      emit({ type: 'error', kind: 'mcp', message: err.message });
+      emit({ type: 'error', kind: 'mcp', message: err.message, ...activeTurnFailureFields() });
       finishActive();
     }
     scheduleSecretCleanup();
@@ -1104,35 +1129,68 @@ export function createZcodeBackend({
     }
   }
 
-  async function sendUser(text) {
+  async function sendUser(input) {
     if (activeRun) return activeRun;
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'TURN_INPUT_INVALID',
+        message: error.message,
+        ...(turnId ? { turnId, dispatchState: 'not-started' } : {}),
+      });
+      return;
+    }
     activeAssistantText = '';
+    activeTurn = turn;
+    activeTurnAccepted = false;
+    sendDispatched = false;
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
     });
 
     try {
       await ensureSession();
-      const userText = String(text || '');
+      const userText = turn.text;
       transcript.push({ role: 'user', text: userText });
 
       // ZCode (like Codex) does not forward the ae-mcp server instructions to
       // the model, so prepend them as a one-shot preamble on the first turn.
-      let turnText = userText;
+      let turnText = withAttachmentManifest(userText, turn.attachments);
       if (transcript.filter((m) => m.role === 'user').length === 1) {
         const instr = (getServerInstructions() || '').trim();
         if (instr) turnText = instr + '\n\n---\n\n' + userText;
       }
 
       // session/send resolves on acceptance, long before turn.completed.
-      rpc.request('session/send', { sessionId, content: turnText }, 180000).catch((e) => {
+      sendDispatched = true;
+      rpc.request('session/send', { sessionId, content: turnText }, 180000).then(() => {
+        if (activeTurn === turn && turn.turnId) {
+          activeTurnAccepted = true;
+          emit({ type: 'turn-accepted', turnId: turn.turnId, transport: 'zcode-manifest' });
+        }
+      }).catch((e) => {
         const message = zcodeErrorMessage(e, 'Failed to start ZCode turn.', lang);
-        emit({ type: 'error', kind: zcodeErrorKind(message), message });
+        emit({
+          type: 'error',
+          kind: zcodeErrorKind(message),
+          message,
+          ...activeTurnFailureFields(),
+        });
         finishActive();
       });
     } catch (e) {
       const message = zcodeErrorMessage(e, 'Failed to start ZCode turn.', lang);
-      emit({ type: 'error', kind: zcodeErrorKind(message), message });
+      emit({
+        type: 'error',
+        kind: zcodeErrorKind(message),
+        message,
+        ...activeTurnFailureFields(),
+      });
       finishActive();
     }
     return activeRun;
@@ -1212,7 +1270,7 @@ export function createZcodeBackend({
     }
     drainApprovals();
     if (activeRun) {
-      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.' });
+      emit({ type: 'error', kind: 'aborted', message: 'Turn aborted.', ...activeTurnFailureFields() });
       finishActive();
     }
   }
@@ -1232,6 +1290,9 @@ export function createZcodeBackend({
     sessionModelRef = null;
     subscribed = false;
     activeRuntimeModel = null;
+    activeTurn = null;
+    activeTurnAccepted = false;
+    sendDispatched = false;
     transcript = [];
     pendingApprovals.clear();
     pendingElicitations.clear();

--- a/plugin/panel/src/components/chat/AttachmentPond.jsx
+++ b/plugin/panel/src/components/chat/AttachmentPond.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { FilePond, registerPlugin } from 'react-filepond';
+import FilePondPluginImagePreview from 'filepond-plugin-image-preview';
+import { MAX_ATTACHMENTS_PER_TURN } from '../../../../shared/chat-attachments.mjs';
+import { Icon } from '../core/Icon';
+
+registerPlugin(FilePondPluginImagePreview);
+
+const DEFAULT_LABELS = {
+  add: '添加文件 Add files',
+  drop: '拖放、粘贴或选择文件 Drop, paste, or browse',
+  staging: '正在准备 Preparing…',
+  ready: '已就绪 Ready',
+  retry: '重试 Retry',
+  remove: '移除 Remove',
+};
+
+function formatBytes(value) {
+  const bytes = Number(value) || 0;
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+}
+
+function findItem(items, fileItem) {
+  return items.find((item) => item.pondId === fileItem?.id || item.file === fileItem?.file);
+}
+
+export const AttachmentPond = React.forwardRef(function AttachmentPond({
+  items = [],
+  disabled = false,
+  labels: suppliedLabels,
+  onAddFile,
+  onRemoveAttachment,
+  onRetryAttachment,
+}, forwardedRef) {
+  const pondRef = React.useRef(null);
+  const labels = { ...DEFAULT_LABELS, ...(suppliedLabels || {}) };
+  const pondFiles = items.map((item) => item.file).filter(Boolean);
+  const labelIdle = labels.drop
+    + ' <span class="filepond--label-action">' + labels.add + '</span>';
+
+  React.useImperativeHandle(forwardedRef, () => ({
+    addFiles(files) {
+      return pondRef.current?.addFiles(Array.from(files || []));
+    },
+  }), []);
+
+  const handleAdd = (error, fileItem) => {
+    if (error || !fileItem?.file || findItem(items, fileItem)) return;
+    onAddFile?.({ pondId: fileItem.id, file: fileItem.file });
+  };
+
+  const handleRemove = (error, fileItem) => {
+    if (error) return;
+    const item = findItem(items, fileItem);
+    if (item) onRemoveAttachment?.(item);
+  };
+
+  return (
+    <div className="ae-attachment-pond">
+      <FilePond
+        ref={pondRef}
+        files={pondFiles}
+        allowMultiple
+        allowPaste
+        allowBrowse={!disabled}
+        allowDrop={!disabled}
+        allowReorder={false}
+        instantUpload={false}
+        maxFiles={MAX_ATTACHMENTS_PER_TURN}
+        credits={false}
+        disabled={disabled}
+        labelIdle={labelIdle}
+        onaddfile={handleAdd}
+        onremovefile={handleRemove}
+      />
+      {items.length ? (
+        <div className="ae-attachment-status-list" aria-live="polite">
+          {items.map((item) => (
+            <div
+              key={item.pondId}
+              className={`ae-attachment-status ae-attachment-status--${item.status}`}
+            >
+              <Icon name="paperclip" size={12} />
+              <span className="ae-attachment-status__name">{item.file?.name || item.ref?.name}</span>
+              <span className="ae-attachment-status__size">
+                {formatBytes(item.file?.size ?? item.ref?.size)}
+              </span>
+              <span className="ae-attachment-status__state">
+                {item.status === 'staging'
+                  ? labels.staging
+                  : item.status === 'error'
+                    ? (item.error?.message || labels.retry)
+                    : labels.ready}
+              </span>
+              {item.status === 'error' ? (
+                <button type="button" onClick={() => onRetryAttachment?.(item)}>
+                  {labels.retry}
+                </button>
+              ) : null}
+              <button type="button" onClick={() => onRemoveAttachment?.(item)}>
+                {labels.remove}
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/plugin/panel/src/components/chat/ChatBubble.jsx
+++ b/plugin/panel/src/components/chat/ChatBubble.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
 import { AIAvatar } from './AIAvatar';
 
-export function ChatBubble({ role = 'ai', children, streaming = false, avatar = true, style }) {
+function formatAttachmentBytes(value) {
+  const bytes = Number(value) || 0;
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+}
+
+export function ChatBubble({
+  role = 'ai',
+  children,
+  attachments = [],
+  streaming = false,
+  avatar = true,
+  style,
+}) {
   if (role === 'user') {
     return (
       <div style={{ display: 'flex', justifyContent: 'flex-end', ...style }}>
@@ -18,7 +33,31 @@ export function ChatBubble({ role = 'ai', children, streaming = false, avatar = 
             overflowWrap: 'break-word',
           }}
         >
-          {children}
+          {children ? <div>{children}</div> : null}
+          {attachments.length ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 3, marginTop: children ? 5 : 0 }}>
+              {attachments.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  style={{
+                    minWidth: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    color: 'var(--text-secondary)',
+                    font: 'var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)',
+                  }}
+                >
+                  <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {attachment.name}
+                  </span>
+                  <span style={{ flex: 'none', color: 'var(--text-tertiary)' }}>
+                    {formatAttachmentBytes(attachment.size)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
     );

--- a/plugin/panel/src/components/chat/Composer.jsx
+++ b/plugin/panel/src/components/chat/Composer.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { Icon } from '../core/Icon';
+import { AttachmentPond } from './AttachmentPond';
+import {
+  attachmentDropFiles,
+  draftIsBusy,
+  isFileTransfer,
+  readyAttachments,
+} from '../../lib/attachmentDraft';
 import {
   COMPOSER_DEFAULT_HEIGHT,
   COMPOSER_MIN_HEIGHT,
@@ -149,14 +156,40 @@ export function Composer({
   maxHeight = FALLBACK_MAX_HEIGHT,
   onHeightChange,
   onHeightReset,
+  attachmentDraft = { items: [] },
+  onAddFile,
+  onRemoveAttachment,
+  onRetryAttachment,
+  attachmentLabels,
 }) {
   const [focus, setFocus] = React.useState(false);
-  const canSend = !disabled && !streaming && value.trim().length > 0;
+  const attachmentPondRef = React.useRef(null);
+  const readyAttachmentCount = readyAttachments(attachmentDraft).length;
+  const attachmentsBusy = draftIsBusy(attachmentDraft)
+    || attachmentDraft.items.some((item) => item.status === 'error');
+  const canSend = !disabled
+    && !streaming
+    && !attachmentsBusy
+    && (value.trim().length > 0 || readyAttachmentCount > 0);
   const handleKey = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (canSend && onSend) onSend();
     }
+  };
+  const handleFileDrag = (event) => {
+    if (disabled || streaming || attachmentDraft.pendingTurnId) return;
+    if (!isFileTransfer(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const handleFileDrop = (event) => {
+    if (disabled || streaming || attachmentDraft.pendingTurnId) return;
+    const files = attachmentDropFiles(event.dataTransfer);
+    if (!files.length) return;
+    event.preventDefault();
+    event.stopPropagation();
+    attachmentPondRef.current?.addFiles(files);
   };
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-15)', ...style }}>
@@ -174,9 +207,9 @@ export function Composer({
             height,
             minHeight: 0,
             display: 'flex',
-            flexDirection: options ? 'column' : 'row',
+            flexDirection: 'column',
             alignItems: 'stretch',
-            gap: options ? 2 : 'var(--space-15)',
+            gap: 2,
             padding: 'var(--space-15)',
             background: 'var(--bg-well)',
             border: `1px solid ${focus && !disabled ? 'var(--border-strong)' : 'var(--border-default)'}`,
@@ -185,30 +218,51 @@ export function Composer({
             opacity: disabled ? 0.5 : 1,
             transition: 'border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)',
           }}
+          onDragEnterCapture={handleFileDrag}
+          onDragOverCapture={handleFileDrag}
+          onDropCapture={handleFileDrop}
         >
-          <textarea
-            rows={1}
-            value={value}
-            placeholder={placeholder}
-            disabled={disabled}
-            onChange={(e) => onChange && onChange(e.target.value)}
-            onFocus={() => setFocus(true)}
-            onBlur={() => setFocus(false)}
-            onKeyDown={handleKey}
-            style={{
-              flex: 1,
-              minWidth: 0,
-              minHeight: 0,
-              overflowY: 'auto',
-              resize: 'none',
-              background: 'transparent',
-              border: 'none',
-              outline: 'none',
-              padding: '4px 2px 4px 4px',
-              color: 'var(--text-primary)',
-              font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`,
-            }}
-          ></textarea>
+          <AttachmentPond
+            ref={attachmentPondRef}
+            items={attachmentDraft.items}
+            disabled={disabled || streaming || Boolean(attachmentDraft.pendingTurnId)}
+            labels={attachmentLabels}
+            onAddFile={onAddFile}
+            onRemoveAttachment={onRemoveAttachment}
+            onRetryAttachment={onRetryAttachment}
+          />
+          <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', alignItems: 'stretch', gap: 'var(--space-15)' }}>
+            <textarea
+              rows={1}
+              value={value}
+              placeholder={placeholder}
+              disabled={disabled}
+              onChange={(e) => onChange && onChange(e.target.value)}
+              onFocus={() => setFocus(true)}
+              onBlur={() => setFocus(false)}
+              onKeyDown={handleKey}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                minHeight: 0,
+                overflowY: 'auto',
+                resize: 'none',
+                background: 'transparent',
+                border: 'none',
+                outline: 'none',
+                padding: '4px 2px 4px 4px',
+                color: 'var(--text-primary)',
+                font: `var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)`,
+              }}
+            ></textarea>
+            {!options ? (
+              streaming ? (
+                <SendButton icon="square" title="停止 Stop" kind="stop" onClick={onStop} />
+              ) : (
+                <SendButton icon="arrow-up" title="发送 Send" kind="send" disabled={!canSend} onClick={canSend ? onSend : undefined} />
+              )
+            ) : null}
+          </div>
           {options ? (
             <div style={{ flex: 'none', display: 'flex', alignItems: 'center', gap: 2, minWidth: 0, overflow: 'visible' }}>
               {/* overflow must stay visible: ComposerChip drop-up menus render
@@ -220,11 +274,7 @@ export function Composer({
                 <SendButton icon="arrow-up" title="发送 Send" kind="send" disabled={!canSend} onClick={canSend ? onSend : undefined} />
               )}
             </div>
-          ) : streaming ? (
-            <SendButton icon="square" title="停止 Stop" kind="stop" onClick={onStop} />
-          ) : (
-            <SendButton icon="arrow-up" title="发送 Send" kind="send" disabled={!canSend} onClick={canSend ? onSend : undefined} />
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/plugin/panel/src/lib/agentLoop.js
+++ b/plugin/panel/src/lib/agentLoop.js
@@ -6,6 +6,7 @@ import {
   safeErrorMessage,
   sensitiveValues,
 } from './exactSecretRedaction.js';
+import { normalizeTurnInput } from '../../../shared/chat-attachments.mjs';
 
 const MAX_TOOL_ROUNDS = 25;
 
@@ -141,10 +142,36 @@ export function createAgentLoop({
     return await executeTool(toolUse);
   }
 
-  async function sendUser(text) {
+  async function sendUser(input) {
     if (activeRun) return activeRun;
 
-    const userMessage = { role: 'user', content: String(text || '') };
+    let turn;
+    try {
+      turn = normalizeTurnInput(input);
+    } catch (error) {
+      const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'TURN_INPUT_INVALID',
+        message: error.message,
+        ...(turnId ? { turnId, dispatchState: 'not-started' } : {}),
+      });
+      return;
+    }
+    if (turn.attachments.length) {
+      emit({
+        type: 'error',
+        kind: 'attachment',
+        code: 'ATTACHMENT_SIDECAR_REQUIRED',
+        message: 'Restore the Claude Agent SDK sidecar to send local files.',
+        turnId: turn.turnId,
+        dispatchState: 'not-started',
+      });
+      return;
+    }
+
+    const userMessage = { role: 'user', content: turn.text };
     messages.push(userMessage);
     emit({ type: 'turn-start' });
 
@@ -153,6 +180,7 @@ export function createAgentLoop({
 
     activeRun = (async () => {
       let activeSensitiveValues = [];
+      let turnAccepted = false;
       try {
         const tools = await mcp.listTools();
         const toolByName = new Map((tools || []).map((tool) => [tool.name, tool]));
@@ -180,6 +208,10 @@ export function createAgentLoop({
           );
           let result;
           try {
+            if (turn.turnId && !turnAccepted) {
+              turnAccepted = true;
+              emit({ type: 'turn-accepted', turnId: turn.turnId, transport: 'legacy-byok' });
+            }
             result = await anthropic({
               requestProfile,
               model: (getModel && getModel()) || DEFAULT_MODEL,
@@ -224,7 +256,15 @@ export function createAgentLoop({
         // gap with synthetic cancelled results so the conversation stays
         // continuable.
         repairDanglingToolUses();
-        emit({ type: 'error', kind, message: safeErrorMessage(e, activeSensitiveValues) });
+        emit({
+          type: 'error',
+          kind,
+          message: safeErrorMessage(e, activeSensitiveValues),
+          ...(!turnAccepted && turn.turnId ? {
+            turnId: turn.turnId,
+            dispatchState: 'not-started',
+          } : {}),
+        });
       } finally {
         activeSensitiveValues = [];
         activeController = null;

--- a/plugin/panel/src/lib/attachmentDraft.js
+++ b/plugin/panel/src/lib/attachmentDraft.js
@@ -1,0 +1,147 @@
+function initialState() {
+  return {
+    text: '',
+    items: [],
+    pendingTurnId: null,
+    pendingSnapshot: null,
+    dispatchState: null,
+    sendError: null,
+  };
+}
+
+export function createAttachmentDraftState() {
+  return initialState();
+}
+
+export function readyAttachments(state) {
+  return state.items
+    .filter((item) => item.status === 'ready' && item.ref)
+    .map((item) => item.ref);
+}
+
+export function draftIsBusy(state) {
+  return state.items.some((item) => item.status === 'staging');
+}
+
+export function draftCanSend(state) {
+  if (state.pendingTurnId || draftIsBusy(state)) return false;
+  if (state.items.some((item) => item.status === 'error')) return false;
+  return state.text.trim().length > 0 || readyAttachments(state).length > 0;
+}
+
+export function isFileTransfer(dataTransfer) {
+  return Array.from(dataTransfer?.types || []).includes('Files');
+}
+
+export function attachmentDropFiles(dataTransfer) {
+  if (!isFileTransfer(dataTransfer)) return [];
+  return Array.from(dataTransfer?.files || []);
+}
+
+function replaceItem(items, pondId, update) {
+  const index = items.findIndex((item) => item.pondId === pondId);
+  if (index < 0) return items;
+  const next = items.slice();
+  next[index] = update(items[index]);
+  return next;
+}
+
+function freezeSnapshot(turn, fallbackState, turnId) {
+  const source = turn || {
+    turnId,
+    text: fallbackState.text,
+    attachments: readyAttachments(fallbackState),
+  };
+  return Object.freeze({
+    turnId: source.turnId,
+    text: source.text,
+    attachments: Object.freeze([...source.attachments]),
+  });
+}
+
+export function reduceAttachmentDraft(state, action) {
+  if (!state || !action) return state;
+
+  if (action.type === 'accepted') {
+    return action.turnId === state.pendingTurnId ? initialState() : state;
+  }
+  if (action.type === 'rejected') {
+    if (action.turnId !== state.pendingTurnId) return state;
+    return {
+      ...state,
+      pendingTurnId: null,
+      pendingSnapshot: null,
+      dispatchState: 'not-started',
+      sendError: action.error || null,
+    };
+  }
+  if (action.type === 'uncertain') {
+    if (action.turnId !== state.pendingTurnId) return state;
+    return {
+      ...state,
+      dispatchState: 'uncertain',
+      sendError: action.error || null,
+    };
+  }
+  if (action.type === 'reset') return initialState();
+
+  if (state.pendingTurnId) return state;
+
+  if (action.type === 'text') {
+    return {
+      ...state,
+      text: String(action.value ?? ''),
+      sendError: null,
+      dispatchState: null,
+    };
+  }
+  if (action.type === 'staging') {
+    const replacement = {
+      pondId: action.pondId,
+      file: action.file,
+      status: 'staging',
+      ref: null,
+      error: null,
+    };
+    const existing = state.items.findIndex((item) => item.pondId === action.pondId);
+    return {
+      ...state,
+      items: existing < 0
+        ? [...state.items, replacement]
+        : state.items.map((item, index) => (index === existing ? replacement : item)),
+      sendError: null,
+    };
+  }
+  if (action.type === 'ready') {
+    const items = replaceItem(state.items, action.pondId, (item) => ({
+      ...item,
+      status: 'ready',
+      ref: action.ref,
+      error: null,
+    }));
+    return items === state.items ? state : { ...state, items };
+  }
+  if (action.type === 'error') {
+    const items = replaceItem(state.items, action.pondId, (item) => ({
+      ...item,
+      status: 'error',
+      ref: null,
+      error: action.error || null,
+    }));
+    return items === state.items ? state : { ...state, items };
+  }
+  if (action.type === 'remove') {
+    const items = state.items.filter((item) => item.pondId !== action.pondId);
+    return items.length === state.items.length ? state : { ...state, items };
+  }
+  if (action.type === 'sending') {
+    return {
+      ...state,
+      pendingTurnId: action.turnId,
+      pendingSnapshot: freezeSnapshot(action.turn, state, action.turnId),
+      dispatchState: 'pending',
+      sendError: null,
+    };
+  }
+  return state;
+}

--- a/plugin/panel/src/lib/backendSelect.js
+++ b/plugin/panel/src/lib/backendSelect.js
@@ -4,7 +4,7 @@ import { pickChannel } from './channels.js';
 // All backends use the same selection algorithm over uniform channel probe
 // arrays. `pref` is the 3-way backend choice (subscription|codex|zcode);
 // channels = { claude: [...], codex: [...], zcode: [...] }.
-export function pickBackend({ pref, channels = {}, lockedChannel = '', nodeOk = true }) {
+export function pickBackend({ pref, channels = {}, lockedChannel = '' }) {
   const group = pref === 'codex' || pref === 'zcode' ? pref : 'claude';
   const list = channels[group] || [];
   const selectedCustom = group === 'codex'
@@ -28,10 +28,9 @@ export function pickBackend({ pref, channels = {}, lockedChannel = '', nodeOk = 
   }
   if (group === 'claude') {
     if (chosen.channel === 'api') {
-      // Provider credentials stay in the direct loop, whose delta/history
-      // redactor can prove exact-secret suppression without retaining a
-      // sidecar credential for the process lifetime.
-      return { backend: 'byok', reason: 'ok', channel: 'api', fixHint: null };
+      // The Claude Agent backend exposes only a loopback route token to the
+      // sidecar; upstream Provider credentials stay in the panel-owned route.
+      return { backend: 'claude-api', reason: 'ok', channel: 'api', fixHint: null };
     }
     return { backend: 'subscription', reason: 'ok', channel: 'subscription', fixHint: null };
   }

--- a/plugin/panel/src/lib/channels.js
+++ b/plugin/panel/src/lib/channels.js
@@ -28,18 +28,20 @@ export function claudeChannels({
     ok: Boolean(probe && probe.nodeOk !== false && probe.loggedIn),
     detail: (probe && probe.detail) || '',
     fixHint: probe && probe.nodeOk === false
-      ? { zh: '内嵌对话需要系统 Node 18+：安装 Node.js LTS 后重新检测；或使用下方「API 直连」通道（无 Node 时自动降级为直连 HTTP）。', en: 'Embedded chat needs system Node 18+: install Node.js LTS and re-check, or use the API direct channel below (falls back to direct HTTP without Node).' }
-      : { zh: '订阅未登录：在终端运行 claude /login 完成登录后重新检测；或改用下方「API 直连」通道。', en: 'Not logged in: run claude /login in a terminal and re-check, or switch to the API direct channel below.' },
+      ? { zh: 'Claude Code 内嵌对话与自定义 Provider 都需要可用的 Node 运行时：修复运行时后重新检测。', en: 'Embedded Claude Code chat and custom Providers both require an available Node runtime. Repair the runtime, then re-check.' }
+      : { zh: '订阅未登录：在终端运行 claude /login 完成登录后重新检测；或改用下方「自定义 Provider」通道。', en: 'Not logged in: run claude /login in a terminal and re-check, or switch to the custom Provider channel below.' },
   };
   const selected = apiProviderSelected === undefined ? Boolean(apiProvider) : Boolean(apiProviderSelected);
   const resolverReady = providerCredentialResolverReady === undefined
     ? (providerAvailable === undefined ? providerHasCredentialPolicy(apiProvider) : providerAvailable)
     : providerCredentialResolverReady;
+  const runtimeReady = !(probe && probe.nodeOk === false);
   const canPreflight = Boolean(
     !providerChecking
     && selected
     && apiProvider?.baseUrl
-    && resolverReady,
+    && resolverReady
+    && runtimeReady
   );
   const api = {
     channel: 'api',
@@ -49,7 +51,9 @@ export function claudeChannels({
     checking: Boolean(providerChecking),
     ok: canPreflight,
     detail: apiProvider && apiProvider.baseUrl ? apiProvider.baseUrl : '',
-    fixHint: apiProvider && resolverReady !== true && !providerChecking
+    fixHint: !runtimeReady
+      ? { zh: 'Claude 自定义 Provider 通过 Agent SDK 运行，需要可用的 Node 运行时：修复运行时后重新检测。', en: 'Claude custom Providers run through the Agent SDK and require an available Node runtime. Repair the runtime, then re-check.' }
+      : apiProvider && resolverReady !== true && !providerChecking
       ? { zh: '系统凭据库不可用：Helper 会随 AE 自动启动，请先重新打开面板或重启 AE；仍失败时再修复当前安装。不会回退读取明文 provider 文件。', en: 'The system credential store is unavailable. Helper starts with AE; reopen the panel or restart AE first, then repair the current install if it still fails. Plaintext provider fallback is disabled.' }
       : { zh: '在「Provider 管理」新增或选择一个通用 Provider（Base URL + API Key）。系统会按模型自动选择 Messages、Responses 或 Chat 路由。', en: 'Add or select a universal Provider (base URL + API key) in Provider Manager. Messages, Responses, or Chat routing is selected per model.' },
   };
@@ -172,8 +176,8 @@ export function codexProviderChannelLock(lockedChannel = '', providerId = '') {
   return lockedChannel === 'custom' ? '' : lockedChannel;
 }
 
-// Legacy pref migration: 'byok' collapses into Claude's api channel (spec:
-// BYOK 并入 Claude); 'opencode' was never exposed in the 3-way UI.
+// Legacy pref migration: `byok` collapses into Claude's API channel. OpenCode
+// and ZCode remain internal adapters, not choices in the built-in two-way UI.
 export function migrateBackendPref(storage) {
   let pref = 'subscription';
   let lockedChannel = '';
@@ -185,10 +189,10 @@ export function migrateBackendPref(storage) {
       lockedChannel = 'api';
       storage.setItem('ae_mcp_backend', pref);
       storage.setItem('ae_mcp_channel_lock', lockedChannel);
-    } else if (raw === 'opencode') {
+    } else if (raw === 'opencode' || raw === 'zcode') {
       pref = 'subscription';
       storage.setItem('ae_mcp_backend', pref);
-    } else if (raw === 'codex' || raw === 'zcode' || raw === 'subscription') {
+    } else if (raw === 'codex' || raw === 'subscription') {
       pref = raw;
     }
   } catch (e) { /* storage unavailable -> defaults */ }

--- a/plugin/panel/src/lib/chatEntries.js
+++ b/plugin/panel/src/lib/chatEntries.js
@@ -1,3 +1,5 @@
+import { displayAttachments } from '../../../shared/chat-attachments.mjs';
+
 function nextId(entries, prefix) {
   return `${prefix}-${entries.length + 1}`;
 }
@@ -9,12 +11,22 @@ function updateTool(entries, toolUseId, updater) {
   });
 }
 
+export function userTurnEntry(turn) {
+  return {
+    id: `user-${turn.turnId}`,
+    type: 'user-text',
+    text: turn.text,
+    attachments: displayAttachments(turn.attachments),
+  };
+}
+
 export function reduceEvent(entries, evt) {
   const current = Array.isArray(entries) ? entries : [];
   if (!evt || !evt.type) return current;
 
   switch (evt.type) {
     case 'turn-start':
+    case 'turn-accepted':
       return current;
 
     case 'text-delta': {

--- a/plugin/panel/src/lib/descriptorSelect.js
+++ b/plugin/panel/src/lib/descriptorSelect.js
@@ -13,8 +13,8 @@ import {
   zcodeDescriptorFromProbedModels,
 } from './backendCapabilities.js';
 
-// effectiveBackend 'byok' = API channel chosen but Node runtime broken; the
-// fetch-based loop serves the same API channel, so it shares the branch.
+// `byok` remains readable only for legacy state/descriptor compatibility.
+// Live custom Claude Provider selection uses `claude-api`.
 export function isClaudeApiBackend(effectiveBackend) {
   return effectiveBackend === 'claude-api' || effectiveBackend === 'byok';
 }

--- a/plugin/panel/src/lib/logExport.js
+++ b/plugin/panel/src/lib/logExport.js
@@ -4,6 +4,21 @@ export function redactSecrets(text, exactSecrets = []) {
   return redactCredentialText(text, exactSecrets);
 }
 
+export function attachmentPathSecrets({ draft, pendingTurn } = {}) {
+  const paths = [];
+  for (const item of draft?.items || []) {
+    if (typeof item?.ref?.localPath === 'string' && item.ref.localPath) {
+      paths.push(item.ref.localPath);
+    }
+  }
+  for (const attachment of pendingTurn?.attachments || []) {
+    if (typeof attachment?.localPath === 'string' && attachment.localPath) {
+      paths.push(attachment.localPath);
+    }
+  }
+  return [...new Set(paths)];
+}
+
 export function buildLogExport({ panelLogs = [], hostInfo = {}, sidecarTail = '', version = '', now = new Date(), exactSecrets = [] } = {}) {
   const lines = [];
   lines.push('# ae-mcp panel log export');

--- a/plugin/panel/src/main.jsx
+++ b/plugin/panel/src/main.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import 'filepond/dist/filepond.min.css';
+import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 import './styles/index.css';
 import { App } from './app/App';
 

--- a/plugin/panel/src/screens/ChatScreen.jsx
+++ b/plugin/panel/src/screens/ChatScreen.jsx
@@ -12,6 +12,11 @@ import { AIAvatar } from '../components/chat/AIAvatar';
 import { eventTitle } from '../lib/activityModel';
 import { buildComposerChips } from '../lib/composerOptions';
 import {
+  createAttachmentDraftState,
+  draftCanSend,
+  readyAttachments,
+} from '../lib/attachmentDraft';
+import {
   COMPOSER_MIN_HEIGHT,
   composerAvailableHeight,
   createComposerHeightState,
@@ -38,6 +43,13 @@ const C = {
     failed: '失败',
     awaiting: '等待批准',
     thinking: '思考中…',
+    attachmentAdd: '添加文件',
+    attachmentDrop: '拖放或粘贴文件',
+    attachmentStaging: '正在准备…',
+    attachmentReady: '已就绪',
+    attachmentRetry: '重试',
+    attachmentRemove: '移除',
+    uncertainTurn: '发送结果不确定。请新建会话核对后再试。',
   },
   en: {
     hello: 'Hi! I can operate the open AE project directly. Try one of these:',
@@ -58,6 +70,13 @@ const C = {
     failed: 'Failed',
     awaiting: 'Awaiting approval',
     thinking: 'Thinking…',
+    attachmentAdd: 'Add files',
+    attachmentDrop: 'Drop or paste files',
+    attachmentStaging: 'Preparing…',
+    attachmentReady: 'Ready',
+    attachmentRetry: 'Retry',
+    attachmentRemove: 'Remove',
+    uncertainTurn: 'Send outcome is uncertain. Start a new session before retrying.',
   },
 };
 
@@ -105,7 +124,7 @@ function titleForTool(entry, lang) {
 function Entry({ entry, lang, onApprove }) {
   const t = C[lang] || C.zh;
   if (entry.type === 'user-text') {
-    return <ChatBubble role="user">{entry.text}</ChatBubble>;
+    return <ChatBubble role="user" attachments={entry.attachments}>{entry.text}</ChatBubble>;
   }
   if (entry.type === 'ai-text') {
     return <ChatBubble role="ai">{entry.text}</ChatBubble>;
@@ -175,9 +194,14 @@ export function ChatScreen({
   onChipEffort,
   onChipFast,
   onChipApproval,
+  attachmentDraft = createAttachmentDraftState(),
+  dispatchAttachmentDraft,
+  createTurnId,
+  onAddFile,
+  onRemoveAttachment,
+  onRetryAttachment,
 }) {
   const t = C[lang] || C.zh;
-  const [draft, setDraft] = React.useState('');
   const logRef = React.useRef(null);
   const layoutRef = React.useRef(null);
   const footerRef = React.useRef(null);
@@ -258,11 +282,33 @@ export function ChatScreen({
     return () => observer.disconnect();
   }, []);
 
-  const send = () => {
-    const text = draft.trim();
-    if (!text || composerDisabled || streaming) return;
-    if (onSend) onSend(text);
-    setDraft('');
+  const sendTurn = (textOverride) => {
+    const text = String(textOverride === undefined ? attachmentDraft.text : textOverride).trim();
+    const candidate = textOverride === undefined
+      ? attachmentDraft
+      : { ...attachmentDraft, text };
+    if (!draftCanSend(candidate) || composerDisabled || streaming || !createTurnId) return;
+    if (textOverride !== undefined) {
+      dispatchAttachmentDraft?.({ type: 'text', value: text });
+    }
+    const turnId = createTurnId();
+    const turn = {
+      turnId,
+      text,
+      attachments: readyAttachments(attachmentDraft),
+    };
+    dispatchAttachmentDraft?.({ type: 'sending', turnId, turn });
+    onSend?.(turn);
+  };
+  const send = () => sendTurn();
+  const sendError = attachmentDraft.sendError;
+  const attachmentLabels = {
+    add: t.attachmentAdd,
+    drop: t.attachmentDrop,
+    staging: t.attachmentStaging,
+    ready: t.attachmentReady,
+    retry: t.attachmentRetry,
+    remove: t.attachmentRemove,
   };
 
   return (
@@ -292,7 +338,7 @@ export function ChatScreen({
                 caption={card.caption}
                 onClick={() => {
                   if (card.onClick) card.onClick(card);
-                  else if (onSend) onSend(card.prompt || card.title);
+                  else sendTurn(card.prompt || card.title);
                 }}
               />
             ))}
@@ -313,20 +359,35 @@ export function ChatScreen({
 
       <div ref={footerRef} style={{ flex: 'none', padding: 'var(--space-2) var(--space-3) var(--space-3)', borderTop: '1px solid var(--border-subtle)' }}>
         <Composer
-          value={draft}
-          onChange={setDraft}
+          value={attachmentDraft.text}
+          onChange={(value) => dispatchAttachmentDraft?.({ type: 'text', value })}
           onSend={send}
           onStop={onStop}
           streaming={streaming}
           disabled={composerDisabled}
           placeholder={t.placeholder}
           options={composerOptions}
-          notice={disabledHint ? <Notice text={disabledHint} actionLabel={noticeActionLabel || t.noticeAction} onAction={onNoticeAction || onNewSession} /> : null}
+          notice={disabledHint
+            ? <Notice text={disabledHint} actionLabel={noticeActionLabel || t.noticeAction} onAction={onNoticeAction || onNewSession} />
+            : sendError
+              ? (
+                <Notice
+                  text={attachmentDraft.dispatchState === 'uncertain' ? t.uncertainTurn : sendError.message}
+                  actionLabel={attachmentDraft.dispatchState === 'uncertain' ? t.newSession : null}
+                  onAction={attachmentDraft.dispatchState === 'uncertain' ? onNewSession : null}
+                />
+              )
+              : null}
           height={composerSize.height}
           minHeight={COMPOSER_MIN_HEIGHT}
           maxHeight={composerSize.maxHeight}
           onHeightChange={(height) => dispatchComposerSize({ type: 'request', height })}
           onHeightReset={() => dispatchComposerSize({ type: 'reset' })}
+          attachmentDraft={attachmentDraft}
+          onAddFile={onAddFile}
+          onRemoveAttachment={onRemoveAttachment}
+          onRetryAttachment={onRetryAttachment}
+          attachmentLabels={attachmentLabels}
         />
       </div>
     </div>

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -376,7 +376,6 @@ export function SettingsScreen({
           <Segmented full value={backend} onChange={onBackendChange} options={[
             { value: 'subscription', label: t.backendSub },
             { value: 'codex', label: t.backendCodex },
-            { value: 'zcode', label: t.backendZcode },
           ]} />
         </Field>
         <ChannelCard

--- a/plugin/panel/src/styles/index.css
+++ b/plugin/panel/src/styles/index.css
@@ -9,6 +9,102 @@ html, body { margin: 0; height: 100%; }
 body { background: var(--bg-panel); color: var(--text-primary); font: var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui); }
 #root { height: 100%; display: flex; flex-direction: column; }
 
+.ae-attachment-pond {
+  flex: none;
+  min-width: 0;
+  max-height: min(42%, 168px);
+  overflow-y: auto;
+}
+
+.ae-attachment-pond .filepond--root {
+  min-height: 30px;
+  margin: 0;
+  font: var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui);
+}
+
+.ae-attachment-pond .filepond--drop-label {
+  min-height: 30px;
+  color: var(--text-tertiary);
+}
+
+.ae-attachment-pond .filepond--panel-root {
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.ae-attachment-pond .filepond--list-scroller {
+  margin: 0;
+}
+
+.ae-attachment-pond .filepond--item {
+  margin: 2px 0;
+}
+
+.ae-attachment-pond .filepond--file {
+  min-height: 32px;
+  padding: 4px 8px;
+  color: var(--text-primary);
+  background: var(--bg-raised);
+}
+
+.ae-attachment-pond .filepond--image-preview {
+  background: var(--bg-well);
+}
+
+.ae-attachment-pond button:focus-visible {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.ae-attachment-status-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 3px;
+}
+
+.ae-attachment-status {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px 4px;
+  color: var(--text-secondary);
+  font: var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui);
+}
+
+.ae-attachment-status--error {
+  color: var(--error);
+}
+
+.ae-attachment-status__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ae-attachment-status__size,
+.ae-attachment-status__state {
+  flex: none;
+  color: var(--text-tertiary);
+}
+
+.ae-attachment-status__state {
+  margin-left: auto;
+}
+
+.ae-attachment-status button {
+  flex: none;
+  padding: 1px 4px;
+  color: inherit;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
 .tools-screen {
   position: relative;
   flex: 1;

--- a/plugin/panel/test/agentLoop.test.js
+++ b/plugin/panel/test/agentLoop.test.js
@@ -128,6 +128,36 @@ test('createAgentLoop streams a pure text turn into history', async () => {
   ]);
 });
 
+test('createAgentLoop rejects attachment turns before legacy BYOK dispatch', async () => {
+  const events = [];
+  const calls = [];
+  const loop = makeLoop({ anthropic: anthropicFromSse([textTurn('unreachable')], calls), events });
+
+  await loop.sendUser({
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: '/tmp/notes.pdf',
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false,
+    }],
+  });
+
+  assert.deepEqual(events, [{
+    type: 'error',
+    kind: 'attachment',
+    code: 'ATTACHMENT_SIDECAR_REQUIRED',
+    message: 'Restore the Claude Agent SDK sidecar to send local files.',
+    turnId: 'turn-1',
+    dispatchState: 'not-started',
+  }]);
+  assert.equal(calls.length, 0);
+  assert.deepEqual(loop.getMessages(), []);
+});
+
 test('createAgentLoop runs a tool directly and continues after tool_result', async () => {
   const events = [];
   const calls = [];

--- a/plugin/panel/test/attachmentDraft.test.js
+++ b/plugin/panel/test/attachmentDraft.test.js
@@ -1,0 +1,205 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  attachmentDropFiles,
+  createAttachmentDraftState,
+  draftCanSend,
+  draftIsBusy,
+  readyAttachments,
+  reduceAttachmentDraft,
+} from '../src/lib/attachmentDraft.js';
+
+function fixtureFile(name = 'clip.bin') {
+  return { name, size: 3, type: 'application/octet-stream' };
+}
+
+function fixtureRef(overrides = {}) {
+  return {
+    id: 'att-1',
+    name: 'clip.bin',
+    localPath: '/tmp/private/clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+    temporary: true,
+    ...overrides,
+  };
+}
+
+function readyState() {
+  let state = createAttachmentDraftState();
+  state = reduceAttachmentDraft(state, { type: 'text', value: 'inspect' });
+  state = reduceAttachmentDraft(state, {
+    type: 'staging',
+    pondId: 'p1',
+    file: fixtureFile(),
+  });
+  return reduceAttachmentDraft(state, {
+    type: 'ready',
+    pondId: 'p1',
+    ref: fixtureRef(),
+  });
+}
+
+test('draft moves one item through staging, ready, error, retry, and remove', () => {
+  const file = fixtureFile();
+  let state = createAttachmentDraftState();
+  state = reduceAttachmentDraft(state, { type: 'staging', pondId: 'p1', file });
+  assert.equal(state.items[0].status, 'staging');
+  assert.equal(draftIsBusy(state), true);
+
+  state = reduceAttachmentDraft(state, {
+    type: 'error',
+    pondId: 'p1',
+    error: { code: 'ATTACHMENT_STAGING_FAILED', message: 'failed' },
+  });
+  assert.equal(state.items[0].status, 'error');
+  assert.equal(state.items[0].file, file);
+  assert.equal(draftCanSend(state), false);
+
+  state = reduceAttachmentDraft(state, { type: 'staging', pondId: 'p1', file });
+  state = reduceAttachmentDraft(state, { type: 'ready', pondId: 'p1', ref: fixtureRef() });
+  assert.equal(state.items[0].status, 'ready');
+  assert.deepEqual(readyAttachments(state), [fixtureRef()]);
+
+  state = reduceAttachmentDraft(state, { type: 'remove', pondId: 'p1' });
+  assert.deepEqual(state.items, []);
+});
+
+test('attachment-only ready state can send while staging and errors cannot', () => {
+  let state = createAttachmentDraftState();
+  state = reduceAttachmentDraft(state, {
+    type: 'staging',
+    pondId: 'p1',
+    file: fixtureFile(),
+  });
+  assert.equal(draftCanSend(state), false);
+
+  state = reduceAttachmentDraft(state, {
+    type: 'ready',
+    pondId: 'p1',
+    ref: fixtureRef(),
+  });
+  assert.equal(draftCanSend(state), true);
+});
+
+test('accepted clears only the matching frozen turn', () => {
+  let state = readyState();
+  state = reduceAttachmentDraft(state, {
+    type: 'sending',
+    turnId: 'turn-1',
+    turn: {
+      turnId: 'turn-1',
+      text: state.text,
+      attachments: readyAttachments(state),
+    },
+  });
+  assert.equal(draftCanSend(state), false);
+  assert.equal(
+    reduceAttachmentDraft(state, { type: 'accepted', turnId: 'other' }),
+    state,
+  );
+
+  const cleared = reduceAttachmentDraft(state, {
+    type: 'accepted',
+    turnId: 'turn-1',
+  });
+  assert.equal(cleared.text, '');
+  assert.deepEqual(cleared.items, []);
+  assert.equal(cleared.pendingTurnId, null);
+  assert.equal(cleared.pendingSnapshot, null);
+});
+
+test('pre-dispatch rejection preserves text and files', () => {
+  let sending = readyState();
+  sending = reduceAttachmentDraft(sending, {
+    type: 'sending',
+    turnId: 'turn-1',
+    turn: {
+      turnId: 'turn-1',
+      text: sending.text,
+      attachments: readyAttachments(sending),
+    },
+  });
+  const rejected = reduceAttachmentDraft(sending, {
+    type: 'rejected',
+    turnId: 'turn-1',
+    error: { code: 'BACKEND_UNAVAILABLE', message: 'backend unavailable' },
+  });
+
+  assert.equal(rejected.text, sending.text);
+  assert.deepEqual(rejected.items, sending.items);
+  assert.equal(rejected.pendingTurnId, null);
+  assert.equal(rejected.pendingSnapshot, null);
+  assert.deepEqual(rejected.sendError, {
+    code: 'BACKEND_UNAVAILABLE',
+    message: 'backend unavailable',
+  });
+  assert.equal(draftCanSend(rejected), true);
+});
+
+test('uncertain rejection freezes the pending turn and blocks resubmission', () => {
+  let sending = readyState();
+  sending = reduceAttachmentDraft(sending, {
+    type: 'sending',
+    turnId: 'turn-1',
+    turn: {
+      turnId: 'turn-1',
+      text: sending.text,
+      attachments: readyAttachments(sending),
+    },
+  });
+  const uncertain = reduceAttachmentDraft(sending, {
+    type: 'uncertain',
+    turnId: 'turn-1',
+    error: { code: 'TRANSPORT_LOST', message: 'outcome unknown' },
+  });
+
+  assert.equal(uncertain.pendingTurnId, 'turn-1');
+  assert.equal(uncertain.dispatchState, 'uncertain');
+  assert.equal(draftCanSend(uncertain), false);
+  assert.equal(
+    reduceAttachmentDraft(uncertain, { type: 'remove', pondId: 'p1' }),
+    uncertain,
+  );
+});
+
+test('stale terminal actions do not change a newer pending draft', () => {
+  let state = readyState();
+  state = reduceAttachmentDraft(state, {
+    type: 'sending',
+    turnId: 'turn-2',
+    turn: {
+      turnId: 'turn-2',
+      text: state.text,
+      attachments: readyAttachments(state),
+    },
+  });
+
+  assert.equal(
+    reduceAttachmentDraft(state, { type: 'rejected', turnId: 'turn-1', error: {} }),
+    state,
+  );
+  assert.equal(
+    reduceAttachmentDraft(state, { type: 'uncertain', turnId: 'turn-1', error: {} }),
+    state,
+  );
+});
+
+test('attachmentDropFiles returns complete file drops and ignores text drops', () => {
+  const first = fixtureFile('one.txt');
+  const second = fixtureFile('two.mov');
+  assert.deepEqual(
+    attachmentDropFiles({
+      types: ['text/plain', 'Files'],
+      files: { 0: first, 1: second, length: 2 },
+    }),
+    [first, second],
+  );
+  assert.deepEqual(
+    attachmentDropFiles({
+      types: ['text/plain'],
+      files: { 0: first, length: 1 },
+    }),
+    [],
+  );
+});

--- a/plugin/panel/test/attachmentStore.test.js
+++ b/plugin/panel/test/attachmentStore.test.js
@@ -73,9 +73,30 @@ test('path-backed originals remain user-owned and are never deleted', async (t) 
 
   assert.equal(ref.temporary, false);
   assert.equal(ref.localPath, original);
+  assert.deepEqual(Object.keys(ref), [
+    'id',
+    'name',
+    'localPath',
+    'size',
+    'mediaType',
+    'temporary',
+  ]);
   store.release(ref.id);
   store.release(ref.id);
   assert.equal(fs.readFileSync(original, 'utf8'), 'video');
+});
+
+test('path-backed input must already be absolute', async (t) => {
+  const root = makeRoot(t);
+  const store = makeStore(root);
+
+  await assert.rejects(
+    store.prepare(
+      { name: 'relative.txt', size: 1, type: 'text/plain', path: 'relative.txt' },
+      { sessionId: 's1', pondId: 'p1' },
+    ),
+    (error) => error.code === 'ATTACHMENT_INVALID',
+  );
 });
 
 test('pathless blob is staged atomically and removed with its session', async (t) => {

--- a/plugin/panel/test/attachmentStore.test.js
+++ b/plugin/panel/test/attachmentStore.test.js
@@ -1,0 +1,235 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createMacosAdapter } from '../src/cep/platform/macos.js';
+import { createAttachmentStore } from '../src/cep/attachmentStore.js';
+import {
+  MAX_ATTACHMENTS_PER_TURN,
+  MAX_CLIPBOARD_ITEM_BYTES,
+  MAX_CLIPBOARD_TURN_BYTES,
+} from '../../shared/chat-attachments.mjs';
+
+function makeRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-attachments-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function makePlatform(tempRoot, overrides = {}) {
+  const platform = createMacosAdapter({
+    platform: 'darwin',
+    arch: 'arm64',
+    home: path.join(tempRoot, 'home'),
+    temp: tempRoot,
+    env: {},
+    fs,
+    spawnImpl() {
+      throw new Error('not expected');
+    },
+    now: () => 0,
+  });
+  if (!Object.keys(overrides).length) return platform;
+  return {
+    ...platform,
+    paths: { ...platform.paths, ...overrides },
+  };
+}
+
+function makeStore(root, overrides = {}) {
+  let sequence = 0;
+  return createAttachmentStore({
+    platform: makePlatform(root, overrides.pathOverrides),
+    randomUUID: () => 'attachment-' + (++sequence),
+    readBlobChunk: (slice) => slice.arrayBuffer(),
+    ...overrides,
+  });
+}
+
+function namedBlob(contents, name = 'clip.bin', type = 'application/octet-stream') {
+  const blob = new Blob([contents], { type });
+  Object.defineProperty(blob, 'name', { value: name });
+  return blob;
+}
+
+function allFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+test('path-backed originals remain user-owned and are never deleted', async (t) => {
+  const root = makeRoot(t);
+  const original = path.join(root, 'original.mov');
+  fs.writeFileSync(original, Buffer.from('video'));
+  const store = makeStore(root);
+
+  const ref = await store.prepare(
+    { name: 'original.mov', size: 5, type: 'video/quicktime', path: original },
+    { sessionId: 's1', pondId: 'p1' },
+  );
+
+  assert.equal(ref.temporary, false);
+  assert.equal(ref.localPath, original);
+  store.release(ref.id);
+  store.release(ref.id);
+  assert.equal(fs.readFileSync(original, 'utf8'), 'video');
+});
+
+test('pathless blob is staged atomically and removed with its session', async (t) => {
+  const root = makeRoot(t);
+  const store = makeStore(root, { chunkBytes: 2 });
+  const ref = await store.prepare(
+    namedBlob(Buffer.from('abc')),
+    { sessionId: 's1', pondId: 'p1' },
+  );
+
+  assert.equal(ref.temporary, true);
+  assert.equal(fs.readFileSync(ref.localPath, 'utf8'), 'abc');
+  assert.equal(path.basename(ref.localPath), 'attachment-1-clip.bin');
+  assert.equal(allFiles(root).some((file) => file.endsWith('.part')), false);
+
+  store.releaseSession('s1');
+  store.releaseSession('s1');
+  assert.equal(fs.existsSync(ref.localPath), false);
+});
+
+test('staged names strip both path separator styles', async (t) => {
+  const root = makeRoot(t);
+  const store = makeStore(root);
+  const ref = await store.prepare(
+    namedBlob(Buffer.from('abc'), '../../nested\\secret.bin'),
+    { sessionId: 's1', pondId: 'p1' },
+  );
+
+  assert.equal(path.basename(ref.localPath), 'attachment-1-secret.bin');
+  assert.equal(ref.name, 'secret.bin');
+});
+
+test('store refuses a thirty-third attachment before touching disk', async (t) => {
+  const root = makeRoot(t);
+  const original = path.join(root, 'original.txt');
+  fs.writeFileSync(original, 'x');
+  const store = makeStore(root);
+  for (let index = 0; index < MAX_ATTACHMENTS_PER_TURN; index += 1) {
+    await store.prepare(
+      { name: 'original.txt', size: 1, type: 'text/plain', path: original },
+      { sessionId: 's1', pondId: 'p' + index },
+    );
+  }
+
+  await assert.rejects(
+    store.prepare(
+      { name: 'original.txt', size: 1, type: 'text/plain', path: original },
+      { sessionId: 's1', pondId: 'overflow' },
+    ),
+    (error) => error.code === 'ATTACHMENT_COUNT_LIMIT',
+  );
+  assert.deepEqual(allFiles(root), [original]);
+});
+
+test('pathless staging enforces per-item and per-turn byte limits', async (t) => {
+  const root = makeRoot(t);
+  const store = makeStore(root, {
+    chunkBytes: MAX_CLIPBOARD_ITEM_BYTES,
+    readBlobChunk: async () => new Uint8Array(),
+  });
+  const fakeBlob = (size, name) => ({
+    name,
+    size,
+    type: 'application/octet-stream',
+    slice() {
+      return {};
+    },
+  });
+
+  await assert.rejects(
+    store.prepare(
+      fakeBlob(MAX_CLIPBOARD_ITEM_BYTES + 1, 'too-large.bin'),
+      { sessionId: 's1', pondId: 'p0' },
+    ),
+    (error) => error.code === 'ATTACHMENT_ITEM_TOO_LARGE',
+  );
+
+  await store.prepare(
+    fakeBlob(MAX_CLIPBOARD_ITEM_BYTES, 'one.bin'),
+    { sessionId: 's1', pondId: 'p1' },
+  );
+  await store.prepare(
+    fakeBlob(MAX_CLIPBOARD_TURN_BYTES - MAX_CLIPBOARD_ITEM_BYTES, 'two.bin'),
+    { sessionId: 's1', pondId: 'p2' },
+  );
+  await assert.rejects(
+    store.prepare(
+      fakeBlob(1, 'overflow.bin'),
+      { sessionId: 's1', pondId: 'p3' },
+    ),
+    (error) => error.code === 'ATTACHMENT_TURN_TOO_LARGE',
+  );
+});
+
+test('partial staging failure removes the part file and record', async (t) => {
+  const root = makeRoot(t);
+  let reads = 0;
+  const store = makeStore(root, {
+    chunkBytes: 2,
+    async readBlobChunk(slice) {
+      reads += 1;
+      if (reads === 2) throw new Error('reader failed');
+      return slice.arrayBuffer();
+    },
+  });
+
+  await assert.rejects(
+    store.prepare(
+      namedBlob(Buffer.from('abcd')),
+      { sessionId: 's1', pondId: 'p1' },
+    ),
+    (error) => error.code === 'ATTACHMENT_STAGING_FAILED',
+  );
+  assert.deepEqual(allFiles(root), []);
+  assert.doesNotThrow(() => store.releaseSession('s1'));
+});
+
+test('cleanup refuses to unlink when containment cannot be proven', async (t) => {
+  const root = makeRoot(t);
+  let containmentAvailable = true;
+  const store = makeStore(root, {
+    pathOverrides: {
+      contains() {
+        return containmentAvailable;
+      },
+    },
+  });
+  const ref = await store.prepare(
+    namedBlob(Buffer.from('abc')),
+    { sessionId: 's1', pondId: 'p1' },
+  );
+
+  containmentAvailable = false;
+  store.release(ref.id);
+  assert.equal(fs.existsSync(ref.localPath), true);
+});
+
+test('dispose removes every managed temporary and preserves originals', async (t) => {
+  const root = makeRoot(t);
+  const original = path.join(root, 'original.txt');
+  fs.writeFileSync(original, 'original');
+  const store = makeStore(root);
+  await store.prepare(
+    { name: 'original.txt', size: 8, type: 'text/plain', path: original },
+    { sessionId: 's1', pondId: 'p1' },
+  );
+  const temporary = await store.prepare(
+    namedBlob(Buffer.from('temp')),
+    { sessionId: 's2', pondId: 'p2' },
+  );
+
+  store.dispose();
+  store.dispose();
+
+  assert.equal(fs.readFileSync(original, 'utf8'), 'original');
+  assert.equal(fs.existsSync(temporary.localPath), false);
+});

--- a/plugin/panel/test/attachmentStore.test.js
+++ b/plugin/panel/test/attachmentStore.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createMacosAdapter } from '../src/cep/platform/macos.js';
+import { createWindowsAdapter } from '../src/cep/platform/windows.js';
 import { createAttachmentStore } from '../src/cep/attachmentStore.js';
 import {
   MAX_ATTACHMENTS_PER_TURN,
@@ -18,9 +19,11 @@ function makeRoot(t) {
 }
 
 function makePlatform(tempRoot, overrides = {}) {
-  const platform = createMacosAdapter({
-    platform: 'darwin',
-    arch: 'arm64',
+  const windows = process.platform === 'win32';
+  const createAdapter = windows ? createWindowsAdapter : createMacosAdapter;
+  const platform = createAdapter({
+    platform: windows ? 'win32' : 'darwin',
+    arch: windows ? 'x64' : 'arm64',
     home: path.join(tempRoot, 'home'),
     temp: tempRoot,
     env: {},

--- a/plugin/panel/test/attachments.test.js
+++ b/plugin/panel/test/attachments.test.js
@@ -83,6 +83,13 @@ test('normalizeTurnInput rejects malformed attachment turns', () => {
   }
 });
 
+test('normalizeTurnInput rejects a turn with neither text nor attachments', () => {
+  assert.throws(
+    () => normalizeTurnInput({ turnId: 'turn-1', text: '', attachments: [] }),
+    /text or attachment/i,
+  );
+});
+
 test('display metadata never contains a local path or ownership flag', () => {
   const value = displayAttachments([fixtureAttachment()]);
   assert.deepEqual(value, [{
@@ -133,5 +140,9 @@ test('attachmentFileUrl encodes macOS and Windows path components', () => {
   assert.equal(
     attachmentFileUrl('C:\\Users\\Test\\AE files\\a#b.png', 'windows-x64'),
     'file:///C:/Users/Test/AE%20files/a%23b.png',
+  );
+  assert.equal(
+    attachmentFileUrl('\\\\server\\share\\AE files\\a#b.png', 'windows-x64'),
+    'file://server/share/AE%20files/a%23b.png',
   );
 });

--- a/plugin/panel/test/attachments.test.js
+++ b/plugin/panel/test/attachments.test.js
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ATTACHMENT_MANIFEST_CLOSE,
+  ATTACHMENT_MANIFEST_OPEN,
+  attachmentFileUrl,
+  attachmentManifest,
+  displayAttachments,
+  normalizeTurnInput,
+  withAttachmentManifest,
+} from '../../shared/chat-attachments.mjs';
+
+function fixtureAttachment(overrides = {}) {
+  return {
+    id: 'att-1',
+    name: 'clip.bin',
+    localPath: '/tmp/private/clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+    temporary: true,
+    ...overrides,
+  };
+}
+
+test('normalizeTurnInput preserves legacy text turns', () => {
+  assert.deepEqual(normalizeTurnInput('hello'), {
+    turnId: '',
+    text: 'hello',
+    attachments: [],
+  });
+});
+
+test('normalizeTurnInput preserves an attachment-only turn and order', () => {
+  const turn = normalizeTurnInput({
+    turnId: 'turn-1',
+    text: '',
+    attachments: [
+      fixtureAttachment(),
+      fixtureAttachment({
+        id: 'att-2',
+        name: 'frame.png',
+        localPath: '/tmp/private/frame.png',
+        size: 9,
+        mediaType: 'image/png',
+        temporary: false,
+      }),
+    ],
+  });
+
+  assert.equal(turn.turnId, 'turn-1');
+  assert.equal(turn.text, '');
+  assert.deepEqual(turn.attachments.map((file) => file.id), ['att-1', 'att-2']);
+  assert.equal(turn.attachments[0].localPath, '/tmp/private/clip.bin');
+  assert.notEqual(turn.attachments, normalizeTurnInput({
+    turnId: 'turn-1',
+    text: '',
+    attachments: [fixtureAttachment()],
+  }).attachments);
+});
+
+test('normalizeTurnInput rejects malformed attachment turns', () => {
+  const invalidTurns = [
+    null,
+    [],
+    { turnId: 7, text: '', attachments: [] },
+    { turnId: 'turn-1', text: 7, attachments: [] },
+    { turnId: 'turn-1', text: '', attachments: 'nope' },
+    { turnId: 'turn-1', text: '', attachments: [{}] },
+    {
+      turnId: 'turn-1',
+      text: '',
+      attachments: [fixtureAttachment({ size: -1 })],
+    },
+    {
+      turnId: 'turn-1',
+      text: '',
+      attachments: [fixtureAttachment({ temporary: 'yes' })],
+    },
+  ];
+
+  for (const value of invalidTurns) {
+    assert.throws(() => normalizeTurnInput(value), TypeError);
+  }
+});
+
+test('display metadata never contains a local path or ownership flag', () => {
+  const value = displayAttachments([fixtureAttachment()]);
+  assert.deepEqual(value, [{
+    id: 'att-1',
+    name: 'clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+  }]);
+  assert.equal(JSON.stringify(value).includes('/tmp/private'), false);
+  assert.equal(Object.hasOwn(value[0], 'temporary'), false);
+});
+
+test('attachment manifest exposes every selected path in order', () => {
+  const manifest = attachmentManifest([
+    fixtureAttachment(),
+    fixtureAttachment({
+      id: 'att-2',
+      name: 'frame.png',
+      localPath: '/tmp/private/frame.png',
+      size: 9,
+      mediaType: '',
+      temporary: false,
+    }),
+  ]);
+
+  assert.equal(manifest, [
+    ATTACHMENT_MANIFEST_OPEN,
+    '{"files":[{"id":"att-1","name":"clip.bin","path":"/tmp/private/clip.bin","size":3,"mediaType":"application/octet-stream"},{"id":"att-2","name":"frame.png","path":"/tmp/private/frame.png","size":9,"mediaType":"application/octet-stream"}]}',
+    ATTACHMENT_MANIFEST_CLOSE,
+  ].join('\n'));
+});
+
+test('withAttachmentManifest leaves text-only turns unchanged', () => {
+  assert.equal(withAttachmentManifest('inspect', []), 'inspect');
+});
+
+test('withAttachmentManifest appends one manifest after text', () => {
+  const value = withAttachmentManifest('inspect', [fixtureAttachment()]);
+  assert.equal(value.startsWith('inspect\n\n' + ATTACHMENT_MANIFEST_OPEN), true);
+  assert.equal(value.endsWith(ATTACHMENT_MANIFEST_CLOSE), true);
+});
+
+test('attachmentFileUrl encodes macOS and Windows path components', () => {
+  assert.equal(
+    attachmentFileUrl('/Users/Test/AE files/a#b.png', 'macos-arm64'),
+    'file:///Users/Test/AE%20files/a%23b.png',
+  );
+  assert.equal(
+    attachmentFileUrl('C:\\Users\\Test\\AE files\\a#b.png', 'windows-x64'),
+    'file:///C:/Users/Test/AE%20files/a%23b.png',
+  );
+});

--- a/plugin/panel/test/backendSelect.test.js
+++ b/plugin/panel/test/backendSelect.test.js
@@ -1,5 +1,6 @@
 import { pickBackend, deriveToolMeta, shouldResetOnBackendChange } from '../src/lib/backendSelect.js';
 import { claudeChannels, codexChannels, zcodeChannels } from '../src/lib/channels.js';
+import { BACKENDS } from '../src/cep/backends/index.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -12,18 +13,29 @@ test('pickBackend: claude subscription channel wins when ok', () => {
   assert.deepEqual(result, { backend: 'subscription', reason: 'ok', channel: 'subscription', fixHint: null });
 });
 
-test('pickBackend: every custom Claude API channel stays on the secret-redacting direct loop', () => {
+test('pickBackend routes every custom Claude API channel through the Claude Agent SDK transport', () => {
   const channels = { claude: [ch('subscription', false), ch('api', true)] };
-  assert.equal(pickBackend({ pref: 'subscription', channels, nodeOk: true }).backend, 'byok');
-  assert.equal(pickBackend({ pref: 'subscription', channels, nodeOk: false }).backend, 'byok');
+  for (const nodeOk of [true, false]) {
+    const selected = pickBackend({ pref: 'subscription', channels, nodeOk });
+    assert.deepEqual(selected, {
+      backend: 'claude-api',
+      reason: 'ok',
+      channel: 'api',
+      fixHint: null,
+    });
+    assert.equal(BACKENDS[selected.backend].attachmentTransport, 'agent-sdk');
+  }
 });
 
-test('pickBackend keeps non-official Anthropic-compatible providers on direct HTTP', () => {
+test('pickBackend keeps non-official Anthropic-compatible providers on the Claude Agent SDK local route', () => {
   const direct = { ...ch('api', true), directHttp: true };
-  assert.equal(
-    pickBackend({ pref: 'subscription', channels: { claude: [ch('subscription', false), direct] }, nodeOk: true }).backend,
-    'byok',
-  );
+  const selected = pickBackend({
+    pref: 'subscription',
+    channels: { claude: [ch('subscription', false), direct] },
+    nodeOk: true,
+  });
+  assert.equal(selected.backend, 'claude-api');
+  assert.equal(BACKENDS[selected.backend].attachmentTransport, 'agent-sdk');
 });
 
 test('pickBackend: probing and no-channel states carry reason + fixHint', () => {

--- a/plugin/panel/test/backends-contract.test.js
+++ b/plugin/panel/test/backends-contract.test.js
@@ -75,7 +75,7 @@ test('registry gives every backend a truthful attachment disposition', () => {
       subscription: 'agent-sdk',
       byok: 'reject',
       'claude-api': 'agent-sdk',
-      codex: 'native',
+      codex: 'native+manifest',
       opencode: 'native',
       zcode: 'manifest',
     },

--- a/plugin/panel/test/backends-contract.test.js
+++ b/plugin/panel/test/backends-contract.test.js
@@ -1,5 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createAgentLoop } from '../src/lib/agentLoop.js';
+import { createClaudeAgentBackend } from '../src/cep/claudeAgentBackend.js';
+import { createCodexBackend } from '../src/cep/codexBackend.js';
+import { createOpenCodeBackend } from '../src/cep/openCodeBackend.js';
+import { createZcodeBackend } from '../src/cep/zcodeBackend.js';
 import { BACKEND_EVENTS } from '../src/cep/backends/contract.js';
 import {
   BACKENDS,
@@ -7,6 +13,39 @@ import {
   assertAttachmentBackendRegistry,
   baseDescriptorFor,
 } from '../src/cep/backends/index.js';
+
+const ATTACHMENT_CONFORMANCE = {
+  subscription: {
+    factory: createClaudeAgentBackend,
+    testFile: 'claudeAgentBackend.test.js',
+    assertion: /turn-accepted.*turn-1.*claude-agent-sdk/s,
+  },
+  'claude-api': {
+    factory: createClaudeAgentBackend,
+    testFile: 'claudeAgentBackend.test.js',
+    assertion: /turn-accepted.*turn-1.*claude-agent-sdk/s,
+  },
+  byok: {
+    factory: createAgentLoop,
+    testFile: 'agentLoop.test.js',
+    assertion: /ATTACHMENT_SIDECAR_REQUIRED.*turn-1.*not-started/s,
+  },
+  codex: {
+    factory: createCodexBackend,
+    testFile: 'codexBackend.test.js',
+    assertion: /turn-accepted.*turn-1.*codex-app-server/s,
+  },
+  opencode: {
+    factory: createOpenCodeBackend,
+    testFile: 'openCodeBackend.test.js',
+    assertion: /turn-accepted.*turn-1.*opencode-file-part/s,
+  },
+  zcode: {
+    factory: createZcodeBackend,
+    testFile: 'zcodeBackend.test.js',
+    assertion: /turn-accepted.*turn-1.*zcode-manifest/s,
+  },
+};
 
 test('contract event vocabulary is the frozen canonical set', () => {
   assert.ok(Object.isFrozen(BACKEND_EVENTS));
@@ -63,6 +102,21 @@ test('attachment registry permits rejection only for legacy byok', () => {
     () => assertAttachmentBackendRegistry(mutated),
     /codex.*reject/i,
   );
+});
+
+test('every attachment registry row has an executable factory conformance vector', () => {
+  assert.deepEqual(Object.keys(ATTACHMENT_CONFORMANCE).sort(), [...REAL_BACKENDS].sort());
+  for (const id of REAL_BACKENDS) {
+    const vector = ATTACHMENT_CONFORMANCE[id];
+    assert.equal(typeof vector.factory, 'function', id + ' factory');
+    const source = readFileSync(new URL(vector.testFile, import.meta.url), 'utf8');
+    assert.match(source, vector.assertion, id + ' conformance assertion');
+    if (BACKENDS[id].attachmentTransport === 'reject') {
+      assert.equal(id, 'byok');
+    } else {
+      assert.notEqual(BACKENDS[id].attachmentTransport, 'reject', id + ' supported transport');
+    }
+  }
 });
 
 test('every registered backend yields a conformant descriptor', () => {

--- a/plugin/panel/test/backends-contract.test.js
+++ b/plugin/panel/test/backends-contract.test.js
@@ -1,7 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { BACKEND_EVENTS } from '../src/cep/backends/contract.js';
-import { BACKENDS, REAL_BACKENDS, baseDescriptorFor } from '../src/cep/backends/index.js';
+import {
+  BACKENDS,
+  REAL_BACKENDS,
+  assertAttachmentBackendRegistry,
+  baseDescriptorFor,
+} from '../src/cep/backends/index.js';
 
 test('contract event vocabulary is the frozen canonical set', () => {
   assert.ok(Object.isFrozen(BACKEND_EVENTS));
@@ -9,6 +14,7 @@ test('contract event vocabulary is the frozen canonical set', () => {
   assert.ok(BACKEND_EVENTS.includes('tool-allowed'));
   assert.ok(BACKEND_EVENTS.includes('tool-denied'));
   assert.ok(BACKEND_EVENTS.includes('thinking'));
+  assert.ok(BACKEND_EVENTS.includes('turn-accepted'));
   for (const e of ['turn-start', 'text-delta', 'tool-start', 'tool-result', 'approval-required', 'turn-end', 'error']) {
     assert.ok(BACKEND_EVENTS.includes(e), 'missing ' + e);
   }
@@ -20,6 +26,43 @@ test('registry exposes the real embedded backends', () => {
     assert.equal(BACKENDS[id].id, id);
     assert.equal(typeof BACKENDS[id].baseDescriptor, 'function');
   }
+});
+
+test('registry gives every backend a truthful attachment disposition', () => {
+  assert.equal(assertAttachmentBackendRegistry(BACKENDS), true);
+  assert.deepEqual(
+    Object.fromEntries(REAL_BACKENDS.map((id) => [id, BACKENDS[id].attachmentTransport])),
+    {
+      subscription: 'agent-sdk',
+      byok: 'reject',
+      'claude-api': 'agent-sdk',
+      codex: 'native',
+      opencode: 'native',
+      zcode: 'manifest',
+    },
+  );
+});
+
+test('attachment registry rejects a missing supported-backend mapping', () => {
+  const mutated = {
+    ...BACKENDS,
+    codex: { ...BACKENDS.codex, attachmentTransport: undefined },
+  };
+  assert.throws(
+    () => assertAttachmentBackendRegistry(mutated),
+    /codex.*attachment transport/i,
+  );
+});
+
+test('attachment registry permits rejection only for legacy byok', () => {
+  const mutated = {
+    ...BACKENDS,
+    codex: { ...BACKENDS.codex, attachmentTransport: 'reject' },
+  };
+  assert.throws(
+    () => assertAttachmentBackendRegistry(mutated),
+    /codex.*reject/i,
+  );
 });
 
 test('every registered backend yields a conformant descriptor', () => {

--- a/plugin/panel/test/channels.test.js
+++ b/plugin/panel/test/channels.test.js
@@ -24,10 +24,35 @@ test('claudeChannels: subscription reflects probe, api reflects provider entry',
     providerAvailable: true,
   });
   assert.equal(withApi[0].ok, false);
-  assert.match(withApi[0].fixHint.zh, /API 直连/);
+  assert.match(withApi[0].fixHint.zh, /自定义 Provider/);
   assert.equal(withApi[1].ok, true);
   assert.equal(withApi[1].canPreflight, true);
   assert.equal(withApi[1].selected, true);
+});
+
+test('claudeChannels fails a custom Provider closed when the shared Agent SDK runtime is unavailable', () => {
+  const provider = {
+    baseUrl: 'https://r',
+    auth: {
+      model: {
+        kind: 'x-api-key',
+        valueRef: {
+          kind: 'secret',
+          reference: 'aemcp-secret://provider/5eb75f05-5d9e-5d9c-85af-f0893e8b90c2/auth-model/v1',
+          revision: 1,
+        },
+      },
+    },
+  };
+  const channels = claudeChannels({
+    probe: { nodeOk: false, loggedIn: false },
+    apiProvider: provider,
+    providerAvailable: true,
+  });
+  assert.equal(channels[1].ok, false);
+  assert.equal(channels[1].canPreflight, false);
+  assert.match(channels[1].fixHint.zh, /Node 运行时/);
+  assert.match(channels[1].fixHint.en, /Node runtime/);
 });
 
 test('codexChannels: cli login state + custom provider channel', () => {
@@ -193,7 +218,7 @@ test('pickChannel: first ok wins; explicit lock is honored even when not ok', ()
   assert.equal(pickChannel([]), null);
 });
 
-test('migrateBackendPref maps legacy byok/opencode prefs onto the 3-way model', () => {
+test('migrateBackendPref maps non-product and legacy prefs onto the two built-in choices', () => {
   function storage(init) {
     const map = new Map(Object.entries(init));
     return { getItem: (k) => (map.has(k) ? map.get(k) : null), setItem: (k, v) => map.set(k, v), map };
@@ -204,6 +229,9 @@ test('migrateBackendPref maps legacy byok/opencode prefs onto the 3-way model', 
   assert.equal(byok.map.get('ae_mcp_channel_lock'), 'api');
   const oc = storage({ ae_mcp_backend: 'opencode' });
   assert.deepEqual(migrateBackendPref(oc), { pref: 'subscription', lockedChannel: '' });
+  const zcode = storage({ ae_mcp_backend: 'zcode' });
+  assert.deepEqual(migrateBackendPref(zcode), { pref: 'subscription', lockedChannel: '' });
+  assert.equal(zcode.map.get('ae_mcp_backend'), 'subscription');
   const keep = storage({ ae_mcp_backend: 'codex', ae_mcp_channel_lock: 'cli' });
   assert.deepEqual(migrateBackendPref(keep), { pref: 'codex', lockedChannel: 'cli' });
   assert.deepEqual(migrateBackendPref(storage({})), { pref: 'subscription', lockedChannel: '' });

--- a/plugin/panel/test/chatEntries.test.js
+++ b/plugin/panel/test/chatEntries.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { reduceEvent } from '../src/lib/chatEntries.js';
+import { reduceEvent, userTurnEntry } from '../src/lib/chatEntries.js';
 
 test('text deltas merge into one ai-text entry', () => {
   let entries = [];
@@ -61,6 +61,39 @@ test('error event appends an error entry', () => {
   assert.deepEqual(entries, [{ id: 'error-1', type: 'error', kind: 'auth', message: 'Invalid key' }]);
 });
 
+test('turn-accepted appends only redacted display attachment metadata', () => {
+  const entry = userTurnEntry({
+    turnId: 'turn-1',
+    text: '',
+    attachments: [{
+      id: 'att-1',
+      name: 'clip.bin',
+      localPath: '/tmp/private/clip.bin',
+      size: 3,
+      mediaType: 'application/octet-stream',
+      temporary: true,
+    }],
+  });
+
+  assert.equal(entry.type, 'user-text');
+  assert.deepEqual(entry.attachments, [{
+    id: 'att-1',
+    name: 'clip.bin',
+    size: 3,
+    mediaType: 'application/octet-stream',
+  }]);
+  assert.equal(JSON.stringify(entry).includes('/tmp/private'), false);
+  assert.equal(JSON.stringify(entry).includes('temporary'), false);
+});
+
+test('turn-accepted alone never invents a transcript entry', () => {
+  const existing = [{ id: 'ai-1', type: 'ai-text', text: 'before' }];
+  assert.equal(
+    reduceEvent(existing, { type: 'turn-accepted', turnId: 'turn-1' }),
+    existing,
+  );
+});
+
 test('external approvals render as high risk without session allowance', () => {
   const source = readFileSync(new URL('../src/screens/ChatScreen.jsx', import.meta.url), 'utf8');
   assert.match(source, /entry\.risk === 'destructive'\s*\|\|\s*entry\.risk === 'external'/);
@@ -74,4 +107,13 @@ test('external approvals render as high risk without session allowance', () => {
     risk: 'external',
   });
   assert.equal(entries[0].risk, 'external');
+});
+
+test('user attachment bubbles render display metadata without path-bearing fields', () => {
+  const chat = readFileSync(new URL('../src/screens/ChatScreen.jsx', import.meta.url), 'utf8');
+  const bubble = readFileSync(new URL('../src/components/chat/ChatBubble.jsx', import.meta.url), 'utf8');
+  assert.match(chat, /attachments=\{entry\.attachments\}/);
+  assert.match(bubble, /attachment\.name/);
+  assert.match(bubble, /formatAttachmentBytes\(attachment\.size\)/);
+  assert.doesNotMatch(bubble, /localPath|temporary|manifest|transport/);
 });

--- a/plugin/panel/test/claudeAgentBackend.test.js
+++ b/plugin/panel/test/claudeAgentBackend.test.js
@@ -164,6 +164,83 @@ test('createClaudeAgentBackend writes user only after ready handshake', async ()
   await pending;
 });
 
+test('createClaudeAgentBackend forwards one normalized attachment turn without exposing paths in events', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const turn = {
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: 'C:\\private\\notes.pdf',
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false,
+    }],
+  };
+  const pending = backend.sendUser(turn);
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+
+  assert.deepEqual(parseWrites(spawned.procs[0]), [{
+    t: 'user',
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: turn.attachments,
+    permissionMode: 'manual',
+    model: 'claude-test',
+  }]);
+
+  spawned.procs[0].pushStdout({
+    t: 'event',
+    event: { type: 'turn-accepted', turnId: 'turn-1', transport: 'claude-agent-sdk' },
+  });
+  spawned.procs[0].pushStdout({
+    t: 'event',
+    event: { type: 'turn-end', stopReason: 'end_turn' },
+  });
+  await pending;
+
+  assert.deepEqual(events, [
+    { type: 'turn-accepted', turnId: 'turn-1', transport: 'claude-agent-sdk' },
+    { type: 'turn-end', stopReason: 'end_turn' },
+  ]);
+  assert.equal(JSON.stringify(events).includes('C:\\private'), false);
+  assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
+});
+
+test('createClaudeAgentBackend redacts active attachment paths from sidecar errors and stderr', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const localPath = 'C:\\private\\notes.pdf';
+  const pending = backend.sendUser({
+    turnId: 'turn-redact',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath,
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false,
+    }],
+  });
+  await flush();
+  spawned.procs[0].pushStdout({ t: 'ready' });
+  await flush();
+  spawned.procs[0].pushStderr('failed to read ' + localPath);
+  spawned.procs[0].pushStdout({
+    t: 'event',
+    event: { type: 'error', kind: 'network', message: 'failed to read ' + localPath },
+  });
+  await pending;
+
+  assert.equal(JSON.stringify(events).includes(localPath), false);
+  assert.match(events.at(-1).message, /\[redacted\]/);
+  assert.equal(backend.getStderrTail().includes(localPath), false);
+  assert.match(backend.getStderrTail(), /\[redacted\]/);
+});
+
 test('createClaudeAgentBackend passes effort and thinking when getters are provided', async () => {
   const { backend, spawned } = makeBackend({
     getEffort: () => 'low',

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -956,6 +956,98 @@ test('createCodexBackend exposes every selected file in a manifest and keeps nat
   assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
 });
 
+test('createCodexBackend redacts an attachment path split across output and transcript', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const { backend, events, spawned } = makeBackend({ getServerInstructions: () => '' });
+  const { pending, proc } = await startTurn(backend, spawned, {
+    turnId: 'turn-redact-output',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+
+  proc.pushStdout({
+    method: 'item/agentMessage/delta',
+    params: { delta: 'C:\\private\\' },
+  });
+  proc.pushStdout({
+    method: 'item/agentMessage/delta',
+    params: { delta: 'customer.mov' },
+  });
+  proc.pushStdout({ method: 'turn/completed', params: {} });
+  await pending;
+
+  const rendered = JSON.stringify({ events, messages: backend.getMessages() });
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createCodexBackend redacts an attachment path split across stderr failure', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const { backend, events, spawned } = makeBackend({ getServerInstructions: () => '' });
+  const { pending, proc } = await startTurn(backend, spawned, {
+    turnId: 'turn-redact-stderr',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+
+  proc.pushStderr('failed C:\\private\\');
+  proc.pushStderr('customer.mov');
+  proc.exit(1);
+  await pending;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createCodexBackend keeps attachment stderr redaction until the persistent process exits', async () => {
+  const path = 'C:\\private\\late-customer.mov';
+  const { backend, events, spawned } = makeBackend({ getServerInstructions: () => '' });
+  const first = await startTurn(backend, spawned, {
+    turnId: 'turn-attachment',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'late-customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  first.proc.pushStdout({ method: 'turn/completed', params: {} });
+  await first.pending;
+
+  first.proc.pushStderr('late C:\\private\\');
+  first.proc.pushStderr('late-customer.mov');
+  const second = backend.sendUser({
+    turnId: 'turn-text-only',
+    text: 'next',
+    attachments: [],
+  });
+  await flush();
+  first.proc.exit(1);
+  await second;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
 test('createCodexBackend maps app-server turn and tool notifications to panel events', async () => {
   const { backend, events, spawned } = makeBackend();
   const { pending, proc } = await startTurn(backend, spawned, 'events');

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -912,7 +912,7 @@ test('createCodexBackend reuses threadId on subsequent turns', async () => {
   await second;
 });
 
-test('createCodexBackend maps selected files to native app-server input and accepts the logical turn once', async () => {
+test('createCodexBackend exposes every selected file in a manifest and keeps native media input', async () => {
   const { backend, events, spawned } = makeBackend({ getServerInstructions: () => '' });
   const turn = {
     turnId: 'turn-1',
@@ -921,15 +921,25 @@ test('createCodexBackend maps selected files to native app-server input and acce
       { id: 'image-1', name: 'frame.png', localPath: 'C:\\tmp\\frame.png', size: 3, mediaType: 'image/png', temporary: false },
       { id: 'audio-1', name: 'audio.wav', localPath: 'C:\\tmp\\audio.wav', size: 4, mediaType: 'audio/wav', temporary: false },
       { id: 'video-1', name: 'clip.mov', localPath: 'C:\\tmp\\clip.mov', size: 5, mediaType: 'video/quicktime', temporary: false },
+      { id: 'text-1', name: 'note.txt', localPath: 'C:\\tmp\\note.txt', size: 6, mediaType: 'text/plain', temporary: false },
+      { id: 'unknown-1', name: 'unknown.payload', localPath: 'C:\\tmp\\unknown.payload', size: 7, mediaType: '', temporary: false },
     ],
   };
   const { pending, proc, turnStart } = await startTurn(backend, spawned, turn);
 
   assert.deepEqual(turnStart.params.input, [
-    { type: 'text', text: 'inspect' },
+    {
+      type: 'text',
+      text: 'inspect\n\n<ae_mcp_attachments version="1">\n'
+        + '{"files":[{"id":"image-1","name":"frame.png","path":"C:\\\\tmp\\\\frame.png","size":3,"mediaType":"image/png"},'
+        + '{"id":"audio-1","name":"audio.wav","path":"C:\\\\tmp\\\\audio.wav","size":4,"mediaType":"audio/wav"},'
+        + '{"id":"video-1","name":"clip.mov","path":"C:\\\\tmp\\\\clip.mov","size":5,"mediaType":"video/quicktime"},'
+        + '{"id":"text-1","name":"note.txt","path":"C:\\\\tmp\\\\note.txt","size":6,"mediaType":"text/plain"},'
+        + '{"id":"unknown-1","name":"unknown.payload","path":"C:\\\\tmp\\\\unknown.payload","size":7,"mediaType":"application/octet-stream"}]}\n'
+        + '</ae_mcp_attachments>',
+    },
     { type: 'localImage', path: 'C:\\tmp\\frame.png' },
     { type: 'localAudio', path: 'C:\\tmp\\audio.wav' },
-    { type: 'mention', name: 'clip.mov', path: 'C:\\tmp\\clip.mov' },
   ]);
 
   proc.pushStdout({ method: 'turn/started', params: { turn: { id: 'codex-turn-1' } } });

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -912,6 +912,40 @@ test('createCodexBackend reuses threadId on subsequent turns', async () => {
   await second;
 });
 
+test('createCodexBackend maps selected files to native app-server input and accepts the logical turn once', async () => {
+  const { backend, events, spawned } = makeBackend({ getServerInstructions: () => '' });
+  const turn = {
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [
+      { id: 'image-1', name: 'frame.png', localPath: 'C:\\tmp\\frame.png', size: 3, mediaType: 'image/png', temporary: false },
+      { id: 'audio-1', name: 'audio.wav', localPath: 'C:\\tmp\\audio.wav', size: 4, mediaType: 'audio/wav', temporary: false },
+      { id: 'video-1', name: 'clip.mov', localPath: 'C:\\tmp\\clip.mov', size: 5, mediaType: 'video/quicktime', temporary: false },
+    ],
+  };
+  const { pending, proc, turnStart } = await startTurn(backend, spawned, turn);
+
+  assert.deepEqual(turnStart.params.input, [
+    { type: 'text', text: 'inspect' },
+    { type: 'localImage', path: 'C:\\tmp\\frame.png' },
+    { type: 'localAudio', path: 'C:\\tmp\\audio.wav' },
+    { type: 'mention', name: 'clip.mov', path: 'C:\\tmp\\clip.mov' },
+  ]);
+
+  proc.pushStdout({ method: 'turn/started', params: { turn: { id: 'codex-turn-1' } } });
+  await flush();
+  assert.deepEqual(events.slice(0, 2), [
+    { type: 'turn-accepted', turnId: 'turn-1', transport: 'codex-app-server' },
+    { type: 'turn-start' },
+  ]);
+  assert.equal(events.filter((event) => event.type === 'turn-accepted').length, 1);
+  assert.equal(JSON.stringify(events).includes('C:\\tmp'), false);
+
+  proc.pushStdout({ method: 'turn/completed', params: {} });
+  await pending;
+  assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
+});
+
 test('createCodexBackend maps app-server turn and tool notifications to panel events', async () => {
   const { backend, events, spawned } = makeBackend();
   const { pending, proc } = await startTurn(backend, spawned, 'events');
@@ -1007,73 +1041,34 @@ test('createCodexBackend emits one model error when RPC rejection and error noti
   }]);
 });
 
-test('createCodexBackend re-detects a recoverable provider once and retries the same turn', async () => {
-  const recoveredProvider = providerFixtureV3({ baseUrl: 'https://recovered.example/v1' });
-  const recoveryCalls = [];
-  const routeCalls = [];
-  let resolveCalls = 0;
-  let refreshed = 0;
+test('createCodexBackend never replays a dispatched turn while acceptance is uncertain', async () => {
+  let recoveryCalls = 0;
   const { backend, events, spawned } = makeBackend({
-    createProviderRoute: (input) => {
-      routeCalls.push(input);
-      return localProviderRoute({ routeToken: `recovery-route-${routeCalls.length}` });
-    },
     getProviderProfile: () => selectedProvider(),
-    resolveRequestProfile: async () => {
-      resolveCalls += 1;
-      return resolvedModelProfile();
+    resolveRequestProfile: async () => resolvedModelProfile(),
+    recoverProviderProfile: async () => {
+      recoveryCalls += 1;
+      return selectedProvider(providerFixtureV3({ baseUrl: 'https://recovered.example/v1' }));
     },
-    recoverProviderProfile: async (provider, facts, modelId) => {
-      recoveryCalls.push({ provider, facts, modelId });
-      return selectedProvider(recoveredProvider);
-    },
-    onProviderProfileRecovered: () => { refreshed += 1; },
   });
-  const { pending, proc } = await startTurn(backend, spawned, 'retry this turn');
+  const turn = { turnId: 'turn-uncertain', text: 'do not replay', attachments: [] };
+  const { pending, proc } = await startTurn(backend, spawned, turn);
 
   proc.pushStdout({ jsonrpc: '2.0', method: 'error', params: { error: { status: 404, message: 'HTTP status 404' } } });
-  for (let index = 0; index < 20 && spawned.procs.length < 2; index += 1) await flush();
-  assert.equal(spawned.procs.length, 2);
-  assert.equal(proc.killed, true);
-  assert.equal(recoveryCalls.length, 1);
-  assert.equal(recoveryCalls[0].provider, CUSTOM_PROVIDER);
-  assert.deepEqual(recoveryCalls[0].facts, { status: 404, code: '' });
-  assert.equal(recoveryCalls[0].modelId, PROVIDER_MODEL_ID);
-  assert.equal(resolveCalls, 0);
-
-  const proc2 = spawned.procs[1];
-  assert.equal(routeCalls.length, 2);
-  assert.equal(routeCalls[1].provider, recoveredProvider);
-  assert.deepEqual(spawned.calls[1].args, expectedLocalProviderArgs());
-  let settled = false;
-  pending.then(() => { settled = true; });
-  proc.pushStdout({ jsonrpc: '2.0', method: 'item/agentMessage/delta', params: { delta: 'stale' } });
-  proc.pushStdout({ jsonrpc: '2.0', method: 'turn/completed', params: {} });
-  proc.exit(1);
-  await flush();
-  assert.equal(settled, false);
-
-  const init = parseWrites(proc2)[0];
-  respond(proc2, init, {});
-  await flush();
-  const threadStart = parseWrites(proc2)[1];
-  respond(proc2, threadStart, { threadId: 'thread_recovered' });
-  await flush();
-  const retriedTurn = parseWrites(proc2)[2];
-  assert.equal(retriedTurn.params.input[0].text, 'retry this turn');
-  respond(proc2, retriedTurn, {});
-  proc2.pushStdout({ jsonrpc: '2.0', method: 'item/agentMessage/delta', params: { delta: 'recovered' } });
-  proc2.pushStdout({ jsonrpc: '2.0', method: 'turn/completed', params: {} });
   await pending;
-  await flush();
 
-  assert.equal(events.some((event) => event.type === 'error'), false);
-  assert.equal(backend.getMessages().filter((message) => message.role === 'user').length, 1);
-  assert.equal(backend.getMessages().at(-1).text, 'recovered');
-  assert.equal(refreshed, 1);
+  assert.equal(recoveryCalls, 0);
+  assert.equal(spawned.procs.length, 1);
+  assert.deepEqual(events.at(-1), {
+    type: 'error',
+    kind: 'mcp',
+    message: 'HTTP status 404',
+    turnId: 'turn-uncertain',
+    dispatchState: 'uncertain',
+  });
 });
 
-test('createCodexBackend re-detects generic 405 and 501 provider failures', async (context) => {
+test('createCodexBackend classifies generic 405 and 501 after dispatch as uncertain without replay', async (context) => {
   for (const status of [405, 501]) {
     await context.test(`HTTP ${status}`, async () => {
       let recoveryCalls = 0;
@@ -1085,56 +1080,63 @@ test('createCodexBackend re-detects generic 405 and 501 provider failures', asyn
           return { provider, modelId };
         },
       });
-      const { pending, proc } = await startTurn(backend, spawned, `recover ${status}`);
+      const turn = { turnId: `turn-${status}`, text: `do not replay ${status}`, attachments: [] };
+      const { pending, proc } = await startTurn(backend, spawned, turn);
       proc.pushStdout({
         jsonrpc: '2.0',
         method: 'error',
         params: { error: { status, message: `HTTP status ${status}` } },
       });
-      await waitFor(() => spawned.procs.length === 2);
-
-      const recoveredProc = spawned.procs[1];
-      await waitFor(() => parseWrites(recoveredProc).length >= 1);
-      respond(recoveredProc, parseWrites(recoveredProc)[0], {});
-      await waitFor(() => parseWrites(recoveredProc).length >= 2);
-      respond(recoveredProc, parseWrites(recoveredProc)[1], { threadId: `thread_${status}` });
-      await waitFor(() => parseWrites(recoveredProc).length >= 3);
-      respond(recoveredProc, parseWrites(recoveredProc)[2], {});
-      recoveredProc.pushStdout({ jsonrpc: '2.0', method: 'turn/completed', params: {} });
       await pending;
 
-      assert.equal(recoveryCalls, 1);
-      assert.equal(events.some((event) => event.type === 'error'), false);
+      assert.equal(recoveryCalls, 0);
+      assert.equal(spawned.procs.length, 1);
+      assert.deepEqual(events.at(-1), {
+        type: 'error',
+        kind: 'mcp',
+        message: `HTTP status ${status}`,
+        turnId: `turn-${status}`,
+        dispatchState: 'uncertain',
+      });
     });
   }
 });
 
-test('createCodexBackend never retries a recoverable provider failure more than once per turn', async () => {
+test('createCodexBackend does not invoke recovery for a rejected turn/start request', async () => {
   let recoveryCalls = 0;
-  const recoveredProvider = providerFixtureV3({ baseUrl: 'https://recovered.example/v1' });
   const { backend, events, spawned } = makeBackend({
     getProviderProfile: () => selectedProvider(),
     resolveRequestProfile: async () => resolvedModelProfile(),
     recoverProviderProfile: async () => {
       recoveryCalls += 1;
-      return selectedProvider(recoveredProvider);
+      return selectedProvider(providerFixtureV3({ baseUrl: 'https://recovered.example/v1' }));
     },
   });
-  const { pending, proc } = await startTurn(backend, spawned, 'retry only once');
-  proc.pushStdout({ jsonrpc: '2.0', method: 'error', params: { error: { statusCode: 404, message: 'HTTP status 404' } } });
-  for (let index = 0; index < 20 && spawned.procs.length < 2; index += 1) await flush();
-  const proc2 = spawned.procs[1];
-  respond(proc2, parseWrites(proc2)[0], {});
-  await flush();
-  respond(proc2, parseWrites(proc2)[1], { threadId: 'thread_retry_once' });
-  await flush();
-  respond(proc2, parseWrites(proc2)[2], {});
-  proc2.pushStdout({ jsonrpc: '2.0', method: 'error', params: { error: { httpStatus: 404, message: 'HTTP status 404' } } });
+  const turn = { turnId: 'turn-rpc-reject', text: 'one attempt', attachments: [] };
+  const { pending, proc, turnStart } = await startTurnRequest(backend, spawned, turn);
+  proc.pushStdout({ id: turnStart.id, error: { statusCode: 404, message: 'HTTP status 404' } });
   await pending;
-  await flush();
-  assert.equal(recoveryCalls, 1);
-  assert.equal(spawned.procs.length, 2);
-  assert.equal(events.at(-1).type, 'error');
+  assert.equal(recoveryCalls, 0);
+  assert.equal(spawned.procs.length, 1);
+  assert.equal(parseWrites(proc).filter((message) => message.method === 'turn/start').length, 1);
+  assert.equal(events.at(-1).dispatchState, 'uncertain');
+});
+
+test('createCodexBackend correlates an app-server exit after dispatch as uncertain', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const turn = { turnId: 'turn-exit', text: 'inspect', attachments: [] };
+  const { pending, proc } = await startTurnRequest(backend, spawned, turn);
+
+  proc.exit(1);
+  await pending;
+
+  assert.deepEqual(events.at(-1), {
+    type: 'error',
+    kind: 'mcp',
+    message: 'codex app-server exited: 1',
+    turnId: 'turn-exit',
+    dispatchState: 'uncertain',
+  });
 });
 
 test('createCodexBackend keeps the original route error redacted when re-detection fails', async () => {
@@ -1231,8 +1233,14 @@ test('createCodexBackend reset prevents an in-flight provider recovery from revi
     },
     onProviderProfileRecovered: () => { refreshed += 1; },
   });
-  const { pending, proc } = await startTurn(backend, spawned, 'reset during recovery');
-  proc.pushStdout({ jsonrpc: '2.0', method: 'error', params: { error: { code: 'unsupported_endpoint', message: 'unsupported endpoint' } } });
+  const pending = backend.sendUser({ turnId: 'turn-before-dispatch', text: 'reset during recovery', attachments: [] });
+  await flush();
+  const proc = spawned.procs[0];
+  const init = parseWrites(proc)[0];
+  respond(proc, init, {});
+  await flush();
+  const threadStart = parseWrites(proc)[1];
+  proc.pushStdout({ id: threadStart.id, error: { code: 'unsupported_endpoint', message: 'unsupported endpoint' } });
   for (let index = 0; index < 20 && recoveryCalls < 1; index += 1) await flush();
   assert.equal(recoveryCalls, 1);
   backend.reset();

--- a/plugin/panel/test/composerAttachmentsWiring.test.js
+++ b/plugin/panel/test/composerAttachmentsWiring.test.js
@@ -92,3 +92,9 @@ test('App owns the draft above Chat tab and disposes its attachment store', () =
   assert.match(app, /\(\) => attachmentStore\.dispose\(\)/);
   assert.match(app, /attachmentStore\.releaseSession\(chatSessionIdRef\.current\)/);
 });
+
+test('App includes active attachment paths in exact log-export redaction', () => {
+  const app = source('../src/app/App.jsx');
+  assert.match(app, /attachmentPathSecrets\(\{\s*draft:\s*attachmentDraft,\s*pendingTurn:\s*pendingTurnRef\.current/s);
+  assert.match(app, /exactSecrets\.push\(\.\.\.attachmentSecrets\)/);
+});

--- a/plugin/panel/test/composerAttachmentsWiring.test.js
+++ b/plugin/panel/test/composerAttachmentsWiring.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function source(relative) {
+  return readFileSync(new URL(relative, import.meta.url), 'utf8');
+}
+
+test('AttachmentPond configures local unrestricted picker, paste, and preview', () => {
+  const pond = source('../src/components/chat/AttachmentPond.jsx');
+  assert.match(pond, /registerPlugin\(FilePondPluginImagePreview\)/);
+  assert.match(pond, /\ballowMultiple\b/);
+  assert.match(pond, /\ballowPaste\b/);
+  assert.match(pond, /\ballowBrowse=\{!disabled\}/);
+  assert.match(pond, /\ballowDrop=\{!disabled\}/);
+  assert.match(pond, /\binstantUpload=\{false\}/);
+  assert.match(pond, /\bmaxFiles=\{MAX_ATTACHMENTS_PER_TURN\}/);
+  assert.match(pond, /filepond--label-action/);
+  assert.doesNotMatch(pond, /acceptedFileTypes|server=|FileReader|readAs|parse|extract|transcod/i);
+});
+
+test('Composer delegates one complete file drop to FilePond and leaves text drops alone', () => {
+  const composer = source('../src/components/chat/Composer.jsx');
+  assert.match(composer, /attachmentDropFiles\(event\.dataTransfer\)/);
+  assert.match(
+    composer,
+    /if \(disabled \|\| streaming \|\| attachmentDraft\.pendingTurnId\) return/,
+  );
+  assert.match(composer, /if \(!files\.length\) return/);
+  assert.match(composer, /event\.preventDefault\(\)/);
+  assert.match(composer, /event\.stopPropagation\(\)/);
+  assert.equal(
+    (composer.match(/attachmentPondRef\.current\?\.addFiles\(files\)/g) || []).length,
+    1,
+  );
+  assert.match(composer, /onDragEnterCapture=\{handleFileDrag\}/);
+  assert.match(composer, /onDragOverCapture=\{handleFileDrag\}/);
+  assert.match(composer, /onDropCapture=\{handleFileDrop\}/);
+});
+
+test('Composer enables attachment-only sends without changing keyboard resize behavior', () => {
+  const composer = source('../src/components/chat/Composer.jsx');
+  assert.match(composer, /readyAttachmentCount > 0/);
+  assert.match(composer, /!attachmentsBusy/);
+  assert.match(composer, /e\.key === 'Enter' && !e\.shiftKey/);
+  assert.match(composer, /function ComposerResizeHandle/);
+  assert.match(composer, /composerKeyboardRequest/);
+  assert.doesNotMatch(composer, /FileReader|readAs|parseAttachment|extractText|videoFrame/i);
+});
+
+test('AttachmentPond keeps staging failures actionable without hiding other items', () => {
+  const pond = source('../src/components/chat/AttachmentPond.jsx');
+  assert.match(pond, /item\.status === 'error'/);
+  assert.match(pond, /onRetryAttachment\?\.\(item\)/);
+  assert.match(pond, /onRemoveAttachment\?\.\(item\)/);
+  assert.match(pond, /items\.map/);
+});

--- a/plugin/panel/test/composerAttachmentsWiring.test.js
+++ b/plugin/panel/test/composerAttachmentsWiring.test.js
@@ -55,3 +55,40 @@ test('AttachmentPond keeps staging failures actionable without hiding other item
   assert.match(pond, /onRemoveAttachment\?\.\(item\)/);
   assert.match(pond, /items\.map/);
 });
+
+test('ChatScreen sends one controlled TurnInput and never clears on click', () => {
+  const chat = source('../src/screens/ChatScreen.jsx');
+  assert.match(chat, /attachmentDraft/);
+  assert.match(chat, /dispatchAttachmentDraft/);
+  assert.match(chat, /const turnId = createTurnId\(\)/);
+  assert.match(chat, /attachments:\s*readyAttachments\(attachmentDraft\)/);
+  assert.match(chat, /type:\s*'sending',\s*turnId,\s*turn/);
+  assert.match(chat, /onSend\?\.\(turn\)/);
+  assert.doesNotMatch(chat, /setDraft\(''\)/);
+  assert.doesNotMatch(chat, /React\.useState\(''\)/);
+});
+
+test('App correlates acceptance before transcript append and releases only at terminal state', () => {
+  const app = source('../src/app/App.jsx');
+  assert.match(app, /pendingTurnRef/);
+  assert.match(app, /evt\.type === 'turn-accepted'/);
+  assert.match(app, /if \(!pending \|\| evt\.turnId !== pending\.turnId\) return/);
+  assert.match(app, /userTurnEntry\(pending\)/);
+  assert.match(app, /dispatchAttachmentDraft\(\{\s*type:\s*'accepted'/);
+  assert.match(app, /dispatchState === 'not-started'/);
+  assert.match(app, /type:\s*'uncertain'/);
+  assert.match(app, /dispatchState:\s*error\?\.dispatchState \|\| 'uncertain'/);
+  assert.match(app, /attachmentStore\.release\(attachment\.id\)/);
+  assert.match(app, /evt\.type === 'turn-end' \|\| evt\.type === 'error'/);
+  assert.doesNotMatch(app, /user-\$\{Date\.now\(\)\}/);
+});
+
+test('App owns the draft above Chat tab and disposes its attachment store', () => {
+  const app = source('../src/app/App.jsx');
+  const draftState = app.indexOf('React.useReducer(\n    reduceAttachmentDraft');
+  const conditionalChat = app.indexOf("tab === 'chat'");
+  assert.ok(draftState >= 0 && draftState < conditionalChat);
+  assert.match(app, /createAttachmentStore/);
+  assert.match(app, /\(\) => attachmentStore\.dispose\(\)/);
+  assert.match(app, /attachmentStore\.releaseSession\(chatSessionIdRef\.current\)/);
+});

--- a/plugin/panel/test/composerResizeWiring.test.js
+++ b/plugin/panel/test/composerResizeWiring.test.js
@@ -56,6 +56,10 @@ test('Composer keeps submission and bottom controls independent from resizing', 
   assert.match(composer, /minHeight:\s*0/);
   assert.match(composer, /flex:\s*'none'/);
   assert.match(composer, /overflow must stay visible/);
+  assert.ok(
+    composer.indexOf('<ComposerResizeHandle') < composer.indexOf('<AttachmentPond'),
+    'attachment surface must stay below the independent resize handle',
+  );
 });
 
 test('ChatScreen owns one session height and observes the shared allocation', () => {

--- a/plugin/panel/test/descriptorSelect.test.js
+++ b/plugin/panel/test/descriptorSelect.test.js
@@ -12,7 +12,7 @@ const v3Provider = {
   },
 };
 
-test('isClaudeApiBackend covers claude-api and node-broken byok, nothing else', () => {
+test('isClaudeApiBackend covers live claude-api and legacy byok state, nothing else', () => {
   assert.equal(isClaudeApiBackend('claude-api'), true);
   assert.equal(isClaudeApiBackend('byok'), true);
   assert.equal(isClaudeApiBackend('subscription'), false);
@@ -26,7 +26,7 @@ test('claude-api + provider probedModels drives the descriptor (regression: was 
   assert.equal(d.defaultModelId, 'glm-5.2');
 });
 
-test('node-broken byok backend uses the same probed-models path', () => {
+test('legacy byok state uses the same probed-models path', () => {
   const base = byokStaticDescriptor();
   const d = selectDescriptor({ effectiveBackend: 'byok', backendPref: 'subscription', baseDescriptor: base, claudeApiProvider: probedProvider });
   assert.equal(d.defaultModelId, 'glm-5.2');

--- a/plugin/panel/test/noSensitiveDefaults.test.js
+++ b/plugin/panel/test/noSensitiveDefaults.test.js
@@ -3,6 +3,8 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { userTurnEntry, reduceEvent } from '../src/lib/chatEntries.js';
+import { attachmentPathSecrets, buildLogExport } from '../src/lib/logExport.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
@@ -37,4 +39,43 @@ test('provider examples and defaults do not expose private hostnames', async () 
     }
   }
   assert.deepEqual(hits, []);
+});
+
+test('attachment paths stay out of transcript, events, diagnostics, and exported logs', () => {
+  const secret = '/private/attachment-secret/customer.mov';
+  const turn = {
+    turnId: 'turn-sensitive',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-sensitive',
+      name: 'customer.mov',
+      localPath: secret,
+      size: 42,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  };
+  const transcript = userTurnEntry(turn);
+  const eventEntries = reduceEvent([], {
+    type: 'error',
+    kind: 'transport',
+    message: 'Attachment failed at [attachment-path]',
+    turnId: turn.turnId,
+    dispatchState: 'uncertain',
+  });
+  const exactSecrets = attachmentPathSecrets({
+    draft: { items: [{ ref: turn.attachments[0] }] },
+    pendingTurn: turn,
+  });
+  const exported = buildLogExport({
+    panelLogs: ['diagnostic selected ' + secret],
+    sidecarTail: 'sidecar failed to read ' + secret,
+    exactSecrets,
+  });
+
+  assert.equal(JSON.stringify(transcript).includes(secret), false);
+  assert.equal(JSON.stringify(eventEntries).includes(secret), false);
+  assert.deepEqual(exactSecrets, [secret]);
+  assert.equal(exported.includes(secret), false);
+  assert.match(exported, /\[redacted\]/);
 });

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -142,6 +142,7 @@ function makeBackend(options = {}) {
   const fetched = makeFetch();
   const fsImpl = makeFs();
   const platform = {
+    id: 'windows-x64',
     paths: { tempRoot: 'C:\\tmp', join: (parts) => parts.join('\\') },
     fs: fsImpl,
     completeSpawnEnv: (base = {}, additions = {}) => ({ ...base, ...additions }),
@@ -164,6 +165,82 @@ function makeBackend(options = {}) {
   });
   return { backend, events, spawned, fetched, fsImpl };
 }
+
+test('createOpenCodeBackend sends official file parts and accepts after the message POST', async () => {
+  const { backend, events, fetched } = makeBackend();
+  const pending = backend.sendUser({
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: 'C:\\tmp\\notes.pdf',
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false,
+    }],
+  });
+  await flush();
+
+  const message = fetched.calls.find((call) => call.path === '/session/session_1/message');
+  assert.deepEqual(message.body, {
+    parts: [
+      { type: 'text', text: 'inspect' },
+      {
+        type: 'file',
+        mime: 'application/pdf',
+        filename: 'notes.pdf',
+        url: 'file:///C:/tmp/notes.pdf',
+      },
+    ],
+  });
+  assert.deepEqual(events[0], {
+    type: 'turn-accepted',
+    turnId: 'turn-1',
+    transport: 'opencode-file-part',
+  });
+  assert.equal(JSON.stringify(events).includes('C:\\tmp'), false);
+
+  fetched.sse.push({ type: 'session.status', properties: { sessionID: 'session_1', status: { type: 'idle' } } });
+  await pending;
+  assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
+});
+
+test('createOpenCodeBackend correlates a failed message POST as uncertain without retry', async () => {
+  const base = makeFetch();
+  let rejectMessage;
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url);
+    if (parsed.pathname === '/session/session_1/message') {
+      base.calls.push({
+        method: options.method || 'GET',
+        path: parsed.pathname,
+        body: options.body ? JSON.parse(options.body) : null,
+      });
+      return await new Promise((_resolve, reject) => { rejectMessage = reject; });
+    }
+    return base.fetchImpl(url, options);
+  };
+  const { backend, events } = makeBackend({ fetchImpl });
+  const pending = backend.sendUser({
+    turnId: 'turn-post-failed',
+    text: 'inspect',
+    attachments: [],
+  });
+  for (let index = 0; index < 20 && !rejectMessage; index += 1) await flush();
+  assert.equal(typeof rejectMessage, 'function');
+  rejectMessage(new Error('message POST disconnected'));
+  await pending;
+
+  assert.deepEqual(events.at(-1), {
+    type: 'error',
+    kind: 'mcp',
+    message: 'message POST disconnected',
+    turnId: 'turn-post-failed',
+    dispatchState: 'uncertain',
+  });
+  assert.equal(base.calls.filter((call) => call.path === '/session/session_1/message').length, 1);
+});
 
 test('createOpenCodeBackend starts opencode serve, writes isolated ae MCP config, and sends a session message', async () => {
   const { backend, spawned, fetched, fsImpl } = makeBackend();

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -8,6 +8,7 @@ async function flush() {
 }
 
 function makeProc() {
+  const stderrHandlers = [];
   const exitHandlers = [];
   const errorHandlers = [];
   let killed = false;
@@ -16,7 +17,11 @@ function makeProc() {
       return killed;
     },
     stdout: { on() {} },
-    stderr: { on() {} },
+    stderr: {
+      on(event, handler) {
+        if (event === 'data') stderrHandlers.push(handler);
+      },
+    },
     on(event, handler) {
       if (event === 'exit') exitHandlers.push(handler);
       if (event === 'error') errorHandlers.push(handler);
@@ -29,6 +34,9 @@ function makeProc() {
     },
     error(error) {
       for (const handler of errorHandlers) handler(error);
+    },
+    pushStderr(text) {
+      for (const handler of stderrHandlers) handler(text);
     },
   };
 }
@@ -204,6 +212,111 @@ test('createOpenCodeBackend sends official file parts and accepts after the mess
   fetched.sse.push({ type: 'session.status', properties: { sessionID: 'session_1', status: { type: 'idle' } } });
   await pending;
   assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
+});
+
+test('createOpenCodeBackend redacts an attachment path split across output and transcript', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const fileUrl = 'file:///C:/private/customer.mov';
+  const { backend, events, fetched } = makeBackend();
+  const pending = backend.sendUser({
+    turnId: 'turn-redact-output',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 12,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  await flush();
+
+  fetched.sse.push({
+    type: 'message.part.delta',
+    properties: { sessionID: 'session_1', field: 'text', delta: 'file:///C:/private/' },
+  });
+  fetched.sse.push({
+    type: 'message.part.delta',
+    properties: { sessionID: 'session_1', field: 'text', delta: 'customer.mov' },
+  });
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'idle' } },
+  });
+  await pending;
+
+  const rendered = JSON.stringify({ events, messages: backend.getMessages() });
+  assert.equal(rendered.includes(path), false);
+  assert.equal(rendered.includes(fileUrl), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createOpenCodeBackend redacts an attachment path split across stderr failure', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const { backend, events, spawned } = makeBackend();
+  const pending = backend.sendUser({
+    turnId: 'turn-redact-stderr',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 12,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  await flush();
+
+  const proc = spawned.procs[0];
+  proc.pushStderr('failed C:\\private\\');
+  proc.pushStderr('customer.mov');
+  proc.exit(1);
+  await pending;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createOpenCodeBackend keeps attachment stderr redaction until the persistent process exits', async () => {
+  const fileUrl = 'file:///C:/private/late-customer.mov';
+  const { backend, events, spawned, fetched } = makeBackend();
+  const first = backend.sendUser({
+    turnId: 'turn-attachment',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'late-customer.mov',
+      localPath: 'C:\\private\\late-customer.mov',
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  await flush();
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'idle' } },
+  });
+  await first;
+
+  const proc = spawned.procs[0];
+  proc.pushStderr('late file:///C:/private/');
+  proc.pushStderr('late-customer.mov');
+  const second = backend.sendUser({
+    turnId: 'turn-text-only',
+    text: 'next',
+    attachments: [],
+  });
+  await flush();
+  proc.exit(1);
+  await second;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(fileUrl), false);
+  assert.match(rendered, /\[redacted\]/);
 });
 
 test('createOpenCodeBackend correlates a failed message POST as uncertain without retry', async () => {

--- a/plugin/panel/test/providerAcceptanceBridge.test.js
+++ b/plugin/panel/test/providerAcceptanceBridge.test.js
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createProviderAcceptanceBridge } from '../src/cep/providerAcceptanceBridge.js';
+import {
+  countMentionedPanelAttachments,
+  createProviderAcceptanceBridge,
+  normalizePanelAcceptanceTurns,
+} from '../src/cep/providerAcceptanceBridge.js';
 
 const UPSTREAM_SECRET = 'sk-upstream-must-never-leave-cep';
 const SECRET_REFERENCE = 'aemcp-secret://provider/credential-id/auth-model/v1';
@@ -142,6 +146,84 @@ function assertNoUpstreamMaterial(value) {
   assert.doesNotMatch(serialized, /private-provider\.example/);
   assert.doesNotMatch(serialized, /"(?:apiRoot|auth|baseUrl|credential|headers|reference)"/);
 }
+
+test('panel acceptance turns preserve legacy prompts and structured attachment order', () => {
+  const prompts = normalizePanelAcceptanceTurns({
+    prompts: ['first', 'second'],
+  });
+  assert.deepEqual(
+    prompts.map((turn) => ({ text: turn.text, attachments: turn.attachments })),
+    [
+      { text: 'first', attachments: [] },
+      { text: 'second', attachments: [] },
+    ],
+  );
+
+  const attachments = Array.from({ length: 5 }, (_, index) => ({
+    id: `attachment-${index + 1}`,
+    name: `fixture-${index + 1}.bin`,
+    localPath: `/private/tmp/fixture-${index + 1}.bin`,
+    size: index + 1,
+    mediaType: 'application/octet-stream',
+    temporary: false,
+  }));
+  const turns = normalizePanelAcceptanceTurns({
+    turns: [{ text: 'inspect', attachments }],
+  });
+  assert.deepEqual(
+    turns[0].attachments.map((attachment) => attachment.id),
+    attachments.map((attachment) => attachment.id),
+  );
+  assert.equal(turns[0].turnId, 'provider-acceptance-1');
+});
+
+test('panel acceptance turns reject ambiguous input and relative attachment paths', () => {
+  assert.throws(
+    () => normalizePanelAcceptanceTurns({
+      prompts: ['legacy'],
+      turns: [{ text: 'structured', attachments: [] }],
+    }),
+    (error) => error.code === 'PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN',
+  );
+  assert.throws(
+    () => normalizePanelAcceptanceTurns({
+      turns: [{
+        text: '',
+        attachments: [{
+          id: 'attachment-1',
+          name: 'fixture.bin',
+          localPath: 'relative/fixture.bin',
+          size: 1,
+          mediaType: 'application/octet-stream',
+          temporary: false,
+        }],
+      }],
+    }),
+    (error) => error.code === 'PROVIDER_ACCEPTANCE_INVALID_PANEL_TURN',
+  );
+});
+
+test('panel acceptance evidence counts attachment names without returning assistant text', () => {
+  const attachments = [
+    { name: 'one.txt' },
+    { name: 'two.png' },
+    { name: 'three.pdf' },
+  ];
+  assert.equal(
+    countMentionedPanelAttachments(
+      [{ role: 'assistant', text: 'I can see one.txt and three.pdf.' }],
+      attachments,
+    ),
+    2,
+  );
+  assert.equal(
+    countMentionedPanelAttachments(
+      [{ role: 'user', text: 'one.txt two.png three.pdf' }],
+      attachments,
+    ),
+    0,
+  );
+});
 
 test('snapshot exposes only Provider identity, revisions, model ids, and capability statuses', () => {
   const bridge = createProviderAcceptanceBridge(bridgeDeps());

--- a/plugin/panel/test/providerUiClosure.test.js
+++ b/plugin/panel/test/providerUiClosure.test.js
@@ -64,6 +64,17 @@ test('Settings offers every v3 Provider to both Claude and Codex selectors', () 
   assert.match(settings, /同一个 Provider 可同时用于 Claude 和 Codex/);
 });
 
+test('Settings exposes only Claude Code and Codex as built-in backend choices', () => {
+  const settings = source('../src/screens/SettingsScreen.jsx');
+  const start = settings.indexOf('<Segmented full value={backend}');
+  const end = settings.indexOf('/>', start);
+  assert.ok(start >= 0 && end > start);
+  const options = settings.slice(start, end);
+  assert.match(options, /value:\s*'subscription'/);
+  assert.match(options, /value:\s*'codex'/);
+  assert.doesNotMatch(options, /value:\s*'zcode'/);
+});
+
 test('App routes provider probing through the v3 profile resolver and CAS flow', () => {
   const app = source('../src/app/App.jsx');
   assert.match(app, /runProviderManagerProbe\s*\(\s*provider\s*,\s*\{/);

--- a/plugin/panel/test/universalProviderRoute.test.js
+++ b/plugin/panel/test/universalProviderRoute.test.js
@@ -771,6 +771,68 @@ test('retries native Messages once without beta values after a generic invalid-b
   }
 });
 
+test('retries native Messages once without the rejected SDK context-management hint', async () => {
+  const records = [];
+  const audit = [];
+  const upstream = controlledUpstream(records, ({ res, attempt }) => {
+    if (attempt === 1) {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        error: {
+          message: 'context_management is not available for this model.',
+        },
+      }));
+      return;
+    }
+    sendNativeMessage(res);
+  });
+  await listen(upstream);
+  const apiRoot = 'http://127.0.0.1:' + upstream.address().port + '/v1';
+  const route = makeRoute({
+    apiRoot,
+    records,
+    capabilities: { 'native-r': 'responses', 'native-m': 'messages', 'chat-m': 'chat' },
+    profileCalls: [],
+    audit,
+  });
+  try {
+    const local = await route.start();
+    const result = await requestText(local.anthropicBaseUrl + '/v1/messages', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ' + local.routeToken,
+        'anthropic-beta': 'supported-beta',
+        'content-type': 'application/json',
+      },
+      body: {
+        model: 'native-m',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'OK' }],
+        context_management: {
+          edits: [{ type: 'clear_thinking_20251015', keep: 'all' }],
+        },
+      },
+    });
+    assert.equal(result.status, 200);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[0].body.context_management, {
+      edits: [{ type: 'clear_thinking_20251015', keep: 'all' }],
+    });
+    assert.equal(records[1].body.context_management, undefined);
+    assert.deepEqual(
+      { ...records[1].body, context_management: records[0].body.context_management },
+      records[0].body,
+    );
+    assert.equal(records[1].headers['anthropic-beta'], 'supported-beta');
+    assert.equal(audit.filter(
+      (entry) => entry.compatibility === 'context-management-rejected',
+    ).length, 1);
+  } finally {
+    await route.close();
+    await closeServer(upstream);
+  }
+});
+
 test('does not retry native Messages for an unrelated upstream 400', async () => {
   const records = [];
   const upstream = controlledUpstream(records, ({ res }) => {
@@ -795,6 +857,47 @@ test('does not retry native Messages for an unrelated upstream 400', async () =>
         'content-type': 'application/json',
       },
       body: { model: 'native-m', max_tokens: 16, messages: [{ role: 'user', content: 'OK' }] },
+    });
+    assert.equal(result.status, 400);
+    assert.equal(records.length, 1);
+  } finally {
+    await route.close();
+    await closeServer(upstream);
+  }
+});
+
+test('does not discard an unknown context-management contract on retry', async () => {
+  const records = [];
+  const upstream = controlledUpstream(records, ({ res }) => {
+    res.writeHead(400, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      error: { message: 'context_management is not available for this model.' },
+    }));
+  });
+  await listen(upstream);
+  const apiRoot = 'http://127.0.0.1:' + upstream.address().port + '/v1';
+  const route = makeRoute({
+    apiRoot,
+    records,
+    capabilities: { 'native-r': 'responses', 'native-m': 'messages', 'chat-m': 'chat' },
+    profileCalls: [],
+  });
+  try {
+    const local = await route.start();
+    const result = await requestText(local.anthropicBaseUrl + '/v1/messages', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ' + local.routeToken,
+        'content-type': 'application/json',
+      },
+      body: {
+        model: 'native-m',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'OK' }],
+        context_management: {
+          edits: [{ type: 'future_context_contract', keep: 'all' }],
+        },
+      },
     });
     assert.equal(result.status, 400);
     assert.equal(records.length, 1);

--- a/plugin/panel/test/universalProviderRoute.test.js
+++ b/plugin/panel/test/universalProviderRoute.test.js
@@ -719,6 +719,58 @@ test('retries native Messages once after removing only explicitly rejected Anthr
   }
 });
 
+test('retries native Messages once without beta values after a generic invalid-beta response', async () => {
+  const records = [];
+  const audit = [];
+  const upstream = controlledUpstream(records, ({ res, attempt }) => {
+    if (attempt === 1) {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        error: {
+          message: 'Invalid beta header.',
+        },
+      }));
+      return;
+    }
+    sendNativeMessage(res);
+  });
+  await listen(upstream);
+  const apiRoot = 'http://127.0.0.1:' + upstream.address().port + '/v1';
+  const route = makeRoute({
+    apiRoot,
+    records,
+    capabilities: { 'native-r': 'responses', 'native-m': 'messages', 'chat-m': 'chat' },
+    profileCalls: [],
+    audit,
+  });
+  try {
+    const local = await route.start();
+    const result = await requestText(local.anthropicBaseUrl + '/v1/messages', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ' + local.routeToken,
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'supported-beta, unsupported-beta',
+        'content-type': 'application/json',
+      },
+      body: {
+        model: 'native-m',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'OK' }],
+      },
+    });
+    assert.equal(result.status, 200);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].headers['anthropic-beta'], 'supported-beta, unsupported-beta');
+    assert.equal(records[1].headers['anthropic-beta'], undefined);
+    assert.deepEqual(records[1].body, records[0].body);
+    assert.equal(audit.filter((entry) => entry.event === 'provider_route_compat_retry').length, 1);
+  } finally {
+    await route.close();
+    await closeServer(upstream);
+  }
+});
+
 test('does not retry native Messages for an unrelated upstream 400', async () => {
   const records = [];
   const upstream = controlledUpstream(records, ({ res }) => {

--- a/plugin/panel/test/zcodeBackend.test.js
+++ b/plugin/panel/test/zcodeBackend.test.js
@@ -198,6 +198,129 @@ test('createZcodeBackend sends one attachment manifest while keeping transcript 
   await pending;
 });
 
+test('createZcodeBackend preserves the attachment manifest after first-turn instructions', async () => {
+  const { backend, spawned } = makeBackend({
+    getServerInstructions: () => 'Follow the server contract.',
+  });
+  const { pending, proc, sendReq } = await startTurn(backend, spawned, {
+    turnId: 'turn-instructions',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: 'C:\\private\\notes.pdf',
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false,
+    }],
+  });
+
+  assert.match(
+    sendReq.params.content,
+    /^Follow the server contract\.\n\n---\n\ninspect\n\n<ae_mcp_attachments version="1">\n/,
+  );
+  assert.match(sendReq.params.content, /"path":"C:\\\\private\\\\notes\.pdf"/);
+
+  pushEvent(proc, 'turn.completed', { response: 'done' });
+  await pending;
+});
+
+test('createZcodeBackend redacts an attachment path split across output and transcript', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const { backend, events, spawned } = makeBackend();
+  const { pending, proc } = await startTurn(backend, spawned, {
+    turnId: 'turn-redact-output',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+
+  pushEvent(proc, 'model.streaming', {
+    delta: 'C:\\private\\',
+    kind: 'text_delta',
+    done: false,
+  });
+  pushEvent(proc, 'model.streaming', {
+    delta: 'customer.mov',
+    kind: 'text_delta',
+    done: false,
+  });
+  pushEvent(proc, 'turn.completed', { response: path });
+  await pending;
+
+  const rendered = JSON.stringify({ events, messages: backend.getMessages() });
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createZcodeBackend redacts an attachment path split across stderr failure', async () => {
+  const path = 'C:\\private\\customer.mov';
+  const { backend, events, spawned } = makeBackend();
+  const pending = backend.sendUser({
+    turnId: 'turn-redact-stderr',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  await flush();
+
+  const proc = spawned.procs[0];
+  proc.pushStderr('failed C:\\private\\');
+  proc.pushStderr('customer.mov');
+  proc.exit(1);
+  await pending;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
+test('createZcodeBackend keeps attachment stderr redaction until the persistent process exits', async () => {
+  const path = 'C:\\private\\late-customer.mov';
+  const { backend, events, spawned } = makeBackend();
+  const first = await startTurn(backend, spawned, {
+    turnId: 'turn-attachment',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'late-customer.mov',
+      localPath: path,
+      size: 20,
+      mediaType: 'video/quicktime',
+      temporary: false,
+    }],
+  });
+  pushEvent(first.proc, 'turn.completed', { response: 'done' });
+  await first.pending;
+
+  first.proc.pushStderr('late C:\\private\\');
+  first.proc.pushStderr('late-customer.mov');
+  const second = backend.sendUser({
+    turnId: 'turn-text-only',
+    text: 'next',
+    attachments: [],
+  });
+  await flush();
+  first.proc.exit(1);
+  await second;
+
+  const rendered = JSON.stringify(events);
+  assert.equal(rendered.includes(path), false);
+  assert.match(rendered, /\[redacted\]/);
+});
+
 test('createZcodeBackend correlates a rejected session/send as uncertain without retry', async () => {
   const { backend, events, spawned } = makeBackend();
   const pending = backend.sendUser({

--- a/plugin/panel/test/zcodeBackend.test.js
+++ b/plugin/panel/test/zcodeBackend.test.js
@@ -171,6 +171,62 @@ async function startTurn(backend, spawned, text = 'hello') {
 
 // --- tests ---
 
+test('createZcodeBackend sends one attachment manifest while keeping transcript text path-free', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const { pending, proc, sendReq } = await startTurn(backend, spawned, {
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [
+      { id: 'att-1', name: 'notes.pdf', localPath: 'C:\\tmp\\notes.pdf', size: 12, mediaType: 'application/pdf', temporary: false },
+      { id: 'att-2', name: 'clip.mov', localPath: 'C:\\tmp\\clip.mov', size: 20, mediaType: 'video/quicktime', temporary: false },
+    ],
+  });
+
+  assert.match(sendReq.params.content, /^inspect\n\n<ae_mcp_attachments version="1">\n/);
+  assert.match(sendReq.params.content, /"path":"C:\\\\tmp\\\\notes\.pdf"/);
+  assert.match(sendReq.params.content, /"path":"C:\\\\tmp\\\\clip\.mov"/);
+  assert.equal((sendReq.params.content.match(/<ae_mcp_attachments/g) || []).length, 1);
+  assert.deepEqual(events.find((event) => event.type === 'turn-accepted'), {
+    type: 'turn-accepted',
+    turnId: 'turn-1',
+    transport: 'zcode-manifest',
+  });
+  assert.deepEqual(backend.getMessages()[0], { role: 'user', text: 'inspect' });
+  assert.equal(JSON.stringify({ events, messages: backend.getMessages() }).includes('C:\\tmp'), false);
+
+  pushEvent(proc, 'turn.completed', { response: 'done' });
+  await pending;
+});
+
+test('createZcodeBackend correlates a rejected session/send as uncertain without retry', async () => {
+  const { backend, events, spawned } = makeBackend();
+  const pending = backend.sendUser({
+    turnId: 'turn-send-failed',
+    text: 'inspect',
+    attachments: [],
+  });
+  await flush();
+  const proc = spawned.procs[0];
+  const createReq = parseWrites(proc)[0];
+  respond(proc, createReq, { session: { sessionId: 'sess_test' }, settings: { model: { available: [] } } });
+  await flush();
+  const subReq = parseWrites(proc).find((message) => message.method === 'session/subscribe');
+  respond(proc, subReq, { sessionId: 'sess_test', eventSeq: 0 });
+  await flush();
+  const sendReq = parseWrites(proc).find((message) => message.method === 'session/send');
+  reject(proc, sendReq, 'session/send disconnected');
+  await pending;
+
+  assert.deepEqual(events.at(-1), {
+    type: 'error',
+    kind: 'mcp',
+    message: 'session/send disconnected',
+    turnId: 'turn-send-failed',
+    dispatchState: 'uncertain',
+  });
+  assert.equal(parseWrites(proc).filter((message) => message.method === 'session/send').length, 1);
+});
+
 test('createZcodeBackend spawns node with zcode.cjs app-server args', async () => {
   const { backend, spawned } = makeBackend();
   backend.sendUser('hello');

--- a/plugin/shared/chat-attachments.mjs
+++ b/plugin/shared/chat-attachments.mjs
@@ -1,0 +1,113 @@
+export const MAX_ATTACHMENTS_PER_TURN = 32;
+export const MAX_CLIPBOARD_ITEM_BYTES = 256 * 1024 * 1024;
+export const MAX_CLIPBOARD_TURN_BYTES = 512 * 1024 * 1024;
+export const ATTACHMENT_MANIFEST_OPEN = '<ae_mcp_attachments version="1">';
+export const ATTACHMENT_MANIFEST_CLOSE = '</ae_mcp_attachments>';
+
+function requireString(value, field, { allowEmpty = false } = {}) {
+  if (typeof value !== 'string' || (!allowEmpty && !value)) {
+    throw new TypeError(field + ' must be ' + (allowEmpty ? 'a string' : 'a non-empty string'));
+  }
+  return value;
+}
+
+function normalizeAttachment(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('attachment must be an object');
+  }
+  if (!Number.isSafeInteger(value.size) || value.size < 0) {
+    throw new TypeError('attachment.size must be a non-negative safe integer');
+  }
+  if (typeof value.temporary !== 'boolean') {
+    throw new TypeError('attachment.temporary must be a boolean');
+  }
+  const attachment = {
+    id: requireString(value.id, 'attachment.id'),
+    name: requireString(value.name, 'attachment.name'),
+    localPath: requireString(value.localPath, 'attachment.localPath'),
+    size: value.size,
+    mediaType: value.mediaType === undefined
+      ? ''
+      : requireString(value.mediaType, 'attachment.mediaType', { allowEmpty: true }),
+    temporary: value.temporary,
+  };
+  return Object.freeze(attachment);
+}
+
+export function normalizeTurnInput(input) {
+  const source = typeof input === 'string'
+    ? { turnId: '', text: input, attachments: [] }
+    : input;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    throw new TypeError('turn input must be a string or object');
+  }
+  const attachments = source.attachments;
+  if (!Array.isArray(attachments)) {
+    throw new TypeError('turn.attachments must be an array');
+  }
+  if (attachments.length > MAX_ATTACHMENTS_PER_TURN) {
+    throw new TypeError('turn.attachments exceeds the per-turn limit');
+  }
+  const normalized = {
+    turnId: requireString(source.turnId, 'turn.turnId', { allowEmpty: true }),
+    text: requireString(source.text, 'turn.text', { allowEmpty: true }),
+    attachments: Object.freeze(attachments.map(normalizeAttachment)),
+  };
+  return Object.freeze(normalized);
+}
+
+export function displayAttachments(attachments) {
+  return attachments.map((value) => {
+    const { id, name, size, mediaType } = normalizeAttachment(value);
+    return Object.freeze({
+      id,
+      name,
+      size,
+      ...(mediaType ? { mediaType } : {}),
+    });
+  });
+}
+
+export function attachmentManifest(attachments) {
+  const files = attachments.map((value) => {
+    const { id, name, localPath, size, mediaType } = normalizeAttachment(value);
+    return {
+      id,
+      name,
+      path: localPath,
+      size,
+      mediaType: mediaType || 'application/octet-stream',
+    };
+  });
+  return ATTACHMENT_MANIFEST_OPEN + '\n'
+    + JSON.stringify({ files }) + '\n'
+    + ATTACHMENT_MANIFEST_CLOSE;
+}
+
+export function withAttachmentManifest(text, attachments) {
+  const body = String(text || '');
+  if (!attachments.length) return body;
+  const manifest = attachmentManifest(attachments);
+  return body ? body + '\n\n' + manifest : manifest;
+}
+
+function encodePathSegments(value) {
+  return value.split('/').map((part) => encodeURIComponent(part)).join('/');
+}
+
+export function attachmentFileUrl(localPath, platformId) {
+  requireString(localPath, 'attachment path');
+  if (platformId === 'macos-arm64') {
+    if (!localPath.startsWith('/')) throw new TypeError('macOS attachment path must be absolute');
+    return 'file://' + encodePathSegments(localPath);
+  }
+  if (platformId === 'windows-x64') {
+    const normalized = localPath.replaceAll('\\', '/');
+    if (!/^[A-Za-z]:\//.test(normalized)) {
+      throw new TypeError('Windows attachment path must be absolute');
+    }
+    const drive = normalized.slice(0, 2);
+    return 'file:///' + drive + encodePathSegments(normalized.slice(2));
+  }
+  throw new TypeError('unsupported attachment platform: ' + platformId);
+}

--- a/plugin/shared/chat-attachments.mjs
+++ b/plugin/shared/chat-attachments.mjs
@@ -53,6 +53,9 @@ export function normalizeTurnInput(input) {
     text: requireString(source.text, 'turn.text', { allowEmpty: true }),
     attachments: Object.freeze(attachments.map(normalizeAttachment)),
   };
+  if (!normalized.text.trim() && !normalized.attachments.length) {
+    throw new TypeError('turn requires text or attachments');
+  }
   return Object.freeze(normalized);
 }
 
@@ -102,7 +105,10 @@ export function attachmentFileUrl(localPath, platformId) {
     return 'file://' + encodePathSegments(localPath);
   }
   if (platformId === 'windows-x64') {
-    const normalized = localPath.replaceAll('\\', '/');
+    const normalized = localPath.replace(/\\/g, '/');
+    if (normalized.startsWith('//')) {
+      return 'file://' + encodePathSegments(normalized.slice(2));
+    }
     if (!/^[A-Za-z]:\//.test(normalized)) {
       throw new TypeError('Windows attachment path must be absolute');
     }

--- a/plugin/sidecar/lib.mjs
+++ b/plugin/sidecar/lib.mjs
@@ -5,6 +5,9 @@ import {
   isCoreAuthorizedDynamicCall,
   planSessionKey
 } from '../shared/tool-approval.mjs'
+import { realpathSync as defaultRealpathSync, statSync as defaultStatSync } from 'node:fs'
+import { isAbsolute as defaultIsAbsolute } from 'node:path'
+import { normalizeTurnInput, withAttachmentManifest } from '../shared/chat-attachments.mjs'
 
 const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
 
@@ -24,6 +27,7 @@ const PROVIDER_ENV_KEYS = [
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN'
 ]
+const ATTACHMENT_READ_RULE = 'Read may be used only for exact paths listed in the current <ae_mcp_attachments> manifest.'
 
 const SYSTEM_PROMPTS = {
   zh: `你是 After Effects 面板内的助手。只使用 ae_ 前缀工具操作 After Effects。回答简短，优先直接完成用户请求。
@@ -95,7 +99,16 @@ export function parseArgv(argv) {
   return options
 }
 
-export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date.now }) {
+export function createSidecar({
+  queryFn,
+  writeLine,
+  argvOptions,
+  env,
+  now = Date.now,
+  isAbsolute = defaultIsAbsolute,
+  realpathSync = defaultRealpathSync,
+  statSync = defaultStatSync
+}) {
   if (typeof queryFn !== 'function') {
     throw new Error('queryFn is required')
   }
@@ -154,8 +167,27 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
   }
 
   function startTurn(message) {
+    let input
+    try {
+      input = canonicalAttachmentTurn(message)
+    } catch {
+      emitEvent({
+        type: 'error',
+        kind: 'attachment',
+        code: 'ATTACHMENT_PATH_INVALID',
+        message: 'Selected attachment path is unavailable: [attachment-path]',
+        turnId: typeof message.turnId === 'string' ? message.turnId : '',
+        dispatchState: 'not-started'
+      })
+      return
+    }
     const controller = new AbortController()
     const turn = {
+      turnId: input.turnId,
+      text: input.text,
+      attachments: input.attachments,
+      selectedRealPaths: new Set(input.attachments.map((attachment) => attachment.localPath)),
+      model: typeof message.model === 'string' && message.model ? message.model : options.model,
       permissionMode: normalizePermissionMode(message.permissionMode),
       effort: typeof message.effort === 'string' && message.effort ? message.effort : 'high',
       thinking: message.thinking === 'adaptive' ? { type: 'adaptive' } : null,
@@ -171,7 +203,7 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
 
     emitEvent({ type: 'turn-start' })
 
-    runTurn(message, turn).finally(() => {
+    runTurn(turn).finally(() => {
       drainApprovals('Turn ended.')
       if (activeTurn === turn) {
         activeTurn = null
@@ -179,14 +211,46 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
     })
   }
 
-  async function runTurn(message, turn) {
+  function canonicalAttachmentTurn(message) {
+    const normalized = normalizeTurnInput({
+      turnId: typeof message.turnId === 'string' ? message.turnId : '',
+      text: typeof message.text === 'string' ? message.text : '',
+      attachments: Array.isArray(message.attachments) ? message.attachments : []
+    })
+    const attachments = normalized.attachments.map((attachment) => {
+      if (!isAbsolute(attachment.localPath)) throw new Error('attachment path must be absolute')
+      const realPath = String(realpathSync(attachment.localPath))
+      if (!isAbsolute(realPath) || !statSync(realPath).isFile()) {
+        throw new Error('attachment path must resolve to a file')
+      }
+      return Object.freeze({ ...attachment, localPath: realPath })
+    })
+    return Object.freeze({
+      turnId: normalized.turnId,
+      text: normalized.text,
+      attachments: Object.freeze(attachments)
+    })
+  }
+
+  function redactAttachmentPaths(value, turn) {
+    let output = String(value || '')
+    for (const path of turn.selectedRealPaths) {
+      output = output.split(path).join('[attachment-path]')
+    }
+    return output
+  }
+
+  async function runTurn(turn) {
     let sawResult = false
     try {
-      const model = typeof message.model === 'string' && message.model ? message.model : options.model
+      const model = typeof turn.model === 'string' && turn.model ? turn.model : options.model
       const queryOptions = buildTurnOptions({ model, turn })
+      if (turn.turnId) {
+        emitEvent({ type: 'turn-accepted', turnId: turn.turnId, transport: 'claude-agent-sdk' })
+      }
 
       for await (const sdkMessage of queryFn({
-        prompt: String(message.text || ''),
+        prompt: withAttachmentManifest(turn.text, turn.attachments),
         options: queryOptions
       })) {
         if (sdkMessage && sdkMessage.type === 'result') sawResult = true
@@ -205,19 +269,24 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
         emitAbortedOnce(turn)
         return
       }
-      emitTerminalEvent(turn, { type: 'error', kind: classifyError(error), message: truncateDetail(error) })
+      emitTerminalEvent(turn, {
+        type: 'error',
+        kind: classifyError(error),
+        message: redactAttachmentPaths(truncateDetail(error), turn)
+      })
     }
   }
 
   function buildTurnOptions({ model, turn }) {
     const tiered = tierTools(turn.permissionMode)
+    const attachmentTools = turn.attachments.length ? ['Read'] : []
     const queryOptions = {
       model,
       mcpServers: buildMcpServers(),
-      allowedTools: tiered.allowedTools,
+      allowedTools: uniqueToolList([...tiered.allowedTools, ...attachmentTools]),
       disallowedTools: DISALLOWED_TOOLS,
       settingSources: [],
-      agents: buildAgents(),
+      agents: buildAgents(turn),
       agent: 'ae',
       canUseTool: async (toolName, input) => canUseTool(toolName, input, turn),
       onElicitation: async (request, context = {}) => handleElicitation(request, turn, context.signal),
@@ -275,14 +344,19 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
     }
   }
 
-  function buildAgents() {
+  function buildAgents(turn) {
+    const attachmentTools = turn.attachments.length ? ['Read'] : []
+    const prompt = turn.attachments.length
+      ? SYSTEM_PROMPTS[options.lang] + '\n\n' + ATTACHMENT_READ_RULE
+      : SYSTEM_PROMPTS[options.lang]
     return {
       ae: {
         description: 'After Effects panel assistant',
-        prompt: SYSTEM_PROMPTS[options.lang],
+        prompt,
         tools: uniqueToolList([
           ...Object.keys(options.annotations),
-          ...options.allowedTools
+          ...options.allowedTools,
+          ...attachmentTools
         ])
       }
     }
@@ -350,7 +424,7 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
         emitTerminalEvent(turn, {
           type: 'error',
           kind: classifyError(message.result || message),
-          message: truncateDetail(message.result || message)
+          message: redactAttachmentPaths(truncateDetail(message.result || message), turn)
         })
       } else {
         emitTerminalEvent(turn, {
@@ -363,6 +437,25 @@ export function createSidecar({ queryFn, writeLine, argvOptions, env, now = Date
 
   async function canUseTool(toolName, input, turn) {
     const name = String(toolName || '')
+    if (name === 'Read') {
+      const filePath = input && input.file_path
+      if (!turn.attachments.length || typeof filePath !== 'string' || !isAbsolute(filePath)) {
+        return { behavior: 'deny', message: 'Read is limited to selected attachment files.' }
+      }
+      try {
+        const realPath = String(realpathSync(filePath))
+        if (
+          realPath !== filePath
+          || !statSync(realPath).isFile()
+          || !turn.selectedRealPaths.has(realPath)
+        ) {
+          return { behavior: 'deny', message: 'Read is limited to selected attachment files.' }
+        }
+        return { behavior: 'allow', updatedInput: input }
+      } catch {
+        return { behavior: 'deny', message: 'Read is limited to selected attachment files.' }
+      }
+    }
     if (!name.startsWith('mcp__ae__')) {
       return {
         behavior: 'deny',

--- a/plugin/sidecar/test/sidecar.test.js
+++ b/plugin/sidecar/test/sidecar.test.js
@@ -89,6 +89,173 @@ test('maps user turn, text, tool_use, tool_result, and result events', async () 
   ])
 })
 
+test('attachment turns expose only exact canonical selected files through Read', async () => {
+  const writes = []
+  let queryInput
+  let releaseQuery
+  const queryGate = new Promise((resolve) => { releaseQuery = resolve })
+  const selectedRealPath = '/private/selected/notes.pdf'
+  const realpaths = new Map([
+    ['/tmp/selected-link.pdf', selectedRealPath],
+    [selectedRealPath, selectedRealPath],
+    ['/tmp/other.pdf', '/tmp/other.pdf'],
+    ['/tmp/dir', '/tmp/dir'],
+    ['/tmp/selected/../selected-link.pdf', selectedRealPath],
+    ['/tmp/outside-link.pdf', '/private/outside.pdf']
+  ])
+  const sidecar = createSidecar({
+    queryFn: async function * (input) {
+      queryInput = input
+      await queryGate
+      yield { type: 'result', subtype: 'success', is_error: false }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {},
+    isAbsolute: (value) => String(value).startsWith('/'),
+    realpathSync: (value) => {
+      if (!realpaths.has(value)) throw new Error('missing')
+      return realpaths.get(value)
+    },
+    statSync: (value) => ({ isFile: () => value !== '/tmp/dir' })
+  })
+
+  sidecar.handleLine(JSON.stringify({
+    t: 'user',
+    turnId: 'turn-1',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: '/tmp/selected-link.pdf',
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false
+    }],
+    permissionMode: 'none'
+  }))
+  await waitFor(() => queryInput !== undefined)
+
+  assert.match(queryInput.prompt, /^inspect\n\n<ae_mcp_attachments version="1">\n/)
+  assert.match(queryInput.prompt, /"path":"\/private\/selected\/notes\.pdf"/)
+  assert.equal(queryInput.options.allowedTools.includes('Read'), true)
+  assert.equal(queryInput.options.agents.ae.tools.includes('Read'), true)
+  assert.match(queryInput.options.agents.ae.prompt, /exact paths listed in the current <ae_mcp_attachments>/)
+  assert.deepEqual(events(writes)[0], {
+    type: 'turn-start'
+  })
+  assert.deepEqual(events(writes)[1], {
+    type: 'turn-accepted',
+    turnId: 'turn-1',
+    transport: 'claude-agent-sdk'
+  })
+  assert.equal(JSON.stringify(events(writes)).includes('/private/selected'), false)
+
+  assert.deepEqual(
+    await queryInput.options.canUseTool('Read', { file_path: selectedRealPath }),
+    { behavior: 'allow', updatedInput: { file_path: selectedRealPath } }
+  )
+  for (const [tool, input] of [
+    ['Read', { file_path: '/tmp/other.pdf' }],
+    ['Read', { file_path: '/tmp/dir' }],
+    ['Read', { file_path: '/tmp/selected/../selected-link.pdf' }],
+    ['Read', { file_path: '/tmp/outside-link.pdf' }],
+    ['Read', {}],
+    ['Write', { file_path: selectedRealPath }],
+    ['Edit', { file_path: selectedRealPath }],
+    ['Bash', { command: 'cat ' + selectedRealPath }],
+    ['Glob', { pattern: '**/*' }]
+  ]) {
+    assert.equal((await queryInput.options.canUseTool(tool, input)).behavior, 'deny')
+  }
+
+  releaseQuery()
+  await waitFor(() => eventCount(writes, 'turn-end') === 1)
+})
+
+test('invalid selected attachment paths fail before query without leaking the path', async () => {
+  const writes = []
+  let queryCalls = 0
+  const sidecar = createSidecar({
+    queryFn: async function * () {
+      queryCalls += 1
+      yield { type: 'result', subtype: 'success', is_error: false }
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {},
+    isAbsolute: (value) => String(value).startsWith('/'),
+    realpathSync: (value) => value,
+    statSync: () => ({ isFile: () => false })
+  })
+
+  sidecar.handleLine(JSON.stringify({
+    t: 'user',
+    turnId: 'turn-invalid',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'folder',
+      localPath: '/private/not-a-file',
+      size: 0,
+      mediaType: '',
+      temporary: false
+    }],
+    permissionMode: 'none'
+  }))
+  await waitFor(() => eventCount(writes, 'error') === 1)
+
+  assert.equal(queryCalls, 0)
+  assert.deepEqual(events(writes).at(-1), {
+    type: 'error',
+    kind: 'attachment',
+    code: 'ATTACHMENT_PATH_INVALID',
+    message: 'Selected attachment path is unavailable: [attachment-path]',
+    turnId: 'turn-invalid',
+    dispatchState: 'not-started'
+  })
+  assert.equal(JSON.stringify(events(writes)).includes('/private/not-a-file'), false)
+})
+
+test('attachment query failures redact the selected real path', async () => {
+  const writes = []
+  const selectedPath = '/private/selected/notes.pdf'
+  const sidecar = createSidecar({
+    queryFn: async function * () {
+      throw new Error('cannot read ' + selectedPath)
+    },
+    writeLine: (obj) => writes.push(obj),
+    argvOptions: defaultOptions,
+    env: {},
+    isAbsolute: (value) => String(value).startsWith('/'),
+    realpathSync: (value) => value,
+    statSync: () => ({ isFile: () => true })
+  })
+
+  sidecar.handleLine(JSON.stringify({
+    t: 'user',
+    turnId: 'turn-query-failed',
+    text: 'inspect',
+    attachments: [{
+      id: 'att-1',
+      name: 'notes.pdf',
+      localPath: selectedPath,
+      size: 12,
+      mediaType: 'application/pdf',
+      temporary: false
+    }],
+    permissionMode: 'none'
+  }))
+  await waitFor(() => eventCount(writes, 'error') === 1)
+
+  assert.equal(JSON.stringify(events(writes)).includes(selectedPath), false)
+  assert.deepEqual(events(writes).at(-1), {
+    type: 'error',
+    kind: 'network',
+    message: 'cannot read [attachment-path]'
+  })
+})
+
 test('clean SDK EOF without a result emits one structured terminal error', async () => {
   const writes = []
   const sidecar = createSidecar({

--- a/scripts/dev/ae-mcp-dev.mjs
+++ b/scripts/dev/ae-mcp-dev.mjs
@@ -122,6 +122,7 @@ export async function main(
       home: command.home,
       formalAeApp: command.formalAeApp,
       components: command.components,
+      requireNode: command.action === 'launch-ae',
       environment,
       dependencies,
     });

--- a/scripts/dev/macos-development.mjs
+++ b/scripts/dev/macos-development.mjs
@@ -9,6 +9,8 @@ import {
 } from './profile-contract.mjs';
 
 const execFileAsync = promisify(childProcess.execFile);
+const DEVELOPMENT_NODE_MINIMUM = '24.17.0';
+const RUNTIME_GENERATION = /^g-[0-9a-f]{16}$/;
 const CORE_IMPORT_PROBE = [
   'import pathlib,sys',
   'sys.path.insert(0,sys.argv[1])',
@@ -33,6 +35,19 @@ function inside(candidate, root) {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function compareVersions(left, right) {
+  const values = (value) => String(value).split(/[+-]/, 1)[0].split('.').map(Number);
+  const a = values(left);
+  const b = values(right);
+  if (a.length !== 3 || b.length !== 3
+      || a.some((value) => !Number.isSafeInteger(value) || value < 0)
+      || b.some((value) => !Number.isSafeInteger(value) || value < 0)) return null;
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] < b[index] ? -1 : 1;
+  }
+  return 0;
+}
+
 async function ordinaryPath(dependencies, target, {
   directory = false,
   executable = false,
@@ -49,6 +64,114 @@ async function ordinaryPath(dependencies, target, {
   }
   if (executable && (info.mode & 0o111) === 0) throw new Error('not executable');
   return resolved;
+}
+
+async function activeRuntimeNodeCandidate(dependencies, home) {
+  const runtimeRoot = path.join(home, '.ae-mcp', 'runtime');
+  const currentPointer = path.join(runtimeRoot, 'current');
+  try {
+    const info = await dependencies.fs.lstat(currentPointer);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > 256) {
+      return { code: 'DEV_NODE_RUNTIME_INVALID' };
+    }
+    const relative = String(
+      await dependencies.fs.readFile(currentPointer, 'utf8'),
+    ).trim();
+    const parts = relative.split('/');
+    const generation = parts.length === 2
+      && parts[0] === 'generations'
+      && RUNTIME_GENERATION.test(parts[1]);
+    const legacy = parts.length === 2
+      && parts[1] === 'macos-arm64'
+      && parts[0] !== '.'
+      && parts[0] !== '..'
+      && !parts[0].includes('\\')
+      && !parts[0].includes('\0');
+    if (!generation && !legacy) return { code: 'DEV_NODE_RUNTIME_INVALID' };
+    return {
+      path: generation
+        ? path.join(runtimeRoot, relative, 'runtime', 'node', 'bin', 'node')
+        : path.join(runtimeRoot, relative, 'node', 'bin', 'node'),
+      runtimeRoot,
+      source: 'active-runtime',
+    };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    return { code: 'DEV_NODE_RUNTIME_INVALID' };
+  }
+}
+
+async function inspectDevelopmentNode(checks, dependencies, home, environment) {
+  const explicit = typeof environment?.AE_MCP_NODE_CLI === 'string'
+    ? environment.AE_MCP_NODE_CLI.trim()
+    : '';
+  let candidate;
+  if (explicit) {
+    candidate = path.isAbsolute(explicit)
+      ? { path: explicit, source: 'explicit' }
+      : { code: 'DEV_NODE_RUNTIME_INVALID' };
+  } else {
+    candidate = await activeRuntimeNodeCandidate(dependencies, home);
+  }
+  if (!candidate) {
+    checks.push(frozenCheck(
+      'development-node',
+      false,
+      '',
+      'DEV_NODE_RUNTIME_MISSING',
+    ));
+    return;
+  }
+  if (candidate.code) {
+    checks.push(frozenCheck('development-node', false, '', candidate.code));
+    return;
+  }
+
+  try {
+    const resolved = await ordinaryPath(
+      dependencies,
+      candidate.path,
+      { executable: true, allowSymlink: true },
+    );
+    if (candidate.runtimeRoot) {
+      const canonicalRoot = await dependencies.realpath(candidate.runtimeRoot);
+      if (!inside(resolved, canonicalRoot)) throw new Error('runtime Node escaped root');
+    }
+    const result = await dependencies.execFile(
+      resolved,
+      ['-p', 'process.version + " " + process.arch'],
+      {
+        env: environment,
+        shell: false,
+        encoding: 'utf8',
+      },
+    );
+    const match = String(result.stdout || '').trim().match(
+      /^v([0-9]+\.[0-9]+\.[0-9]+) (arm64)$/,
+    );
+    const compared = match ? compareVersions(match[1], DEVELOPMENT_NODE_MINIMUM) : null;
+    if (!match || compared === null || compared < 0) {
+      throw new Error('development Node is incompatible');
+    }
+    checks.push(frozenCheck(
+      'development-node',
+      true,
+      resolved,
+      undefined,
+      {
+        version: match[1],
+        arch: match[2],
+        source: candidate.source,
+      },
+    ));
+  } catch {
+    checks.push(frozenCheck(
+      'development-node',
+      false,
+      candidate.path,
+      'DEV_NODE_RUNTIME_INVALID',
+    ));
+  }
 }
 
 async function inspectPath(checks, dependencies, {
@@ -113,6 +236,7 @@ async function inspectRequiredPaths({
   home,
   formalAeApp,
   components,
+  requireNode,
   environment,
   dependencies,
 }) {
@@ -305,6 +429,9 @@ async function inspectRequiredPaths({
       directory: true,
     });
   }
+  if (requireNode) {
+    await inspectDevelopmentNode(checks, dependencies, home, environment);
+  }
 
   return checks;
 }
@@ -359,6 +486,7 @@ export async function inspectDevelopmentEnvironment({
   home,
   formalAeApp,
   components = ['core'],
+  requireNode = false,
   environment = process.env,
   dependencies = createDefaultMacosDependencies(),
 }) {
@@ -379,6 +507,7 @@ export async function inspectDevelopmentEnvironment({
     home,
     formalAeApp,
     components,
+    requireNode,
     environment,
     dependencies: merged,
   });
@@ -391,6 +520,9 @@ export async function inspectDevelopmentEnvironment({
     interpreterPath: checks.find((check) => check.id === 'core-interpreter').path,
     formalAeApp: checks.find((check) => check.id === 'formal-ae-app').path,
     formalAeExecutable: checks.find((check) => check.id === 'formal-ae-executable').path,
+    ...(requireNode ? {
+      nodePath: checks.find((check) => check.id === 'development-node').path,
+    } : {}),
     checks: Object.freeze(checks),
     blockers: Object.freeze(blockers),
   });
@@ -408,6 +540,12 @@ export async function launchDevelopmentAe(report, {
       'development environment must pass doctor before launch',
     );
   }
+  if (!report.nodePath) {
+    throw developmentError(
+      'DEV_NODE_RUNTIME_MISSING',
+      'development launch requires a compatible Node runtime',
+    );
+  }
   if (await processInspector.afterEffectsRunning()) {
     throw developmentError(
       'DEV_AE_ALREADY_RUNNING',
@@ -419,7 +557,11 @@ export async function launchDevelopmentAe(report, {
     detached: true,
     stdio: 'ignore',
     shell: false,
-    env: { ...environment, AE_MCP_DEV_RUNTIME: report.checkoutPath },
+    env: {
+      ...environment,
+      AE_MCP_DEV_RUNTIME: report.checkoutPath,
+      AE_MCP_NODE_CLI: report.nodePath,
+    },
   });
   child.unref();
   return Object.freeze({

--- a/scripts/dev/test/ae-mcp-dev.test.mjs
+++ b/scripts/dev/test/ae-mcp-dev.test.mjs
@@ -133,6 +133,15 @@ test('CLI reports an already-running AE without spawning another host', async ()
   assert.equal(result.output.error.code, 'DEV_AE_ALREADY_RUNNING');
 });
 
+test('CLI launch requires doctor to resolve a compatible development Node', async () => {
+  const h = harness();
+  const result = await main(['launch-ae'], h);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(h.calls[0].kind, 'doctor');
+  assert.equal(h.calls[0].options.requireNode, true);
+});
+
 test('Core-only sync has zero process steps and ignores CEP source dependency state', async () => {
   const h = harness();
   const result = await main(['sync', '--component', 'core'], h);

--- a/scripts/dev/test/macos-development.test.mjs
+++ b/scripts/dev/test/macos-development.test.mjs
@@ -216,12 +216,95 @@ test('doctor checks CEP source dependencies only when CEP is selected', async (t
   ).length, 3);
 });
 
-test('launch refuses a running AE and otherwise spawns only the exact formal executable', async (t) => {
+test('launch doctor reuses and validates the active RuntimeManager Node without installing', async (t) => {
+  const h = await fixture(t);
+  const runtimeRoot = path.join(h.home, '.ae-mcp', 'runtime');
+  const relative = 'generations/g-0123456789abcdef';
+  const nodePath = await writeFile(
+    runtimeRoot,
+    `${relative}/runtime/node/bin/node`,
+    '#!/bin/sh\nexit 0\n',
+    0o755,
+  );
+  await writeFile(runtimeRoot, 'current', `${relative}\n`);
+  const canonicalNode = await fs.promises.realpath(nodePath);
+  const originalExecFile = h.dependencies.execFile;
+  h.dependencies.execFile = async (file, args, options) => {
+    if (file === canonicalNode) {
+      h.calls.push({ file, args, options });
+      return { stdout: 'v24.17.0 arm64\n', stderr: '' };
+    }
+    return originalExecFile(file, args, options);
+  };
+
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    requireNode: true,
+    dependencies: h.dependencies,
+  });
+
+  assert.equal(report.ok, true, JSON.stringify(report, null, 2));
+  assert.equal(report.nodePath, canonicalNode);
+  assert.deepEqual(
+    report.checks.find((check) => check.id === 'development-node'),
+    {
+      id: 'development-node',
+      ok: true,
+      path: canonicalNode,
+      version: '24.17.0',
+      arch: 'arm64',
+      source: 'active-runtime',
+    },
+  );
+  assert.equal(
+    h.calls.some((call) => call.file === canonicalNode
+      && call.args.join(' ') === '-p process.version + " " + process.arch'),
+    true,
+  );
+});
+
+test('launch doctor fails closed when no compatible development Node is available', async (t) => {
   const h = await fixture(t);
   const report = await inspectDevelopmentEnvironment({
     repoRoot: h.repoRoot,
     home: h.home,
     formalAeApp: h.formalAeApp,
+    requireNode: true,
+    environment: {},
+    dependencies: h.dependencies,
+  });
+
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.blockers.map((item) => item.code), [
+    'DEV_NODE_RUNTIME_MISSING',
+  ]);
+});
+
+test('launch refuses a running AE and otherwise spawns only the exact formal executable', async (t) => {
+  const h = await fixture(t);
+  const nodePath = await writeFile(
+    h.root,
+    'node-v24/bin/node',
+    '#!/bin/sh\nexit 0\n',
+    0o755,
+  );
+  const originalExecFile = h.dependencies.execFile;
+  const canonicalNode = await fs.promises.realpath(nodePath);
+  h.dependencies.execFile = async (file, args, options) => {
+    if (file === canonicalNode) {
+      h.calls.push({ file, args, options });
+      return { stdout: 'v24.17.0 arm64\n', stderr: '' };
+    }
+    return originalExecFile(file, args, options);
+  };
+  const report = await inspectDevelopmentEnvironment({
+    repoRoot: h.repoRoot,
+    home: h.home,
+    formalAeApp: h.formalAeApp,
+    requireNode: true,
+    environment: { AE_MCP_NODE_CLI: nodePath },
     dependencies: h.dependencies,
   });
   let spawned = null;
@@ -259,6 +342,7 @@ test('launch refuses a running AE and otherwise spawns only the exact formal exe
   assert.equal(spawned.options.shell, false);
   assert.equal(spawned.options.env.SENTINEL, 'kept');
   assert.equal(spawned.options.env.AE_MCP_DEV_RUNTIME, report.checkoutPath);
+  assert.equal(spawned.options.env.AE_MCP_NODE_CLI, report.nodePath);
   assert.equal(spawned.unrefCalls, 1);
   assert.deepEqual(receipt, {
     schemaVersion: 1,

--- a/scripts/package/build-platform-helper.mjs
+++ b/scripts/package/build-platform-helper.mjs
@@ -81,7 +81,10 @@ export function validateHelperIdentityPolicy(policy, platform) {
         'com.adobe.cep.CEPHtmlEngine',
         'ae-mcp-platform-helper',
       ])
-      && mac.caller?.brokerDirectParentSigningIdentifier === 'com.adobe.cep.CEPHtmlEngine';
+      && mac.caller?.brokerDirectParentSigningIdentifier
+        === 'com.adobe.cep.CEPHtmlEngine Helper (Renderer)'
+      && mac.caller?.brokerRequiredAncestorSigningIdentifier
+        === 'com.adobe.cep.CEPHtmlEngine';
   const windowsValid = platform === 'windows-x64'
       && windows?.platform === platform
       && windows.minimumOsVersion === '11.0.26100'

--- a/scripts/package/build-platform-helper.mjs
+++ b/scripts/package/build-platform-helper.mjs
@@ -79,7 +79,9 @@ export function validateHelperIdentityPolicy(policy, platform) {
       && JSON.stringify(mac.caller?.afterEffectsMajors) === JSON.stringify([25, 26])
       && JSON.stringify(mac.caller?.directSigningIdentifiers) === JSON.stringify([
         'com.adobe.cep.CEPHtmlEngine',
-      ]);
+        'ae-mcp-platform-helper',
+      ])
+      && mac.caller?.brokerDirectParentSigningIdentifier === 'com.adobe.cep.CEPHtmlEngine';
   const windowsValid = platform === 'windows-x64'
       && windows?.platform === platform
       && windows.minimumOsVersion === '11.0.26100'

--- a/scripts/package/macos-helper-entitlements.mjs
+++ b/scripts/package/macos-helper-entitlements.mjs
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const TEAM_ID = /^[A-Z0-9]{10}$/;
+const HELPER_ID = 'com.junkdoge.ae-mcp.platform-helper';
+
+function signingError(message) {
+  const error = new Error(message);
+  error.code = 'SIGNING_IDENTITY_INVALID';
+  return error;
+}
+
+export function renderMacosHelperEntitlements(teamId) {
+  if (!TEAM_ID.test(String(teamId || ''))) {
+    throw signingError('protected Apple Team ID is invalid');
+  }
+  const applicationIdentifier = `${teamId}.${HELPER_ID}`;
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<dict>',
+    '    <key>com.apple.application-identifier</key>',
+    `    <string>${applicationIdentifier}</string>`,
+    '    <key>keychain-access-groups</key>',
+    '    <array>',
+    `        <string>${applicationIdentifier}</string>`,
+    '    </array>',
+    '</dict>',
+    '</plist>',
+    '',
+  ].join('\n');
+}
+
+function parseArguments(argv) {
+  let teamId = '';
+  let out = '';
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--team-id') teamId = argv[++index] || '';
+    else if (argv[index] === '--out') out = argv[++index] || '';
+    else throw signingError('expected --team-id and --out');
+  }
+  if (!teamId || !out) throw signingError('expected --team-id and --out');
+  return { teamId, out };
+}
+
+export function writeMacosHelperEntitlements({ teamId, out }) {
+  fs.writeFileSync(out, renderMacosHelperEntitlements(teamId), {
+    encoding: 'utf8',
+    mode: 0o600,
+    flag: 'wx',
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  try {
+    writeMacosHelperEntitlements(parseArguments(process.argv.slice(2)));
+  } catch (error) {
+    process.stderr.write(`${error?.code || 'SIGNING_IDENTITY_INVALID'}: ${error?.message || error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/package/sign-macos-nested.sh
+++ b/scripts/package/sign-macos-nested.sh
@@ -106,6 +106,13 @@ hash_root() {
 
 temporary="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/ae-mcp-signing.XXXXXX")"
 trap '/bin/rm -rf "$temporary"' EXIT
+resolved_entitlements_path="$temporary/PlatformHelper.entitlements"
+node scripts/package/macos-helper-entitlements.mjs \
+  --team-id "$AE_MCP_APPLE_TEAM_ID" \
+  --out "$resolved_entitlements_path" \
+  || fail 'SIGNING_IDENTITY_INVALID: platform Helper entitlements could not be rendered'
+/usr/bin/plutil -lint "$resolved_entitlements_path" >/dev/null \
+  || fail 'SIGNING_IDENTITY_INVALID: platform Helper entitlements are invalid'
 
 verify_native() {
   local candidate="$1"
@@ -123,10 +130,19 @@ sign_native() {
   verify_native "$candidate"
 }
 
+sign_native_with_entitlements() {
+  local candidate="$1"
+  /usr/bin/codesign --force --sign "$AE_MCP_APPLE_SIGNING_IDENTITY" \
+    --options runtime --timestamp --entitlements "$resolved_entitlements_path" \
+    "$candidate" >/dev/null 2>&1 \
+    || fail 'SIGNING_COMMAND_FAILED: Developer ID Helper signing failed'
+  verify_native "$candidate"
+}
+
 sign_bundle() {
   local candidate="$1"
   /usr/bin/codesign --force --sign "$AE_MCP_APPLE_SIGNING_IDENTITY" \
-    --options runtime --timestamp --entitlements "$entitlements_path" \
+    --options runtime --timestamp --entitlements "$resolved_entitlements_path" \
     "$candidate" >/dev/null 2>&1 \
     || fail 'SIGNING_COMMAND_FAILED: Developer ID XPC bundle signing failed'
   /usr/bin/codesign --verify --strict --verbose=4 "$candidate" >/dev/null 2>&1 \
@@ -160,7 +176,7 @@ printf 'SIGNING_XATTR_AUDIT %s\n' "$xattr_audit"
 
 source_stage_sha="$(/usr/bin/shasum -a 256 "$root/bundle-manifest.json" | /usr/bin/awk '{print $1}')"
 before_helper="$(hash_root)"
-sign_native "$helper_path"
+sign_native_with_entitlements "$helper_path"
 after_helper="$(hash_root)"
 
 sign_native "$xpc_executable"
@@ -248,9 +264,23 @@ verify_protected_identity() {
   identity_index=$((identity_index + 1))
 }
 
+verify_keychain_entitlements() {
+  local candidate="$1"
+  local extracted="$temporary/keychain-entitlements-$identity_index.plist"
+  local expected="$AE_MCP_APPLE_TEAM_ID.com.junkdoge.ae-mcp.platform-helper"
+  /usr/bin/codesign --display --entitlements "$extracted" "$candidate" >/dev/null 2>&1 \
+    || fail 'SIGNING_IDENTITY_INVALID: Helper Keychain entitlements could not be inspected'
+  [[ "$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$extracted" 2>/dev/null)" = "$expected" ]] \
+    || fail 'SIGNING_IDENTITY_INVALID: Helper application identifier is invalid'
+  [[ "$(/usr/libexec/PlistBuddy -c 'Print :keychain-access-groups:0' "$extracted" 2>/dev/null)" = "$expected" ]] \
+    || fail 'SIGNING_IDENTITY_INVALID: Helper Keychain access group is invalid'
+}
+
 verify_protected_identity "$helper_path"
+verify_keychain_entitlements "$helper_path"
 verify_protected_identity "$xpc_executable"
 verify_protected_identity "$xpc_bundle"
+verify_keychain_entitlements "$xpc_bundle"
 verify_protected_identity "$addon_path"
 [[ "$launcher_architecture" != 'macho-arm64' ]] \
   || verify_protected_identity "$launcher_path"

--- a/scripts/package/test/macos-helper-entitlements.test.mjs
+++ b/scripts/package/test/macos-helper-entitlements.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  renderMacosHelperEntitlements,
+} from '../macos-helper-entitlements.mjs';
+
+test('release helper entitlements bind Data Protection Keychain to the protected team', () => {
+  const rendered = renderMacosHelperEntitlements('ABCDE12345');
+
+  assert.match(
+    rendered,
+    /<key>com\.apple\.application-identifier<\/key>\s*<string>ABCDE12345\.com\.junkdoge\.ae-mcp\.platform-helper<\/string>/,
+  );
+  assert.match(
+    rendered,
+    /<key>keychain-access-groups<\/key>\s*<array>\s*<string>ABCDE12345\.com\.junkdoge\.ae-mcp\.platform-helper<\/string>\s*<\/array>/,
+  );
+  assert.doesNotMatch(rendered, /__AE_MCP_APPLE_TEAM_ID__/);
+});
+
+test('release helper entitlements reject an unprotected or malformed team id', () => {
+  for (const value of ['', 'abcde12345', 'ABCDE1234', 'ABCDE12345.extra']) {
+    assert.throws(
+      () => renderMacosHelperEntitlements(value),
+      { code: 'SIGNING_IDENTITY_INVALID' },
+    );
+  }
+});

--- a/scripts/package/test/signing-plan.test.mjs
+++ b/scripts/package/test/signing-plan.test.mjs
@@ -396,7 +396,7 @@ test('mac nested signer uses current lipo grammar and signs helper payload botto
   assert.doesNotMatch(source, /lipo\s+-verify_arch\s+arm64/);
   assert.match(source, /lipo\s+"\$candidate"\s+-verify_arch\s+arm64/);
 
-  const helperSign = source.indexOf('sign_native "$helper_path"');
+  const helperSign = source.indexOf('sign_native_with_entitlements "$helper_path"');
   const xpcExecutableSign = source.indexOf('sign_native "$xpc_executable"');
   const xpcBundleSign = source.indexOf('sign_bundle "$xpc_bundle"');
   const addonSign = source.indexOf('sign_native "$addon_path"');
@@ -410,6 +410,8 @@ test('mac nested signer uses current lipo grammar and signs helper payload botto
   assert.match(source, /\[\[ "\$AE_MCP_APPLE_SIGNING_IDENTITY" != '-' \]\]/);
   assert.match(source, /\[\[ -x "\$candidate" \]\]/);
   assert.match(source, /grep -Eq '\^CodeDirectory \.\* flags=\.\*runtime'/);
+  assert.match(source, /macos-helper-entitlements\.mjs/);
+  assert.match(source, /--entitlements "\$resolved_entitlements_path"/);
 });
 
 test('windows nested signer signs and verifies the declared N-API transport', async () => {
@@ -498,7 +500,7 @@ test('Windows Authenticode object fixtures reject any unverified nested object b
 test('mac nested signer runs the audited xattr preflight before any signing', async () => {
   const source = await fs.promises.readFile('scripts/package/sign-macos-nested.sh', 'utf8');
   const preflight = source.indexOf('macos-signing-xattrs.mjs --root "$helper_root"');
-  const firstSign = source.indexOf('sign_native "$helper_path"');
+  const firstSign = source.indexOf('sign_native_with_entitlements "$helper_path"');
   assert.ok(preflight >= 0 && preflight < firstSign);
   assert.match(source, /SIGNING_XATTR_AUDIT/);
   assert.doesNotMatch(source, /xattr\s+-c(?:\s|$)/);


### PR DESCRIPTION
## Common

- Change type: isolated product fix
- Issue or package Issue: Refs #113
- User-visible outcome: users can select, preview, remove, and send generic local files from the built-in composer; the selected backend receives structured raw local-file references and decides how to interpret the content.
- Scope and explicit non-goals: includes FilePond composer integration, draft lifecycle and limits, Codex and Claude Code routing, supporting macOS Helper/runtime repairs required by the real panel path, and path/credential redaction. It does not parse, upload, transcode, import into AE, or gate file formats by model capability. Issue #113 remains separately tracked because its body still describes an older allowlist/parsing strategy and combines the separately delivered resize work.

Commands and results:

```text
npm run build (plugin/panel): passed
npm test -- --test-concurrency=1 (plugin/panel): passed
npm test -- --test-concurrency=1 (plugin/host, outside socket-restricted sandbox): 173/173 passed
focused Codex/OpenCode/ZCode backend review suite: 139/139 passed
focused attachment store suite: 9/9 passed
focused macOS Helper registration suite: 8/8 passed
git diff --check: passed
macOS Helper documented compatibility test command: 31 tests across 5 suites passed
package, sidecar, development and governance suites: passed before the final test-only portability fixes
GitHub required CI: all three checks passed on the merged head
```

Review findings and disposition:

- Blocker fixed: attachment paths reflected through split output, stderr, or transcript are now redacted.
- Blocker fixed: process-lifetime stderr redaction persists after an attachment turn until process exit/reset, including OpenCode file URLs.
- Blocker fixed: ZCode first-turn instructions no longer replace the attachment manifest.
- Mutation proof: restoring the former per-turn stderr lifecycle made all three late-stderr guards fail; restoring the fix made the suite pass.
- CI portability fixes changed tests only: POSIX permission intent is asserted on every runner, real mode is additionally read back on POSIX, and attachment-store tests use the runner-native path adapter.
- Independent final review: no Critical, Important, or Minor findings; Ready to merge.
- Known unrelated resource-timing flake is tracked separately; its focused file passed on replay.

## Native package evidence

N/A: this is panel/backend product work and introduces no AE-native capability or new AEGP mechanism. Existing real-AE HDEV for built-in Codex and Claude Code exercised generic attachments and remained non-candidate evidence. Packaged T5/T6 were not run.
