### PR TITLE
fix(panel): bind Sidecar to selected runtime

### DIFF
--- a/docs/RUNTIME_MANAGER.md
+++ b/docs/RUNTIME_MANAGER.md
@@ -33,6 +33,16 @@ The current layout is schema-v2: generation metadata lives under `generations/` 
 
 当前目录布局是 schema-v2：generation 元数据位于 `generations/`，已校验的 runtime 内容通过 `layers/` 共享。迁移期间，RuntimeManager 仍可读取位于 `runtime/<version>-<source-sha>/` 的有效 schema-v1 generation。`current` 与 `previous` 是仅有的保留 generation 引用，二者都是普通文本文件。RuntimeManager 通过同目录临时文件和原子 rename 写入每个指针；进程级互斥锁会串行化多个 Panel 实例的校验、安装、激活、修复、回滚和卸载操作。每个 generation 会保留自身经过校验的 launcher 字节，确保回滚和 fallback 使用匹配入口。稳定 launcher 只读取 `current`，再以 `-I -m ae_mcp` 启动所选包内 Python。
 
+On macOS production paths, the panel also resolves the Claude Agent sidecar
+from the selected generation's verified `componentReceipt.canonicalPath`.
+It does not pair the selected Node executable with an extension-owned sidecar
+or fall back to another payload copy.
+
+在 macOS 正式路径中，面板也会从已选 generation 的已验证
+`componentReceipt.canonicalPath` 解析 Claude Agent Sidecar。它不会把已选
+Node 可执行文件与扩展目录中的另一份 Sidecar 混用，也不会回退到其他
+payload 副本。
+
 After a successful transition, RuntimeManager prunes every other valid generation it owns, including readable schema-v1 generations, and then prunes their unreferenced shared layers. Directories with an unknown, malformed, or unowned record are preserved.
 
 成功转换后，RuntimeManager 会清理它拥有的其他有效 generation（包括可读取的 schema-v1 generation），随后清理其未被引用的共享 layer。记录未知、格式错误或不属于 RuntimeManager 的目录会被保留。

