### PR TITLE
fix(runtime): bound RuntimeManager generation pruning

### DIFF
--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -23,7 +23,7 @@ RuntimeManager 保护普通安装流程的正确性，不是断电续跑或抵�
   runtime/generations/g-<id>/
     install-record.json
     ae-mcp-launcher                    launcher bound to this generation / 与该版本绑定的入口
-    macos-arm64 -> ../../layers/<manifest-sha>/i-<id>/macos-arm64
+    runtime -> ../../layers/<manifest-sha>/i-<id>/macos-arm64
   runtime/layers/<manifest-sha>/i-<id>/
     layer-record.json
     macos-arm64/                       verified packaged runtime / 已校验包内运行时

--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -20,15 +20,22 @@ RuntimeManager 保护普通安装流程的正确性，不是断电续跑或抵�
   bin/ae-mcp                         stable absolute launcher / 稳定绝对入口
   runtime/current                    active relative runtime pointer / 当前相对指针
   runtime/previous                   verified rollback pointer / 已校验回滚指针
-  runtime/<version>-<source-sha>/
+  runtime/generations/g-<id>/
     install-record.json
     ae-mcp-launcher                    launcher bound to this generation / 与该版本绑定的入口
-    macos-arm64/                     verified packaged runtime / 已校验包内运行时
+    macos-arm64 -> ../../layers/<manifest-sha>/i-<id>/macos-arm64
+  runtime/layers/<manifest-sha>/i-<id>/
+    layer-record.json
+    macos-arm64/                       verified packaged runtime / 已校验包内运行时
 ```
 
-`current` and `previous` are ordinary text files. RuntimeManager writes each pointer through a sibling temporary file and an atomic rename. A process-safe exclusive lock serializes panel instances while they verify, install, activate, repair, roll back, or uninstall a runtime. Each generation retains its verified launcher bytes so rollback and fallback select a matching launcher. The stable launcher reads only `current` and invokes the selected packaged Python with `-I -m ae_mcp`.
+The current layout is schema-v2: generation metadata lives under `generations/` and verified runtime content is shared through `layers/`. RuntimeManager can still read a valid schema-v1 generation at `runtime/<version>-<source-sha>/` during migration. `current` and `previous` are the only retained generation references; they are ordinary text files. RuntimeManager writes each pointer through a sibling temporary file and an atomic rename. A process-safe exclusive lock serializes panel instances while they verify, install, activate, repair, roll back, or uninstall a runtime. Each generation retains its verified launcher bytes so rollback and fallback select a matching launcher. The stable launcher reads only `current` and invokes the selected packaged Python with `-I -m ae_mcp`.
 
-`current` 与 `previous` 都是普通文本文件。RuntimeManager 通过同目录临时文件和原子 rename 写入每个指针；进程级互斥锁会串行化多个 Panel 实例的校验、安装、激活、修复、回滚和卸载操作。每个 generation 会保留自身经过校验的 launcher 字节，确保回滚和 fallback 使用匹配入口。稳定 launcher 只读取 `current`，再以 `-I -m ae_mcp` 启动所选包内 Python。
+当前目录布局是 schema-v2：generation 元数据位于 `generations/`，已校验的 runtime 内容通过 `layers/` 共享。迁移期间，RuntimeManager 仍可读取位于 `runtime/<version>-<source-sha>/` 的有效 schema-v1 generation。`current` 与 `previous` 是仅有的保留 generation 引用，二者都是普通文本文件。RuntimeManager 通过同目录临时文件和原子 rename 写入每个指针；进程级互斥锁会串行化多个 Panel 实例的校验、安装、激活、修复、回滚和卸载操作。每个 generation 会保留自身经过校验的 launcher 字节，确保回滚和 fallback 使用匹配入口。稳定 launcher 只读取 `current`，再以 `-I -m ae_mcp` 启动所选包内 Python。
+
+After a successful transition, RuntimeManager prunes every other valid generation it owns, including readable schema-v1 generations, and then prunes their unreferenced shared layers. Directories with an unknown, malformed, or unowned record are preserved.
+
+成功转换后，RuntimeManager 会清理它拥有的其他有效 generation（包括可读取的 schema-v1 generation），随后清理其未被引用的共享 layer。记录未知、格式错误或不属于 RuntimeManager 的目录会被保留。
 
 ## State transitions / 状态转换
 

--- a/docs/superpowers/plans/2026-07-30-runtime-generation-pruning.md
+++ b/docs/superpowers/plans/2026-07-30-runtime-generation-pruning.md
@@ -1,0 +1,241 @@
+# Runtime Generation Pruning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close Issue #179 by bounding RuntimeManager-owned disk state to the active `current` generation and the verified `previous` rollback generation, including legacy schema-v1 state and pre-activation rejection cleanup.
+
+**Architecture:** Extend the existing ownership-aware garbage collector rather than adding a new cleanup service. A single `reclaimOwnedState()` path will retain the exact `current`, `previous`, and operation-local in-progress references, remove only directories whose install records prove RuntimeManager ownership, and preserve unknown or malformed directories. Selection failures that occur before pointer activation will invoke the same collector with freshly known retained references.
+
+**Tech Stack:** JavaScript ES modules, Node.js `node:test`, CEP RuntimeManager filesystem adapter.
+
+## Global Constraints
+
+- Retain the active `current` generation and at most one verified `previous` rollback generation.
+- Reclaim only RuntimeManager-owned state proven by a valid schema-v1 install record or the existing valid schema-v2 generation/layer records.
+- Preserve unknown, malformed, non-owned, staging, evidence, fixture, and unrelated directories.
+- A launcher-incompatible selection rejected before activation must not leave a complete generation or runtime layer.
+- Keep the existing lifecycle counters for reclaimed generations, layers, logical bytes, and physical bytes.
+- No PID/start-token expansion, heartbeat, lease, stale-process forensics, power-loss continuation, cross-restart recovery, hostile-process hardening, generalized cleanup framework, or Windows RuntimeManager change.
+- This is a non-AE isolated RuntimeManager fix. Focused Node tests are the acceptance path; do not manufacture T4/T5/T6 or real-AE evidence.
+
+---
+
+### Task 1: Reclaim unreferenced legacy generations and document the policy
+
+**Files:**
+- Modify: `plugin/panel/test/runtimeManager.test.js`
+- Modify: `plugin/panel/src/cep/runtimeManager.js`
+- Modify: `docs/RUNTIME_MANAGER.md`
+
+**Interfaces:**
+- Consumes: existing `validateLegacyInstallRecord()`, `validateGenerationRecord()`, `treeUsage()`, `emptyLifecycle()`, and pointer-relative values.
+- Produces: `reclaimOwnedState({ currentRelative, previousRelative, inProgressRelative })`, replacing the narrower `reclaimOwnedV2()` call sites without changing their result shape.
+
+- [ ] **Step 1: Write the failing legacy-retention regression test**
+
+Extend the existing schema-v1 migration test into a two-transition scenario:
+
+```js
+const migrated = await managerFor(h, v1.extensionRoot).ensureReady();
+assert.equal(
+  (await fs.promises.readFile(h.platform.paths.previousPointer, 'utf8')).trim(),
+  legacy.relative,
+);
+
+const upgraded = await managerFor(h, v2.extensionRoot).ensureReady();
+assert.equal(upgraded.action, 'upgrade');
+assert.equal(upgraded.lifecycle.generations.reclaimed, 1);
+await assert.rejects(
+  fs.promises.lstat(legacy.generationRoot),
+  { code: 'ENOENT' },
+);
+```
+
+The first transition must still retain the schema-v1 rollback target. The second transition must remove it only after both pointers reference schema-v2 generations.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="schema-v1 generation" plugin/panel/test/runtimeManager.test.js
+```
+
+Expected: FAIL because the legacy generation directory still exists after it loses both pointer references.
+
+- [ ] **Step 3: Implement ownership-aware legacy pruning**
+
+Rename `reclaimOwnedV2()` to `reclaimOwnedState()` and retain every non-empty exact relative passed as `currentRelative`, `previousRelative`, or `inProgressRelative`.
+
+After the existing schema-v2 generation pass, inspect only direct child directories of `runtimeRoot`. Skip hidden names and the managed `generations` and `layers` roots. For each remaining directory:
+
+```js
+const relative = `${entry.name}/${platform.id}`;
+if (retained.has(relative)) continue;
+const record = validateLegacyInstallRecord(
+  await readJson(
+    paths.join([root, entry.name, INSTALL_RECORD]),
+    'RUNTIME_INSTALL_RECORD_INVALID',
+  ),
+  relative,
+);
+```
+
+Only after that validation succeeds, measure the directory with `treeUsage()`, remove it, and increment `generations.reclaimed`, `logicalBytes.reclaimed`, and `physicalBytes.reclaimed`. Invalid, missing, malformed, or non-owned records remain untouched.
+
+Replace all existing `reclaimOwnedV2()` calls with `reclaimOwnedState()`. Remove the now-duplicated schema-v1 deletion loop from `uninstall()`, because `reclaimOwnedState()` with no retained pointers owns that behavior.
+
+- [ ] **Step 4: Run the focused test and full RuntimeManager suite**
+
+Run:
+
+```bash
+node --test --test-name-pattern="schema-v1 generation" plugin/panel/test/runtimeManager.test.js
+node --test plugin/panel/test/runtimeManager.test.js
+```
+
+Expected: the focused test passes and all RuntimeManager tests pass.
+
+- [ ] **Step 5: Document the exact retention and ownership boundary**
+
+Update `docs/RUNTIME_MANAGER.md` in English and Chinese:
+
+- show the current schema-v2 `generations/` and shared `layers/` layout while noting readable schema-v1 migration;
+- state that `current` and `previous` are the only retained generation references;
+- state that successful transitions prune other valid RuntimeManager-owned generations and their unreferenced layers;
+- state that unknown/malformed/unowned directories are preserved;
+- retain the existing explicit non-goals.
+
+- [ ] **Step 6: Verify formatting and commit**
+
+Run:
+
+```bash
+git diff --check
+node --test plugin/panel/test/runtimeManager.test.js
+git add plugin/panel/src/cep/runtimeManager.js plugin/panel/test/runtimeManager.test.js docs/RUNTIME_MANAGER.md
+git commit -m "fix(runtime): prune unreferenced legacy generations"
+```
+
+Expected: `git diff --check` exits 0, the RuntimeManager suite passes, and one focused commit is created.
+
+---
+
+### Task 2: Remove completed state after pre-activation rejection
+
+**Files:**
+- Modify: `plugin/panel/test/runtimeManager.test.js`
+- Modify: `plugin/panel/src/cep/runtimeManager.js`
+
+**Interfaces:**
+- Consumes: Task 1 `reclaimOwnedState()` and the existing `assertLauncherTransitionCompatible()`, `installLauncher()`, `activate()`, `installPackaged()`, and pointer-state objects.
+- Produces: `prepareSelectedForActivation(selected, current, previous)`, which either completes compatibility/launcher preparation or reclaims the unreferenced selection before rethrowing the original error.
+
+- [ ] **Step 1: Write failing upgrade and repair rejection tests**
+
+Add a test-only helper that counts valid managed directories:
+
+```js
+async function managedDirectoryCounts(runtimeRoot) {
+  const generations = await fs.promises.readdir(path.join(runtimeRoot, 'generations'));
+  const layersRoot = path.join(runtimeRoot, 'layers');
+  const layerDigests = await fs.promises.readdir(layersRoot);
+  let layers = 0;
+  for (const digest of layerDigests) {
+    layers += (await fs.promises.readdir(path.join(layersRoot, digest))).length;
+  }
+  return { generations: generations.length, layers };
+}
+```
+
+For an installed v1 payload and a v2 payload with a different fixture launcher contract:
+
+```js
+const before = await managedDirectoryCounts(h.platform.paths.runtimeRoot);
+await assert.rejects(
+  incompatible.ensureReady(),
+  { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' },
+);
+assert.deepEqual(
+  await managedDirectoryCounts(h.platform.paths.runtimeRoot),
+  before,
+);
+```
+
+Add the same observable assertion for `incompatible.repair()`. Keep the existing pointer and launcher byte-for-byte assertions.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="launcher contract" plugin/panel/test/runtimeManager.test.js
+```
+
+Expected: FAIL because the rejected selection leaves at least one additional completed managed generation, and `repair()` also leaves a new runtime layer.
+
+- [ ] **Step 3: Implement the narrow pre-activation cleanup boundary**
+
+Add:
+
+```js
+async function prepareSelectedForActivation(selected, current, previous) {
+  try {
+    assertLauncherTransitionCompatible(selected, current);
+    await installLauncher(selected);
+  } catch (error) {
+    await reclaimOwnedState({
+      currentRelative: current?.relative || null,
+      previousRelative: previous?.relative || null,
+      inProgressRelative: null,
+    });
+    throw error;
+  }
+}
+```
+
+Use it only where a newly completed selection has been created but `activate()` has not started:
+
+- the new-selection branch of `ensureReady()`;
+- `repair()`, after reading both `current` and `previous`.
+
+Do not wrap `activate()` itself. Pointer-write uncertainty is outside this reproduced pre-activation defect and must not be expanded here.
+
+- [ ] **Step 4: Run the focused tests and full RuntimeManager suite**
+
+Run:
+
+```bash
+node --test --test-name-pattern="launcher contract" plugin/panel/test/runtimeManager.test.js
+node --test plugin/panel/test/runtimeManager.test.js
+```
+
+Expected: both rejection paths restore the managed generation/layer counts, pointer and launcher assertions remain unchanged, and the full RuntimeManager suite passes.
+
+- [ ] **Step 5: Verify formatting and commit**
+
+Run:
+
+```bash
+git diff --check
+node --test plugin/panel/test/runtimeManager.test.js
+git add plugin/panel/src/cep/runtimeManager.js plugin/panel/test/runtimeManager.test.js
+git commit -m "fix(runtime): reclaim rejected selections"
+```
+
+Expected: `git diff --check` exits 0, the RuntimeManager suite passes, and one focused commit is created.
+
+---
+
+## Final Verification
+
+Run:
+
+```bash
+node --test plugin/panel/test/runtimeManager.test.js
+node --test plugin/panel/test/runtimeActivationWiring.test.js
+node --test scripts/package/test/runtime-manager-stage.test.mjs
+git diff --check origin/main...HEAD
+```
+
+Expected: all focused RuntimeManager/activation/staging tests pass with no formatting errors. Real AE, packaged candidate generation, T5, and T6 are explicitly not required because the public AE execution path and installed-runtime behavior are not changed.

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -31228,6 +31228,27 @@
         );
       }
     }
+    async function prepareSelectedForActivation(selected, current, previous) {
+      var _a2, _b2, _c2, _d2;
+      try {
+        assertLauncherTransitionCompatible(selected, current);
+        await installLauncher(selected);
+      } catch (error) {
+        await reclaimOwnedState({
+          currentRelative: (current == null ? void 0 : current.relative) || null,
+          previousRelative: (previous == null ? void 0 : previous.relative) || null,
+          inProgressRelative: null
+        });
+        const selectedLayer = selected.record.layer;
+        if (selected.lifecycle.layers.created === 1 && ((_b2 = (_a2 = current == null ? void 0 : current.record) == null ? void 0 : _a2.layer) == null ? void 0 : _b2.relative) !== selectedLayer.relative && ((_d2 = (_c2 = previous == null ? void 0 : previous.record) == null ? void 0 : _c2.layer) == null ? void 0 : _d2.relative) !== selectedLayer.relative) {
+          await promises.rm(
+            paths.join([root, "layers", selectedLayer.id, selectedLayer.instanceId]),
+            { recursive: true, force: true }
+          );
+        }
+        throw error;
+      }
+    }
     async function refreshLayerReceipt(layerRoot, record, directory) {
       const refreshed = {
         ...record,
@@ -31440,10 +31461,10 @@
         throw error;
       }
     }
-    async function reclaimOwnedV2({ currentRelative, previousRelative, inProgressRelative }) {
+    async function reclaimOwnedState({ currentRelative, previousRelative, inProgressRelative }) {
       const lifecycle = emptyLifecycle();
       const retained = new Set(
-        [currentRelative, previousRelative, inProgressRelative].filter((value) => value == null ? void 0 : value.startsWith("generations/"))
+        [currentRelative, previousRelative, inProgressRelative].filter((value) => typeof value === "string" && value.length > 0)
       );
       const referencedLayers = /* @__PURE__ */ new Set();
       let layerGcSafe = true;
@@ -31469,6 +31490,30 @@
         const generationRoot = paths.join([generationsRoot, entry.name]);
         const usage = await treeUsage(generationRoot);
         await promises.rm(generationRoot, { recursive: true, force: true });
+        lifecycle.generations.reclaimed += 1;
+        lifecycle.logicalBytes.reclaimed += usage.logicalBytes;
+        lifecycle.physicalBytes.reclaimed += usage.physicalBytes;
+      }
+      const legacyEntries = await promises.readdir(root, { withFileTypes: true });
+      for (const entry of legacyEntries) {
+        if (!entry.isDirectory() || entry.name.startsWith(".") || entry.name === "generations" || entry.name === "layers") continue;
+        const relative = `${entry.name}/${platform.id}`;
+        if (retained.has(relative)) continue;
+        try {
+          validateLegacyInstallRecord(
+            await readJson2(
+              paths.join([root, entry.name, INSTALL_RECORD]),
+              "RUNTIME_INSTALL_RECORD_INVALID"
+            ),
+            relative
+          );
+        } catch (error) {
+          if (error instanceof RuntimeManagerError || (error == null ? void 0 : error.code) === "ENOENT") continue;
+          throw error;
+        }
+        const legacyRoot = paths.join([root, entry.name]);
+        const usage = await treeUsage(legacyRoot);
+        await promises.rm(legacyRoot, { recursive: true, force: true });
         lifecycle.generations.reclaimed += 1;
         lifecycle.logicalBytes.reclaimed += usage.logicalBytes;
         lifecycle.physicalBytes.reclaimed += usage.physicalBytes;
@@ -31578,7 +31623,7 @@
           await installLauncher(previous);
           await writePointer(paths.currentPointer, previous.relative);
           await removePointer(paths.previousPointer);
-          const reclaimed2 = await reclaimOwnedV2({
+          const reclaimed2 = await reclaimOwnedState({
             currentRelative: previous.relative,
             previousRelative: null,
             inProgressRelative: previous.relative
@@ -31605,7 +31650,7 @@
         } catch (error) {
           if (!current.ok) throw error;
           await installLauncher(current);
-          const reclaimed2 = await reclaimOwnedV2({
+          const reclaimed2 = await reclaimOwnedState({
             currentRelative: current.relative,
             previousRelative: previous.ok ? previous.relative : null,
             inProgressRelative: current.relative
@@ -31630,7 +31675,7 @@
         const trustedSignalsMatch = declaredRuntimeMatches && current.record.schemaVersion === 2 && current.signals.runtimeManifest.size === packaged.signals.runtimeManifest.size && current.signals.launcher.size === packaged.signals.launcher.size && current.signals.node.size === packaged.signals.node.size && current.signals.python.size === packaged.signals.python.size && current.signals.python.type === packaged.signals.python.type && current.signals.python.linkTarget === packaged.signals.python.linkTarget;
         if (trustedSignalsMatch) {
           await installLauncher(current);
-          const reclaimed2 = await reclaimOwnedV2({
+          const reclaimed2 = await reclaimOwnedState({
             currentRelative: current.relative,
             previousRelative: previous.ok ? previous.relative : null,
             inProgressRelative: current.relative
@@ -31662,10 +31707,9 @@
         }
         packaged = await verifyPackagedPayload();
         const selected = await installPackaged(packaged);
-        assertLauncherTransitionCompatible(selected, current);
-        await installLauncher(selected);
+        await prepareSelectedForActivation(selected, current, previous);
         await activate(selected, current);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: selected.relative,
           previousRelative: current.ok ? current.relative : null,
           inProgressRelative: selected.relative
@@ -31703,11 +31747,11 @@
       return withLock(async () => {
         const packaged = await verifyPackagedPayload();
         const current = await pointerState(paths.currentPointer);
+        const previous = await pointerState(paths.previousPointer);
         const selected = await installPackaged(packaged, { repair: true });
-        assertLauncherTransitionCompatible(selected, current);
-        await installLauncher(selected);
+        await prepareSelectedForActivation(selected, current, previous);
         await activate(selected, current);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: selected.relative,
           previousRelative: current.ok ? current.relative : null,
           inProgressRelative: selected.relative
@@ -31741,7 +31785,7 @@
         await writePointer(paths.currentPointer, previous.relative);
         if (current.ok && current.relative !== previous.relative) await writePointer(paths.previousPointer, current.relative);
         else await removePointer(paths.previousPointer);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: previous.relative,
           previousRelative: current.ok && current.relative !== previous.relative ? current.relative : null,
           inProgressRelative: previous.relative
@@ -31771,29 +31815,11 @@
         await removePointer(paths.previousPointer);
         await promises.rm(paths.launcher, { force: true });
         await promises.rm(stableLauncherRecordPath, { force: true });
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: null,
           previousRelative: null,
           inProgressRelative: null
         });
-        const entries = await promises.readdir(root, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-          const recordPath = paths.join([root, entry.name, INSTALL_RECORD]);
-          try {
-            validateLegacyInstallRecord(
-              await readJson2(recordPath, "RUNTIME_INSTALL_RECORD_INVALID"),
-              `${entry.name}/${platform.id}`
-            );
-            const legacyRoot = paths.join([root, entry.name]);
-            const usage = await treeUsage(legacyRoot);
-            await promises.rm(legacyRoot, { recursive: true, force: true });
-            reclaimed.generations.reclaimed += 1;
-            reclaimed.logicalBytes.reclaimed += usage.logicalBytes;
-            reclaimed.physicalBytes.reclaimed += usage.physicalBytes;
-          } catch (error) {
-          }
-        }
         return {
           ok: true,
           action: "uninstall",

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -979,6 +979,20 @@ export function createRuntimeManager({
     }
   }
 
+  async function prepareSelectedForActivation(selected, current, previous) {
+    try {
+      assertLauncherTransitionCompatible(selected, current);
+      await installLauncher(selected);
+    } catch (error) {
+      await reclaimOwnedState({
+        currentRelative: current?.relative || null,
+        previousRelative: previous?.relative || null,
+        inProgressRelative: null,
+      });
+      throw error;
+    }
+  }
+
   async function refreshLayerReceipt(layerRoot, record, directory) {
     const refreshed = {
       ...record,
@@ -1458,8 +1472,7 @@ export function createRuntimeManager({
       }
       packaged = await verifyPackagedPayload();
       const selected = await installPackaged(packaged);
-      assertLauncherTransitionCompatible(selected, current);
-      await installLauncher(selected);
+      await prepareSelectedForActivation(selected, current, previous);
       await activate(selected, current);
       const reclaimed = await reclaimOwnedState({
         currentRelative: selected.relative,
@@ -1500,9 +1513,9 @@ export function createRuntimeManager({
     return withLock(async () => {
       const packaged = await verifyPackagedPayload();
       const current = await pointerState(paths.currentPointer);
+      const previous = await pointerState(paths.previousPointer);
       const selected = await installPackaged(packaged, { repair: true });
-      assertLauncherTransitionCompatible(selected, current);
-      await installLauncher(selected);
+      await prepareSelectedForActivation(selected, current, previous);
       await activate(selected, current);
       const reclaimed = await reclaimOwnedState({
         currentRelative: selected.relative,

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -1191,11 +1191,11 @@ export function createRuntimeManager({
     }
   }
 
-  async function reclaimOwnedV2({ currentRelative, previousRelative, inProgressRelative }) {
+  async function reclaimOwnedState({ currentRelative, previousRelative, inProgressRelative }) {
     const lifecycle = emptyLifecycle();
     const retained = new Set(
       [currentRelative, previousRelative, inProgressRelative]
-        .filter((value) => value?.startsWith('generations/')),
+        .filter((value) => typeof value === 'string' && value.length > 0),
     );
     const referencedLayers = new Set();
     let layerGcSafe = true;
@@ -1221,6 +1221,32 @@ export function createRuntimeManager({
       const generationRoot = paths.join([generationsRoot, entry.name]);
       const usage = await treeUsage(generationRoot);
       await promises.rm(generationRoot, { recursive: true, force: true });
+      lifecycle.generations.reclaimed += 1;
+      lifecycle.logicalBytes.reclaimed += usage.logicalBytes;
+      lifecycle.physicalBytes.reclaimed += usage.physicalBytes;
+    }
+
+    const legacyEntries = await promises.readdir(root, { withFileTypes: true });
+    for (const entry of legacyEntries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')
+          || entry.name === 'generations' || entry.name === 'layers') continue;
+      const relative = `${entry.name}/${platform.id}`;
+      if (retained.has(relative)) continue;
+      try {
+        validateLegacyInstallRecord(
+          await readJson(
+            paths.join([root, entry.name, INSTALL_RECORD]),
+            'RUNTIME_INSTALL_RECORD_INVALID',
+          ),
+          relative,
+        );
+      } catch (error) {
+        if (error instanceof RuntimeManagerError || error?.code === 'ENOENT') continue;
+        throw error;
+      }
+      const legacyRoot = paths.join([root, entry.name]);
+      const usage = await treeUsage(legacyRoot);
+      await promises.rm(legacyRoot, { recursive: true, force: true });
       lifecycle.generations.reclaimed += 1;
       lifecycle.logicalBytes.reclaimed += usage.logicalBytes;
       lifecycle.physicalBytes.reclaimed += usage.physicalBytes;
@@ -1339,7 +1365,7 @@ export function createRuntimeManager({
         await installLauncher(previous);
         await writePointer(paths.currentPointer, previous.relative);
         await removePointer(paths.previousPointer);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: previous.relative,
           previousRelative: null,
           inProgressRelative: previous.relative,
@@ -1366,7 +1392,7 @@ export function createRuntimeManager({
       } catch (error) {
         if (!current.ok) throw error;
         await installLauncher(current);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: current.relative,
           previousRelative: previous.ok ? previous.relative : null,
           inProgressRelative: current.relative,
@@ -1403,7 +1429,7 @@ export function createRuntimeManager({
         && current.signals.python.linkTarget === packaged.signals.python.linkTarget;
       if (trustedSignalsMatch) {
         await installLauncher(current);
-        const reclaimed = await reclaimOwnedV2({
+        const reclaimed = await reclaimOwnedState({
           currentRelative: current.relative,
           previousRelative: previous.ok ? previous.relative : null,
           inProgressRelative: current.relative,
@@ -1435,7 +1461,7 @@ export function createRuntimeManager({
       assertLauncherTransitionCompatible(selected, current);
       await installLauncher(selected);
       await activate(selected, current);
-      const reclaimed = await reclaimOwnedV2({
+      const reclaimed = await reclaimOwnedState({
         currentRelative: selected.relative,
         previousRelative: current.ok ? current.relative : null,
         inProgressRelative: selected.relative,
@@ -1478,7 +1504,7 @@ export function createRuntimeManager({
       assertLauncherTransitionCompatible(selected, current);
       await installLauncher(selected);
       await activate(selected, current);
-      const reclaimed = await reclaimOwnedV2({
+      const reclaimed = await reclaimOwnedState({
         currentRelative: selected.relative,
         previousRelative: current.ok ? current.relative : null,
         inProgressRelative: selected.relative,
@@ -1509,7 +1535,7 @@ export function createRuntimeManager({
       await writePointer(paths.currentPointer, previous.relative);
       if (current.ok && current.relative !== previous.relative) await writePointer(paths.previousPointer, current.relative);
       else await removePointer(paths.previousPointer);
-      const reclaimed = await reclaimOwnedV2({
+      const reclaimed = await reclaimOwnedState({
         currentRelative: previous.relative,
         previousRelative: current.ok && current.relative !== previous.relative
           ? current.relative : null,
@@ -1537,30 +1563,11 @@ export function createRuntimeManager({
       await removePointer(paths.previousPointer);
       await promises.rm(paths.launcher, { force: true });
       await promises.rm(stableLauncherRecordPath, { force: true });
-      const reclaimed = await reclaimOwnedV2({
+      const reclaimed = await reclaimOwnedState({
         currentRelative: null,
         previousRelative: null,
         inProgressRelative: null,
       });
-      const entries = await promises.readdir(root, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-        const recordPath = paths.join([root, entry.name, INSTALL_RECORD]);
-        try {
-          validateLegacyInstallRecord(
-            await readJson(recordPath, 'RUNTIME_INSTALL_RECORD_INVALID'),
-            `${entry.name}/${platform.id}`,
-          );
-          const legacyRoot = paths.join([root, entry.name]);
-          const usage = await treeUsage(legacyRoot);
-          await promises.rm(legacyRoot, { recursive: true, force: true });
-          reclaimed.generations.reclaimed += 1;
-          reclaimed.logicalBytes.reclaimed += usage.logicalBytes;
-          reclaimed.physicalBytes.reclaimed += usage.physicalBytes;
-        } catch (error) {
-          // Unknown directories are not owned by RuntimeManager and are retained.
-        }
-      }
       return {
         ok: true,
         action: 'uninstall',

--- a/plugin/panel/src/cep/runtimeManager.js
+++ b/plugin/panel/src/cep/runtimeManager.js
@@ -989,6 +989,17 @@ export function createRuntimeManager({
         previousRelative: previous?.relative || null,
         inProgressRelative: null,
       });
+      const selectedLayer = selected.record.layer;
+      if (
+        selected.lifecycle.layers.created === 1
+        && current?.record?.layer?.relative !== selectedLayer.relative
+        && previous?.record?.layer?.relative !== selectedLayer.relative
+      ) {
+        await promises.rm(
+          paths.join([root, 'layers', selectedLayer.id, selectedLayer.instanceId]),
+          { recursive: true, force: true },
+        );
+      }
       throw error;
     }
   }

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -182,6 +182,17 @@ async function harness(t) {
   return { root, home, platform: adapter(home) };
 }
 
+async function managedDirectoryCounts(runtimeRoot) {
+  const generations = await fs.promises.readdir(path.join(runtimeRoot, 'generations'));
+  const layersRoot = path.join(runtimeRoot, 'layers');
+  const layerDigests = await fs.promises.readdir(layersRoot);
+  let layers = 0;
+  for (const digest of layerDigests) {
+    layers += (await fs.promises.readdir(path.join(layersRoot, digest))).length;
+  }
+  return { generations: generations.length, layers };
+}
+
 function managerFor(h, extensionRoot, options = {}) {
   return createRuntimeManager({
     platform: h.platform,
@@ -640,15 +651,25 @@ macosRuntimeTest('a launcher contract change cannot publish a mixed launcher/run
     version: '0.10.0', sourceCommitSha: '2'.repeat(40), marker: 'two', launcherVersion: 'v2',
   });
   const one = managerFor(h, v1.extensionRoot);
-  const two = managerFor(h, v2.extensionRoot);
+  const incompatible = managerFor(h, v2.extensionRoot);
   const installed = await one.ensureReady();
   const pointerBefore = await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8');
   const launcherBefore = await fs.promises.readFile(h.platform.paths.launcher);
+  const before = await managedDirectoryCounts(h.platform.paths.runtimeRoot);
 
-  await assert.rejects(two.ensureReady(), { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' });
+  await assert.rejects(
+    incompatible.ensureReady(),
+    { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' },
+  );
+  assert.deepEqual(await managedDirectoryCounts(h.platform.paths.runtimeRoot), before);
 
   assert.equal(await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8'), pointerBefore);
   assert.deepEqual(await fs.promises.readFile(h.platform.paths.launcher), launcherBefore);
+  await assert.rejects(
+    incompatible.repair(),
+    { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' },
+  );
+  assert.deepEqual(await managedDirectoryCounts(h.platform.paths.runtimeRoot), before);
   const launched = await execFileAsync(installed.launcher, ['--unchanged'], {
     env: { HOME: h.home, AE_MCP_HOME: h.platform.paths.configRoot, PATH: '/usr/bin:/bin' },
   });

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -406,11 +406,14 @@ macosRuntimeTest('clean macOS install activates and starts the bundled core with
 
 macosRuntimeTest('a readable schema-v1 generation migrates forward without deleting the legacy runtime', async (t) => {
   const h = await harness(t);
-  const payload = await packageFixture(h.root, {
+  const v1 = await packageFixture(h.root, {
     version: '0.9.3', sourceCommitSha: '1'.repeat(40), marker: 'legacy',
   });
-  const legacy = await seedLegacyGeneration(h, payload);
-  const manager = managerFor(h, payload.extensionRoot);
+  const v2 = await packageFixture(h.root, {
+    version: '0.10.0', sourceCommitSha: '2'.repeat(40), marker: 'upgraded',
+  });
+  const legacy = await seedLegacyGeneration(h, v1);
+  const manager = managerFor(h, v1.extensionRoot);
   const before = await manager.inspect();
   assert.equal(before.current.ok, true, JSON.stringify(before.current));
 
@@ -433,12 +436,17 @@ macosRuntimeTest('a readable schema-v1 generation migrates forward without delet
   assert.equal(stableReceipt.signal.path, h.platform.paths.launcher);
   assert.equal(stableReceipt.signal.size > 0, true);
   assert.equal(stableReceipt.signal.mtimeMs > 0, true);
+
+  const upgraded = await managerFor(h, v2.extensionRoot).ensureReady();
+
+  assert.equal(upgraded.action, 'upgrade');
+  assert.equal(upgraded.lifecycle.generations.reclaimed, 1);
+  await assert.rejects(fs.promises.lstat(legacy.generationRoot), { code: 'ENOENT' });
   const uninstalled = await manager.uninstall();
-  assert.equal(uninstalled.lifecycle.generations.reclaimed >= 2, true);
-  assert.equal(uninstalled.lifecycle.layers.reclaimed, 1);
+  assert.equal(uninstalled.lifecycle.generations.reclaimed, 2);
+  assert.equal(uninstalled.lifecycle.layers.reclaimed, 2);
   assert.equal(uninstalled.lifecycle.logicalBytes.reclaimed > 0, true);
   assert.equal(uninstalled.lifecycle.physicalBytes.reclaimed > 0, true);
-  await assert.rejects(fs.promises.lstat(legacy.generationRoot), { code: 'ENOENT' });
 });
 
 macosRuntimeTest('upgrade, downgrade, and rollback atomically select verified versions', async (t) => {

--- a/plugin/panel/test/runtimeManager.test.js
+++ b/plugin/panel/test/runtimeManager.test.js
@@ -655,6 +655,12 @@ macosRuntimeTest('a launcher contract change cannot publish a mixed launcher/run
   const installed = await one.ensureReady();
   const pointerBefore = await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8');
   const launcherBefore = await fs.promises.readFile(h.platform.paths.launcher);
+  const malformed = path.join(
+    h.platform.paths.runtimeRoot,
+    'generations',
+    'g-0000000000000000',
+  );
+  await fs.promises.mkdir(malformed, { recursive: true });
   const before = await managedDirectoryCounts(h.platform.paths.runtimeRoot);
 
   await assert.rejects(
@@ -662,6 +668,7 @@ macosRuntimeTest('a launcher contract change cannot publish a mixed launcher/run
     { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' },
   );
   assert.deepEqual(await managedDirectoryCounts(h.platform.paths.runtimeRoot), before);
+  assert.equal((await fs.promises.lstat(malformed)).isDirectory(), true);
 
   assert.equal(await fs.promises.readFile(h.platform.paths.currentPointer, 'utf8'), pointerBefore);
   assert.deepEqual(await fs.promises.readFile(h.platform.paths.launcher), launcherBefore);
@@ -670,6 +677,7 @@ macosRuntimeTest('a launcher contract change cannot publish a mixed launcher/run
     { code: 'RUNTIME_LAUNCHER_MIGRATION_REQUIRED' },
   );
   assert.deepEqual(await managedDirectoryCounts(h.platform.paths.runtimeRoot), before);
+  assert.equal((await fs.promises.lstat(malformed)).isDirectory(), true);
   const launched = await execFileAsync(installed.launcher, ['--unchanged'], {
     env: { HOME: h.home, AE_MCP_HOME: h.platform.paths.configRoot, PATH: '/usr/bin:/bin' },
   });


### PR DESCRIPTION
## Summary

- document and enforce a two-pointer RuntimeManager retention policy (`current` plus `previous`)
- reclaim valid RuntimeManager-owned schema-v1 generations after they lose both pointer references
- reclaim generation/layer state created by launcher-incompatible selections before activation
- preserve malformed, unknown, and non-owned runtime state

## Scope

This is a bounded non-AE RuntimeManager correctness fix. It does not add PID/start-token tracking, heartbeats, leases, power-loss continuation, generalized cleanup infrastructure, Windows changes, release work, or AE hardware validation.

## Verification

- `node --test plugin/panel/test/runtimeManager.test.js` — 19/19 passed
- `node --test plugin/panel/test/runtimeActivationWiring.test.js` — 2/2 passed
- `node --test scripts/package/test/runtime-manager-stage.test.mjs` — 1/1 passed
- `git diff --check origin/main...HEAD` — passed
- two task-scoped reviews and one whole-branch review completed; the single reproduced blocker was fixed and its scoped re-review approved

Closes #179.
Advances the reproduced orphan-generation subcase of #148; selected-runtime payload ownership remains out of scope.
