### PR TITLE
Fix snapshot platform claims and repair stale macOS helper registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Embedded panel chat or external MCP client
   -> After Effects
 ```
 
-`ae_previewFrame` renders real comp pixels through `CompItem.saveFrameToPng`, with viewer snapshot only as a fallback. `packages/snapshot-mss` provides the cross-platform `mss` screenshot backend for `ae_snapshot` screen capture.
+`ae_previewFrame` remains the AE-internal `CompItem.saveFrameToPng` path for rendering real comp pixels, with viewer snapshot only as a fallback. `packages/snapshot-mss` provides Windows `ae_snapshot` screen capture through the `mss` backend.
 
 The MCP core is backend-agnostic: external clients can talk to AE through the stdio server, while the CEP panel can also host built-in agent chat. The existing panel layer handles backend setup, approvals, diagnostics, and activity history. The published v0.9.2 Windows asset predates bundled-runtime activation; current v0.9.3 macOS development includes a panel RuntimeManager that verifies, installs, atomically activates, repairs, rolls back, and uninstalls the packaged runtime without using an online package manager. Claude, Codex, and ZCode are built-in panel backends; OpenCode and other tools can still connect as external MCP clients.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ v0.9.2 已发布资产面向以下已验证范围：
   -> After Effects
 ```
 
-`ae_previewFrame` 通过 `CompItem.saveFrameToPng` 渲染真实合成像素，viewer snapshot 只作为 fallback。`packages/snapshot-mss` 提供跨平台 `mss` 截图后端，用于 `ae_snapshot` 屏幕捕获。
+`ae_previewFrame` 仍是 AE 内部的 `CompItem.saveFrameToPng` 路径，用于渲染真实合成像素，viewer snapshot 只作为 fallback。`packages/snapshot-mss` 通过 `mss` backend 提供 Windows `ae_snapshot` 屏幕捕获。
 
 MCP core 本身保持后端无关：外部客户端可以通过 stdio server 与 AE 对话，CEP 面板也可以在 AE 内承载内嵌 agent 对话。现有面板层负责后端配置、审批、诊断和活动历史。已发布的 v0.9.2 Windows 资产早于包内 runtime 激活能力；当前 v0.9.3 macOS 开发版本已经实现 Panel RuntimeManager，可在不调用在线包管理器的情况下校验、安装、原子激活、修复、回滚和卸载包内 runtime。Claude、Codex、ZCode 是面板内置后端；OpenCode 和其他工具仍可以作为外部 MCP 客户端接入。
 