--- a/docs/superpowers/plans/2026-07-30-selected-runtime-sidecar-ownership.md
+++ b/docs/superpowers/plans/2026-07-30-selected-runtime-sidecar-ownership.md
@@ -1,0 +1,573 @@
+# Selected Runtime Sidecar Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the macOS production Claude Agent sidecar come only from the RuntimeManager generation already selected and verified for the panel.
+
+**Architecture:** Extend the existing pure `resolveSidecarPath()` boundary to consume RuntimeManager's existing `componentReceipt.canonicalPath`; do not add a second pointer reader or a general payload registry. Add a small pure selection-state adapter for `App.jsx` so startup remains non-throwing while macOS waits for runtime activation, and so incompatible selections disable the Claude channel before any sidecar spawn.
+
+**Tech Stack:** CEP panel JavaScript (ES modules), React 18, Node `node:test`, existing platform path adapters, existing RuntimeManager receipts.
+
+## Global Constraints
+
+- macOS production must never fall back to `<extension>/runtime/macos-arm64/...` after RuntimeManager is enabled.
+- `.debug` development continues to use `<extension>/sidecar/agent-sidecar.mjs`.
+- Windows continues to use `<extension>/runtime/windows-x64/node/sidecar/agent-sidecar.mjs`.
+- Consume the existing `componentReceipt`; do not parse `runtime/current` or install records outside RuntimeManager.
+- Do not add PID, start-token, heartbeat, process census, lock, pruning, repair, generalized payload-registry, or runner infrastructure.
+- Do not add full-tree hashing; RuntimeManager's existing manifest verification remains authoritative.
+- Do not change Claude sidecar protocol, Provider behavior, helper registration, capture, signing, notarization, or installer behavior.
+- Every production-code behavior change follows RED -> GREEN -> focused regression; do not write implementation before observing the specified test fail for the expected reason.
+- Classify review findings under AGENTS.md section 5. Only reproduced current-path blockers may expand P0; all other hardening stays follow-up or out of scope.
+
+---
+
+### Task 1: Resolve the Sidecar from the verified runtime receipt
+
+**Files:**
+- Modify: `plugin/panel/src/cep/claudeAuth.js:7-22`
+- Modify: `plugin/panel/test/claudeAuth.test.js:1-72`
+
+**Interfaces:**
+- Consumes: RuntimeManager success results shaped as `{ ok, action, componentReceipt }`, where `componentReceipt.component === "core-runtime"`, `componentReceipt.platform === platform.id`, and `componentReceipt.canonicalPath` is the verified runtime directory.
+- Produces: `resolveSidecarPath({ extRoot, fsImpl?, platform?, runtimeSelection? }): string | null`.
+- Error: incompatible provided selections throw an `Error` whose `code` is exactly `RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE`.
+- `null`: macOS production has not received a verified selection yet. It is a pending state, not a fallback path.
+
+- [ ] **Step 1: Add complete platform and runtime-selection fixtures**
+
+At the top of `plugin/panel/test/claudeAuth.test.js`, add:
+
+```js
+import path from 'node:path';
+```
+
+After `windowsPlatform()`, add fixtures that mirror the RuntimeManager result fields consumed at the boundary:
+
+```js
+function macPaths() {
+  const runtimeRoot = '/Users/test/.ae-mcp/runtime';
+  return {
+    runtimeRoot,
+    join: (parts) => path.posix.join(...parts),
+    resolve: (parts) => path.posix.resolve(...parts),
+    isAbsolute: (value) => path.posix.isAbsolute(value),
+    contains: (root, candidate) => {
+      const normalizedRoot = path.posix.resolve(root);
+      const normalizedCandidate = path.posix.resolve(candidate);
+      return normalizedCandidate === normalizedRoot
+        || normalizedCandidate.startsWith(normalizedRoot + '/');
+    },
+  };
+}
+
+function macPlatform() {
+  return { id: 'macos-arm64', paths: macPaths() };
+}
+
+function selectedRuntime(canonicalPath, action = 'ready') {
+  return {
+    ok: true,
+    action,
+    launcher: '/Users/test/.ae-mcp/bin/ae-mcp',
+    relative: 'generations/g-0123456789abcdef',
+    version: '0.9.3',
+    sourceCommitSha: 'a'.repeat(40),
+    componentReceipt: {
+      schemaVersion: 1,
+      component: 'core-runtime',
+      platform: 'macos-arm64',
+      version: '0.9.3',
+      sourceRevision: 'a'.repeat(40),
+      sourceRevisionRole: 'advisory',
+      canonicalPath,
+      installReceiptPath: '/Users/test/.ae-mcp/runtime/generations/g-0123456789abcdef/install-record.json',
+      generation: 'generations/g-0123456789abcdef',
+      layerId: 'b'.repeat(64),
+      signals: {},
+      stableLauncher: {
+        canonicalPath: '/Users/test/.ae-mcp/bin/ae-mcp',
+        installReceiptPath: '/Users/test/.ae-mcp/runtime/stable-launcher-record.json',
+        signal: {},
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Write failing macOS selection tests**
+
+Add these tests before the existing Windows production tests:
+
+```js
+test('resolveSidecarPath waits for a verified macOS production runtime selection', () => {
+  const result = resolveSidecarPath({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.equal(result, null);
+});
+
+test('resolveSidecarPath uses the selected macOS generation for ready retained and fallback results', () => {
+  const cases = [
+    ['ready', '/Users/test/.ae-mcp/runtime/layers/a/i-ready/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/a/i-ready/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+    ['retained', '/Users/test/.ae-mcp/runtime/layers/b/i-retained/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/b/i-retained/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+    ['fallback', '/Users/test/.ae-mcp/runtime/layers/c/i-fallback/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/c/i-fallback/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+  ];
+
+  for (const [action, canonicalPath, expected] of cases) {
+    const result = resolveSidecarPath({
+      extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+      platform: macPlatform(),
+      runtimeSelection: selectedRuntime(canonicalPath, action),
+      fsImpl: { existsSync: () => false },
+    });
+    assert.equal(result, expected);
+  }
+});
+
+test('resolveSidecarPath rejects incompatible macOS runtime receipts without an extension fallback', () => {
+  const base = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/i-valid/macos-arm64');
+  const cases = [
+    { ...base, componentReceipt: { ...base.componentReceipt, component: 'platform-helper' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, platform: 'windows-x64' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, canonicalPath: 'relative/runtime' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, canonicalPath: '/Applications/Adobe/CEP/extensions/ae-mcp/runtime/macos-arm64' } },
+  ];
+
+  for (const runtimeSelection of cases) {
+    assert.throws(
+      () => resolveSidecarPath({
+        extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+        platform: macPlatform(),
+        runtimeSelection,
+        fsImpl: { existsSync: () => false },
+      }),
+      (error) => error?.code === 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE',
+    );
+  }
+});
+```
+
+Name the break these tests catch: restoring the extension-owned macOS runtime candidate, ignoring retained/fallback selection, or accepting an unrelated/out-of-root receipt.
+
+- [ ] **Step 3: Run the new tests and verify RED**
+
+Run:
+
+```bash
+node --test plugin/panel/test/claudeAuth.test.js
+```
+
+Expected: the macOS pending test fails because current code returns
+`/Applications/Adobe/CEP/extensions/ae-mcp/runtime/macos-arm64/node/sidecar/agent-sidecar.mjs`;
+the selected-generation test fails for the same reason; and incompatible receipts do not throw.
+
+- [ ] **Step 4: Implement the minimal receipt-based resolver**
+
+In `plugin/panel/src/cep/claudeAuth.js`, add:
+
+```js
+function incompatibleSidecarSelection(message) {
+  const error = new Error(message);
+  error.code = 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE';
+  return error;
+}
+```
+
+Change the resolver signature and production branch to:
+
+```js
+export function resolveSidecarPath({
+  extRoot,
+  fsImpl,
+  platform,
+  runtimeSelection,
+} = {}) {
+  const adapter = platform || createPlatformAdapter();
+  const root = normalizeCepSystemPath(extRoot || adapter.paths.configRoot, adapter);
+  const developmentMarker = adapter.paths.join([root, '.debug']);
+  const developmentSidecar = adapter.paths.join([root, 'sidecar', 'agent-sidecar.mjs']);
+  const extensionRuntimeSidecar = adapter.paths.join([
+    root, 'runtime', adapter.id, 'node', 'sidecar', 'agent-sidecar.mjs',
+  ]);
+  const fs = fsImpl || adapter.fs;
+  if (!fs || typeof fs.existsSync !== 'function') {
+    throw new Error('platform filesystem is unavailable');
+  }
+  if (fs.existsSync(developmentMarker) && fs.existsSync(developmentSidecar)) {
+    return developmentSidecar;
+  }
+  if (adapter.id !== 'macos-arm64') return extensionRuntimeSidecar;
+  if (!runtimeSelection) return null;
+
+  const receipt = runtimeSelection.componentReceipt;
+  const canonicalPath = receipt?.canonicalPath;
+  if (receipt?.component !== 'core-runtime'
+      || receipt?.platform !== adapter.id
+      || typeof canonicalPath !== 'string'
+      || !adapter.paths.isAbsolute(canonicalPath)
+      || !adapter.paths.contains(adapter.paths.runtimeRoot, canonicalPath)) {
+    throw incompatibleSidecarSelection(
+      'The selected runtime does not own a compatible Claude sidecar payload',
+    );
+  }
+  return adapter.paths.join([
+    canonicalPath, 'node', 'sidecar', 'agent-sidecar.mjs',
+  ]);
+}
+```
+
+Do not inspect the sidecar file independently here: the selected runtime
+manifest has already been verified by RuntimeManager.
+
+- [ ] **Step 5: Verify GREEN and existing Windows/development behavior**
+
+Run:
+
+```bash
+node --test plugin/panel/test/claudeAuth.test.js
+```
+
+Expected: all tests pass, including the pre-existing `.debug`, Windows, probe,
+timeout, and stderr tests.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add plugin/panel/src/cep/claudeAuth.js plugin/panel/test/claudeAuth.test.js
+git commit -m "fix(panel): resolve sidecar from selected runtime"
+```
+
+---
+
+### Task 2: Gate App probing on the selected Sidecar state
+
+**Files:**
+- Modify: `plugin/panel/src/cep/claudeAuth.js`
+- Modify: `plugin/panel/test/claudeAuth.test.js`
+- Modify: `plugin/panel/src/app/App.jsx:24,609-653,831-856,1122-1140`
+- Modify: `docs/RUNTIME_MANAGER.md:32-38`
+
+**Interfaces:**
+- Consumes: `runtimeActivation` shaped as `{ state: "starting"|"ready"|"error", result, error }`.
+- Produces: `resolveSidecarSelection({ runtimeActivation, extRoot, fsImpl?, platform? })` returning exactly one of:
+  - `{ state: "ready", path: string, error: null }`
+  - `{ state: "pending", path: null, error: null }`
+  - `{ state: "error", path: null, error: Error }`
+- App passes `runtimeActivation.result` only through this adapter; it does not read runtime pointers.
+
+- [ ] **Step 1: Write failing selection-state tests**
+
+Extend the import in `plugin/panel/test/claudeAuth.test.js`:
+
+```js
+import {
+  probeClaudeLogin,
+  resolveSidecarPath,
+  resolveSidecarSelection,
+} from '../src/cep/claudeAuth.js';
+```
+
+Add:
+
+```js
+test('resolveSidecarSelection keeps macOS pending until runtime activation is ready', () => {
+  const selection = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'starting', result: null, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.deepEqual(selection, { state: 'pending', path: null, error: null });
+});
+
+test('resolveSidecarSelection exposes the verified path only after macOS activation', () => {
+  const runtime = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/i-active/macos-arm64');
+  const selection = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: runtime, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.deepEqual(selection, {
+    state: 'ready',
+    path: '/Users/test/.ae-mcp/runtime/layers/a/i-active/macos-arm64/node/sidecar/agent-sidecar.mjs',
+    error: null,
+  });
+});
+
+test('resolveSidecarSelection preserves RuntimeManager and receipt errors before dispatch', () => {
+  const runtimeError = Object.assign(new Error('runtime failed'), {
+    code: 'RUNTIME_MANIFEST_INVALID',
+  });
+  const activationFailure = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'error', result: null, error: runtimeError },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.equal(activationFailure.state, 'error');
+  assert.equal(activationFailure.path, null);
+  assert.equal(activationFailure.error, runtimeError);
+
+  const runtime = selectedRuntime('/Applications/Adobe/CEP/extensions/ae-mcp/runtime/macos-arm64');
+  const receiptFailure = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: runtime, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.equal(receiptFailure.state, 'error');
+  assert.equal(receiptFailure.path, null);
+  assert.equal(receiptFailure.error.code, 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE');
+});
+
+test('resolveSidecarSelection keeps Windows and debug paths independent of RuntimeManager', () => {
+  const windows = resolveSidecarSelection({
+    extRoot: 'C:\\ext',
+    platform: windowsPlatform(),
+    runtimeActivation: { state: 'ready', result: null, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.deepEqual(windows, {
+    state: 'ready',
+    path: 'C:\\ext\\runtime\\windows-x64\\node\\sidecar\\agent-sidecar.mjs',
+    error: null,
+  });
+
+  const debug = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: null, error: null },
+    fsImpl: {
+      existsSync: (value) => value === '/Applications/Adobe/CEP/extensions/ae-mcp/.debug'
+        || value === '/Applications/Adobe/CEP/extensions/ae-mcp/sidecar/agent-sidecar.mjs',
+    },
+  });
+  assert.deepEqual(debug, {
+    state: 'ready',
+    path: '/Applications/Adobe/CEP/extensions/ae-mcp/sidecar/agent-sidecar.mjs',
+    error: null,
+  });
+});
+
+test('probeClaudeLogin does not resolve Node or spawn while Sidecar selection is pending', async () => {
+  let nodeResolutions = 0;
+  let spawns = 0;
+  const result = await probeClaudeLogin({
+    sidecarPath: null,
+    resolveNode: async () => {
+      nodeResolutions += 1;
+      return { ok: true, nodePath: 'node', version: '20.0.0' };
+    },
+    spawnImpl: () => {
+      spawns += 1;
+      return makeProc();
+    },
+  });
+
+  assert.deepEqual(result, {
+    loggedIn: false,
+    nodeOk: false,
+    detail: 'verified runtime sidecar is not ready',
+  });
+  assert.equal(nodeResolutions, 0);
+  assert.equal(spawns, 0);
+});
+```
+
+Name the break these tests catch: spawning before activation, hiding the
+authoritative RuntimeManager error, or accidentally imposing macOS
+RuntimeManager behavior on Windows/development.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+node --test plugin/panel/test/claudeAuth.test.js
+```
+
+Expected: module import fails because `resolveSidecarSelection` is not exported.
+
+- [ ] **Step 3: Implement the pure selection-state adapter**
+
+In `plugin/panel/src/cep/claudeAuth.js`, after `resolveSidecarPath()`, add:
+
+```js
+export function resolveSidecarSelection({
+  runtimeActivation,
+  extRoot,
+  fsImpl,
+  platform,
+} = {}) {
+  const adapter = platform || createPlatformAdapter();
+  if (adapter.id === 'macos-arm64'
+      && runtimeActivation?.state === 'error'
+      && runtimeActivation.error) {
+    return { state: 'error', path: null, error: runtimeActivation.error };
+  }
+  try {
+    const path = resolveSidecarPath({
+      extRoot,
+      fsImpl,
+      platform: adapter,
+      runtimeSelection: runtimeActivation?.state === 'ready'
+        ? runtimeActivation.result
+        : null,
+    });
+    return path
+      ? { state: 'ready', path, error: null }
+      : { state: 'pending', path: null, error: null };
+  } catch (error) {
+    return { state: 'error', path: null, error };
+  }
+}
+```
+
+At the start of `probeClaudeLogin()`, before selecting the platform adapter or
+resolving Node, add:
+
+```js
+if (!sidecarPath) {
+  return {
+    loggedIn: false,
+    nodeOk: false,
+    detail: 'verified runtime sidecar is not ready',
+  };
+}
+```
+
+- [ ] **Step 4: Verify the state adapter and no-spawn guard are GREEN**
+
+Run:
+
+```bash
+node --test plugin/panel/test/claudeAuth.test.js
+```
+
+Expected: all Claude-auth tests pass.
+
+- [ ] **Step 5: Wire App to the selection state without an interim probe**
+
+In `plugin/panel/src/app/App.jsx`, import `resolveSidecarSelection` instead of
+`resolveSidecarPath`:
+
+```js
+import { probeClaudeLogin, resolveSidecarSelection } from '../cep/claudeAuth';
+```
+
+Replace the existing `sidecarPath` memo with:
+
+```js
+const sidecarSelection = React.useMemo(() => resolveSidecarSelection({
+  extRoot,
+  platform,
+  runtimeActivation,
+}), [extRoot, platform, runtimeActivation]);
+const sidecarPath = sidecarSelection.path;
+```
+
+At the start of `runClaudeProbe`, after `setProbe(null)`, add the gate:
+
+```js
+if (sidecarSelection.state !== 'ready') {
+  if (sidecarSelection.state === 'error') {
+    const error = sidecarSelection.error;
+    setProbe({
+      loggedIn: false,
+      nodeOk: false,
+      detail: error?.message || String(error),
+    });
+  }
+  return () => { alive = false; };
+}
+```
+
+Add `sidecarSelection` to the callback dependencies:
+
+```js
+}, [platform, resolvePanelNode, sidecarPath, sidecarSelection]);
+```
+
+The existing `probe === null` channel state keeps the composer/backend disabled
+while selection is pending. An error sets `nodeOk:false`, which disables both
+Claude subscription and Provider sidecar channels before `sendUser`.
+
+- [ ] **Step 6: Document the selected Sidecar ownership**
+
+After the schema-v2/current/previous paragraph in `docs/RUNTIME_MANAGER.md`,
+add one English and one Chinese paragraph:
+
+```md
+On macOS production paths, the panel also resolves the Claude Agent sidecar
+from the selected generation's verified `componentReceipt.canonicalPath`.
+It does not pair the selected Node executable with an extension-owned sidecar
+or fall back to another payload copy.
+
+在 macOS 正式路径中，面板也会从已选 generation 的已验证
+`componentReceipt.canonicalPath` 解析 Claude Agent Sidecar。它不会把已选
+Node 可执行文件与扩展目录中的另一份 Sidecar 混用，也不会回退到其他
+payload 副本。
+```
+
+- [ ] **Step 7: Run focused tests and the production panel build**
+
+Run:
+
+```bash
+node --test \
+  plugin/panel/test/claudeAuth.test.js \
+  plugin/panel/test/runtimeManager.test.js \
+  plugin/panel/test/runtimeActivationWiring.test.js
+(cd plugin/panel && npm run build)
+```
+
+Expected: focused tests pass and the React production bundle builds without an
+import, hook-dependency, or syntax error.
+
+- [ ] **Step 8: Run the complete panel suite**
+
+Run:
+
+```bash
+(cd plugin/panel && npm test)
+```
+
+Expected: all panel tests pass with zero failures.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add \
+  plugin/panel/src/cep/claudeAuth.js \
+  plugin/panel/test/claudeAuth.test.js \
+  plugin/panel/src/app/App.jsx \
+  docs/RUNTIME_MANAGER.md
+git commit -m "fix(panel): bind Claude sidecar to runtime activation"
+```
+
+---
+
+## Completion Gate
+
+After both tasks pass their task-scoped reviews:
+
+1. Run one concentrated whole-branch review.
+2. Run `git diff --check`.
+3. Re-run the focused tests, panel production build, and complete panel suite
+   from the reviewed HEAD.
+4. Do not start AE unless the implementation changed installed-runtime
+   behavior beyond the selected-path wiring described above.
+5. Open one PR for #148, wait for required CI, merge only if review and CI have
+   no current-path blocker, then close #148 with its focused verification
+   evidence.
+6. Stop at the repository's next-package approval gate before starting #66.

--- a/docs/superpowers/specs/2026-07-30-selected-runtime-sidecar-ownership-design.md
+++ b/docs/superpowers/specs/2026-07-30-selected-runtime-sidecar-ownership-design.md
@@ -1,0 +1,111 @@
+# Selected Runtime Sidecar Ownership Design
+
+## Context
+
+Issue #148 now has one remaining outcome after PR #201: the production Claude
+Agent sidecar must come from the verified runtime generation selected by
+RuntimeManager. Today `resolveSidecarPath()` constructs a path below the
+extension bundle and explicitly does not consult RuntimeManager's selection.
+That can pair the selected Node executable with sidecar code from a different
+payload generation.
+
+The sidecar is an auxiliary Node process used by the panel's embedded Claude
+and Provider flows. It is not the MCP Core, the CEP host, or the in-process
+AEGP plug-in.
+
+## Decision
+
+The panel will consume RuntimeManager's existing verified selection receipt
+instead of adding another runtime-pointer reader or a general payload registry.
+
+On macOS production paths:
+
+1. RuntimeManager finishes `ensureReady()` and returns its existing
+   `componentReceipt`.
+2. The panel passes that selected runtime result to `resolveSidecarPath()`.
+3. The resolver validates that the receipt describes the expected
+   `core-runtime` component for the active platform and carries an absolute
+   canonical path within RuntimeManager's runtime root.
+4. The resolver derives
+   `node/sidecar/agent-sidecar.mjs` below that canonical runtime directory.
+5. Claude login probing waits until this selected path is available. It never
+   probes the extension bundle's production runtime as an interim fallback.
+
+RuntimeManager already verifies the selected runtime manifest and its file
+inventory before returning the receipt. The sidecar resolver therefore does
+not rehash the runtime tree or independently parse `runtime/current`.
+
+## Platform Behavior
+
+- A `.debug` development extension continues to use
+  `<extension>/sidecar/agent-sidecar.mjs`.
+- Windows keeps its existing bundled path
+  `<extension>/runtime/windows-x64/node/sidecar/agent-sidecar.mjs`; Windows has
+  no RuntimeManager selection contract in this Issue.
+- macOS production requires the verified RuntimeManager selection. It does not
+  fall back to an extension-owned sidecar path.
+
+## Error Contract
+
+Before a macOS production selection is ready, Claude probing remains pending
+and does not spawn Node.
+
+An incompatible selection produces a bounded compatibility error before
+sidecar dispatch. Incompatible means that the receipt:
+
+- is not for component `core-runtime`;
+- does not match the active platform;
+- lacks an absolute canonical path; or
+- resolves outside RuntimeManager's runtime root.
+
+A selected sidecar that cannot be started is reported with its selected path;
+the panel does not retry another payload copy. Existing RuntimeManager errors
+remain authoritative when no verified generation can be selected.
+
+## Wiring
+
+`App.jsx` will derive the sidecar selection from `runtimeActivation.result`.
+The Claude backend will be recreated when the selected path changes, matching
+the existing React dependency behavior. The automatic login probe will run
+only after a valid development, Windows, or selected macOS path exists.
+
+No new RuntimeManager method or cross-payload abstraction is introduced.
+
+## Verification
+
+Test-driven changes will cover:
+
+- macOS production chooses the active verified generation even when an
+  extension-bundled sidecar also exists;
+- retained and fallback RuntimeManager results select their own canonical
+  generation payload;
+- absent or incompatible macOS selections do not resolve or spawn an extension
+  fallback;
+- `.debug` development behavior remains unchanged;
+- Windows behavior remains unchanged; and
+- App wiring waits for runtime activation and passes the selected result into
+  the resolver.
+
+Run the focused panel tests for Claude authentication, RuntimeManager, and
+runtime activation wiring. Expand to the complete panel test suite after the
+focused tests pass. A single ordinary non-candidate HDEV is required only if
+the implementation changes the installed-runtime behavior beyond this tested
+path selection.
+
+## Non-Goals
+
+- PID, start-token, heartbeat, process-restart census, or generalized runner
+  infrastructure.
+- RuntimeManager lock, pruning, repair, or pointer-lifecycle changes.
+- Full runtime-tree hashing on routine startup.
+- Windows RuntimeManager work.
+- Claude sidecar protocol or Provider feature changes.
+- macOS helper registration, ScreenCaptureKit, signing, notarization, or
+  installer work.
+
+## Completion
+
+Issue #148 is complete when macOS production Sidecar selection is derived only
+from RuntimeManager's verified active result, incompatible selections fail
+before dispatch without another payload fallback, development and Windows
+behavior remain unchanged, and the focused plus complete panel suites pass.

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -39954,12 +39954,22 @@ data: ${JSON.stringify(payload)}
   }
 
   // src/cep/claudeAuth.js
-  function resolveSidecarPath({ extRoot, fsImpl, platform } = {}) {
+  function incompatibleSidecarSelection(message) {
+    const error = new Error(message);
+    error.code = "RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE";
+    return error;
+  }
+  function resolveSidecarPath({
+    extRoot,
+    fsImpl,
+    platform,
+    runtimeSelection
+  } = {}) {
     const adapter = platform || createPlatformAdapter();
     const root = normalizeCepSystemPath(extRoot || adapter.paths.configRoot, adapter);
     const developmentMarker = adapter.paths.join([root, ".debug"]);
     const developmentSidecar = adapter.paths.join([root, "sidecar", "agent-sidecar.mjs"]);
-    const runtimeSidecar = adapter.paths.join([
+    const extensionRuntimeSidecar = adapter.paths.join([
       root,
       "runtime",
       adapter.id,
@@ -39968,9 +39978,64 @@ data: ${JSON.stringify(payload)}
       "agent-sidecar.mjs"
     ]);
     const fs = fsImpl || adapter.fs;
-    if (!fs || typeof fs.existsSync !== "function") throw new Error("platform filesystem is unavailable");
-    if (fs.existsSync(developmentMarker) && fs.existsSync(developmentSidecar)) return developmentSidecar;
-    return runtimeSidecar;
+    if (!fs || typeof fs.existsSync !== "function") {
+      throw new Error("platform filesystem is unavailable");
+    }
+    if (fs.existsSync(developmentMarker) && fs.existsSync(developmentSidecar)) {
+      return developmentSidecar;
+    }
+    if (adapter.id !== "macos-arm64") return extensionRuntimeSidecar;
+    if (!runtimeSelection) return null;
+    const receipt = runtimeSelection.componentReceipt;
+    const canonicalPath = receipt == null ? void 0 : receipt.canonicalPath;
+    if ((receipt == null ? void 0 : receipt.component) !== "core-runtime" || (receipt == null ? void 0 : receipt.platform) !== adapter.id || typeof canonicalPath !== "string" || !adapter.paths.isAbsolute(canonicalPath) || !adapter.paths.contains(adapter.paths.runtimeRoot, canonicalPath)) {
+      throw incompatibleSidecarSelection(
+        "The selected runtime does not own a compatible Claude sidecar payload"
+      );
+    }
+    return adapter.paths.join([
+      canonicalPath,
+      "node",
+      "sidecar",
+      "agent-sidecar.mjs"
+    ]);
+  }
+  function resolveSidecarSelection({
+    runtimeActivation,
+    extRoot,
+    fsImpl,
+    platform
+  } = {}) {
+    const adapter = platform || createPlatformAdapter();
+    if (adapter.id === "macos-arm64" && (runtimeActivation == null ? void 0 : runtimeActivation.state) === "error" && runtimeActivation.error) {
+      return { state: "error", path: null, error: runtimeActivation.error };
+    }
+    try {
+      const path = resolveSidecarPath({
+        extRoot,
+        fsImpl,
+        platform: adapter,
+        runtimeSelection: (runtimeActivation == null ? void 0 : runtimeActivation.state) === "ready" ? runtimeActivation.result : null
+      });
+      return path ? { state: "ready", path, error: null } : { state: "pending", path: null, error: null };
+    } catch (error) {
+      return { state: "error", path: null, error };
+    }
+  }
+  async function resolveNodeForSidecarSelection({
+    resolveNode,
+    runtimeSelection,
+    platform
+  } = {}) {
+    var _a, _b, _c;
+    const resolved = await resolveNode({ platform });
+    const sidecarCanonicalPath = (_a = runtimeSelection == null ? void 0 : runtimeSelection.componentReceipt) == null ? void 0 : _a.canonicalPath;
+    if (sidecarCanonicalPath && ((_c = (_b = resolved == null ? void 0 : resolved.runtime) == null ? void 0 : _b.componentReceipt) == null ? void 0 : _c.canonicalPath) !== sidecarCanonicalPath) {
+      const error = new Error("Selected Sidecar and Node runtime receipts do not match");
+      error.code = "RUNTIME_SIDECAR_NODE_SELECTION_MISMATCH";
+      throw error;
+    }
+    return resolved;
   }
   async function probeClaudeLogin({
     platform,
@@ -39980,6 +40045,13 @@ data: ${JSON.stringify(payload)}
     env,
     timeoutMs = 3e4
   } = {}) {
+    if (!sidecarPath) {
+      return {
+        loggedIn: false,
+        nodeOk: false,
+        detail: "verified runtime sidecar is not ready"
+      };
+    }
     const adapter = platform || (spawnImpl ? {
       completeSpawnEnv: (base = {}, additions = {}) => ({ ...base, ...additions }),
       spawn: (executable, args, options) => spawnImpl(executable.path, [...executable.argsPrefix || [], ...args], options)
@@ -49955,10 +50027,19 @@ ${baseUrl}`),
     const runtimeReady = runtimeActivation.state === "ready";
     const mcpCommand = runtimeManager ? platform.paths.launcher : "ae-mcp";
     const resolvePanelNode = import_react46.default.useCallback(
-      ({ platform: requestedPlatform } = {}) => runtimeManager ? runtimeManager.resolveNode() : resolveSystemNode({ platform: requestedPlatform || platform }),
-      [platform, runtimeManager]
+      ({ platform: requestedPlatform } = {}) => runtimeManager ? resolveNodeForSidecarSelection({
+        resolveNode: () => runtimeManager.resolveNode(),
+        runtimeSelection: runtimeActivation.result,
+        platform: requestedPlatform || platform
+      }) : resolveSystemNode({ platform: requestedPlatform || platform }),
+      [platform, runtimeActivation.result, runtimeManager]
     );
-    const sidecarPath = import_react46.default.useMemo(() => resolveSidecarPath({ extRoot, platform }), [extRoot, platform]);
+    const sidecarSelection = import_react46.default.useMemo(() => resolveSidecarSelection({
+      extRoot,
+      platform,
+      runtimeActivation
+    }), [extRoot, platform, runtimeActivation]);
+    const sidecarPath = sidecarSelection.path;
     const getMcpSpec = import_react46.default.useCallback(async () => {
       try {
         const spec = await resolveMcpCommand({ extRoot, platform, runtimeManager });
@@ -50394,6 +50475,19 @@ ${baseUrl}`),
     const runClaudeProbe = import_react46.default.useCallback(() => {
       let alive = true;
       setProbe(null);
+      if (sidecarSelection.state !== "ready") {
+        if (sidecarSelection.state === "error") {
+          const error = sidecarSelection.error;
+          setProbe({
+            loggedIn: false,
+            nodeOk: false,
+            detail: (error == null ? void 0 : error.message) || String(error)
+          });
+        }
+        return () => {
+          alive = false;
+        };
+      }
       probeClaudeLogin({
         platform,
         resolveNode: resolvePanelNode,
@@ -50406,7 +50500,7 @@ ${baseUrl}`),
       return () => {
         alive = false;
       };
-    }, [platform, resolvePanelNode, sidecarPath]);
+    }, [platform, resolvePanelNode, sidecarPath, sidecarSelection]);
     import_react46.default.useEffect(() => {
       if (backendPref !== "subscription") return void 0;
       return runClaudeProbe();

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -21,7 +21,7 @@ import { createApprovalTierFile, withToolApprovalTier } from '../cep/approvalTie
 import { createToolsApi } from '../cep/toolsApi';
 import { createLegacyApiKeyStore } from '../cep/apiKey';
 import { createZcodeCredentialManager } from '../cep/zcodeCredential.js';
-import { probeClaudeLogin, resolveSidecarPath } from '../cep/claudeAuth';
+import { probeClaudeLogin, resolveSidecarSelection } from '../cep/claudeAuth';
 import { createClaudeAgentBackend, resolveSystemNode } from '../cep/claudeAgentBackend';
 import { createCodexBackend } from '../cep/codexBackend';
 import { createOpenCodeBackend } from '../cep/openCodeBackend';
@@ -649,7 +649,12 @@ function Shell({ cs }) {
       : resolveSystemNode({ platform: requestedPlatform || platform })),
     [platform, runtimeManager],
   );
-  const sidecarPath = React.useMemo(() => resolveSidecarPath({ extRoot, platform }), [extRoot, platform]);
+  const sidecarSelection = React.useMemo(() => resolveSidecarSelection({
+    extRoot,
+    platform,
+    runtimeActivation,
+  }), [extRoot, platform, runtimeActivation]);
+  const sidecarPath = sidecarSelection.path;
   const getMcpSpec = React.useCallback(async () => {
     try {
       const spec = await resolveMcpCommand({ extRoot, platform, runtimeManager });
@@ -1122,6 +1127,17 @@ function Shell({ cs }) {
   const runClaudeProbe = React.useCallback(() => {
     let alive = true;
     setProbe(null);
+    if (sidecarSelection.state !== 'ready') {
+      if (sidecarSelection.state === 'error') {
+        const error = sidecarSelection.error;
+        setProbe({
+          loggedIn: false,
+          nodeOk: false,
+          detail: error?.message || String(error),
+        });
+      }
+      return () => { alive = false; };
+    }
     probeClaudeLogin({
       platform,
       resolveNode: resolvePanelNode,
@@ -1132,7 +1148,7 @@ function Shell({ cs }) {
       if (alive) setProbe({ loggedIn: false, nodeOk: false, detail: e && e.message ? e.message : String(e) });
     });
     return () => { alive = false; };
-  }, [platform, resolvePanelNode, sidecarPath]);
+  }, [platform, resolvePanelNode, sidecarPath, sidecarSelection]);
 
   React.useEffect(() => {
     if (backendPref !== 'subscription') return undefined;

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -21,7 +21,7 @@ import { createApprovalTierFile, withToolApprovalTier } from '../cep/approvalTie
 import { createToolsApi } from '../cep/toolsApi';
 import { createLegacyApiKeyStore } from '../cep/apiKey';
 import { createZcodeCredentialManager } from '../cep/zcodeCredential.js';
-import { probeClaudeLogin, resolveSidecarSelection } from '../cep/claudeAuth';
+import { probeClaudeLogin, resolveNodeForSidecarSelection, resolveSidecarSelection } from '../cep/claudeAuth';
 import { createClaudeAgentBackend, resolveSystemNode } from '../cep/claudeAgentBackend';
 import { createCodexBackend } from '../cep/codexBackend';
 import { createOpenCodeBackend } from '../cep/openCodeBackend';
@@ -645,9 +645,13 @@ function Shell({ cs }) {
   const mcpCommand = runtimeManager ? platform.paths.launcher : 'ae-mcp';
   const resolvePanelNode = React.useCallback(
     ({ platform: requestedPlatform } = {}) => (runtimeManager
-      ? runtimeManager.resolveNode()
+      ? resolveNodeForSidecarSelection({
+        resolveNode: () => runtimeManager.resolveNode(),
+        runtimeSelection: runtimeActivation.result,
+        platform: requestedPlatform || platform,
+      })
       : resolveSystemNode({ platform: requestedPlatform || platform })),
-    [platform, runtimeManager],
+    [platform, runtimeActivation.result, runtimeManager],
   );
   const sidecarSelection = React.useMemo(() => resolveSidecarSelection({
     extRoot,

--- a/plugin/panel/src/cep/claudeAuth.js
+++ b/plugin/panel/src/cep/claudeAuth.js
@@ -78,6 +78,22 @@ export function resolveSidecarSelection({
   }
 }
 
+export async function resolveNodeForSidecarSelection({
+  resolveNode,
+  runtimeSelection,
+  platform,
+} = {}) {
+  const resolved = await resolveNode({ platform });
+  const sidecarCanonicalPath = runtimeSelection?.componentReceipt?.canonicalPath;
+  if (sidecarCanonicalPath
+      && resolved?.runtime?.componentReceipt?.canonicalPath !== sidecarCanonicalPath) {
+    const error = new Error('Selected Sidecar and Node runtime receipts do not match');
+    error.code = 'RUNTIME_SIDECAR_NODE_SELECTION_MISMATCH';
+    throw error;
+  }
+  return resolved;
+}
+
 export async function probeClaudeLogin({
   platform,
   resolveNode,

--- a/plugin/panel/src/cep/claudeAuth.js
+++ b/plugin/panel/src/cep/claudeAuth.js
@@ -49,6 +49,35 @@ export function resolveSidecarPath({
   ]);
 }
 
+export function resolveSidecarSelection({
+  runtimeActivation,
+  extRoot,
+  fsImpl,
+  platform,
+} = {}) {
+  const adapter = platform || createPlatformAdapter();
+  if (adapter.id === 'macos-arm64'
+      && runtimeActivation?.state === 'error'
+      && runtimeActivation.error) {
+    return { state: 'error', path: null, error: runtimeActivation.error };
+  }
+  try {
+    const path = resolveSidecarPath({
+      extRoot,
+      fsImpl,
+      platform: adapter,
+      runtimeSelection: runtimeActivation?.state === 'ready'
+        ? runtimeActivation.result
+        : null,
+    });
+    return path
+      ? { state: 'ready', path, error: null }
+      : { state: 'pending', path: null, error: null };
+  } catch (error) {
+    return { state: 'error', path: null, error };
+  }
+}
+
 export async function probeClaudeLogin({
   platform,
   resolveNode,
@@ -57,6 +86,13 @@ export async function probeClaudeLogin({
   env,
   timeoutMs = 30000,
 } = {}) {
+  if (!sidecarPath) {
+    return {
+      loggedIn: false,
+      nodeOk: false,
+      detail: 'verified runtime sidecar is not ready',
+    };
+  }
   const adapter = platform || (spawnImpl ? {
     completeSpawnEnv: (base = {}, additions = {}) => ({ ...base, ...additions }),
     spawn: (executable, args, options) => spawnImpl(executable.path, [...(executable.argsPrefix || []), ...args], options),

--- a/plugin/panel/src/cep/claudeAuth.js
+++ b/plugin/panel/src/cep/claudeAuth.js
@@ -4,21 +4,49 @@ import { createPlatformAdapter } from './platform/index.js';
 import { resolveSystemNode } from './claudeAgentBackend.js';
 import { normalizeCepSystemPath } from './platform/paths.js';
 
-export function resolveSidecarPath({ extRoot, fsImpl, platform } = {}) {
+function incompatibleSidecarSelection(message) {
+  const error = new Error(message);
+  error.code = 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE';
+  return error;
+}
+
+export function resolveSidecarPath({
+  extRoot,
+  fsImpl,
+  platform,
+  runtimeSelection,
+} = {}) {
   const adapter = platform || createPlatformAdapter();
   const root = normalizeCepSystemPath(extRoot || adapter.paths.configRoot, adapter);
   const developmentMarker = adapter.paths.join([root, '.debug']);
   const developmentSidecar = adapter.paths.join([root, 'sidecar', 'agent-sidecar.mjs']);
-  const runtimeSidecar = adapter.paths.join([
+  const extensionRuntimeSidecar = adapter.paths.join([
     root, 'runtime', adapter.id, 'node', 'sidecar', 'agent-sidecar.mjs',
   ]);
   const fs = fsImpl || adapter.fs;
-  if (!fs || typeof fs.existsSync !== 'function') throw new Error('platform filesystem is unavailable');
-  if (fs.existsSync(developmentMarker) && fs.existsSync(developmentSidecar)) return developmentSidecar;
-  // Returning the deterministic production candidate keeps App construction
-  // non-throwing; the login probe reports a missing/incomplete payload with the
-  // exact path.  This immutable extension path never consults runtime/current.
-  return runtimeSidecar;
+  if (!fs || typeof fs.existsSync !== 'function') {
+    throw new Error('platform filesystem is unavailable');
+  }
+  if (fs.existsSync(developmentMarker) && fs.existsSync(developmentSidecar)) {
+    return developmentSidecar;
+  }
+  if (adapter.id !== 'macos-arm64') return extensionRuntimeSidecar;
+  if (!runtimeSelection) return null;
+
+  const receipt = runtimeSelection.componentReceipt;
+  const canonicalPath = receipt?.canonicalPath;
+  if (receipt?.component !== 'core-runtime'
+      || receipt?.platform !== adapter.id
+      || typeof canonicalPath !== 'string'
+      || !adapter.paths.isAbsolute(canonicalPath)
+      || !adapter.paths.contains(adapter.paths.runtimeRoot, canonicalPath)) {
+    throw incompatibleSidecarSelection(
+      'The selected runtime does not own a compatible Claude sidecar payload',
+    );
+  }
+  return adapter.paths.join([
+    canonicalPath, 'node', 'sidecar', 'agent-sidecar.mjs',
+  ]);
 }
 
 export async function probeClaudeLogin({

--- a/plugin/panel/test/claudeAuth.test.js
+++ b/plugin/panel/test/claudeAuth.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import path from 'node:path';
 import { probeClaudeLogin, resolveSidecarPath } from '../src/cep/claudeAuth.js';
 
 function makeProc() {
@@ -37,6 +38,55 @@ function windowsPlatform() {
   return { id: 'windows-x64', paths: windowsPaths() };
 }
 
+function macPaths() {
+  const runtimeRoot = '/Users/test/.ae-mcp/runtime';
+  return {
+    runtimeRoot,
+    join: (parts) => path.posix.join(...parts),
+    resolve: (parts) => path.posix.resolve(...parts),
+    isAbsolute: (value) => path.posix.isAbsolute(value),
+    contains: (root, candidate) => {
+      const normalizedRoot = path.posix.resolve(root);
+      const normalizedCandidate = path.posix.resolve(candidate);
+      return normalizedCandidate === normalizedRoot
+        || normalizedCandidate.startsWith(normalizedRoot + '/');
+    },
+  };
+}
+
+function macPlatform() {
+  return { id: 'macos-arm64', paths: macPaths() };
+}
+
+function selectedRuntime(canonicalPath, action = 'ready') {
+  return {
+    ok: true,
+    action,
+    launcher: '/Users/test/.ae-mcp/bin/ae-mcp',
+    relative: 'generations/g-0123456789abcdef',
+    version: '0.9.3',
+    sourceCommitSha: 'a'.repeat(40),
+    componentReceipt: {
+      schemaVersion: 1,
+      component: 'core-runtime',
+      platform: 'macos-arm64',
+      version: '0.9.3',
+      sourceRevision: 'a'.repeat(40),
+      sourceRevisionRole: 'advisory',
+      canonicalPath,
+      installReceiptPath: '/Users/test/.ae-mcp/runtime/generations/g-0123456789abcdef/install-record.json',
+      generation: 'generations/g-0123456789abcdef',
+      layerId: 'b'.repeat(64),
+      signals: {},
+      stableLauncher: {
+        canonicalPath: '/Users/test/.ae-mcp/bin/ae-mcp',
+        installReceiptPath: '/Users/test/.ae-mcp/runtime/stable-launcher-record.json',
+        signal: {},
+      },
+    },
+  };
+}
+
 test('resolveSidecarPath returns the local sidecar only for a .debug development extension', () => {
   const hits = new Set(['C:\\ext\\.debug', 'C:\\ext\\sidecar\\agent-sidecar.mjs']);
   const result = resolveSidecarPath({
@@ -46,6 +96,59 @@ test('resolveSidecarPath returns the local sidecar only for a .debug development
   });
 
   assert.equal(result, 'C:\\ext\\sidecar\\agent-sidecar.mjs');
+});
+
+test('resolveSidecarPath waits for a verified macOS production runtime selection', () => {
+  const result = resolveSidecarPath({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.equal(result, null);
+});
+
+test('resolveSidecarPath uses the selected macOS generation for ready retained and fallback results', () => {
+  const cases = [
+    ['ready', '/Users/test/.ae-mcp/runtime/layers/a/i-ready/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/a/i-ready/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+    ['retained', '/Users/test/.ae-mcp/runtime/layers/b/i-retained/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/b/i-retained/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+    ['fallback', '/Users/test/.ae-mcp/runtime/layers/c/i-fallback/macos-arm64',
+      '/Users/test/.ae-mcp/runtime/layers/c/i-fallback/macos-arm64/node/sidecar/agent-sidecar.mjs'],
+  ];
+
+  for (const [action, canonicalPath, expected] of cases) {
+    const result = resolveSidecarPath({
+      extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+      platform: macPlatform(),
+      runtimeSelection: selectedRuntime(canonicalPath, action),
+      fsImpl: { existsSync: () => false },
+    });
+    assert.equal(result, expected);
+  }
+});
+
+test('resolveSidecarPath rejects incompatible macOS runtime receipts without an extension fallback', () => {
+  const base = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/i-valid/macos-arm64');
+  const cases = [
+    { ...base, componentReceipt: { ...base.componentReceipt, component: 'platform-helper' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, platform: 'windows-x64' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, canonicalPath: 'relative/runtime' } },
+    { ...base, componentReceipt: { ...base.componentReceipt, canonicalPath: '/Applications/Adobe/CEP/extensions/ae-mcp/runtime/macos-arm64' } },
+  ];
+
+  for (const runtimeSelection of cases) {
+    assert.throws(
+      () => resolveSidecarPath({
+        extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+        platform: macPlatform(),
+        runtimeSelection,
+        fsImpl: { existsSync: () => false },
+      }),
+      (error) => error?.code === 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE',
+    );
+  }
 });
 
 test('resolveSidecarPath returns the bundled runtime sidecar in production', () => {

--- a/plugin/panel/test/claudeAuth.test.js
+++ b/plugin/panel/test/claudeAuth.test.js
@@ -2,7 +2,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
-import { probeClaudeLogin, resolveSidecarPath } from '../src/cep/claudeAuth.js';
+import {
+  probeClaudeLogin,
+  resolveSidecarPath,
+  resolveSidecarSelection,
+} from '../src/cep/claudeAuth.js';
 
 function makeProc() {
   const proc = new EventEmitter();
@@ -173,6 +177,88 @@ test('resolveSidecarPath returns a diagnostic runtime candidate without throwing
   assert.equal(result, 'C:\\missing\\runtime\\windows-x64\\node\\sidecar\\agent-sidecar.mjs');
 });
 
+test('resolveSidecarSelection keeps macOS pending until runtime activation is ready', () => {
+  const selection = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'starting', result: null, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.deepEqual(selection, { state: 'pending', path: null, error: null });
+});
+
+test('resolveSidecarSelection exposes the verified path only after macOS activation', () => {
+  const runtime = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/i-active/macos-arm64');
+  const selection = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: runtime, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+
+  assert.deepEqual(selection, {
+    state: 'ready',
+    path: '/Users/test/.ae-mcp/runtime/layers/a/i-active/macos-arm64/node/sidecar/agent-sidecar.mjs',
+    error: null,
+  });
+});
+
+test('resolveSidecarSelection preserves RuntimeManager and receipt errors before dispatch', () => {
+  const runtimeError = Object.assign(new Error('runtime failed'), {
+    code: 'RUNTIME_MANIFEST_INVALID',
+  });
+  const activationFailure = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'error', result: null, error: runtimeError },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.equal(activationFailure.state, 'error');
+  assert.equal(activationFailure.path, null);
+  assert.equal(activationFailure.error, runtimeError);
+
+  const runtime = selectedRuntime('/Applications/Adobe/CEP/extensions/ae-mcp/runtime/macos-arm64');
+  const receiptFailure = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: runtime, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.equal(receiptFailure.state, 'error');
+  assert.equal(receiptFailure.path, null);
+  assert.equal(receiptFailure.error.code, 'RUNTIME_SIDECAR_SELECTION_INCOMPATIBLE');
+});
+
+test('resolveSidecarSelection keeps Windows and debug paths independent of RuntimeManager', () => {
+  const windows = resolveSidecarSelection({
+    extRoot: 'C:\\ext',
+    platform: windowsPlatform(),
+    runtimeActivation: { state: 'ready', result: null, error: null },
+    fsImpl: { existsSync: () => false },
+  });
+  assert.deepEqual(windows, {
+    state: 'ready',
+    path: 'C:\\ext\\runtime\\windows-x64\\node\\sidecar\\agent-sidecar.mjs',
+    error: null,
+  });
+
+  const debug = resolveSidecarSelection({
+    extRoot: '/Applications/Adobe/CEP/extensions/ae-mcp',
+    platform: macPlatform(),
+    runtimeActivation: { state: 'ready', result: null, error: null },
+    fsImpl: {
+      existsSync: (value) => value === '/Applications/Adobe/CEP/extensions/ae-mcp/.debug'
+        || value === '/Applications/Adobe/CEP/extensions/ae-mcp/sidecar/agent-sidecar.mjs',
+    },
+  });
+  assert.deepEqual(debug, {
+    state: 'ready',
+    path: '/Applications/Adobe/CEP/extensions/ae-mcp/sidecar/agent-sidecar.mjs',
+    error: null,
+  });
+});
+
 test('probeClaudeLogin resolves logged in probe-result', async () => {
   const proc = makeProc();
   let spawnArgs;
@@ -265,4 +351,28 @@ test('probeClaudeLogin reports resolveNode failure and does not spawn', async ()
 
   assert.equal(spawned, false);
   assert.deepEqual(result, { loggedIn: false, nodeOk: false, detail: 'node missing' });
+});
+
+test('probeClaudeLogin does not resolve Node or spawn while Sidecar selection is pending', async () => {
+  let nodeResolutions = 0;
+  let spawns = 0;
+  const result = await probeClaudeLogin({
+    sidecarPath: null,
+    resolveNode: async () => {
+      nodeResolutions += 1;
+      return { ok: true, nodePath: 'node', version: '20.0.0' };
+    },
+    spawnImpl: () => {
+      spawns += 1;
+      return makeProc();
+    },
+  });
+
+  assert.deepEqual(result, {
+    loggedIn: false,
+    nodeOk: false,
+    detail: 'verified runtime sidecar is not ready',
+  });
+  assert.equal(nodeResolutions, 0);
+  assert.equal(spawns, 0);
 });

--- a/plugin/panel/test/claudeAuth.test.js
+++ b/plugin/panel/test/claudeAuth.test.js
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import {
   probeClaudeLogin,
+  resolveNodeForSidecarSelection,
   resolveSidecarPath,
   resolveSidecarSelection,
 } from '../src/cep/claudeAuth.js';
@@ -351,6 +352,78 @@ test('probeClaudeLogin reports resolveNode failure and does not spawn', async ()
 
   assert.equal(spawned, false);
   assert.deepEqual(result, { loggedIn: false, nodeOk: false, detail: 'node missing' });
+});
+
+test('resolveNodeForSidecarSelection rejects a Node receipt from another selected runtime generation', async () => {
+  const selectionA = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/generation-a/macos-arm64');
+  const resolvedNodeB = {
+    ok: true,
+    nodePath: '/Users/test/.ae-mcp/runtime/layers/a/generation-b/macos-arm64/node/bin/node',
+    version: '24.17.0',
+    runtime: {
+      componentReceipt: {
+        ...selectionA.componentReceipt,
+        canonicalPath: '/Users/test/.ae-mcp/runtime/layers/a/generation-b/macos-arm64',
+      },
+    },
+  };
+  let resolutions = 0;
+
+  await assert.rejects(
+    () => resolveNodeForSidecarSelection({
+      resolveNode: async () => {
+        resolutions += 1;
+        return resolvedNodeB;
+      },
+      runtimeSelection: selectionA,
+      platform: macPlatform(),
+    }),
+    (error) => error.code === 'RUNTIME_SIDECAR_NODE_SELECTION_MISMATCH',
+  );
+  assert.equal(resolutions, 1);
+});
+
+test('probeClaudeLogin does not spawn a generation-B Node for a generation-A Sidecar selection', async () => {
+  const selectionA = selectedRuntime('/Users/test/.ae-mcp/runtime/layers/a/generation-a/macos-arm64');
+  const resolvedNodeB = {
+    ok: true,
+    nodePath: '/Users/test/.ae-mcp/runtime/layers/a/generation-b/macos-arm64/node/bin/node',
+    version: '24.17.0',
+    runtime: {
+      componentReceipt: {
+        ...selectionA.componentReceipt,
+        canonicalPath: '/Users/test/.ae-mcp/runtime/layers/a/generation-b/macos-arm64',
+      },
+    },
+  };
+  let spawns = 0;
+  const resolveSelectedNode = ({ platform }) => resolveNodeForSidecarSelection({
+    resolveNode: async () => resolvedNodeB,
+    runtimeSelection: selectionA,
+    platform,
+  });
+  const result = await probeClaudeLogin({
+    platform: macPlatform(),
+    resolveNode: async (options) => {
+      try {
+        return await resolveSelectedNode(options);
+      } catch (error) {
+        return { ok: false, detail: error.message };
+      }
+    },
+    sidecarPath: '/Users/test/.ae-mcp/runtime/layers/a/generation-a/macos-arm64/node/sidecar/agent-sidecar.mjs',
+    spawnImpl: () => {
+      spawns += 1;
+      return makeProc();
+    },
+  });
+
+  assert.deepEqual(result, {
+    loggedIn: false,
+    nodeOk: false,
+    detail: 'Selected Sidecar and Node runtime receipts do not match',
+  });
+  assert.equal(spawns, 0);
 });
 
 test('probeClaudeLogin does not resolve Node or spawn while Sidecar selection is pending', async () => {


### PR DESCRIPTION
## Summary

- resolve the macOS production Claude Agent Sidecar only from RuntimeManager's selected and verified `componentReceipt.canonicalPath`
- keep `.debug` and Windows behavior unchanged while gating macOS probing until runtime activation is ready
- reject a cross-generation Node/Sidecar pair before process spawn
- document selected-generation Sidecar ownership

## Root cause

The panel previously resolved the production Sidecar from the extension bundle
while RuntimeManager selected Node from an installed runtime generation. During
review, a second mismatch boundary was reproduced: Node resolution could
reselect generation B after the Sidecar had been bound to generation A.

The implementation now derives the Sidecar from the selected receipt and
compares the Node result's runtime receipt with that same selection before
dispatch.

## Validation

- `git diff --check`
- focused Panel tests: 40 passed, 0 failed
- production Panel build: passed
- complete Panel suite: 1083 passed, 0 failed, 2 skipped
- three task-scoped independent reviews: approved with no remaining findings
- concentrated branch review: one reproduced blocker fixed; focused round-two
  re-review confirmed it addressed with no new Critical or Important findings

No After Effects hardware session was run because this package changes only
the tested Panel path-selection boundary and does not add new AE behavior.

Closes #148