--- a/docs/superpowers/plans/2026-07-30-snapshot-truthfulness-helper-repair.md
+++ b/docs/superpowers/plans/2026-07-30-snapshot-truthfulness-helper-repair.md
@@ -1,0 +1,1077 @@
+# Snapshot Truthfulness and macOS Helper Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship one PR that makes `snapshot-mss` truthfully Windows-only and
+adds an explicit panel action that repairs a stale macOS platform-helper
+registration.
+
+**Architecture:** The PR has two independent tracks. The Python snapshot track
+changes only platform eligibility and the promises around it. The macOS helper
+track adds `repairRegistered()` to the existing launchd registrar, selects that
+operation through a one-shot transport construction option, and lets the
+HostController replace its helper client/transport when the user invokes
+Repair Helper.
+
+**Tech Stack:** Python 3.10+, pytest, Node.js CommonJS host modules,
+`node:test`, React 18 CEP panel, esbuild, macOS per-user launchd.
+
+## Global Constraints
+
+- Work only in
+  `/Users/junk_doge/Documents/ae-mcp/.worktrees/issues-178-66-snapshot-helper-repair`
+  on branch `codex/issues-178-66-snapshot-helper-repair`; the root checkout has
+  unrelated user changes and must remain untouched.
+- Keep #178 and #66 in one PR but in separate logical commits, test groups, and
+  issue dispositions.
+- Follow strict red-green-refactor: no production behavior change before its
+  focused test has failed for the expected missing behavior.
+- `MssSnapshotter.supports_platform()` returns `True` only for
+  `sys.platform == "win32"`.
+- Do not change the Windows screenshot implementation or the native
+  `ae.previewFrame` path.
+- Routine macOS startup continues to perform only absent-service bootstrap or
+  exact-path reuse. It never executes `bootout`.
+- Only the explicit user repair path may replace the fixed per-user service
+  `gui/<uid>/com.junkdoge.ae-mcp.platform-helper`.
+- Repair must reverify the current payload before launchd mutation, use only
+  `/bin/launchctl`, verify the loaded Program equals the current helper path,
+  then create a fresh transport/client and complete `capabilities()`.
+- A missing service during explicit repair is recoverable. Other launchctl
+  failures remain structured failures and are not blindly retried.
+- Helper failures exposed to React preserve sanitized codes and never expose
+  payload paths, command output, secret values, or native error messages.
+- Do not add PID tracking, start-token comparison, process census, generalized
+  runner infrastructure, routine full-tree hash walks, automatic
+  multi-instance coordination, or unrelated security hardening.
+- Do not change Swift/XPC protocol code, RuntimeManager, Keychain policy,
+  ScreenCaptureKit, installer/uninstaller, signing, notarization, or AEGP.
+- Keep ScreenCaptureKit work in #67, installer lifecycle in #69, and signed
+  clean-machine release attestation in #70.
+- Generate `plugin/client/dist/app.js` with
+  `npm --prefix plugin/panel run build`; never edit the bundle by hand.
+- Per-task reviewers classify findings under AGENTS.md section 5. A
+  non-reproduced edge case is follow-up or out of scope, not an automatic
+  implementation request.
+
+## File Responsibility Map
+
+- `packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py`: implements the
+  snapshotter predicate and Windows capture behavior.
+- `packages/snapshot-mss/tests/test_mss_snapshot.py`: proves platform
+  eligibility, discovery consequence, and existing capture behavior.
+- `packages/snapshot-mss/pyproject.toml`,
+  `packages/snapshot-mss/README.md`, `README.md`, and `README.zh-CN.md`: state
+  the public Windows-only `snapshot-mss` support contract.
+- `plugin/host/platform-helper-registration.js`: owns verified launchd
+  inspection, bootstrap, explicit replacement, and exact Program verification.
+- `plugin/host/platform-helper-registration.test.js`: executes the registrar
+  against controlled payloads and injected `/bin/launchctl` behavior.
+- `plugin/host/platform-helper-transport.js`: chooses normal registration or
+  explicit repair before opening the macOS stdio broker.
+- `plugin/host/platform-helper-transport.test.js`: proves ordering and Windows
+  non-regression at the transport boundary.
+- `plugin/panel/src/cep/hostBridge.js`: owns the live CEP helper
+  client/transport lifecycle and exposes `repairPlatformHelper()`.
+- `plugin/panel/test/hostBridge.test.js`: proves repair replaces the failed
+  helper binding and completes a sanitized capability handshake.
+- `plugin/panel/src/app/providerInitState.js`: classifies helper failures and
+  computes the Repair Helper view model.
+- `plugin/panel/test/providerInitState.test.js`: proves Repair Helper visibility
+  and disabled state from observable provider initialization facts.
+- `plugin/panel/src/app/App.jsx`: invokes HostController repair, records
+  progress, and reruns provider initialization.
+- `plugin/panel/src/screens/SettingsScreen.jsx`: renders the explicit Repair
+  Helper action.
+- `plugin/client/dist/app.js`: generated panel bundle.
+
+---
+
+### Task 1: Make `snapshot-mss` Truthfully Windows-Only
+
+**Files:**
+
+- Modify: `packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py`
+- Modify: `packages/snapshot-mss/tests/test_mss_snapshot.py`
+- Modify: `packages/snapshot-mss/pyproject.toml`
+- Modify: `packages/snapshot-mss/README.md`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+**Interfaces:**
+
+- Consumes: Python's exact `sys.platform` values.
+- Produces:
+  `MssSnapshotter.supports_platform() -> bool`, true only on `win32`.
+- Preserves: `MssSnapshotter.capture(...)` and the existing Windows
+  HWND-to-rectangle behavior.
+
+- [ ] **Step 1: Replace the incorrect predicate test with platform cases**
+
+In `packages/snapshot-mss/tests/test_mss_snapshot.py`, use the already imported
+`sys` and add the discovery import:
+
+```python
+from ae_mcp.snapshot.discovery import select_snapshotter
+```
+
+Replace `test_supports_platform_always_true` with:
+
+```python
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [("win32", True), ("darwin", False), ("linux", False)],
+)
+def test_supports_platform_only_when_window_capture_is_implemented(platform, expected):
+    with patch.object(sys, "platform", platform):
+        assert MssSnapshotter().supports_platform() is expected
+
+
+def test_darwin_discovery_does_not_select_mss():
+    with patch.object(sys, "platform", "darwin"), patch(
+        "ae_mcp.snapshot.discovery._scan_entry_points",
+        return_value={"mss": MssSnapshotter},
+    ):
+        assert select_snapshotter() is None
+```
+
+The predicate test catches an unconditional return. The discovery test catches
+a later regression that makes the concrete backend eligible on Darwin.
+
+- [ ] **Step 2: Run the new tests and verify the intended red result**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/snapshot-mss/tests/test_mss_snapshot.py::test_supports_platform_only_when_window_capture_is_implemented \
+  packages/snapshot-mss/tests/test_mss_snapshot.py::test_darwin_discovery_does_not_select_mss \
+  -q
+```
+
+Expected: Darwin and Linux predicate cases fail because the current method
+returns `True`; Darwin discovery selects `mss`.
+
+- [ ] **Step 3: Implement the minimal predicate**
+
+In `packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py`:
+
+```python
+"""Windows AE-window ae.snapshot implementation backed by mss."""
+from __future__ import annotations
+
+import sys
+import time
+```
+
+Change the method to:
+
+```python
+def supports_platform(self) -> bool:
+    return sys.platform == "win32"
+```
+
+Do not change `capture()`.
+
+- [ ] **Step 4: Run the focused tests and verify green**
+
+Run the command from Step 2.
+
+Expected: all parameter cases and Darwin discovery pass.
+
+- [ ] **Step 5: Correct user-facing package promises**
+
+Use these meanings consistently:
+
+- Python module docstring: Windows AE-window implementation backed by `mss`.
+- `pyproject.toml` description:
+  `Windows mss-based After Effects window capture for ae-mcp`.
+- Package README, Chinese:
+  `ae-mcp-snapshot-mss` 是 ae-mcp 的 Windows 截图 backend。
+- Package README, English:
+  `ae-mcp-snapshot-mss` is the Windows screenshot backend for ae-mcp.
+- Root README and Chinese README: `snapshot-mss` provides Windows
+  `ae_snapshot` screen capture; `ae_previewFrame` remains the AE-internal
+  `CompItem.saveFrameToPng` path.
+
+Do not claim that the underlying `mss` library is Windows-only; the limitation
+belongs to this backend's AE-window targeting implementation.
+
+- [ ] **Step 6: Run the snapshot and public filtering regressions**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/snapshot-mss/tests/test_mss_snapshot.py \
+  packages/core/tests/test_snapshot_discovery.py \
+  packages/core/tests/test_status_tool.py \
+  packages/core/tests/test_server_native_tools.py \
+  -q
+```
+
+Expected: all pass. Existing core tests prove that `select_snapshotter() is
+None` removes `ae.snapshot` from the public tool set.
+
+- [ ] **Step 7: Commit the independent #178 track**
+
+```bash
+git add \
+  packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py \
+  packages/snapshot-mss/tests/test_mss_snapshot.py \
+  packages/snapshot-mss/pyproject.toml \
+  packages/snapshot-mss/README.md \
+  README.md \
+  README.zh-CN.md
+git commit -m "fix(snapshot): advertise only implemented platform support"
+```
+
+---
+
+### Task 2: Add the Explicit launchd Repair Primitive
+
+**Files:**
+
+- Modify: `plugin/host/platform-helper-registration.js`
+- Modify: `plugin/host/platform-helper-registration.test.js`
+
+**Interfaces:**
+
+- Consumes:
+  `prepareMacosHelperRegistration({ addonPath, fsImpl, createHash, execFile,
+  homedir, getuid, processId })`.
+- Produces:
+  `repairRegistered() -> Promise<{action: "already-current" | "repaired",
+  helperPath: string}>` alongside the existing `helperPath` and
+  `ensureRegistered()`.
+- Preserves: normal `ensureRegistered()` never calls `bootout`.
+
+- [ ] **Step 1: Add a red test for stale-path explicit replacement**
+
+Add a test named
+`macOS explicit repair replaces a stale registration and verifies the current helper`
+to `plugin/host/platform-helper-registration.test.js`.
+
+Use `writeMacosFixture(t)`, `registrationFor(...)`, the literal service
+`gui/501/com.junkdoge.ae-mcp.platform-helper`, and an injected `execFile` that
+records calls. It must return a stale Program for the first `print`, accept
+`bootout` and `bootstrap`, and return `fixture.helperPath` for the final
+`print`.
+
+Assert:
+
+```javascript
+assert.deepEqual(await registration.repairRegistered(), {
+    action: 'repaired',
+    helperPath: fixture.helperPath,
+});
+assert.deepEqual(calls.map(([, args]) => args[0]), [
+    'print',
+    'bootout',
+    'bootstrap',
+    'print',
+]);
+assert.deepEqual(calls[1][1], ['bootout', service]);
+```
+
+- [ ] **Step 2: Verify the replacement test is red**
+
+Run:
+
+```bash
+node --test \
+  --test-name-pattern="explicit repair replaces" \
+  plugin/host/platform-helper-registration.test.js
+```
+
+Expected: fail because `registration.repairRegistered` is not defined.
+
+- [ ] **Step 3: Add the minimal repair API**
+
+In `prepareMacosHelperRegistration`, retain the absolute addon path and add:
+
+```javascript
+async function repairRegistered() {
+    const currentPayload = verifyMacosPayload(
+        path.resolve(input.addonPath),
+        dependencies,
+    );
+    const current = await launchctl(['print', service], { allowMissing: true });
+    if (current.found) {
+        try {
+            requireExactProgram(current.stdout, currentPayload.helperPath);
+            return Object.freeze({
+                action: 'already-current',
+                helperPath: currentPayload.helperPath,
+            });
+        } catch (error) {
+            if (!error || error.code !== 'PLATFORM_HELPER_REPAIR_REQUIRED') {
+                throw error;
+            }
+        }
+        await launchctl(['bootout', service], { allowMissing: true });
+    }
+    const plistPath = materializePrivatePlist(currentPayload, dependencies);
+    await launchctl(['bootstrap', domain, plistPath]);
+    const registered = await launchctl(['print', service]);
+    requireExactProgram(registered.stdout, currentPayload.helperPath);
+    return Object.freeze({
+        action: 'repaired',
+        helperPath: currentPayload.helperPath,
+    });
+}
+```
+
+Return it from the frozen registration object:
+
+```javascript
+return Object.freeze({
+    helperPath: payload.helperPath,
+    ensureRegistered,
+    repairRegistered,
+});
+```
+
+Keep `register()` and `ensureRegistered()` unchanged.
+
+- [ ] **Step 4: Run the replacement test and verify green**
+
+Run the Step 2 command.
+
+Expected: pass with the exact `print → bootout → bootstrap → print` sequence.
+
+- [ ] **Step 5: Add red tests for the repair boundaries**
+
+Add these separate tests with literal expected calls:
+
+1. `macOS explicit repair reuses an already-current registration`
+   - first `print` contains `fixture.helperPath`;
+   - result is `{ action: "already-current", helperPath }`;
+   - calls are exactly `["print"]`.
+2. `macOS explicit repair bootstraps when the service is already absent`
+   - first `print` fails with `{ code: 113 }`;
+   - calls are `["print", "bootstrap", "print"]`;
+   - no `bootout` call occurs.
+3. `macOS explicit repair reverifies the payload before launchd mutation`
+   - construct the registration, then append `tampered` to
+     `fixture.helperPath`;
+   - `repairRegistered()` rejects with
+     `PLATFORM_HELPER_REPAIR_REQUIRED`;
+   - `launchctlCalls === 0`.
+4. `macOS explicit repair stops on a non-missing bootout failure`
+   - stale `print`, then `bootout` fails with `{ code: 5 }`;
+   - reject with `HELPER_START_FAILED`;
+   - no `bootstrap` occurs.
+5. `macOS explicit repair continues when bootout observes a missing service`
+   - stale `print`, then `bootout` fails with `{ code: 113 }`;
+   - continue through `bootstrap` and exact final `print`.
+6. `macOS normal registration never boots out a stale service`
+   - call `ensureRegistered()` against a stale Program;
+   - reject with `PLATFORM_HELPER_REPAIR_REQUIRED`;
+   - calls are exactly `["print"]`.
+
+- [ ] **Step 6: Verify the new boundary tests expose the missing distinction**
+
+Run:
+
+```bash
+node --test \
+  --test-name-pattern="explicit repair|normal registration never" \
+  plugin/host/platform-helper-registration.test.js
+```
+
+Expected before the next implementation step: the non-missing `bootout`
+failure case shows that the existing `allowMissing` behavior incorrectly
+swallows every command failure.
+
+- [ ] **Step 7: Restrict missing-service recovery to launchctl code 113**
+
+Add:
+
+```javascript
+function launchctlServiceMissing(error) {
+    return Boolean(error) && Number(error.code) === 113;
+}
+```
+
+In `launchctlRunner`, replace the unconditional `if (allowMissing)` branch
+with:
+
+```javascript
+if (allowMissing && launchctlServiceMissing(error)) {
+    resolve(Object.freeze({ found: false, stdout: '' }));
+    return;
+}
+```
+
+All other failures continue through the existing sanitized
+`HELPER_START_FAILED` path.
+
+- [ ] **Step 8: Run the complete registrar suite**
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-registration.test.js
+```
+
+Expected: all existing registration tests and all explicit repair tests pass.
+
+- [ ] **Step 9: Commit the registrar primitive**
+
+```bash
+git add \
+  plugin/host/platform-helper-registration.js \
+  plugin/host/platform-helper-registration.test.js
+git commit -m "feat(macos): repair stale helper registration explicitly"
+```
+
+---
+
+### Task 3: Rebuild the CEP Helper Binding Through Repair Mode
+
+**Files:**
+
+- Modify: `plugin/host/platform-helper-transport.js`
+- Modify: `plugin/host/platform-helper-transport.test.js`
+- Modify: `plugin/panel/src/cep/hostBridge.js`
+- Modify: `plugin/panel/test/hostBridge.test.js`
+
+**Interfaces:**
+
+- Consumes from Task 2:
+  `{ helperPath, ensureRegistered, repairRegistered }`.
+- Produces:
+  `createPlatformHelperTransport({ ..., repairRegistration?: boolean })`.
+- Produces:
+  `createHostController(...).repairPlatformHelper() -> Promise<Capabilities>`.
+- Preserves: the host facade methods `capabilities`, `secretGet`, `secretSet`,
+  and `secretDelete`; Windows transport behavior is unchanged.
+
+- [ ] **Step 1: Add a red transport ordering test**
+
+Update the default macOS registrar fixture in
+`plugin/host/platform-helper-transport.test.js` so it defines both methods:
+
+```javascript
+return {
+    helperPath: '/verified/platform/helper',
+    ensureRegistered: async function () {},
+    repairRegistered: async function () {},
+};
+```
+
+Add:
+
+```javascript
+test('macOS repair transport replaces registration before opening the broker', async () => {
+    const events = [];
+    const transport = createPlatformHelperTransport(macOptions({
+        repairRegistration: true,
+        prepareMacosHelperRegistration: function () {
+            return {
+                helperPath: '/verified/platform/helper',
+                ensureRegistered: async function () {
+                    events.push('ensure');
+                },
+                repairRegistered: async function () {
+                    events.push('repair');
+                },
+            };
+        },
+        createMacosBrokerTransport: function () {
+            events.push('broker');
+            return {
+                request: async function () { return 'ready'; },
+                close: async function () {},
+            };
+        },
+    }));
+
+    assert.equal(await transport.request('request'), 'ready');
+    assert.deepEqual(events, ['repair', 'broker']);
+    await transport.close();
+});
+```
+
+- [ ] **Step 2: Verify the transport test is red**
+
+Run:
+
+```bash
+node --test \
+  --test-name-pattern="repair transport replaces" \
+  plugin/host/platform-helper-transport.test.js
+```
+
+Expected: fail because the current transport always calls
+`ensureRegistered()`.
+
+- [ ] **Step 3: Select the approved registration operation**
+
+Require `repairRegistered` in `validMacosRegistration`:
+
+```javascript
+&& typeof value.ensureRegistered === 'function'
+&& typeof value.repairRegistered === 'function';
+```
+
+Before opening the broker in `connect()`:
+
+```javascript
+if (input.repairRegistration === true) {
+    await macosRegistration.repairRegistered();
+} else {
+    await macosRegistration.ensureRegistered();
+}
+```
+
+Do not add `bootout` or launchd knowledge to the transport.
+
+- [ ] **Step 4: Run the complete transport suite**
+
+Run:
+
+```bash
+node --test plugin/host/platform-helper-transport.test.js
+```
+
+Expected: the repair ordering test and all Windows/macOS existing tests pass.
+In the existing process-boundary source test, remove only `\bbootout\b` from
+the registration-source forbidden regex so it becomes:
+
+```javascript
+/shell:\s*true|\bexec\s*\(|\bspawn\s*\(|\bkill\b|stdio:\s*'inherit'/i
+```
+
+The test must continue to reject shell execution, inherited stdio, kill
+behavior, and process APIs in other host files. Behavioral registrar tests,
+not a source-text assertion, prove the exact `bootout` operation.
+
+- [ ] **Step 5: Add a red HostController replacement test**
+
+In `plugin/panel/test/hostBridge.test.js`, add
+`host controller repair replaces the stale helper binding and handshakes the replacement`.
+
+Use the existing `fakeHostDependencyRuntime`, `macHostAdapter`, and fake host
+shape. Have `createPlatformHelperTransportImpl(options)` record
+`options.repairRegistration` and return transport 1 for the normal bind and
+transport 2 for the repair bind. Client 1's `capabilities()` rejects with code
+`PLATFORM_HELPER_REPAIR_REQUIRED`; client 2 returns:
+
+```javascript
+{
+  protocolVersion: 1,
+  helperVersion: 'test-helper',
+  authenticatedCaller: true,
+  secretBackend: 'keychain',
+  methods: ['secret.get', 'secret.set', 'secret.delete'],
+}
+```
+
+Assert:
+
+```javascript
+await assert.rejects(
+  controller.getHost().capabilities(),
+  { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+);
+assert.equal(typeof controller.repairPlatformHelper, 'function');
+assert.equal(
+  (await controller.repairPlatformHelper()).authenticatedCaller,
+  true,
+);
+assert.deepEqual(repairModes, [false, true]);
+assert.equal((await controller.getHost().capabilities()).helperVersion, 'test-helper');
+assert.equal(firstClientCloses, 1);
+```
+
+- [ ] **Step 6: Verify the HostController test is red**
+
+Run:
+
+```bash
+node --test \
+  --test-name-pattern="repair replaces the stale helper binding" \
+  plugin/panel/test/hostBridge.test.js
+```
+
+Expected: fail because `repairPlatformHelper` is not exported by the
+controller and the transport factory is never called with repair mode.
+
+- [ ] **Step 7: Refactor the helper bind around one reusable context**
+
+In `createHostController`, add:
+
+```javascript
+let helperBindingContext = null;
+```
+
+Extend `bindPlatformHelperFacade` to accept
+`repairRegistration = false`, pass the boolean to the transport factory, and
+store the binding context for the current host:
+
+```javascript
+transport = transportFactory({
+  platformId: adapter.id,
+  runtime: helperRuntime(adapter.id),
+  repairRegistration,
+});
+```
+
+After the current host is established in `start`, retain only:
+
+```javascript
+helperBindingContext = { cepRequire, extRoot, hostInstance: nextHost };
+```
+
+Clear `helperBindingContext` wherever the current lifecycle clears `host`,
+including start replacement, startup failure, and `beforeunload`.
+
+- [ ] **Step 8: Implement `repairPlatformHelper()` with a fresh binding**
+
+Add an async controller method with this behavior:
+
+```javascript
+async function repairPlatformHelper() {
+  const context = helperBindingContext;
+  const currentHost = host;
+  if (adapter.id !== 'macos-arm64'
+      || !context
+      || !currentHost
+      || context.hostInstance !== currentHost) {
+    throw helperUnavailableError();
+  }
+
+  const priorClient = helperClient;
+  helperClient = null;
+  closeHelperClient(priorClient);
+  bindPlatformHelperFacade({
+    ...context,
+    repairRegistration: true,
+  });
+
+  if (host !== currentHost) {
+    throw helperUnavailableError();
+  }
+  try {
+    return await currentHost.capabilities();
+  } catch (error) {
+    throw sanitizeHelperError(error);
+  }
+}
+```
+
+Return it from the controller:
+
+```javascript
+return { start, restart, repairPlatformHelper, getHost: () => host };
+```
+
+The new binding replaces all helper facade methods on `currentHost`. Calling
+`currentHost.capabilities()` even when construction produced no client
+preserves the sanitized binding error installed by
+`bindPlatformHelperFacade`. A failed replacement remains a repairable state;
+another explicit invocation constructs another fresh binding.
+
+- [ ] **Step 9: Add and pass failure-boundary tests**
+
+Add:
+
+1. `host controller repair preserves a sanitized replacement failure`
+   - replacement client rejects with a message containing a private path and
+     code `HELPER_START_FAILED`;
+   - controller rejection has code `HELPER_START_FAILED`;
+   - returned message contains neither the path nor the native message.
+2. `Windows host controller does not offer macOS helper replacement`
+   - use the Windows adapter;
+   - `repairPlatformHelper()` rejects with `HELPER_UNAVAILABLE`;
+   - no repair-mode transport is constructed.
+
+Run:
+
+```bash
+node --test \
+  plugin/host/platform-helper-transport.test.js \
+  plugin/panel/test/hostBridge.test.js
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit transport and CEP lifecycle integration**
+
+```bash
+git add \
+  plugin/host/platform-helper-transport.js \
+  plugin/host/platform-helper-transport.test.js \
+  plugin/panel/src/cep/hostBridge.js \
+  plugin/panel/test/hostBridge.test.js
+git commit -m "feat(panel): rebuild helper binding after explicit repair"
+```
+
+---
+
+### Task 4: Wire the Repair Helper Action Into Settings
+
+**Files:**
+
+- Modify: `plugin/panel/src/app/providerInitState.js`
+- Modify: `plugin/panel/test/providerInitState.test.js`
+- Modify: `plugin/panel/src/app/App.jsx`
+- Modify: `plugin/panel/src/screens/SettingsScreen.jsx`
+- Modify: `plugin/client/dist/app.js`
+
+**Interfaces:**
+
+- Consumes from Task 3:
+  `ctrl.current.repairPlatformHelper() -> Promise<Capabilities>`.
+- Produces:
+  `platformHelperRepairView(providerInit, repairing, hasAction) ->
+  null | { disabled: boolean, label: "repair" | "repairing" }`.
+- Produces:
+  `providerRepairFailure(error) -> { state: "unavailable",
+  error: "PLATFORM_HELPER_REPAIR_REQUIRED", detail: string }`.
+- Adds `SettingsScreen` props:
+  `onRepairPlatformHelper?: () => Promise<void>` and
+  `providerRepairing?: boolean`.
+- Preserves: provider lists and provider secrets remain unchanged while helper
+  repair is unavailable or fails.
+
+- [ ] **Step 1: Add red view-model tests**
+
+In `plugin/panel/test/providerInitState.test.js`, import
+`platformHelperRepairView` and add:
+
+```javascript
+test('Repair Helper is available only for the explicit repair-required state', async () => {
+  const {
+    platformHelperRepairView,
+    providerRepairFailure,
+  } = await import('../src/app/providerInitState.js');
+  assert.deepEqual(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      false,
+      true,
+    ),
+    { disabled: false, label: 'repair' },
+  );
+  assert.deepEqual(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      true,
+      true,
+    ),
+    { disabled: true, label: 'repairing' },
+  );
+  for (const providerInit of [
+    { state: 'checking', error: '' },
+    { state: 'ready', error: '' },
+    { state: 'unavailable', error: 'PLATFORM_HELPER_START_FAILED' },
+  ]) {
+    assert.equal(platformHelperRepairView(providerInit, false, true), null);
+  }
+  assert.equal(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      false,
+      false,
+    ),
+    null,
+  );
+
+  const failure = new Error('private helper path');
+  failure.code = 'HELPER_START_FAILED';
+  assert.deepEqual(providerRepairFailure(failure), {
+    state: 'unavailable',
+    error: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+    detail: 'PLATFORM_HELPER_START_FAILED',
+  });
+  assert.equal(JSON.stringify(providerRepairFailure(failure)).includes('private helper path'), false);
+});
+```
+
+- [ ] **Step 2: Verify the view-model test is red**
+
+Run:
+
+```bash
+node --test \
+  --test-name-pattern="Repair Helper is available" \
+  plugin/panel/test/providerInitState.test.js
+```
+
+Expected: fail because `platformHelperRepairView` is not exported.
+
+- [ ] **Step 3: Implement the pure view model**
+
+In `plugin/panel/src/app/providerInitState.js`:
+
+```javascript
+export function platformHelperRepairView(providerInit, repairing, hasAction) {
+  if (!hasAction
+      || providerInit?.state !== 'unavailable'
+      || providerInit?.error !== 'PLATFORM_HELPER_REPAIR_REQUIRED') {
+    return null;
+  }
+  return {
+    disabled: repairing === true,
+    label: repairing === true ? 'repairing' : 'repair',
+  };
+}
+
+export function providerRepairFailure(error) {
+  const classified = providerInitFailure(error);
+  return {
+    state: 'unavailable',
+    error: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+    detail: classified.error,
+  };
+}
+```
+
+Run the Step 2 command and expect pass.
+
+- [ ] **Step 4: Render the explicit action from the approved state**
+
+In `SettingsScreen.jsx`:
+
+- import `platformHelperRepairView`;
+- add Chinese strings `repairHelper: "修复 Helper"` and
+  `repairingHelper: "正在修复 Helper…"`; add English strings
+  `repairHelper: "Repair Helper"` and
+  `repairingHelper: "Repairing Helper…"`;
+- add props `onRepairPlatformHelper` and `providerRepairing = false`;
+- compute:
+
+```javascript
+const helperRepair = platformHelperRepairView(
+  providerInit,
+  providerRepairing,
+  typeof onRepairPlatformHelper === 'function',
+);
+```
+
+Inside the existing provider alert, after the diagnostic text, render:
+
+```jsx
+{helperRepair ? (
+  <div style={{ marginTop: 6 }}>
+    <Button
+      variant="secondary"
+      size="sm"
+      disabled={helperRepair.disabled}
+      onClick={onRepairPlatformHelper}
+    >
+      {helperRepair.label === 'repairing' ? t.repairingHelper : t.repairHelper}
+    </Button>
+  </div>
+) : null}
+```
+
+Do not render the action for generic helper startup failures or provider-store
+failures.
+
+Change the displayed diagnostic suffix from `providerInit.error` to
+`providerInit.detail || providerInit.error`. This keeps the action keyed to the
+repair-required state while showing only an existing sanitized classification
+such as `PLATFORM_HELPER_START_FAILED`.
+
+- [ ] **Step 5: Wire one repair attempt and provider reinitialization**
+
+In `App.jsx`, add `providerRepairFailure` to the existing import from
+`./providerInitState`, then add:
+
+```javascript
+const [providerRepairing, setProviderRepairing] = React.useState(false);
+const [providerInitEpoch, setProviderInitEpoch] = React.useState(0);
+```
+
+Add an async callback:
+
+```javascript
+const repairPlatformHelper = React.useCallback(async () => {
+  if (providerRepairing) return;
+  setProviderRepairing(true);
+  try {
+    const controller = ctrl.current;
+    if (!controller || typeof controller.repairPlatformHelper !== 'function') {
+      throw providerRuntimeUnavailableError();
+    }
+    await controller.repairPlatformHelper();
+    pushLog('Platform Helper repaired; rechecking protected provider state');
+    setProviderInitEpoch((current) => current + 1);
+  } catch (error) {
+    setProviderInit(providerRepairFailure(error));
+    pushLog('Platform Helper repair failed: ' + (
+      typeof error?.code === 'string' ? error.code : 'HELPER_UNAVAILABLE'
+    ));
+  } finally {
+    setProviderRepairing(false);
+  }
+}, [providerRepairing, pushLog]);
+```
+
+Add `providerInitEpoch` to the existing provider initialization effect's
+dependency array. The effect remains the single place that performs the full
+`capabilities()` check, migration ordering, protected-secret readback, and
+ready-state transition.
+
+Pass to `SettingsScreen`:
+
+```jsx
+providerInit={providerInit}
+providerRepairing={providerRepairing}
+onRepairPlatformHelper={repairPlatformHelper}
+```
+
+The alert remains visible and the button remains disabled during the repair
+promise. Success triggers one provider initialization rerun; failure keeps the
+sanitized repair-required state.
+
+- [ ] **Step 6: Run panel state and helper lifecycle tests**
+
+Run:
+
+```bash
+node --test \
+  plugin/panel/test/providerInitState.test.js \
+  plugin/panel/test/providerUiClosure.test.js \
+  plugin/panel/test/hostBridge.test.js
+```
+
+Expected: all pass. Existing provider closure tests continue to prove that
+provider data is not replaced on repairable initialization failure.
+
+- [ ] **Step 7: Build the panel and verify the generated bundle**
+
+Run:
+
+```bash
+npm --prefix plugin/panel run build
+```
+
+Expected: build exits 0 and updates `plugin/client/dist/app.js`.
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 8: Commit the user-visible Repair Helper action**
+
+```bash
+git add \
+  plugin/panel/src/app/providerInitState.js \
+  plugin/panel/test/providerInitState.test.js \
+  plugin/panel/src/app/App.jsx \
+  plugin/panel/src/screens/SettingsScreen.jsx \
+  plugin/client/dist/app.js
+git commit -m "feat(panel): expose explicit platform helper repair"
+```
+
+---
+
+## Integrated Verification Gate
+
+After all four task reviews are clean, run the following without editing
+production source between commands.
+
+### Focused Python
+
+```bash
+uv run pytest \
+  packages/snapshot-mss/tests/test_mss_snapshot.py \
+  packages/core/tests/test_snapshot_discovery.py \
+  packages/core/tests/test_status_tool.py \
+  packages/core/tests/test_server_native_tools.py \
+  -q
+```
+
+### Focused Helper and Panel
+
+```bash
+node --test \
+  plugin/host/platform-helper-registration.test.js \
+  plugin/host/platform-helper-transport.test.js \
+  plugin/panel/test/hostBridge.test.js \
+  plugin/panel/test/providerInitState.test.js \
+  plugin/panel/test/providerUiClosure.test.js
+```
+
+### Affected Package Regressions
+
+```bash
+npm --prefix plugin/host test
+npm --prefix plugin/panel test
+npm --prefix plugin/panel run build
+node --test scripts/package/test/*.test.mjs
+git diff --exit-code -- plugin/client/dist/app.js
+git diff --check
+git status --short
+```
+
+Expected:
+
+- every test/build command exits 0;
+- rebuilding the panel leaves the committed bundle unchanged;
+- status contains no generated or test residue;
+- the only branch changes are the approved design, plan, #178 track, registrar
+  primitive, transport/HostController integration, Settings action, tests,
+  documentation, and generated bundle.
+
+## Review Gate
+
+- Generate a whole-branch review package from merge base `357b20c` through the
+  final implementation head.
+- Dispatch one most-capable final reviewer for spec compliance and code
+  quality.
+- Classify each finding as current blocker, follow-up, or out of scope.
+- If the review finds current blockers, dispatch one combined fix wave and one
+  scoped re-review. Do not add a second broad implementation wave.
+
+## Real macOS/AE HDEV Gate
+
+Use the built development panel/helper from this worktree. Do not create an
+`.aep` fixture and do not mutate an AE project.
+
+1. Record branch head, helper manifest path, helper executable path, component
+   versions, sizes, and mtimes.
+2. Register the fixed product label once with a controlled stale Program path.
+3. Launch the normal AE build and open the actual panel.
+4. Confirm provider initialization reports
+   `PLATFORM_HELPER_REPAIR_REQUIRED` and shows Repair Helper.
+5. Trigger Repair Helper through the panel without asking the user to perform
+   routine GUI steps.
+6. Verify `/bin/launchctl print
+   gui/<uid>/com.junkdoge.ae-mcp.platform-helper` reports the current verified
+   helper Program.
+7. From real CEP, verify `capabilities()` reports protocol version 1, the
+   expected method set, and `authenticatedCaller: true`.
+8. Use one non-sensitive temporary reference to perform
+   `secretSet → secretGet → secretDelete`; verify the final read reports absent.
+9. Make one representative public MCP read and record its structured result.
+10. Restore the development machine to the current verified registration and
+    record that no temporary secret remains.
+
+This is a narrow development HDEV, not a signed release test and not an AEGP
+T5/T6 run.
+
+## PR, Merge, and Clean-Main Closure
+
+1. Push the branch and open one PR linking #178 and #66.
+2. Include separate per-issue acceptance summaries in the PR body.
+3. Run required CI once after the final concentrated review is clean.
+4. Merge only when focused tests, required CI, final review, and pre-merge HDEV
+   are green.
+5. Build from clean `main` at the merge commit and repeat only the minimal
+   stale-registration Repair Helper plus `capabilities()` smoke.
+6. Close #178 with the predicate, discovery/filtering, docs, and CI evidence.
+7. Close #66 with explicit repair, real AE HDEV, merge, and clean-main smoke
+   evidence.
+8. Leave #67, #69, and #70 open with their existing product boundaries.

--- a/docs/superpowers/specs/2026-07-30-snapshot-truthfulness-helper-repair-design.md
+++ b/docs/superpowers/specs/2026-07-30-snapshot-truthfulness-helper-repair-design.md
@@ -1,0 +1,250 @@
+# Snapshot Truthfulness and macOS Helper Repair Design
+
+Date: 2026-07-30
+
+Issues: #178, #66
+
+Status: Approved for written-spec review
+
+## Goal
+
+Deliver one deliberately batched product PR with two independently reviewable
+outcomes:
+
+1. `snapshot-mss` advertises only the platform support it actually implements.
+2. A user can explicitly repair a stale macOS platform-helper registration from
+   the panel without a developer shell command.
+
+The two outcomes share a branch, PR, review, and CI run because the user
+explicitly selected them as one delivery unit. They do not share implementation
+state, and each keeps its own tests and acceptance disposition.
+
+## Current Observed State
+
+### Issue #178
+
+`MssSnapshotter.supports_platform()` currently returns `True` on every platform,
+but its AE-window lookup and capture path is implemented only for Windows. On
+macOS and Linux, discovery can select the backend and expose `ae.snapshot`, but
+the call then fails because no AE window handle can be resolved.
+
+The macOS platform helper does not make this claim true. Its ScreenCaptureKit
+backend remains a separate unfinished capability owned by #67.
+
+### Issue #66
+
+PR #196 already delivered the original positive-path registration mechanism:
+
+- the panel verifies the staged helper payload;
+- a private per-user launchd plist is materialized;
+- an absent service is bootstrapped without a manual `launchctl` command;
+- a service already pointing at the exact current helper is reused;
+- the real CEP path reaches XPC through the verified helper's stdio broker.
+
+The remaining reproduced gap is narrower than the old issue body. If the fixed
+product launchd label is already registered to a different helper path, startup
+fails closed with `PLATFORM_HELPER_REPAIR_REQUIRED`, but the panel provides no
+supported action to replace that stale registration.
+
+Signed install, update, rollback, uninstall, reboot, clean-machine acceptance,
+and production attestation remain release work in #69 and #70.
+
+## Design Decisions
+
+### One PR, Two Independent Tracks
+
+The PR will contain separate logical commits and test groups for #178 and #66.
+No #178 code will depend on the helper repair path, and completing helper repair
+will not cause `snapshot-mss` to claim macOS support.
+
+### Track A: Truthful `snapshot-mss` Platform Support
+
+`MssSnapshotter.supports_platform()` will return `True` only when
+`sys.platform == "win32"`.
+
+The existing discovery and public-tool filtering behavior remains unchanged:
+
+```text
+Windows
+  -> snapshot-mss is eligible
+  -> ae.snapshot can be selected and exposed
+
+macOS or Linux
+  -> snapshot-mss is ineligible
+  -> it is not selected
+  -> ae.status does not report it
+  -> ae.snapshot is not exposed through tools/list
+```
+
+Tests will cover Windows, Darwin, and Linux predicates plus the discovery/tool
+filtering consequence. User-facing package metadata and English/Chinese
+documentation will stop calling this backend cross-platform.
+
+This track does not implement macOS/Linux window lookup, ScreenCaptureKit, TCC
+handling, full-screen fallback, or changes to the native `ae.previewFrame`
+path.
+
+### Track B: Explicit macOS Helper Repair
+
+Routine startup behavior remains unchanged:
+
+```text
+service absent
+  -> bootstrap current verified helper
+
+service points to current verified helper
+  -> reuse registration
+
+service points to another path
+  -> fail closed with PLATFORM_HELPER_REPAIR_REQUIRED
+  -> offer explicit Repair Helper action
+```
+
+Repair is user-triggered and operates only on the repository's fixed,
+product-owned launchd label. It will:
+
+1. reverify the current staged helper manifest and payload;
+2. inspect the current registration again;
+3. boot out the fixed per-user service;
+4. treat an already-absent service as a recoverable intermediate state;
+5. atomically materialize the plist for the current verified helper;
+6. bootstrap the service;
+7. use `launchctl print` to verify that the loaded Program exactly matches the
+   current verified helper;
+8. recreate the panel transport and call `capabilities()` to prove a real
+   helper handshake.
+
+The normal startup path will not automatically boot out or restart a stale
+registration. The repair path will not inspect or modify unrelated launchd
+services.
+
+### Panel State
+
+The Repair Helper action is shown only for the specific
+`PLATFORM_HELPER_REPAIR_REQUIRED` state. While repair is running, the action is
+disabled so one panel instance cannot issue concurrent repairs.
+
+On success, the panel replaces the failed transport/client, completes the
+capability handshake, clears the repair-required state, and returns to its
+normal ready state.
+
+On failure, the panel remains in a repairable state and shows the existing
+sanitized diagnostic code. It does not blindly retry. A missing service during
+the explicit `bootout` step is the only ignored launchctl condition because the
+desired next state is already reached.
+
+### Error and Recovery Boundary
+
+The repair API returns structured outcomes for:
+
+- current helper payload verification failure;
+- `bootout` failure other than service-not-found;
+- plist materialization failure;
+- `bootstrap` failure;
+- loaded Program mismatch after bootstrap;
+- transport creation or `capabilities()` handshake failure.
+
+No PID tracking, start-token comparison, process census, generalized runner
+framework, routine full-tree hash walk, or automatic multi-instance
+coordination is added. A newly discovered edge case is a current blocker only
+if it reproduces on this explicit repair acceptance path; otherwise it is a
+follow-up or out of scope under AGENTS.md section 5.
+
+## Expected Change Surface
+
+Track A is expected to touch:
+
+- `packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py`
+- `packages/snapshot-mss/tests/test_mss_snapshot.py`
+- snapshot discovery/public-tool tests only if needed to expose the behavioral
+  consequence directly
+- `packages/snapshot-mss/pyproject.toml`
+- `packages/snapshot-mss/README.md`
+- `README.md`
+- `README.zh-CN.md`
+
+Track B is expected to touch:
+
+- `plugin/host/platform-helper-registration.js`
+- `plugin/host/platform-helper-registration.test.js`
+- `plugin/host/platform-helper-transport.js`
+- `plugin/host/platform-helper-transport.test.js`
+- `plugin/panel/src/cep/hostBridge.js`
+- focused host-bridge tests
+- the panel settings state/action wiring and focused tests
+- generated `plugin/client/dist/app.js`
+
+The exact file list may contract after test-first implementation. Expanding
+into Swift protocol code, RuntimeManager, installer/uninstaller, signing,
+notarization, Keychain policy, ScreenCaptureKit, or AEGP is out of scope unless
+the approved acceptance path reproduces a blocker there.
+
+## Verification
+
+### Track A
+
+- red-first predicate tests for Windows, Darwin, and Linux;
+- discovery/public-tool filtering test proving unsupported platforms do not
+  expose `ae.snapshot`;
+- existing mocked Windows capture tests remain green;
+- documentation and package metadata no longer claim cross-platform support.
+
+No AE hardware run is required because the capture implementation and Windows
+runtime path do not change.
+
+### Track B Focused Tests
+
+Registration tests cover:
+
+- absent registration bootstrap;
+- exact-path idempotent reuse;
+- stale-path startup fail-closed;
+- explicit stale-path replacement;
+- service already absent during repair;
+- bootstrap failure;
+- post-bootstrap Program mismatch.
+
+Host/panel tests cover:
+
+- Repair Helper appears only for the repair-required state;
+- the action is single-flight in the UI;
+- success rebuilds the transport and completes `capabilities()`;
+- failure leaves a sanitized, retryable repair state;
+- Windows behavior remains unchanged.
+
+The affected host/panel suites, generated-bundle checks, packaging contracts,
+and required CI must pass.
+
+### Real macOS/AE Acceptance
+
+Before merge, one prepared narrow HDEV will:
+
+1. create a controlled stale registration for the product-owned label;
+2. start the real AE panel and observe the repair-required state;
+3. trigger Repair Helper through the panel;
+4. verify the loaded Program is the current verified helper;
+5. call `capabilities()` from the real CEP path and verify protocol/method
+   metadata and authenticated caller state;
+6. set, read back, and delete one non-sensitive temporary secret;
+7. complete one representative public MCP read to prove the panel/Core path
+   remains live.
+
+No `.aep` fixture or AE project mutation is required.
+
+After merge, a clean-`main` build repeats only the minimal helper
+repair/handshake smoke. This is not an AEGP capability package and does not run
+native T5/T6 or create candidate project evidence.
+
+## Review and Closure
+
+Use one concentrated subagent review by default and no more than two rounds.
+Only a reproduced acceptance blocker expands the implementation. CI and HDEV
+results are evidence for the separate per-issue dispositions:
+
+- close #178 when the truthful predicate, filtering consequence, documentation,
+  and required CI are verified;
+- close #66 when explicit repair passes focused tests, real AE HDEV, merge, and
+  the clean-`main` repair/handshake smoke;
+- leave signed installer lifecycle and production attestation in #69/#70;
+- leave macOS capture implementation and truthful ScreenCaptureKit capability
+  reporting in #67.

--- a/packages/snapshot-mss/README.md
+++ b/packages/snapshot-mss/README.md
@@ -2,9 +2,9 @@
 
 ## 中文
 
-`ae-mcp-snapshot-mss` 是 ae-mcp 的跨平台截图 backend，基于 [mss](https://python-mss.readthedocs.io/) 和 Pillow。它通过 Python entry point 注册 snapshotter `mss`，供 `ae.snapshot` 和 preview 相关流程使用。
+`ae-mcp-snapshot-mss` 是 ae-mcp 的 Windows 截图 backend。它基于 [mss](https://python-mss.readthedocs.io/) 和 Pillow，通过 Python entry point 注册 snapshotter `mss`，供 `ae.snapshot` 和 preview 相关流程使用。
 
-当前实现按屏幕区域截图；Windows 下可通过 HWND 转换到窗口矩形。它不是 AE Render Queue，也不负责 CEP 面板或 MCP server。
+当前实现通过 HWND 将 After Effects 窗口转换为屏幕矩形后截图。它不是 AE Render Queue，也不负责 CEP 面板或 MCP server。
 
 ### 安装
 
@@ -22,9 +22,9 @@ MIT。
 
 ## English
 
-`ae-mcp-snapshot-mss` is the cross-platform screenshot backend for ae-mcp, built on [mss](https://python-mss.readthedocs.io/) and Pillow. It registers the `mss` snapshotter through a Python entry point for `ae.snapshot` and preview-related flows.
+`ae-mcp-snapshot-mss` is the Windows screenshot backend for ae-mcp. Built on [mss](https://python-mss.readthedocs.io/) and Pillow, it registers the `mss` snapshotter through a Python entry point for `ae.snapshot` and preview-related flows.
 
-The current implementation captures by screen rectangle; on Windows, HWND can be translated to a window rectangle. It is not AE Render Queue, and it does not provide the CEP panel or MCP server.
+The implementation translates the After Effects window HWND to a screen rectangle before capturing. It is not AE Render Queue, and it does not provide the CEP panel or MCP server.
 
 ### Install
 

--- a/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
+++ b/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
@@ -1,6 +1,7 @@
-"""mss-backed cross-platform ae.snapshot implementation."""
+"""Windows AE-window ae.snapshot implementation backed by mss."""
 from __future__ import annotations
 
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -16,8 +17,7 @@ class MssSnapshotter(Snapshotter):
     name = "mss"
 
     def supports_platform(self) -> bool:
-        # mss runs on Windows, macOS, Linux
-        return True
+        return sys.platform == "win32"
 
     async def capture(
         self,

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ae-mcp-snapshot-mss"
 version = "0.9.2"
-description = "Cross-platform mss-based screen capture for ae-mcp"
+description = "Windows mss-based After Effects window capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/packages/snapshot-mss/tests/test_mss_snapshot.py
+++ b/packages/snapshot-mss/tests/test_mss_snapshot.py
@@ -6,10 +6,24 @@ import pytest
 
 from ae_mcp_snapshot_mss import MssSnapshotter
 from ae_mcp_snapshot_mss._hwnd_rect import _select_largest_ae_window, _is_ae_window
+from ae_mcp.snapshot.discovery import select_snapshotter
 
 
-def test_supports_platform_always_true():
-    assert MssSnapshotter().supports_platform() is True
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [("win32", True), ("darwin", False), ("linux", False)],
+)
+def test_supports_platform_only_when_window_capture_is_implemented(platform, expected):
+    with patch.object(sys, "platform", platform):
+        assert MssSnapshotter().supports_platform() is expected
+
+
+def test_darwin_discovery_does_not_select_mss():
+    with patch.object(sys, "platform", "darwin"), patch(
+        "ae_mcp.snapshot.discovery._scan_entry_points",
+        return_value={"mss": MssSnapshotter},
+    ):
+        assert select_snapshotter() is None
 
 
 def test_name_is_mss():
@@ -114,5 +128,4 @@ def test_select_returns_none_when_no_ae_window():
          "rect": (0, 0, 800, 600)},   # AE but not visible
     ]
     assert _select_largest_ae_window(windows) is None
-
 

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react.production.min.js
+  // node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
+    "node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/index.js
+  // node_modules/react/index.js
   var require_react = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/index.js"(exports, module) {
+    "node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
+  // node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/index.js
+  // node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/index.js"(exports, module) {
+    "node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
+  // node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/index.js
+  // node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/index.js"(exports, module) {
+    "node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/client.js
+  // node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/client.js"(exports) {
+    "node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/jsx-runtime.js
+  // node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
+    "node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7279,9 +7279,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond/dist/filepond.js
+  // node_modules/filepond/dist/filepond.js
   var require_filepond = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond/dist/filepond.js"(exports, module) {
+    "node_modules/filepond/dist/filepond.js"(exports, module) {
       (function(global, factory) {
         typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = global || self, factory(global.FilePond = {}));
       })(exports, function(exports2) {
@@ -16345,9 +16345,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-filepond/dist/react-filepond.js
+  // node_modules/react-filepond/dist/react-filepond.js
   var require_react_filepond = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-filepond/dist/react-filepond.js"(exports) {
+    "node_modules/react-filepond/dist/react-filepond.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", {
         value: true
@@ -16485,9 +16485,9 @@
     }
   });
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js
+  // node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js
   var require_filepond_plugin_image_preview = __commonJS({
-    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"(exports, module) {
+    "node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"(exports, module) {
       (function(global, factory) {
         typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = global || self, global.FilePondPluginImagePreview = factory());
       })(exports, function() {
@@ -19302,19 +19302,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -19327,7 +19327,7 @@
     strokeLinejoin: "round"
   };
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
+  // node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -19359,7 +19359,7 @@
     }
   );
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -19373,13 +19373,13 @@
     return Component;
   };
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
+  // node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -19391,7 +19391,7 @@
     ]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
+  // node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -19404,7 +19404,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
+  // node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -19429,58 +19429,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
+  // node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
+  // node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
+  // node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
+  // node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
+  // node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -19500,7 +19500,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
+  // node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -19512,7 +19512,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
+  // node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -19521,7 +19521,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
+  // node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -19533,28 +19533,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
+  // node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
+  // node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
+  // node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -19563,7 +19563,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
+  // node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -19573,23 +19573,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
+  // node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
+  // node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
+  // node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
+  // node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -19597,25 +19597,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
+  // node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
+  // node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
+  // node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -19627,7 +19627,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
+  // node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -19639,7 +19639,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -19652,7 +19652,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
+  // node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -19663,7 +19663,7 @@
     ]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -19678,12 +19678,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
+  // node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -19692,7 +19692,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -19701,7 +19701,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -19714,13 +19714,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
+  // node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -19731,13 +19731,13 @@
     ]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
+  // node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
+  // node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -25,9 +25,9 @@
     mod
   ));
 
-  // node_modules/react/cjs/react.production.min.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react.production.min.js
   var require_react_production_min = __commonJS({
-    "node_modules/react/cjs/react.production.min.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react.production.min.js"(exports) {
       "use strict";
       var l = Symbol.for("react.element");
       var n = Symbol.for("react.portal");
@@ -298,9 +298,9 @@
     }
   });
 
-  // node_modules/react/index.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/index.js
   var require_react = __commonJS({
-    "node_modules/react/index.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_production_min();
@@ -310,9 +310,9 @@
     }
   });
 
-  // node_modules/scheduler/cjs/scheduler.production.min.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js
   var require_scheduler_production_min = __commonJS({
-    "node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/cjs/scheduler.production.min.js"(exports) {
       "use strict";
       function f(a, b) {
         var c = a.length;
@@ -563,9 +563,9 @@
     }
   });
 
-  // node_modules/scheduler/index.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/index.js
   var require_scheduler = __commonJS({
-    "node_modules/scheduler/index.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/scheduler/index.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_scheduler_production_min();
@@ -575,9 +575,9 @@
     }
   });
 
-  // node_modules/react-dom/cjs/react-dom.production.min.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js
   var require_react_dom_production_min = __commonJS({
-    "node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/cjs/react-dom.production.min.js"(exports) {
       "use strict";
       var aa = require_react();
       var ca = require_scheduler();
@@ -7185,9 +7185,9 @@
     }
   });
 
-  // node_modules/react-dom/index.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/index.js
   var require_react_dom = __commonJS({
-    "node_modules/react-dom/index.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/index.js"(exports, module) {
       "use strict";
       function checkDCE() {
         if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === "undefined" || typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== "function") {
@@ -7211,9 +7211,9 @@
     }
   });
 
-  // node_modules/react-dom/client.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/client.js
   var require_client = __commonJS({
-    "node_modules/react-dom/client.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-dom/client.js"(exports) {
       "use strict";
       var m = require_react_dom();
       if (true) {
@@ -7242,9 +7242,9 @@
     }
   });
 
-  // node_modules/react/cjs/react-jsx-runtime.production.min.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js
   var require_react_jsx_runtime_production_min = __commonJS({
-    "node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/cjs/react-jsx-runtime.production.min.js"(exports) {
       "use strict";
       var f = require_react();
       var k = Symbol.for("react.element");
@@ -7267,9 +7267,9 @@
     }
   });
 
-  // node_modules/react/jsx-runtime.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/jsx-runtime.js
   var require_jsx_runtime = __commonJS({
-    "node_modules/react/jsx-runtime.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react/jsx-runtime.js"(exports, module) {
       "use strict";
       if (true) {
         module.exports = require_react_jsx_runtime_production_min();
@@ -7279,9 +7279,9 @@
     }
   });
 
-  // node_modules/filepond/dist/filepond.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond/dist/filepond.js
   var require_filepond = __commonJS({
-    "node_modules/filepond/dist/filepond.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond/dist/filepond.js"(exports, module) {
       (function(global, factory) {
         typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = global || self, factory(global.FilePond = {}));
       })(exports, function(exports2) {
@@ -16345,9 +16345,9 @@
     }
   });
 
-  // node_modules/react-filepond/dist/react-filepond.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-filepond/dist/react-filepond.js
   var require_react_filepond = __commonJS({
-    "node_modules/react-filepond/dist/react-filepond.js"(exports) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/react-filepond/dist/react-filepond.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", {
         value: true
@@ -16485,9 +16485,9 @@
     }
   });
 
-  // node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js
   var require_filepond_plugin_image_preview = __commonJS({
-    "node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"(exports, module) {
+    "../../../issue82-jsx-lifecycle/plugin/panel/node_modules/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js"(exports, module) {
       (function(global, factory) {
         typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = global || self, global.FilePondPluginImagePreview = factory());
       })(exports, function() {
@@ -19302,19 +19302,19 @@
   // src/components/core/Icon.jsx
   var import_react4 = __toESM(require_react(), 1);
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var import_react3 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/shared/src/utils.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/shared/src/utils.js
   var toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
   var mergeClasses = (...classes) => classes.filter((className, index, array) => {
     return Boolean(className) && array.indexOf(className) === index;
   }).join(" ");
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var import_react2 = __toESM(require_react());
 
-  // node_modules/lucide-react/dist/esm/defaultAttributes.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/defaultAttributes.js
   var defaultAttributes = {
     xmlns: "http://www.w3.org/2000/svg",
     width: 24,
@@ -19327,7 +19327,7 @@
     strokeLinejoin: "round"
   };
 
-  // node_modules/lucide-react/dist/esm/Icon.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/Icon.js
   var Icon = (0, import_react2.forwardRef)(
     ({
       color = "currentColor",
@@ -19359,7 +19359,7 @@
     }
   );
 
-  // node_modules/lucide-react/dist/esm/createLucideIcon.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/createLucideIcon.js
   var createLucideIcon = (iconName, iconNode) => {
     const Component = (0, import_react3.forwardRef)(
       ({ className, ...props }, ref) => (0, import_react3.createElement)(Icon, {
@@ -19373,13 +19373,13 @@
     return Component;
   };
 
-  // node_modules/lucide-react/dist/esm/icons/arrow-up.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/arrow-up.js
   var ArrowUp = createLucideIcon("ArrowUp", [
     ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
     ["path", { d: "M12 19V5", key: "x0mq9r" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/book-open.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/book-open.js
   var BookOpen = createLucideIcon("BookOpen", [
     ["path", { d: "M12 7v14", key: "1akyts" }],
     [
@@ -19391,7 +19391,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/box.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/box.js
   var Box = createLucideIcon("Box", [
     [
       "path",
@@ -19404,7 +19404,7 @@
     ["path", { d: "M12 22V12", key: "d0xqtd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/brain.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/brain.js
   var Brain = createLucideIcon("Brain", [
     [
       "path",
@@ -19429,58 +19429,58 @@
     ["path", { d: "M19.967 17.484A4 4 0 0 1 18 18", key: "159ez6" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/check.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/check.js
   var Check = createLucideIcon("Check", [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-down.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-down.js
   var ChevronDown = createLucideIcon("ChevronDown", [
     ["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/chevron-right.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/chevron-right.js
   var ChevronRight = createLucideIcon("ChevronRight", [
     ["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-alert.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-alert.js
   var CircleAlert = createLucideIcon("CircleAlert", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
     ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle-slash.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle-slash.js
   var CircleSlash = createLucideIcon("CircleSlash", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["line", { x1: "9", x2: "15", y1: "15", y2: "9", key: "1dfufj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/circle.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/circle.js
   var Circle = createLucideIcon("Circle", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/copy.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/copy.js
   var Copy = createLucideIcon("Copy", [
     ["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2", key: "17jyea" }],
     ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", key: "zix9uf" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/download.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/download.js
   var Download = createLucideIcon("Download", [
     ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
     ["polyline", { points: "7 10 12 15 17 10", key: "2ggqvy" }],
     ["line", { x1: "12", x2: "12", y1: "15", y2: "3", key: "1vk2je" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/external-link.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/external-link.js
   var ExternalLink = createLucideIcon("ExternalLink", [
     ["path", { d: "M15 3h6v6", key: "1q9fwt" }],
     ["path", { d: "M10 14 21 3", key: "gplh6r" }],
     ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6", key: "a6xqqp" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye-off.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye-off.js
   var EyeOff = createLucideIcon("EyeOff", [
     [
       "path",
@@ -19500,7 +19500,7 @@
     ["path", { d: "m2 2 20 20", key: "1ooewy" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/eye.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/eye.js
   var Eye = createLucideIcon("Eye", [
     [
       "path",
@@ -19512,7 +19512,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/file-text.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/file-text.js
   var FileText = createLucideIcon("FileText", [
     ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z", key: "1rqfz7" }],
     ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4", key: "tnqrlb" }],
@@ -19521,7 +19521,7 @@
     ["path", { d: "M16 17H8", key: "z1uh3a" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/github.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/github.js
   var Github = createLucideIcon("Github", [
     [
       "path",
@@ -19533,28 +19533,28 @@
     ["path", { d: "M9 18c-4.51 2-5-2-7-2", key: "9comsn" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/globe.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/globe.js
   var Globe = createLucideIcon("Globe", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20", key: "13o1zl" }],
     ["path", { d: "M2 12h20", key: "9i4pu4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/history.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/history.js
   var History = createLucideIcon("History", [
     ["path", { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" }],
     ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
     ["path", { d: "M12 7v5l4 2", key: "1fdv2h" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/info.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/info.js
   var Info = createLucideIcon("Info", [
     ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
     ["path", { d: "M12 16v-4", key: "1dtifu" }],
     ["path", { d: "M12 8h.01", key: "e9boi3" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list-checks.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/list-checks.js
   var ListChecks = createLucideIcon("ListChecks", [
     ["path", { d: "m3 17 2 2 4-4", key: "1jhpwq" }],
     ["path", { d: "m3 7 2 2 4-4", key: "1obspn" }],
@@ -19563,7 +19563,7 @@
     ["path", { d: "M13 18h8", key: "oe0vm4" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/list.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/list.js
   var List = createLucideIcon("List", [
     ["path", { d: "M3 12h.01", key: "nlz23k" }],
     ["path", { d: "M3 18h.01", key: "1tta3j" }],
@@ -19573,23 +19573,23 @@
     ["path", { d: "M8 6h13", key: "ik3vkj" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/message-square.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/message-square.js
   var MessageSquare = createLucideIcon("MessageSquare", [
     ["path", { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", key: "1lielz" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/pause.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/pause.js
   var Pause = createLucideIcon("Pause", [
     ["rect", { x: "14", y: "4", width: "4", height: "16", rx: "1", key: "zuxfzm" }],
     ["rect", { x: "6", y: "4", width: "4", height: "16", rx: "1", key: "1okwgv" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/play.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/play.js
   var Play = createLucideIcon("Play", [
     ["polygon", { points: "6 3 20 12 6 21 6 3", key: "1oa8hb" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plug.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/plug.js
   var Plug = createLucideIcon("Plug", [
     ["path", { d: "M12 22v-5", key: "1ega77" }],
     ["path", { d: "M9 8V2", key: "14iosj" }],
@@ -19597,25 +19597,25 @@
     ["path", { d: "M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z", key: "osxo6l" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/plus.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/plus.js
   var Plus = createLucideIcon("Plus", [
     ["path", { d: "M5 12h14", key: "1ays0h" }],
     ["path", { d: "M12 5v14", key: "s699le" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/rotate-cw.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/rotate-cw.js
   var RotateCw = createLucideIcon("RotateCw", [
     ["path", { d: "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", key: "1p45f6" }],
     ["path", { d: "M21 3v5h-5", key: "1q7to0" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/search.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/search.js
   var Search = createLucideIcon("Search", [
     ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
     ["path", { d: "m21 21-4.3-4.3", key: "1qie3q" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/send.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/send.js
   var Send = createLucideIcon("Send", [
     [
       "path",
@@ -19627,7 +19627,7 @@
     ["path", { d: "m21.854 2.147-10.94 10.939", key: "12cjpa" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/settings.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/settings.js
   var Settings = createLucideIcon("Settings", [
     [
       "path",
@@ -19639,7 +19639,7 @@
     ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield-alert.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield-alert.js
   var ShieldAlert = createLucideIcon("ShieldAlert", [
     [
       "path",
@@ -19652,7 +19652,7 @@
     ["path", { d: "M12 16h.01", key: "1drbdi" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/shield.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/shield.js
   var Shield = createLucideIcon("Shield", [
     [
       "path",
@@ -19663,7 +19663,7 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/sparkles.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/sparkles.js
   var Sparkles = createLucideIcon("Sparkles", [
     [
       "path",
@@ -19678,12 +19678,12 @@
     ["path", { d: "M5 18H3", key: "zchphs" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/square.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/square.js
   var Square = createLucideIcon("Square", [
     ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/stethoscope.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/stethoscope.js
   var Stethoscope = createLucideIcon("Stethoscope", [
     ["path", { d: "M11 2v2", key: "1539x4" }],
     ["path", { d: "M5 2v2", key: "1yf1q8" }],
@@ -19692,7 +19692,7 @@
     ["circle", { cx: "20", cy: "10", r: "2", key: "ts1r5v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/trash-2.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/trash-2.js
   var Trash2 = createLucideIcon("Trash2", [
     ["path", { d: "M3 6h18", key: "d0wm0j" }],
     ["path", { d: "M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6", key: "4alrt4" }],
@@ -19701,7 +19701,7 @@
     ["line", { x1: "14", x2: "14", y1: "11", y2: "17", key: "xtxkd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/triangle-alert.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/triangle-alert.js
   var TriangleAlert = createLucideIcon("TriangleAlert", [
     [
       "path",
@@ -19714,13 +19714,13 @@
     ["path", { d: "M12 17h.01", key: "p32p05" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/undo-2.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/undo-2.js
   var Undo2 = createLucideIcon("Undo2", [
     ["path", { d: "M9 14 4 9l5-5", key: "102s5s" }],
     ["path", { d: "M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11", key: "f3b9sd" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/wrench.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/wrench.js
   var Wrench = createLucideIcon("Wrench", [
     [
       "path",
@@ -19731,13 +19731,13 @@
     ]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/x.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/x.js
   var X = createLucideIcon("X", [
     ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
     ["path", { d: "m6 6 12 12", key: "d8bk6v" }]
   ]);
 
-  // node_modules/lucide-react/dist/esm/icons/zap.js
+  // ../../../issue82-jsx-lifecycle/plugin/panel/node_modules/lucide-react/dist/esm/icons/zap.js
   var Zap = createLucideIcon("Zap", [
     [
       "path",
@@ -21659,6 +21659,378 @@
     throw new PlatformCapabilityError("UNSUPPORTED_PLATFORM", deps.platform + "-" + deps.arch + " is not supported");
   }
 
+  // src/lib/exactSecretRedaction.js
+  function sensitiveValues(profile) {
+    var _a;
+    const values = [];
+    if (typeof ((_a = profile == null ? void 0 : profile.auth) == null ? void 0 : _a.value) === "string" && profile.auth.value) {
+      values.push(profile.auth.value);
+      const scheme = profile.auth.value.match(/^(?:Bearer|Basic)\s+(.+)$/i);
+      if (scheme == null ? void 0 : scheme[1]) values.push(scheme[1]);
+    }
+    for (const header of (profile == null ? void 0 : profile.extraHeaders) || []) {
+      if (typeof (header == null ? void 0 : header.value) === "string" && header.value) values.push(header.value);
+    }
+    return Array.from(new Set(values)).sort((a, b) => b.length - a.length);
+  }
+  function normalizedSecrets(values) {
+    const variants = [];
+    for (const value of values || []) {
+      if (typeof value !== "string" || !value) continue;
+      variants.push(value);
+      try {
+        const encoded = JSON.stringify(value);
+        if ((encoded == null ? void 0 : encoded.startsWith('"')) && encoded.endsWith('"')) variants.push(encoded.slice(1, -1));
+      } catch {
+      }
+    }
+    return Array.from(new Set(variants.filter(Boolean))).sort((a, b) => b.length - a.length);
+  }
+  var MAX_DECODE_CHARS = 1024 * 1024;
+  var MAX_DECODE_LAYERS = 3;
+  var MAX_STRUCTURE_CHARS = 16 * 1024 * 1024;
+  function decodePercentRuns(value) {
+    return String(value).replace(/(?:%[0-9a-f]{2})+/gi, (run) => {
+      try {
+        return decodeURIComponent(run);
+      } catch {
+        return run;
+      }
+    });
+  }
+  function decodeUnicodeEscapes(value) {
+    return String(value).replace(/\\u([0-9a-f]{4})/gi, (_match, hex) => String.fromCharCode(Number.parseInt(hex, 16)));
+  }
+  function decodedTextLayers(value) {
+    let current = String(value);
+    const layers = [current];
+    for (let layer = 0; layer < MAX_DECODE_LAYERS; layer += 1) {
+      if (!current.includes("%") && !/\\u[0-9a-f]{4}/i.test(current)) break;
+      if (current.length > MAX_DECODE_CHARS) return null;
+      const decoded = decodeUnicodeEscapes(decodePercentRuns(current));
+      if (decoded === current) break;
+      layers.push(decoded);
+      current = decoded;
+    }
+    return layers;
+  }
+  function textContainsSecret(value, secrets) {
+    const layers = decodedTextLayers(value);
+    if (layers === null) return true;
+    return layers.some((layer) => secrets.some((secret) => layer.includes(secret)));
+  }
+  function containsExactSecret(value, values = []) {
+    const secrets = normalizedSecrets(values);
+    if (!secrets.length) return false;
+    const visiting = /* @__PURE__ */ new WeakSet();
+    const valueParts = [];
+    const keyParts = [];
+    const keyValueParts = [];
+    const leafKeyValueParts = [];
+    let structureChars = 0;
+    const containsText = (candidate) => textContainsSecret(candidate, secrets);
+    const appendPart = (parts, candidate) => {
+      const text = String(candidate);
+      structureChars += text.length;
+      if (structureChars > MAX_STRUCTURE_CHARS) return true;
+      parts.push(text);
+      return false;
+    };
+    const visit = (candidate) => {
+      if (typeof candidate === "function") return true;
+      if (typeof candidate !== "object" || candidate === null) {
+        try {
+          if (appendPart(valueParts, candidate)) return true;
+          if (appendPart(keyValueParts, candidate)) return true;
+          return containsText(candidate);
+        } catch {
+          return true;
+        }
+      }
+      if (visiting.has(candidate)) return true;
+      let keys;
+      try {
+        keys = Reflect.ownKeys(candidate);
+      } catch {
+        return true;
+      }
+      visiting.add(candidate);
+      try {
+        for (const key of keys) {
+          try {
+            const item = Reflect.get(candidate, key);
+            if (appendPart(keyParts, key)) return true;
+            if (appendPart(keyValueParts, key)) return true;
+            if (containsText(key)) return true;
+            if (typeof item !== "function" && (typeof item !== "object" || item === null)) {
+              if (appendPart(leafKeyValueParts, key)) return true;
+              if (appendPart(leafKeyValueParts, item)) return true;
+            }
+            if (visit(item)) return true;
+          } catch {
+            return true;
+          }
+        }
+        return false;
+      } finally {
+        visiting.delete(candidate);
+      }
+    };
+    if (visit(value)) return true;
+    return [valueParts, keyParts, keyValueParts, leafKeyValueParts].some((parts) => containsText(parts.join("")));
+  }
+  function containsExactSecretAcrossBoundary(seedValues, payload, values = []) {
+    const secrets = normalizedSecrets(values);
+    if (!secrets.length) return false;
+    const valueParts = [];
+    const keyParts = [];
+    const keyValueParts = [];
+    const leafKeyValueParts = [];
+    const visiting = /* @__PURE__ */ new WeakSet();
+    let chars = 0;
+    const append = (parts, value) => {
+      const text = String(value);
+      chars += text.length;
+      if (chars > MAX_STRUCTURE_CHARS) return false;
+      parts.push(text);
+      return true;
+    };
+    const visit = (value) => {
+      if (typeof value === "function") return false;
+      if (typeof value !== "object" || value === null) {
+        return append(valueParts, value) && append(keyValueParts, value);
+      }
+      if (visiting.has(value)) return false;
+      let keys;
+      try {
+        keys = Reflect.ownKeys(value);
+      } catch {
+        return false;
+      }
+      visiting.add(value);
+      try {
+        for (const key of keys) {
+          let item;
+          try {
+            item = Reflect.get(value, key);
+          } catch {
+            return false;
+          }
+          if (!append(keyParts, key) || !append(keyValueParts, key)) return false;
+          if (typeof item !== "function" && (typeof item !== "object" || item === null)) {
+            if (!append(valueParts, item) || !append(keyValueParts, item) || !append(leafKeyValueParts, key) || !append(leafKeyValueParts, item)) return false;
+          } else if (!visit(item)) {
+            return false;
+          }
+        }
+        return true;
+      } finally {
+        visiting.delete(value);
+      }
+    };
+    if (!visit(payload)) return true;
+    const candidates = [
+      ...leafKeyValueParts,
+      valueParts.join(""),
+      keyParts.join(""),
+      keyValueParts.join(""),
+      leafKeyValueParts.join("")
+    ];
+    let seeds;
+    try {
+      seeds = Array.from(seedValues || [], (value) => String(value));
+    } catch {
+      return true;
+    }
+    for (const seed of seeds) {
+      for (const candidate of candidates) {
+        if (textContainsSecret(seed + candidate, secrets) || textContainsSecret(candidate + seed, secrets)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+  function redactText(value, values = []) {
+    let text = String(value == null ? "" : value);
+    const secrets = normalizedSecrets(values);
+    if (!secrets.length) return text;
+    const marker = secrets.some((secret) => "[redacted]".includes(secret)) ? "" : "[redacted]";
+    const decodedLayers = decodedTextLayers(text);
+    if (decodedLayers === null) return marker;
+    if (decodedLayers.slice(1).some((layer) => secrets.some((secret) => layer.includes(secret)))) {
+      return marker;
+    }
+    const maximumPasses = Math.max(1, secrets.length * 4 + 8);
+    for (let pass = 0; pass < maximumPasses; pass += 1) {
+      let changed = false;
+      for (const secret of secrets) {
+        if (!text.includes(secret)) continue;
+        text = text.split(secret).join(marker);
+        changed = true;
+      }
+      if (!changed) return text;
+    }
+    return secrets.some((secret) => text.includes(secret)) ? "" : text;
+  }
+  function redactValueParts(value, values) {
+    if (typeof value === "string") return redactText(value, values);
+    if (value === null || ["number", "boolean", "bigint"].includes(typeof value)) {
+      const text = String(value);
+      const redacted = redactText(text, values);
+      return redacted === text ? value : redacted;
+    }
+    if (Array.isArray(value)) return value.map((item) => redactValueParts(item, values));
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+      redactText(key, values),
+      redactValueParts(item, values)
+    ]));
+  }
+  function redactValue(value, values = []) {
+    const redacted = redactValueParts(value, values);
+    if (!containsExactSecret(redacted, values)) return redacted;
+    const secrets = normalizedSecrets(values);
+    return secrets.some((secret) => "[redacted]".includes(secret)) ? "" : "[redacted]";
+  }
+  function createDeltaRedactor(values, emitText) {
+    const secrets = normalizedSecrets(values);
+    let buffer = "";
+    const keep = secrets.reduce((maximum, value) => Math.max(maximum, value.length - 1), 0);
+    return {
+      feed(delta) {
+        if (!secrets.length) {
+          emitText(String(delta || ""));
+          return;
+        }
+        buffer = redactText(buffer + String(delta || ""), secrets);
+        if (buffer.length > keep) {
+          emitText(buffer.slice(0, buffer.length - keep));
+          buffer = buffer.slice(buffer.length - keep);
+        }
+      },
+      flush() {
+        if (buffer) emitText(redactText(buffer, secrets));
+        buffer = "";
+      },
+      discard() {
+        buffer = "";
+      }
+    };
+  }
+  function createByteRedactor(values, emitBytes) {
+    const secrets = normalizedSecrets(values).map((value) => Buffer.from(value, "utf8")).filter((value) => value.length > 0).sort((left, right) => right.length - left.length);
+    const displayMarker = Buffer.from("[redacted]", "utf8");
+    const marker = secrets.some((secret) => displayMarker.includes(secret)) ? Buffer.alloc(0) : displayMarker;
+    const maximum = secrets.reduce((length, secret) => Math.max(length, secret.length), 0);
+    let pending = Buffer.alloc(0);
+    function emit(value) {
+      if (value.length > 0) emitBytes(value);
+    }
+    function drain(flush) {
+      if (!secrets.length) {
+        emit(pending);
+        pending = Buffer.alloc(0);
+        return;
+      }
+      while (pending.length > 0) {
+        const boundary = flush ? pending.length : Math.max(0, pending.length - maximum + 1);
+        if (!flush && boundary === 0) return;
+        let matchIndex = -1;
+        let matchSecret = null;
+        for (const secret of secrets) {
+          const index = pending.indexOf(secret);
+          if (index < 0 || !flush && index >= boundary) continue;
+          if (matchIndex < 0 || index < matchIndex || index === matchIndex && secret.length > matchSecret.length) {
+            matchIndex = index;
+            matchSecret = secret;
+          }
+        }
+        if (matchIndex < 0) {
+          emit(pending.subarray(0, boundary));
+          pending = pending.subarray(boundary);
+          if (!flush) return;
+          continue;
+        }
+        emit(pending.subarray(0, matchIndex));
+        emit(marker);
+        pending = pending.subarray(matchIndex + matchSecret.length);
+      }
+    }
+    return {
+      feed(chunk) {
+        const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk || "");
+        if (!value.length) return;
+        pending = pending.length ? Buffer.concat([pending, value]) : Buffer.from(value);
+        drain(false);
+      },
+      flush() {
+        drain(true);
+      },
+      discard() {
+        pending = Buffer.alloc(0);
+      }
+    };
+  }
+  function safeErrorMessage(error, values = []) {
+    return redactText(error && error.message ? error.message : "Agent loop failed.", values);
+  }
+
+  // src/app/providerInitState.js
+  var HELPER_FAILURE_CODES = /* @__PURE__ */ new Set([
+    "HELPER_UNAUTHORIZED",
+    "PROTOCOL_VERSION_UNSUPPORTED",
+    "SECRET_STORE_UNAVAILABLE",
+    "PLATFORM_HELPER_REPAIR_REQUIRED",
+    "INVALID_REQUEST",
+    "MESSAGE_TOO_LARGE"
+  ]);
+  var MIGRATION_FAILURE_CODES = /* @__PURE__ */ new Set([
+    "PROVIDER_STORE_CONFLICT",
+    "INVALID_PROVIDER_MIGRATION",
+    "INVALID_MIGRATION_JOURNAL"
+  ]);
+  var SECRET_MISMATCH_CODES = /* @__PURE__ */ new Set([
+    "SECRET_CONFLICT",
+    "SECRET_NOT_FOUND",
+    "INVALID_REFERENCE"
+  ]);
+  function providerInitFailure(error) {
+    const code = typeof (error == null ? void 0 : error.code) === "string" ? error.code : "";
+    let failure2 = "PROVIDER_INITIALIZATION_FAILED";
+    if (code === "HELPER_UNAVAILABLE" || code === "HELPER_START_FAILED") {
+      failure2 = "PLATFORM_HELPER_START_FAILED";
+    } else if (HELPER_FAILURE_CODES.has(code)) failure2 = "PLATFORM_HELPER_REPAIR_REQUIRED";
+    else if (code === "PROVIDER_STORE_INVALID" || code === "PROVIDER_STORE_CREDENTIAL_CONTAMINATION") failure2 = "PROVIDER_STORE_CORRUPT";
+    else if (code === "PROVIDER_STORE_UNAVAILABLE") failure2 = "PROVIDER_STORE_UNAVAILABLE";
+    else if (MIGRATION_FAILURE_CODES.has(code)) failure2 = "PROVIDER_MIGRATION_CONFLICT";
+    else if (SECRET_MISMATCH_CODES.has(code)) failure2 = "PROVIDER_SECRET_MISMATCH";
+    return { state: "unavailable", error: failure2 };
+  }
+  function platformHelperRepairView(providerInit, repairing, hasAction) {
+    if (!hasAction || (providerInit == null ? void 0 : providerInit.state) !== "unavailable" || (providerInit == null ? void 0 : providerInit.error) !== "PLATFORM_HELPER_REPAIR_REQUIRED") {
+      return null;
+    }
+    return {
+      disabled: repairing === true,
+      label: repairing === true ? "repairing" : "repair"
+    };
+  }
+  function providerRepairFailure(error) {
+    const classified = providerInitFailure(error);
+    return {
+      state: "unavailable",
+      error: "PLATFORM_HELPER_REPAIR_REQUIRED",
+      detail: classified.error
+    };
+  }
+  function assertProviderStateCredentialFree(providerState, exactSecrets = []) {
+    if (!containsExactSecret(providerState == null ? void 0 : providerState.providers, exactSecrets)) return providerState;
+    const error = new Error("Stored Provider data contains protected credential material.");
+    error.code = "PROVIDER_STORE_CREDENTIAL_CONTAMINATION";
+    throw error;
+  }
+
   // src/screens/SettingsScreen.jsx
   var import_jsx_runtime17 = __toESM(require_jsx_runtime(), 1);
   var REPO_URL = "https://github.com/JUNKDOGE-JOE/after-effects-mcp";
@@ -21698,6 +22070,8 @@
       claude3pNote: "\u540C\u4E00\u4E2A Provider \u53EF\u540C\u65F6\u7528\u4E8E Claude \u548C Codex\uFF1B\u534F\u8BAE\u4E0E\u517C\u5BB9\u8F6C\u6362\u6309\u5F53\u524D\u6A21\u578B\u81EA\u52A8\u9009\u62E9\u3002",
       providerHelperStartFailed: "Provider \u51ED\u636E\u529F\u80FD\u5DF2\u5B89\u5168\u505C\u7528\u3002\u5E73\u53F0 Helper \u4F1A\u968F AE \u81EA\u52A8\u542F\u52A8\uFF0C\u4F46\u672C\u6B21\u672A\u80FD\u542F\u52A8\u6216\u8FDE\u63A5\uFF1B\u8BF7\u5148\u91CD\u65B0\u6253\u5F00\u9762\u677F\uFF0C\u4ECD\u5931\u8D25\u65F6\u91CD\u542F AE\u3002\u4E0D\u4F1A\u56DE\u9000\u8BFB\u53D6\u660E\u6587\u51ED\u636E\u3002",
       providerHelperRepair: "Provider \u51ED\u636E\u529F\u80FD\u5DF2\u5B89\u5168\u505C\u7528\u3002\u5E73\u53F0 Helper \u5DF2\u542F\u52A8\u4F46\u672A\u901A\u8FC7\u63E1\u624B\u3001\u7248\u672C\u6216\u6388\u6743\u68C0\u67E5\uFF1B\u8BF7\u91CD\u542F AE\uFF0C\u4ECD\u5931\u8D25\u65F6\u518D\u4FEE\u590D\u5F53\u524D\u5B89\u88C5\u3002\u4E0D\u4F1A\u56DE\u9000\u8BFB\u53D6\u660E\u6587\u51ED\u636E\u3002",
+      repairHelper: "\u4FEE\u590D Helper",
+      repairingHelper: "\u6B63\u5728\u4FEE\u590D Helper\u2026",
       providerStoreCorrupt: "Provider \u914D\u7F6E\u6587\u4EF6\u635F\u574F\uFF1B\u5F53\u524D\u5217\u8868\u5DF2\u4FDD\u7559\u3002\u8BF7\u5148\u4ECE\u5907\u4EFD\u6062\u590D providers.json\uFF0C\u518D\u70B9\u300C\u91CD\u65B0\u68C0\u6D4B\u300D\u3002",
       providerStoreUnavailable: "Provider \u914D\u7F6E\u6587\u4EF6\u4E0D\u53EF\u7528\uFF1B\u5F53\u524D\u5217\u8868\u5DF2\u4FDD\u7559\u3002\u8BF7\u68C0\u67E5 ~/.ae-mcp \u7684\u78C1\u76D8\u7A7A\u95F4\u4E0E\u8BFB\u5199\u6743\u9650\u3002",
       providerMigrationConflict: "Provider \u8FC1\u79FB\u671F\u95F4\u914D\u7F6E\u53D1\u751F\u51B2\u7A81\uFF1B\u5F53\u524D\u5217\u8868\u5DF2\u4FDD\u7559\u3002\u8BF7\u5173\u95ED\u5176\u4ED6\u9762\u677F\u5B9E\u4F8B\u540E\u91CD\u65B0\u542F\u52A8 AE \u518D\u68C0\u6D4B\u3002",
@@ -21761,6 +22135,8 @@
       claude3pNote: "The same Provider can serve Claude and Codex; protocol routing and compatibility conversion are selected per model.",
       providerHelperStartFailed: "Provider credentials are safely disabled. Platform Helper starts with AE but could not start or connect in this session. Reopen the panel, then restart AE if it still fails. Plaintext fallback is disabled.",
       providerHelperRepair: "Provider credentials are safely disabled. Platform Helper started but failed its handshake, version, or authorization check. Restart AE, then repair the current install if it still fails. Plaintext fallback is disabled.",
+      repairHelper: "Repair Helper",
+      repairingHelper: "Repairing Helper\u2026",
       providerStoreCorrupt: "The provider configuration is corrupt; the current list was retained. Restore providers.json from backup, then re-check.",
       providerStoreUnavailable: "The provider configuration is unavailable; the current list was retained. Check disk space and permissions for ~/.ae-mcp.",
       providerMigrationConflict: "The provider configuration changed during migration; the current list was retained. Close other panel instances, restart AE, then re-check.",
@@ -21954,6 +22330,8 @@
     codexCliConfig = null,
     providerManager = null,
     providerInit = { state: "checking", error: "" },
+    onRepairPlatformHelper,
+    providerRepairing = false,
     logLevel = "info",
     onLogLevel,
     onExportLogs,
@@ -21969,6 +22347,11 @@
       PROVIDER_SECRET_MISMATCH: t.providerSecretMismatch,
       PROVIDER_INITIALIZATION_FAILED: t.providerInitializationFailed
     }[providerInit.error] || t.providerInitializationFailed;
+    const helperRepair = platformHelperRepairView(
+      providerInit,
+      providerRepairing,
+      typeof onRepairPlatformHelper === "function"
+    );
     const zcodeModelLocked = zcodeDefaultModelLocked({ backend, models: modelOptions });
     const [customModelDraft, setCustomModelDraft] = import_react19.default.useState(customModel);
     const [draftPort, setDraftPort] = import_react19.default.useState(String(port));
@@ -22050,7 +22433,17 @@
         ),
         providerInit.state === "unavailable" ? /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { role: "alert", style: { padding: "7px 8px", border: "1px solid var(--error-border)", borderRadius: "var(--radius-md)", background: "var(--error-bg)", color: "var(--error)", font: "400 10px/1.5 var(--font-ui)" }, children: [
           providerInitMessage,
-          providerInit.error ? ` (${providerInit.error})` : ""
+          providerInit.detail || providerInit.error ? ` (${providerInit.detail || providerInit.error})` : "",
+          helperRepair ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { marginTop: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
+            Button,
+            {
+              variant: "secondary",
+              size: "sm",
+              disabled: helperRepair.disabled,
+              onClick: onRepairPlatformHelper,
+              children: helperRepair.label === "repairing" ? t.repairingHelper : t.repairHelper
+            }
+          ) }) : null
         ] }) : null,
         providerManager,
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Field, { label: t.modelDefault, children: zcodeModelLocked ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { minHeight: 28, display: "flex", alignItems: "center", padding: "0 8px", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: zcodeManagedModelLabel(lang, backend === "zcode" ? model : "") }) : /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Select, { value: model, onChange: onModelChange, options: modelOptions || [
@@ -26822,7 +27215,7 @@
     const ipv4 = mapped ? mapped[1] : host;
     return /^127(?:\.\d{1,3}){3}$/.test(ipv4);
   }
-  function decodePercentRuns(value) {
+  function decodePercentRuns2(value) {
     return String(value).replace(/(?:%[0-9a-f]{2})+/gi, (run) => {
       try {
         return decodeURIComponent(run);
@@ -26841,7 +27234,7 @@
         const candidate = segments[index + 1];
         if (CREDENTIAL_PATH_LABELS.has(label) && !/^v\d+(?:\.\d+)*$/i.test(candidate)) return true;
       }
-      const decoded = decodePercentRuns(current);
+      const decoded = decodePercentRuns2(current);
       if (decoded === current) break;
       current = decoded;
     }
@@ -27965,323 +28358,6 @@
       return { action: "accept", content: { decision: "session" } };
     }
     return { action: "decline", content: {} };
-  }
-
-  // src/lib/exactSecretRedaction.js
-  function sensitiveValues(profile) {
-    var _a;
-    const values = [];
-    if (typeof ((_a = profile == null ? void 0 : profile.auth) == null ? void 0 : _a.value) === "string" && profile.auth.value) {
-      values.push(profile.auth.value);
-      const scheme = profile.auth.value.match(/^(?:Bearer|Basic)\s+(.+)$/i);
-      if (scheme == null ? void 0 : scheme[1]) values.push(scheme[1]);
-    }
-    for (const header of (profile == null ? void 0 : profile.extraHeaders) || []) {
-      if (typeof (header == null ? void 0 : header.value) === "string" && header.value) values.push(header.value);
-    }
-    return Array.from(new Set(values)).sort((a, b) => b.length - a.length);
-  }
-  function normalizedSecrets(values) {
-    const variants = [];
-    for (const value of values || []) {
-      if (typeof value !== "string" || !value) continue;
-      variants.push(value);
-      try {
-        const encoded = JSON.stringify(value);
-        if ((encoded == null ? void 0 : encoded.startsWith('"')) && encoded.endsWith('"')) variants.push(encoded.slice(1, -1));
-      } catch {
-      }
-    }
-    return Array.from(new Set(variants.filter(Boolean))).sort((a, b) => b.length - a.length);
-  }
-  var MAX_DECODE_CHARS = 1024 * 1024;
-  var MAX_DECODE_LAYERS = 3;
-  var MAX_STRUCTURE_CHARS = 16 * 1024 * 1024;
-  function decodePercentRuns2(value) {
-    return String(value).replace(/(?:%[0-9a-f]{2})+/gi, (run) => {
-      try {
-        return decodeURIComponent(run);
-      } catch {
-        return run;
-      }
-    });
-  }
-  function decodeUnicodeEscapes(value) {
-    return String(value).replace(/\\u([0-9a-f]{4})/gi, (_match, hex) => String.fromCharCode(Number.parseInt(hex, 16)));
-  }
-  function decodedTextLayers(value) {
-    let current = String(value);
-    const layers = [current];
-    for (let layer = 0; layer < MAX_DECODE_LAYERS; layer += 1) {
-      if (!current.includes("%") && !/\\u[0-9a-f]{4}/i.test(current)) break;
-      if (current.length > MAX_DECODE_CHARS) return null;
-      const decoded = decodeUnicodeEscapes(decodePercentRuns2(current));
-      if (decoded === current) break;
-      layers.push(decoded);
-      current = decoded;
-    }
-    return layers;
-  }
-  function textContainsSecret(value, secrets) {
-    const layers = decodedTextLayers(value);
-    if (layers === null) return true;
-    return layers.some((layer) => secrets.some((secret) => layer.includes(secret)));
-  }
-  function containsExactSecret(value, values = []) {
-    const secrets = normalizedSecrets(values);
-    if (!secrets.length) return false;
-    const visiting = /* @__PURE__ */ new WeakSet();
-    const valueParts = [];
-    const keyParts = [];
-    const keyValueParts = [];
-    const leafKeyValueParts = [];
-    let structureChars = 0;
-    const containsText = (candidate) => textContainsSecret(candidate, secrets);
-    const appendPart = (parts, candidate) => {
-      const text = String(candidate);
-      structureChars += text.length;
-      if (structureChars > MAX_STRUCTURE_CHARS) return true;
-      parts.push(text);
-      return false;
-    };
-    const visit = (candidate) => {
-      if (typeof candidate === "function") return true;
-      if (typeof candidate !== "object" || candidate === null) {
-        try {
-          if (appendPart(valueParts, candidate)) return true;
-          if (appendPart(keyValueParts, candidate)) return true;
-          return containsText(candidate);
-        } catch {
-          return true;
-        }
-      }
-      if (visiting.has(candidate)) return true;
-      let keys;
-      try {
-        keys = Reflect.ownKeys(candidate);
-      } catch {
-        return true;
-      }
-      visiting.add(candidate);
-      try {
-        for (const key of keys) {
-          try {
-            const item = Reflect.get(candidate, key);
-            if (appendPart(keyParts, key)) return true;
-            if (appendPart(keyValueParts, key)) return true;
-            if (containsText(key)) return true;
-            if (typeof item !== "function" && (typeof item !== "object" || item === null)) {
-              if (appendPart(leafKeyValueParts, key)) return true;
-              if (appendPart(leafKeyValueParts, item)) return true;
-            }
-            if (visit(item)) return true;
-          } catch {
-            return true;
-          }
-        }
-        return false;
-      } finally {
-        visiting.delete(candidate);
-      }
-    };
-    if (visit(value)) return true;
-    return [valueParts, keyParts, keyValueParts, leafKeyValueParts].some((parts) => containsText(parts.join("")));
-  }
-  function containsExactSecretAcrossBoundary(seedValues, payload, values = []) {
-    const secrets = normalizedSecrets(values);
-    if (!secrets.length) return false;
-    const valueParts = [];
-    const keyParts = [];
-    const keyValueParts = [];
-    const leafKeyValueParts = [];
-    const visiting = /* @__PURE__ */ new WeakSet();
-    let chars = 0;
-    const append = (parts, value) => {
-      const text = String(value);
-      chars += text.length;
-      if (chars > MAX_STRUCTURE_CHARS) return false;
-      parts.push(text);
-      return true;
-    };
-    const visit = (value) => {
-      if (typeof value === "function") return false;
-      if (typeof value !== "object" || value === null) {
-        return append(valueParts, value) && append(keyValueParts, value);
-      }
-      if (visiting.has(value)) return false;
-      let keys;
-      try {
-        keys = Reflect.ownKeys(value);
-      } catch {
-        return false;
-      }
-      visiting.add(value);
-      try {
-        for (const key of keys) {
-          let item;
-          try {
-            item = Reflect.get(value, key);
-          } catch {
-            return false;
-          }
-          if (!append(keyParts, key) || !append(keyValueParts, key)) return false;
-          if (typeof item !== "function" && (typeof item !== "object" || item === null)) {
-            if (!append(valueParts, item) || !append(keyValueParts, item) || !append(leafKeyValueParts, key) || !append(leafKeyValueParts, item)) return false;
-          } else if (!visit(item)) {
-            return false;
-          }
-        }
-        return true;
-      } finally {
-        visiting.delete(value);
-      }
-    };
-    if (!visit(payload)) return true;
-    const candidates = [
-      ...leafKeyValueParts,
-      valueParts.join(""),
-      keyParts.join(""),
-      keyValueParts.join(""),
-      leafKeyValueParts.join("")
-    ];
-    let seeds;
-    try {
-      seeds = Array.from(seedValues || [], (value) => String(value));
-    } catch {
-      return true;
-    }
-    for (const seed of seeds) {
-      for (const candidate of candidates) {
-        if (textContainsSecret(seed + candidate, secrets) || textContainsSecret(candidate + seed, secrets)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-  function redactText(value, values = []) {
-    let text = String(value == null ? "" : value);
-    const secrets = normalizedSecrets(values);
-    if (!secrets.length) return text;
-    const marker = secrets.some((secret) => "[redacted]".includes(secret)) ? "" : "[redacted]";
-    const decodedLayers = decodedTextLayers(text);
-    if (decodedLayers === null) return marker;
-    if (decodedLayers.slice(1).some((layer) => secrets.some((secret) => layer.includes(secret)))) {
-      return marker;
-    }
-    const maximumPasses = Math.max(1, secrets.length * 4 + 8);
-    for (let pass = 0; pass < maximumPasses; pass += 1) {
-      let changed = false;
-      for (const secret of secrets) {
-        if (!text.includes(secret)) continue;
-        text = text.split(secret).join(marker);
-        changed = true;
-      }
-      if (!changed) return text;
-    }
-    return secrets.some((secret) => text.includes(secret)) ? "" : text;
-  }
-  function redactValueParts(value, values) {
-    if (typeof value === "string") return redactText(value, values);
-    if (value === null || ["number", "boolean", "bigint"].includes(typeof value)) {
-      const text = String(value);
-      const redacted = redactText(text, values);
-      return redacted === text ? value : redacted;
-    }
-    if (Array.isArray(value)) return value.map((item) => redactValueParts(item, values));
-    if (!value || typeof value !== "object") return value;
-    return Object.fromEntries(Object.entries(value).map(([key, item]) => [
-      redactText(key, values),
-      redactValueParts(item, values)
-    ]));
-  }
-  function redactValue(value, values = []) {
-    const redacted = redactValueParts(value, values);
-    if (!containsExactSecret(redacted, values)) return redacted;
-    const secrets = normalizedSecrets(values);
-    return secrets.some((secret) => "[redacted]".includes(secret)) ? "" : "[redacted]";
-  }
-  function createDeltaRedactor(values, emitText) {
-    const secrets = normalizedSecrets(values);
-    let buffer = "";
-    const keep = secrets.reduce((maximum, value) => Math.max(maximum, value.length - 1), 0);
-    return {
-      feed(delta) {
-        if (!secrets.length) {
-          emitText(String(delta || ""));
-          return;
-        }
-        buffer = redactText(buffer + String(delta || ""), secrets);
-        if (buffer.length > keep) {
-          emitText(buffer.slice(0, buffer.length - keep));
-          buffer = buffer.slice(buffer.length - keep);
-        }
-      },
-      flush() {
-        if (buffer) emitText(redactText(buffer, secrets));
-        buffer = "";
-      },
-      discard() {
-        buffer = "";
-      }
-    };
-  }
-  function createByteRedactor(values, emitBytes) {
-    const secrets = normalizedSecrets(values).map((value) => Buffer.from(value, "utf8")).filter((value) => value.length > 0).sort((left, right) => right.length - left.length);
-    const displayMarker = Buffer.from("[redacted]", "utf8");
-    const marker = secrets.some((secret) => displayMarker.includes(secret)) ? Buffer.alloc(0) : displayMarker;
-    const maximum = secrets.reduce((length, secret) => Math.max(length, secret.length), 0);
-    let pending = Buffer.alloc(0);
-    function emit(value) {
-      if (value.length > 0) emitBytes(value);
-    }
-    function drain(flush) {
-      if (!secrets.length) {
-        emit(pending);
-        pending = Buffer.alloc(0);
-        return;
-      }
-      while (pending.length > 0) {
-        const boundary = flush ? pending.length : Math.max(0, pending.length - maximum + 1);
-        if (!flush && boundary === 0) return;
-        let matchIndex = -1;
-        let matchSecret = null;
-        for (const secret of secrets) {
-          const index = pending.indexOf(secret);
-          if (index < 0 || !flush && index >= boundary) continue;
-          if (matchIndex < 0 || index < matchIndex || index === matchIndex && secret.length > matchSecret.length) {
-            matchIndex = index;
-            matchSecret = secret;
-          }
-        }
-        if (matchIndex < 0) {
-          emit(pending.subarray(0, boundary));
-          pending = pending.subarray(boundary);
-          if (!flush) return;
-          continue;
-        }
-        emit(pending.subarray(0, matchIndex));
-        emit(marker);
-        pending = pending.subarray(matchIndex + matchSecret.length);
-      }
-    }
-    return {
-      feed(chunk) {
-        const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk || "");
-        if (!value.length) return;
-        pending = pending.length ? Buffer.concat([pending, value]) : Buffer.from(value);
-        drain(false);
-      },
-      flush() {
-        drain(true);
-      },
-      discard() {
-        pending = Buffer.alloc(0);
-      }
-    };
-  }
-  function safeErrorMessage(error, values = []) {
-    return redactText(error && error.message ? error.message : "Agent loop failed.", values);
   }
 
   // src/lib/agentLoop.js
@@ -46806,44 +46882,6 @@ data: ${JSON.stringify(payload)}
     };
   }
 
-  // src/app/providerInitState.js
-  var HELPER_FAILURE_CODES = /* @__PURE__ */ new Set([
-    "HELPER_UNAUTHORIZED",
-    "PROTOCOL_VERSION_UNSUPPORTED",
-    "SECRET_STORE_UNAVAILABLE",
-    "PLATFORM_HELPER_REPAIR_REQUIRED",
-    "INVALID_REQUEST",
-    "MESSAGE_TOO_LARGE"
-  ]);
-  var MIGRATION_FAILURE_CODES = /* @__PURE__ */ new Set([
-    "PROVIDER_STORE_CONFLICT",
-    "INVALID_PROVIDER_MIGRATION",
-    "INVALID_MIGRATION_JOURNAL"
-  ]);
-  var SECRET_MISMATCH_CODES = /* @__PURE__ */ new Set([
-    "SECRET_CONFLICT",
-    "SECRET_NOT_FOUND",
-    "INVALID_REFERENCE"
-  ]);
-  function providerInitFailure(error) {
-    const code = typeof (error == null ? void 0 : error.code) === "string" ? error.code : "";
-    let failure2 = "PROVIDER_INITIALIZATION_FAILED";
-    if (code === "HELPER_UNAVAILABLE" || code === "HELPER_START_FAILED") {
-      failure2 = "PLATFORM_HELPER_START_FAILED";
-    } else if (HELPER_FAILURE_CODES.has(code)) failure2 = "PLATFORM_HELPER_REPAIR_REQUIRED";
-    else if (code === "PROVIDER_STORE_INVALID" || code === "PROVIDER_STORE_CREDENTIAL_CONTAMINATION") failure2 = "PROVIDER_STORE_CORRUPT";
-    else if (code === "PROVIDER_STORE_UNAVAILABLE") failure2 = "PROVIDER_STORE_UNAVAILABLE";
-    else if (MIGRATION_FAILURE_CODES.has(code)) failure2 = "PROVIDER_MIGRATION_CONFLICT";
-    else if (SECRET_MISMATCH_CODES.has(code)) failure2 = "PROVIDER_SECRET_MISMATCH";
-    return { state: "unavailable", error: failure2 };
-  }
-  function assertProviderStateCredentialFree(providerState, exactSecrets = []) {
-    if (!containsExactSecret(providerState == null ? void 0 : providerState.providers, exactSecrets)) return providerState;
-    const error = new Error("Stored Provider data contains protected credential material.");
-    error.code = "PROVIDER_STORE_CREDENTIAL_CONTAMINATION";
-    throw error;
-  }
-
   // src/components/settings/ProviderManagerSection.jsx
   var import_react43 = __toESM(require_react(), 1);
 
@@ -48836,6 +48874,7 @@ data: ${JSON.stringify(payload)}
     const adapter = platform || createPlatformAdapter();
     let host = null;
     let helperClient = null;
+    let helperBindingContext = null;
     let platformRoots = null;
     let beforeUnloadInstalled = false;
     let lifecycleGeneration = 0;
@@ -48855,7 +48894,12 @@ data: ${JSON.stringify(payload)}
       } catch {
       }
     }
-    function bindPlatformHelperFacade({ cepRequire: cepRequire5, extRoot, hostInstance }) {
+    function bindPlatformHelperFacade({
+      cepRequire: cepRequire5,
+      extRoot,
+      hostInstance,
+      repairRegistration = false
+    }) {
       let transport = null;
       let nextClient = null;
       let bindingError = null;
@@ -48874,7 +48918,8 @@ data: ${JSON.stringify(payload)}
         })();
         transport = transportFactory({
           platformId: adapter.id,
-          runtime: helperRuntime(adapter.id)
+          runtime: helperRuntime(adapter.id),
+          repairRegistration
         });
         if (!transport || typeof transport.request !== "function" || typeof transport.close !== "function") {
           throw helperUnavailableError();
@@ -48915,6 +48960,7 @@ data: ${JSON.stringify(payload)}
       const priorClient = helperClient;
       host = null;
       helperClient = null;
+      helperBindingContext = null;
       platformRoots = null;
       if (priorHost || priorClient) disposeLifecycle(priorClient, priorHost);
       try {
@@ -48940,6 +48986,7 @@ data: ${JSON.stringify(payload)}
         nextHost.setCSInterface(cs2);
         if (nextHost.setPlatformRoots) nextHost.setPlatformRoots(roots);
         host = nextHost;
+        helperBindingContext = { cepRequire: cepRequire5, extRoot, hostInstance: nextHost };
         bindPlatformHelperFacade({ cepRequire: cepRequire5, extRoot, hostInstance: nextHost });
         if (!beforeUnloadInstalled) {
           const installBeforeUnload = addBeforeUnload || ((handler) => window.addEventListener("beforeunload", handler));
@@ -48948,6 +48995,7 @@ data: ${JSON.stringify(payload)}
             const closingClient = helperClient;
             const closingHost = host;
             helperClient = null;
+            helperBindingContext = null;
             host = null;
             platformRoots = null;
             disposeLifecycle(closingClient, closingHost, { closeClient: false });
@@ -48964,6 +49012,7 @@ data: ${JSON.stringify(payload)}
         const failedClient = helperClient;
         host = null;
         helperClient = null;
+        helperBindingContext = null;
         platformRoots = null;
         disposeLifecycle(failedClient, failedHost);
         if (generation === lifecycleGeneration) onStatus("error", port, e.message);
@@ -48981,7 +49030,29 @@ data: ${JSON.stringify(payload)}
         }, platformRoots);
       }
     }
-    return { start, restart, getHost: () => host };
+    async function repairPlatformHelper() {
+      const context = helperBindingContext;
+      const currentHost = host;
+      if (adapter.id !== "macos-arm64" || !context || !currentHost || context.hostInstance !== currentHost) {
+        throw helperUnavailableError();
+      }
+      const priorClient = helperClient;
+      helperClient = null;
+      closeHelperClient(priorClient);
+      bindPlatformHelperFacade({
+        ...context,
+        repairRegistration: true
+      });
+      if (host !== currentHost) {
+        throw helperUnavailableError();
+      }
+      try {
+        return await currentHost.capabilities();
+      } catch (error) {
+        throw sanitizeHelperError(error);
+      }
+    }
+    return { start, restart, repairPlatformHelper, getHost: () => host };
   }
 
   // src/lib/expertGuidance.js
@@ -49771,6 +49842,8 @@ data: ${JSON.stringify(payload)}
     const zcodeStoredKeyRef = import_react46.default.useRef("");
     const [zcodeCredentialEpoch, setZcodeCredentialEpoch] = import_react46.default.useState(0);
     const [providerInit, setProviderInit] = import_react46.default.useState({ state: "checking", error: "" });
+    const [providerRepairing, setProviderRepairing] = import_react46.default.useState(false);
+    const [providerInitEpoch, setProviderInitEpoch] = import_react46.default.useState(0);
     const [providers, setProviders] = import_react46.default.useState([]);
     const [claudeProviderId, setClaudeProviderId] = import_react46.default.useState(() => readPref("ae_mcp_claude_provider", ""));
     const [codexProviderId, setCodexProviderId] = import_react46.default.useState(() => readPref("ae_mcp_codex_provider", ""));
@@ -50654,6 +50727,24 @@ ${baseUrl}`),
       if (!keepLogLine(logLevelRef.current, m)) return;
       setLogs((xs) => [...xs.slice(-199), `[${(/* @__PURE__ */ new Date()).toLocaleTimeString()}] ${m}`]);
     }, []);
+    const repairPlatformHelper = import_react46.default.useCallback(async () => {
+      if (providerRepairing) return;
+      setProviderRepairing(true);
+      try {
+        const controller = ctrl.current;
+        if (!controller || typeof controller.repairPlatformHelper !== "function") {
+          throw providerRuntimeUnavailableError();
+        }
+        await controller.repairPlatformHelper();
+        pushLog("Platform Helper repaired; rechecking protected provider state");
+        setProviderInitEpoch((current) => current + 1);
+      } catch (error) {
+        setProviderInit(providerRepairFailure(error));
+        pushLog("Platform Helper repair failed: " + (typeof (error == null ? void 0 : error.code) === "string" ? error.code : "HELPER_UNAVAILABLE"));
+      } finally {
+        setProviderRepairing(false);
+      }
+    }, [providerRepairing, pushLog]);
     const exportLogs = import_react46.default.useCallback(() => {
       try {
         const exactSecrets = providerSecretService.getRedactionValues();
@@ -50790,7 +50881,7 @@ ${baseUrl}`),
       return () => {
         alive = false;
       };
-    }, [status.state, providerStore, providerSecretService, getHost, legacyKeyStore, platform, pushLog, zcodeCredentialManager]);
+    }, [status.state, providerStore, providerSecretService, getHost, legacyKeyStore, platform, pushLog, providerInitEpoch, zcodeCredentialManager]);
     import_react46.default.useEffect(() => {
       if (!drawerOpen) return void 0;
       const update = () => {
@@ -51021,6 +51112,8 @@ ${baseUrl}`),
             providers,
             providerManager,
             providerInit,
+            providerRepairing,
+            onRepairPlatformHelper: repairPlatformHelper,
             claudeProviderId,
             onClaudeProviderChange: (id) => {
               setClaudeProviderId(id);

--- a/plugin/host/platform-helper-registration.js
+++ b/plugin/host/platform-helper-registration.js
@@ -210,6 +210,10 @@ function materializePrivatePlist(payload, input) {
     return destination;
 }
 
+function launchctlServiceMissing(error) {
+    return Boolean(error) && Number(error.code) === 113;
+}
+
 function launchctlRunner(input) {
     return function launchctl(args, options) {
         const allowMissing = Boolean(options && options.allowMissing);
@@ -219,7 +223,7 @@ function launchctlRunner(input) {
                 if (settled) return;
                 settled = true;
                 if (error) {
-                    if (allowMissing) {
+                    if (allowMissing && launchctlServiceMissing(error)) {
                         resolve(Object.freeze({ found: false, stdout: '' }));
                         return;
                     }
@@ -274,7 +278,8 @@ function prepareMacosHelperRegistration(options) {
     if (!Number.isSafeInteger(userIdentifier) || userIdentifier < 0) {
         throw new TypeError('current user identifier is invalid');
     }
-    const payload = verifyMacosPayload(path.resolve(input.addonPath), dependencies);
+    const addonPath = path.resolve(input.addonPath);
+    const payload = verifyMacosPayload(addonPath, dependencies);
     const launchctl = launchctlRunner(dependencies);
     const domain = `gui/${userIdentifier}`;
     const service = `${domain}/${HELPER_ID}`;
@@ -304,9 +309,37 @@ function prepareMacosHelperRegistration(options) {
         return registrationPromise;
     }
 
+    async function repairRegistered() {
+        const currentPayload = verifyMacosPayload(addonPath, dependencies);
+        const current = await launchctl(['print', service], { allowMissing: true });
+        if (current.found) {
+            try {
+                requireExactProgram(current.stdout, currentPayload.helperPath);
+                return Object.freeze({
+                    action: 'already-current',
+                    helperPath: currentPayload.helperPath,
+                });
+            } catch (error) {
+                if (!error || error.code !== 'PLATFORM_HELPER_REPAIR_REQUIRED') {
+                    throw error;
+                }
+            }
+            await launchctl(['bootout', service], { allowMissing: true });
+        }
+        const plistPath = materializePrivatePlist(currentPayload, dependencies);
+        await launchctl(['bootstrap', domain, plistPath]);
+        const registered = await launchctl(['print', service]);
+        requireExactProgram(registered.stdout, currentPayload.helperPath);
+        return Object.freeze({
+            action: 'repaired',
+            helperPath: currentPayload.helperPath,
+        });
+    }
+
     return Object.freeze({
         helperPath: payload.helperPath,
         ensureRegistered,
+        repairRegistered,
     });
 }
 

--- a/plugin/host/platform-helper-registration.test.js
+++ b/plugin/host/platform-helper-registration.test.js
@@ -260,6 +260,208 @@ test('macOS registration rejects an already-loaded different helper', async (t) 
     });
 });
 
+test('macOS explicit repair replaces a stale registration and verifies the current helper', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    let printCalls = 0;
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        if (args[0] === 'print') {
+            printCalls += 1;
+            const helperPath = printCalls === 1
+                ? '/tmp/stale-helper'
+                : fixture.helperPath;
+            queueMicrotask(() => callback(
+                null,
+                `${service} = {\n\tprogram = ${helperPath}\n}\n`,
+                '',
+            ));
+            return;
+        }
+        queueMicrotask(() => callback(null, '', ''));
+    });
+
+    assert.deepEqual(await registration.repairRegistered(), {
+        action: 'repaired',
+        helperPath: fixture.helperPath,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), [
+        'print',
+        'bootout',
+        'bootstrap',
+        'print',
+    ]);
+    assert.deepEqual(calls[1][1], ['bootout', service]);
+});
+
+test('macOS explicit repair reuses an already-current registration', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        queueMicrotask(() => callback(
+            null,
+            `${service} = {\n\tprogram = ${fixture.helperPath}\n}\n`,
+            '',
+        ));
+    });
+
+    assert.deepEqual(await registration.repairRegistered(), {
+        action: 'already-current',
+        helperPath: fixture.helperPath,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), ['print']);
+});
+
+test('macOS explicit repair bootstraps when the service is already absent', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    let printCalls = 0;
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        if (args[0] === 'print') {
+            printCalls += 1;
+            if (printCalls === 1) {
+                queueMicrotask(() => callback(
+                    Object.assign(new Error('service absent'), { code: 113 }),
+                    '',
+                    '',
+                ));
+                return;
+            }
+            queueMicrotask(() => callback(
+                null,
+                `${service} = {\n\tprogram = ${fixture.helperPath}\n}\n`,
+                '',
+            ));
+            return;
+        }
+        queueMicrotask(() => callback(null, '', ''));
+    });
+
+    assert.deepEqual(await registration.repairRegistered(), {
+        action: 'repaired',
+        helperPath: fixture.helperPath,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), [
+        'print',
+        'bootstrap',
+        'print',
+    ]);
+});
+
+test('macOS explicit repair reverifies the payload before launchd mutation', async (t) => {
+    const fixture = writeMacosFixture(t);
+    let launchctlCalls = 0;
+    const registration = registrationFor(fixture, function () {
+        launchctlCalls += 1;
+    });
+    fs.appendFileSync(fixture.helperPath, 'tampered');
+
+    await assert.rejects(registration.repairRegistered(), {
+        code: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+        retryable: false,
+    });
+    assert.equal(launchctlCalls, 0);
+});
+
+test('macOS explicit repair stops on a non-missing bootout failure', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        if (args[0] === 'print') {
+            queueMicrotask(() => callback(
+                null,
+                `${service} = {\n\tprogram = /tmp/stale-helper\n}\n`,
+                '',
+            ));
+            return;
+        }
+        if (args[0] === 'bootout') {
+            queueMicrotask(() => callback(
+                Object.assign(new Error('bootout failed'), { code: 5 }),
+                '',
+                '',
+            ));
+            return;
+        }
+        queueMicrotask(() => callback(null, '', ''));
+    });
+
+    await assert.rejects(registration.repairRegistered(), {
+        code: 'HELPER_START_FAILED',
+        retryable: true,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), ['print', 'bootout']);
+});
+
+test('macOS explicit repair continues when bootout observes a missing service', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    let printCalls = 0;
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        if (args[0] === 'print') {
+            printCalls += 1;
+            const helperPath = printCalls === 1
+                ? '/tmp/stale-helper'
+                : fixture.helperPath;
+            queueMicrotask(() => callback(
+                null,
+                `${service} = {\n\tprogram = ${helperPath}\n}\n`,
+                '',
+            ));
+            return;
+        }
+        if (args[0] === 'bootout') {
+            queueMicrotask(() => callback(
+                Object.assign(new Error('service disappeared'), { code: 113 }),
+                '',
+                '',
+            ));
+            return;
+        }
+        queueMicrotask(() => callback(null, '', ''));
+    });
+
+    assert.deepEqual(await registration.repairRegistered(), {
+        action: 'repaired',
+        helperPath: fixture.helperPath,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), [
+        'print',
+        'bootout',
+        'bootstrap',
+        'print',
+    ]);
+});
+
+test('macOS normal registration never boots out a stale service', async (t) => {
+    const fixture = writeMacosFixture(t);
+    const calls = [];
+    const service = 'gui/501/com.junkdoge.ae-mcp.platform-helper';
+    const registration = registrationFor(fixture, function (file, args, options, callback) {
+        calls.push([file, [...args]]);
+        queueMicrotask(() => callback(
+            null,
+            `${service} = {\n\tprogram = /tmp/stale-helper\n}\n`,
+            '',
+        ));
+    });
+
+    await assert.rejects(registration.ensureRegistered(), {
+        code: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+        retryable: false,
+    });
+    assert.deepEqual(calls.map(([, args]) => args[0]), ['print']);
+});
+
 test('macOS registration sanitizes bootstrap failures without fallback', async (t) => {
     const fixture = writeMacosFixture(t);
     let calls = 0;

--- a/plugin/host/platform-helper-transport.js
+++ b/plugin/host/platform-helper-transport.js
@@ -149,7 +149,8 @@ function validMacosRegistration(value) {
     return value
         && typeof value.helperPath === 'string'
         && value.helperPath.length > 0
-        && typeof value.ensureRegistered === 'function';
+        && typeof value.ensureRegistered === 'function'
+        && typeof value.repairRegistered === 'function';
 }
 
 function createPlatformHelperTransport(options) {
@@ -290,7 +291,11 @@ function createPlatformHelperTransport(options) {
             opened = await connectWindows();
         } else {
             try {
-                await macosRegistration.ensureRegistered();
+                if (input.repairRegistration === true) {
+                    await macosRegistration.repairRegistered();
+                } else {
+                    await macosRegistration.ensureRegistered();
+                }
                 const createBrokerTransport = input.createMacosBrokerTransport
                     || createPlatformHelperStdioTransport;
                 opened = createBrokerTransport({

--- a/plugin/host/platform-helper-transport.test.js
+++ b/plugin/host/platform-helper-transport.test.js
@@ -32,6 +32,7 @@ function macOptions(overrides) {
             return {
                 helperPath: '/verified/ae-mcp-platform-helper',
                 ensureRegistered: async function () {},
+                repairRegistered: async function () {},
             };
         },
         ...overrides,
@@ -184,6 +185,35 @@ test('macOS uses the verified stdio broker and never loads the addon', async () 
     await transport.close();
 });
 
+test('macOS repair transport replaces registration before opening the broker', async () => {
+    const events = [];
+    const transport = createPlatformHelperTransport(macOptions({
+        repairRegistration: true,
+        prepareMacosHelperRegistration: function () {
+            return {
+                helperPath: '/verified/platform/helper',
+                ensureRegistered: async function () {
+                    events.push('ensure');
+                },
+                repairRegistered: async function () {
+                    events.push('repair');
+                },
+            };
+        },
+        createMacosBrokerTransport: function () {
+            events.push('broker');
+            return {
+                request: async function () { return 'ready'; },
+                close: async function () {},
+            };
+        },
+    }));
+
+    assert.equal(await transport.request('request'), 'ready');
+    assert.deepEqual(events, ['repair', 'broker']);
+    await transport.close();
+});
+
 test('macOS registration completes before the stdio broker starts or sends a request', async () => {
     const events = [];
     let releaseRegistration;
@@ -200,6 +230,7 @@ test('macOS registration completes before the stdio broker starts or sends a req
                     await registrationGate;
                     events.push('register:done');
                 },
+                repairRegistered: async function () {},
             };
         },
         loadAddon: function () {
@@ -245,6 +276,7 @@ test('concurrent macOS requests share one registration and one native transport'
                     registrations += 1;
                     await nextTurn();
                 },
+                repairRegistered: async function () {},
             };
         },
         createMacosBrokerTransport: function () {
@@ -275,6 +307,7 @@ test('macOS registration lifecycle errors remain bounded and block native XPC', 
                     ensureRegistered: async function () {
                         throw Object.assign(new Error('sensitive local detail'), fixture);
                     },
+                    repairRegistered: async function () {},
                 };
             },
             createMacosBrokerTransport: function () {
@@ -389,7 +422,7 @@ test('process launch is isolated to the verified platform Helper JS boundaries',
     assert.match(registrationSource, /require\('child_process'\)\.execFile/);
     assert.doesNotMatch(
         registrationSource,
-        /shell:\s*true|\bexec\s*\(|\bspawn\s*\(|\bbootout\b|\bkill\b|stdio:\s*'inherit'/i,
+        /shell:\s*true|\bexec\s*\(|\bspawn\s*\(|\bkill\b|stdio:\s*'inherit'/i,
     );
     const stdioSource = fs.readFileSync(
         path.join(__dirname, 'platform-helper-stdio-transport.js'),

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -40,7 +40,7 @@ import { migrateProviderStoreV2ToV3 } from '../cep/providerSchemaMigration';
 import { createSecretMigrationRunner } from '../cep/platform/secret-migration';
 import { deleteProviderProfile, drainPendingProviderSecretDeletes, importProviderDraft, saveProviderDraft } from './providerProfileFlow';
 import { runProviderManagerProbe } from './providerProbeFlow.js';
-import { assertProviderStateCredentialFree, providerInitFailure } from './providerInitState';
+import { assertProviderStateCredentialFree, providerInitFailure, providerRepairFailure } from './providerInitState';
 import { ProviderManagerSection } from '../components/settings/ProviderManagerSection';
 import { probeProviderModels } from '../cep/modelProbe';
 import { detectCcSwitch, readCcSwitchProviderDrafts } from '../cep/ccSwitch';
@@ -397,6 +397,8 @@ function Shell({ cs }) {
   const zcodeStoredKeyRef = React.useRef('');
   const [zcodeCredentialEpoch, setZcodeCredentialEpoch] = React.useState(0);
   const [providerInit, setProviderInit] = React.useState({ state: 'checking', error: '' });
+  const [providerRepairing, setProviderRepairing] = React.useState(false);
+  const [providerInitEpoch, setProviderInitEpoch] = React.useState(0);
   const [providers, setProviders] = React.useState([]);
   const [claudeProviderId, setClaudeProviderId] = React.useState(() => readPref('ae_mcp_claude_provider', ''));
   const [codexProviderId, setCodexProviderId] = React.useState(() => readPref('ae_mcp_codex_provider', ''));
@@ -1315,6 +1317,27 @@ function Shell({ cs }) {
     setLogs((xs) => [...xs.slice(-199), `[${new Date().toLocaleTimeString()}] ${m}`]);
   }, []);
 
+  const repairPlatformHelper = React.useCallback(async () => {
+    if (providerRepairing) return;
+    setProviderRepairing(true);
+    try {
+      const controller = ctrl.current;
+      if (!controller || typeof controller.repairPlatformHelper !== 'function') {
+        throw providerRuntimeUnavailableError();
+      }
+      await controller.repairPlatformHelper();
+      pushLog('Platform Helper repaired; rechecking protected provider state');
+      setProviderInitEpoch((current) => current + 1);
+    } catch (error) {
+      setProviderInit(providerRepairFailure(error));
+      pushLog('Platform Helper repair failed: ' + (
+        typeof error?.code === 'string' ? error.code : 'HELPER_UNAVAILABLE'
+      ));
+    } finally {
+      setProviderRepairing(false);
+    }
+  }, [providerRepairing, pushLog]);
+
   const exportLogs = React.useCallback(() => {
     try {
       const exactSecrets = providerSecretService.getRedactionValues();
@@ -1446,7 +1469,7 @@ function Shell({ cs }) {
       }
     })();
     return () => { alive = false; };
-  }, [status.state, providerStore, providerSecretService, getHost, legacyKeyStore, platform, pushLog, zcodeCredentialManager]);
+  }, [status.state, providerStore, providerSecretService, getHost, legacyKeyStore, platform, pushLog, providerInitEpoch, zcodeCredentialManager]);
 
   // Keep connection info fresh while the drawer is open.
   React.useEffect(() => {
@@ -1685,6 +1708,8 @@ function Shell({ cs }) {
             providers={providers}
             providerManager={providerManager}
             providerInit={providerInit}
+            providerRepairing={providerRepairing}
+            onRepairPlatformHelper={repairPlatformHelper}
             claudeProviderId={claudeProviderId}
             onClaudeProviderChange={(id) => { setClaudeProviderId(id); writePref('ae_mcp_claude_provider', id); }}
             codexProviderId={codexProviderId}

--- a/plugin/panel/src/app/providerInitState.js
+++ b/plugin/panel/src/app/providerInitState.js
@@ -32,6 +32,27 @@ export function providerInitFailure(error) {
   return { state: 'unavailable', error: failure };
 }
 
+export function platformHelperRepairView(providerInit, repairing, hasAction) {
+  if (!hasAction
+      || providerInit?.state !== 'unavailable'
+      || providerInit?.error !== 'PLATFORM_HELPER_REPAIR_REQUIRED') {
+    return null;
+  }
+  return {
+    disabled: repairing === true,
+    label: repairing === true ? 'repairing' : 'repair',
+  };
+}
+
+export function providerRepairFailure(error) {
+  const classified = providerInitFailure(error);
+  return {
+    state: 'unavailable',
+    error: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+    detail: classified.error,
+  };
+}
+
 export function assertProviderStateCredentialFree(providerState, exactSecrets = []) {
   if (!containsExactSecret(providerState?.providers, exactSecrets)) return providerState;
   const error = new Error('Stored Provider data contains protected credential material.');

--- a/plugin/panel/src/cep/hostBridge.js
+++ b/plugin/panel/src/cep/hostBridge.js
@@ -251,6 +251,7 @@ export function createHostController({
   const adapter = platform || createPlatformAdapter();
   let host = null;
   let helperClient = null;
+  let helperBindingContext = null;
   let platformRoots = null;
   let beforeUnloadInstalled = false;
   let lifecycleGeneration = 0;
@@ -266,7 +267,12 @@ export function createHostController({
     try { if (hostInstance && typeof hostInstance.stop === 'function') hostInstance.stop(); } catch { /* best effort */ }
   }
 
-  function bindPlatformHelperFacade({ cepRequire, extRoot, hostInstance }) {
+  function bindPlatformHelperFacade({
+    cepRequire,
+    extRoot,
+    hostInstance,
+    repairRegistration = false,
+  }) {
     let transport = null;
     let nextClient = null;
     let bindingError = null;
@@ -286,6 +292,7 @@ export function createHostController({
       transport = transportFactory({
         platformId: adapter.id,
         runtime: helperRuntime(adapter.id),
+        repairRegistration,
       });
       if (!transport || typeof transport.request !== 'function' || typeof transport.close !== 'function') {
         throw helperUnavailableError();
@@ -327,6 +334,7 @@ export function createHostController({
     const priorClient = helperClient;
     host = null;
     helperClient = null;
+    helperBindingContext = null;
     platformRoots = null;
     if (priorHost || priorClient) disposeLifecycle(priorClient, priorHost);
     try {
@@ -352,6 +360,7 @@ export function createHostController({
       nextHost.setCSInterface(cs);
       if (nextHost.setPlatformRoots) nextHost.setPlatformRoots(roots);
       host = nextHost;
+      helperBindingContext = { cepRequire, extRoot, hostInstance: nextHost };
       bindPlatformHelperFacade({ cepRequire, extRoot, hostInstance: nextHost });
       // Release the port when this JS context goes away (panel close or a
       // devtools reload) — otherwise the orphaned listener keeps the port and
@@ -364,6 +373,7 @@ export function createHostController({
           const closingClient = helperClient;
           const closingHost = host;
           helperClient = null;
+          helperBindingContext = null;
           host = null;
           platformRoots = null;
           disposeLifecycle(closingClient, closingHost, { closeClient: false });
@@ -380,6 +390,7 @@ export function createHostController({
       const failedClient = helperClient;
       host = null;
       helperClient = null;
+      helperBindingContext = null;
       platformRoots = null;
       disposeLifecycle(failedClient, failedHost);
       if (generation === lifecycleGeneration) onStatus('error', port, e.message);
@@ -397,5 +408,32 @@ export function createHostController({
       }, platformRoots);
     }
   }
-  return { start, restart, getHost: () => host };
+  async function repairPlatformHelper() {
+    const context = helperBindingContext;
+    const currentHost = host;
+    if (adapter.id !== 'macos-arm64'
+        || !context
+        || !currentHost
+        || context.hostInstance !== currentHost) {
+      throw helperUnavailableError();
+    }
+
+    const priorClient = helperClient;
+    helperClient = null;
+    closeHelperClient(priorClient);
+    bindPlatformHelperFacade({
+      ...context,
+      repairRegistration: true,
+    });
+
+    if (host !== currentHost) {
+      throw helperUnavailableError();
+    }
+    try {
+      return await currentHost.capabilities();
+    } catch (error) {
+      throw sanitizeHelperError(error);
+    }
+  }
+  return { start, restart, repairPlatformHelper, getHost: () => host };
 }

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -15,6 +15,7 @@ import { zcodeDefaultModelLocked as shouldLockZcodeDefaultModel, zcodeManagedMod
 import { Icon } from '../components/core/Icon';
 import { loadSectionState, saveSectionState, toggleSection } from '../lib/settingsSections';
 import { createPlatformAdapter } from '../cep/platform/index';
+import { platformHelperRepairView } from '../app/providerInitState';
 
 const REPO_URL = 'https://github.com/JUNKDOGE-JOE/after-effects-mcp';
 const DOCS_URL = 'https://github.com/JUNKDOGE-JOE/after-effects-mcp#readme';
@@ -51,6 +52,8 @@ const S = {
     claude3pNote: '同一个 Provider 可同时用于 Claude 和 Codex；协议与兼容转换按当前模型自动选择。',
     providerHelperStartFailed: 'Provider 凭据功能已安全停用。平台 Helper 会随 AE 自动启动，但本次未能启动或连接；请先重新打开面板，仍失败时重启 AE。不会回退读取明文凭据。',
     providerHelperRepair: 'Provider 凭据功能已安全停用。平台 Helper 已启动但未通过握手、版本或授权检查；请重启 AE，仍失败时再修复当前安装。不会回退读取明文凭据。',
+    repairHelper: '修复 Helper',
+    repairingHelper: '正在修复 Helper…',
     providerStoreCorrupt: 'Provider 配置文件损坏；当前列表已保留。请先从备份恢复 providers.json，再点「重新检测」。',
     providerStoreUnavailable: 'Provider 配置文件不可用；当前列表已保留。请检查 ~/.ae-mcp 的磁盘空间与读写权限。',
     providerMigrationConflict: 'Provider 迁移期间配置发生冲突；当前列表已保留。请关闭其他面板实例后重新启动 AE 再检测。',
@@ -114,6 +117,8 @@ const S = {
     claude3pNote: 'The same Provider can serve Claude and Codex; protocol routing and compatibility conversion are selected per model.',
     providerHelperStartFailed: 'Provider credentials are safely disabled. Platform Helper starts with AE but could not start or connect in this session. Reopen the panel, then restart AE if it still fails. Plaintext fallback is disabled.',
     providerHelperRepair: 'Provider credentials are safely disabled. Platform Helper started but failed its handshake, version, or authorization check. Restart AE, then repair the current install if it still fails. Plaintext fallback is disabled.',
+    repairHelper: 'Repair Helper',
+    repairingHelper: 'Repairing Helper…',
     providerStoreCorrupt: 'The provider configuration is corrupt; the current list was retained. Restore providers.json from backup, then re-check.',
     providerStoreUnavailable: 'The provider configuration is unavailable; the current list was retained. Check disk space and permissions for ~/.ae-mcp.',
     providerMigrationConflict: 'The provider configuration changed during migration; the current list was retained. Close other panel instances, restart AE, then re-check.',
@@ -321,6 +326,8 @@ export function SettingsScreen({
   codexCliConfig = null,
   providerManager = null,
   providerInit = { state: 'checking', error: '' },
+  onRepairPlatformHelper,
+  providerRepairing = false,
   logLevel = 'info',
   onLogLevel,
   onExportLogs,
@@ -336,6 +343,11 @@ export function SettingsScreen({
     PROVIDER_SECRET_MISMATCH: t.providerSecretMismatch,
     PROVIDER_INITIALIZATION_FAILED: t.providerInitializationFailed,
   }[providerInit.error] || t.providerInitializationFailed;
+  const helperRepair = platformHelperRepairView(
+    providerInit,
+    providerRepairing,
+    typeof onRepairPlatformHelper === 'function',
+  );
   const zcodeModelLocked = shouldLockZcodeDefaultModel({ backend, models: modelOptions });
   const [customModelDraft, setCustomModelDraft] = React.useState(customModel);
   const [draftPort, setDraftPort] = React.useState(String(port));
@@ -430,7 +442,19 @@ export function SettingsScreen({
         />
         {providerInit.state === 'unavailable' ? (
           <div role="alert" style={{ padding: '7px 8px', border: '1px solid var(--error-border)', borderRadius: 'var(--radius-md)', background: 'var(--error-bg)', color: 'var(--error)', font: '400 10px/1.5 var(--font-ui)' }}>
-            {providerInitMessage}{providerInit.error ? ` (${providerInit.error})` : ''}
+            {providerInitMessage}{providerInit.detail || providerInit.error ? ` (${providerInit.detail || providerInit.error})` : ''}
+            {helperRepair ? (
+              <div style={{ marginTop: 6 }}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={helperRepair.disabled}
+                  onClick={onRepairPlatformHelper}
+                >
+                  {helperRepair.label === 'repairing' ? t.repairingHelper : t.repairHelper}
+                </Button>
+              </div>
+            ) : null}
           </div>
         ) : null}
         {providerManager}

--- a/plugin/panel/test/hostBridge.test.js
+++ b/plugin/panel/test/hostBridge.test.js
@@ -568,6 +568,170 @@ test('real host controller exposes in-process Foundation helper pass-through met
   ]);
 });
 
+test('host controller repair replaces the stale helper binding and handshakes the replacement', async () => {
+  const repairModes = [];
+  let firstClientCloses = 0;
+  const transports = [1, 2].map((id) => ({ id, request() {}, close() {} }));
+  const replacementCapabilities = {
+    protocolVersion: 1,
+    helperVersion: 'test-helper',
+    authenticatedCaller: true,
+    secretBackend: 'keychain',
+    methods: ['secret.get', 'secret.set', 'secret.delete'],
+  };
+  const clients = [
+    {
+      async capabilities() {
+        const error = new Error('stale helper registration');
+        error.code = 'PLATFORM_HELPER_REPAIR_REQUIRED';
+        throw error;
+      },
+      async secretGet() {}, async secretSet() {}, async secretDelete() {},
+      close() { firstClientCloses += 1; },
+    },
+    {
+      async capabilities() { return replacementCapabilities; },
+      async secretGet() {}, async secretSet() {}, async secretDelete() {},
+      close() {},
+    },
+  ];
+  const host = {
+    setRuntimeDependencies() {}, setCSInterface() {},
+    start(_port, callback) { callback(null); }, stop() {},
+  };
+  const runtime = fakeHostDependencyRuntime({
+    platformId: 'macos-arm64', extensionRoot: '/Applications/AE MCP',
+    express: function bundledExpress() {},
+  });
+  const controller = createHostController({
+    cs: { getSystemPath: () => '/Applications/AE MCP' },
+    extensionRoot: '/Applications/AE MCP',
+    platform: macHostAdapter(runtime.fs, '/Applications/AE MCP/runtime'),
+    requireImpl: (request) => request === 'module' ? runtime.moduleApi : (request === 'path' ? path : host),
+    createPlatformHelperTransportImpl(options) {
+      repairModes.push(options.repairRegistration);
+      return transports[repairModes.length - 1];
+    },
+    createPlatformHelperClientImpl({ transport }) {
+      return clients[transport.id - 1];
+    },
+    onStatus: () => {}, onLog: () => {}, addBeforeUnload: () => {},
+  });
+
+  controller.start(11488);
+  await assert.rejects(
+    controller.getHost().capabilities(),
+    { code: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+  );
+  assert.equal(typeof controller.repairPlatformHelper, 'function');
+  assert.equal(
+    (await controller.repairPlatformHelper()).authenticatedCaller,
+    true,
+  );
+  assert.deepEqual(repairModes, [false, true]);
+  assert.equal((await controller.getHost().capabilities()).helperVersion, 'test-helper');
+  assert.equal(firstClientCloses, 1);
+});
+
+test('host controller repair preserves a sanitized replacement failure', async () => {
+  const transports = [1, 2].map((id) => ({ id, request() {}, close() {} }));
+  const clients = [
+    {
+      async capabilities() { return { authenticatedCaller: true }; },
+      async secretGet() {}, async secretSet() {}, async secretDelete() {}, close() {},
+    },
+    {
+      async capabilities() {
+        const error = new Error(
+          'launchctl failed for /Users/private/Library/Application Support/AE MCP/helper',
+        );
+        error.code = 'HELPER_START_FAILED';
+        throw error;
+      },
+      async secretGet() {}, async secretSet() {}, async secretDelete() {}, close() {},
+    },
+  ];
+  const host = {
+    setRuntimeDependencies() {}, setCSInterface() {},
+    start(_port, callback) { callback(null); }, stop() {},
+  };
+  const runtime = fakeHostDependencyRuntime({
+    platformId: 'macos-arm64', extensionRoot: '/Applications/AE MCP',
+    express: function bundledExpress() {},
+  });
+  let transportIndex = 0;
+  const controller = createHostController({
+    cs: { getSystemPath: () => '/Applications/AE MCP' },
+    extensionRoot: '/Applications/AE MCP',
+    platform: macHostAdapter(runtime.fs, '/Applications/AE MCP/runtime'),
+    requireImpl: (request) => request === 'module' ? runtime.moduleApi : (request === 'path' ? path : host),
+    createPlatformHelperTransportImpl() {
+      return transports[transportIndex++];
+    },
+    createPlatformHelperClientImpl({ transport }) {
+      return clients[transport.id - 1];
+    },
+    onStatus: () => {}, onLog: () => {}, addBeforeUnload: () => {},
+  });
+
+  controller.start(11488);
+  await assert.rejects(
+    controller.repairPlatformHelper(),
+    (error) => {
+      assert.equal(error.code, 'HELPER_START_FAILED');
+      assert.equal(error.message.includes('/Users/private'), false);
+      assert.equal(error.message.includes('launchctl failed'), false);
+      return true;
+    },
+  );
+});
+
+test('Windows host controller does not offer macOS helper replacement', async () => {
+  const repairModes = [];
+  const host = {
+    setRuntimeDependencies() {}, setCSInterface() {},
+    start(_port, callback) { callback(null); }, stop() {},
+  };
+  const runtime = fakeHostDependencyRuntime({
+    platformId: 'windows-x64', extensionRoot: 'C:\\Program Files\\AE MCP',
+    express: function bundledExpress() {},
+  });
+  const platform = createWindowsAdapter({
+    platform: 'win32',
+    arch: 'x64',
+    home: 'C:\\Users\\a',
+    temp: 'C:\\Temp',
+    env: {},
+    fs: runtime.fs,
+    spawnImpl() { throw new Error('not expected'); },
+    now: () => 0,
+  });
+  const controller = createHostController({
+    cs: { getSystemPath: () => 'file:///C:/Program%20Files/AE%20MCP' },
+    extensionRoot: 'C:\\Program Files\\AE MCP',
+    platform,
+    requireImpl: (request) => request === 'module' ? runtime.moduleApi : (request === 'path' ? path : host),
+    createPlatformHelperTransportImpl(options) {
+      repairModes.push(options.repairRegistration);
+      return { request() {}, close() {} };
+    },
+    createPlatformHelperClientImpl() {
+      return {
+        async capabilities() {}, async secretGet() {}, async secretSet() {},
+        async secretDelete() {}, close() {},
+      };
+    },
+    onStatus: () => {}, onLog: () => {}, addBeforeUnload: () => {},
+  });
+
+  controller.start(11488);
+  await assert.rejects(
+    controller.repairPlatformHelper(),
+    { code: 'HELPER_UNAVAILABLE' },
+  );
+  assert.deepEqual(repairModes, [false]);
+});
+
 test('host controller loads the bundled helper client and transport modules by exact extension paths', async () => {
   const loaded = [];
   const transport = { request() {}, close() {} };

--- a/plugin/panel/test/providerInitState.test.js
+++ b/plugin/panel/test/providerInitState.test.js
@@ -50,6 +50,53 @@ test('provider init failure state never exposes the original message', async () 
   assert.equal(JSON.stringify(result).includes('sensitive implementation detail'), false);
 });
 
+test('Repair Helper is available only for the explicit repair-required state', async () => {
+  const {
+    platformHelperRepairView,
+    providerRepairFailure,
+  } = await import('../src/app/providerInitState.js');
+  assert.deepEqual(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      false,
+      true,
+    ),
+    { disabled: false, label: 'repair' },
+  );
+  assert.deepEqual(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      true,
+      true,
+    ),
+    { disabled: true, label: 'repairing' },
+  );
+  for (const providerInit of [
+    { state: 'checking', error: '' },
+    { state: 'ready', error: '' },
+    { state: 'unavailable', error: 'PLATFORM_HELPER_START_FAILED' },
+  ]) {
+    assert.equal(platformHelperRepairView(providerInit, false, true), null);
+  }
+  assert.equal(
+    platformHelperRepairView(
+      { state: 'unavailable', error: 'PLATFORM_HELPER_REPAIR_REQUIRED' },
+      false,
+      false,
+    ),
+    null,
+  );
+
+  const failure = new Error('private helper path');
+  failure.code = 'HELPER_START_FAILED';
+  assert.deepEqual(providerRepairFailure(failure), {
+    state: 'unavailable',
+    error: 'PLATFORM_HELPER_REPAIR_REQUIRED',
+    detail: 'PLATFORM_HELPER_START_FAILED',
+  });
+  assert.equal(JSON.stringify(providerRepairFailure(failure)).includes('private helper path'), false);
+});
+
 test('provider init rejects persisted model metadata containing resolved credentials', async () => {
   const { assertProviderStateCredentialFree } = await import('../src/app/providerInitState.js');
   for (const secret of ['opaque"provider-secret', 'opaque\\provider-secret']) {


### PR DESCRIPTION
## Summary

- make `snapshot-mss` advertise only the Windows platform that the backend
  actually implements
- add an explicit, user-triggered macOS repair path for a stale launchd
  platform-helper registration
- rebuild the panel's helper transport, client, facade, and capability
  handshake after repair, then rerun normal provider initialization
- expose a narrowly gated **Repair Helper** action only for
  `PLATFORM_HELPER_REPAIR_REQUIRED`

Closes #178.
Closes #66.

## Why

`snapshot-mss` previously claimed Darwin support even though its implementation
is Windows-only. Separately, a copied or updated CEP payload could leave the
macOS launchd label registered against an old helper path. Normal startup must
remain non-mutating, but users need one explicit action that repairs the stale
registration and reconnects the existing panel session without restarting AE.

## Validation

- focused helper/panel tests: 77 passed
- focused snapshot Python tests: 36 passed
- full host tests: 98 passed
- full panel tests: 1087 passed, 2 skipped
- package tests: 415 passed, 6 skipped
- panel production build and generated-bundle reproducibility check passed
- independent concentrated Subagent review: approved, no blockers
- one non-candidate real macOS/AE HDEV:
  - deliberately registered the helper label with `/usr/bin/true`
  - AE 26.3.0.87 showed `PLATFORM_HELPER_REPAIR_REQUIRED`
  - the explicit repair action cleared the alert
  - launchd readback showed the current canonical helper `Program`
  - real CEP HostController capability handshake passed
  - Keychain set/get/delete/final-missing sequence passed
  - public `ae_diagnose` confirmed host, Python bridge, auth, and AE response
  - AE and CEP were closed through the normal After Effects Quit menu

No `.aep` fixture was created. This PR intentionally does not add automatic
repair, RuntimeManager/process hardening, ScreenCaptureKit work, or signed
install/update/uninstall behavior.
