### PR TITLE
ci(macos): add native foundation CI and release verifiers

### DIFF
--- a/.github/workflows/platform-foundation-ci.yml
+++ b/.github/workflows/platform-foundation-ci.yml
@@ -1,0 +1,179 @@
+name: macOS native foundation
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-foundation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-arm64:
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      AE_MCP_RUNTIME_LICENSE_APPROVAL: ${{ github.workspace }}/packaging/runtime-license-approvals.json
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Select exact bootstrap Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24.17.0
+
+      - name: Select exact bootstrap uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          version: 0.11.7
+          python-version: 3.13.13
+          enable-cache: false
+
+      - name: Assert native arm64 runner and locked bootstrap tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(uname -m)" == 'arm64' ]]
+          [[ "$(node --version)" == 'v24.17.0' ]]
+          [[ "$(uv --version)" == 'uv 0.11.7 '* ]]
+          [[ "$(python --version)" == 'Python 3.13.13' ]]
+
+      - name: Run focused foundation tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          swift test --package-path native/platform-helper/macos
+          node --test native/platform-helper/protocol/protocol.test.mjs
+          node --test native/platform-helper/macos/Tests/*.test.mjs
+          node --test \
+            plugin/host/platform-helper-registration.test.js \
+            plugin/host/platform-helper-transport.test.js \
+            plugin/panel/test/runtimeManager.test.js
+          node --test scripts/package/test/verify-final-native-signatures.test.mjs
+          node --test scripts/release/test/verify-product-acceptance-coverage.test.mjs
+
+      - name: Download locked Node headers
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+          import { downloadLockedAsset } from './scripts/package/lib/locked-download.mjs';
+
+          const runtimeLock = JSON.parse(
+            await fs.promises.readFile('packaging/runtime-lock.json', 'utf8'),
+          );
+          const archivePath = path.resolve(
+            process.env.RUNNER_TEMP,
+            'node-v24.17.0-headers.tar.gz',
+          );
+          await downloadLockedAsset({
+            ...runtimeLock.node.headers,
+            destination: archivePath,
+          });
+          await fs.promises.appendFile(
+            process.env.GITHUB_ENV,
+            `AE_MCP_NODE_HEADERS_ARCHIVE=${archivePath}\n`,
+          );
+          NODE
+
+      - name: Build locked runtime and helper once
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/package/build-portable-runtime.mjs \
+            --platform macos-arm64 \
+            --out build/runtime/macos-arm64
+          node scripts/package/build-platform-helper.mjs \
+            --platform macos-arm64 \
+            --out build/helper/macos-arm64
+          AE_MCP_MACOS_ADDON_PATH="$GITHUB_WORKSPACE/build/helper/macos-arm64/lib/ae-mcp-platform-helper-transport.node" \
+            node --test native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs
+
+      - name: Stage and verify one unsigned bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          export AE_MCP_SOURCE_COMMIT_SHA="$(git rev-parse HEAD)"
+          node scripts/package/stage-platform-bundle.mjs \
+            --platform macos-arm64 \
+            --profile release-audit \
+            --version 0.9.2 \
+            --out build/stage/macos-arm64
+          node scripts/package/verify-platform-bundle.mjs \
+            --root build/stage/macos-arm64 \
+            --platform macos-arm64 \
+            --profile release-audit \
+            --version 0.9.2
+
+      - name: Write bounded foundation receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { execFile } from 'node:child_process';
+          import { promisify } from 'node:util';
+          import {
+            sha256Directory,
+            sha256File,
+          } from './scripts/package/lib/files.mjs';
+          import { writeCanonicalJson } from './scripts/package/lib/manifest.mjs';
+
+          const execFileAsync = promisify(execFile);
+          const commandOutput = async (command, args) => (
+            await execFileAsync(command, args, { encoding: 'utf8' })
+          ).stdout.trim();
+          const sourceCommitSha = await commandOutput('git', ['rev-parse', 'HEAD']);
+          const swift = await commandOutput('swift', ['--version']);
+          const xcode = await commandOutput('xcodebuild', ['-version']);
+          const runtimeManifestSha256 = await sha256File(
+            'build/runtime/macos-arm64/runtime-manifest.json',
+          );
+          const stagedBundleManifestSha256 = await sha256File(
+            'build/stage/macos-arm64/bundle-manifest.json',
+          );
+          const stagedRootSha256 = await sha256Directory(
+            'build/stage/macos-arm64',
+          );
+          await writeCanonicalJson(
+            'build/evidence/platform-foundation-receipt.json',
+            {
+              schemaVersion: 1,
+              sourceCommitSha,
+              runner: {
+                os: process.platform,
+                architecture: process.arch,
+              },
+              toolchain: {
+                node: process.version,
+                swift,
+                xcode,
+              },
+              runtimeManifestSha256,
+              stagedBundleManifestSha256,
+              stagedRootSha256,
+              afterEffectsEvidence: {
+                produced: false,
+                reason: 'credential-free-foundation-ci',
+              },
+            },
+          );
+          NODE
+
+      - name: Upload bounded foundation receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: macos-foundation-receipt-${{ github.sha }}
+          path: build/evidence/platform-foundation-receipt.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/platform-foundation-ci.yml
+++ b/.github/workflows/platform-foundation-ci.yml
@@ -38,6 +38,14 @@ jobs:
           python-version: 3.13.13
           enable-cache: false
 
+      - name: Install exact bootstrap Python
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv python install 3.13.13
+          python_path="$(uv python find 3.13.13)"
+          [[ "$("$python_path" --version)" == 'Python 3.13.13' ]]
+
       - name: Assert native arm64 runner and locked bootstrap tools
         shell: bash
         run: |
@@ -45,7 +53,6 @@ jobs:
           [[ "$(uname -m)" == 'arm64' ]]
           [[ "$(node --version)" == 'v24.17.0' ]]
           [[ "$(uv --version)" == 'uv 0.11.7 '* ]]
-          [[ "$(python --version)" == 'Python 3.13.13' ]]
 
       - name: Run focused foundation tests
         shell: bash

--- a/.github/workflows/platform-foundation-ci.yml
+++ b/.github/workflows/platform-foundation-ci.yml
@@ -127,6 +127,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/build/evidence"
           node --input-type=module <<'NODE'
           import { execFile } from 'node:child_process';
           import { promisify } from 'node:util';

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,6 +21,8 @@ artifact-manifest-v0.9.2.json
 
 ### 2. 外部前置条件
 
+macOS foundation workflow 与两项 RC verifier 实现现已存在。approval 与 product-acceptance selector 仍有意保持 `blocked`；在另行评审的真实签名证据和 AE/Windows 硬件证据提供之前，credentialed RC 无法通过。
+
 触发签名 RC 前必须逐项确认：
 
 - revised “条件式 A→B” signed-helper architecture 已取得明确批准，并完成其 Phase 0 签名/可行性证据；未批准时不得实现或声称 helper、Tool Library、provider route 已闭环。
@@ -135,6 +137,8 @@ artifact-manifest-v0.9.2.json
 Both platforms come from one candidate SHA. Any platform failure, source change, dependency/signing change, or artifact mismatch permanently rejects that candidate. A fix requires a new SHA, build run, artifact set, and dual attestations.
 
 ### 2. External Prerequisites
+
+The macOS foundation workflow and both RC verifier implementations are present. The approval and product-acceptance selectors intentionally remain `blocked`; a credentialed RC cannot pass until separately reviewed real signature and AE/Windows hardware evidence is supplied.
 
 Before a signed RC is triggered, verify all of the following:
 

--- a/docs/superpowers/plans/2026-07-31-macos-native-foundation-ci.md
+++ b/docs/superpowers/plans/2026-07-31-macos-native-foundation-ci.md
@@ -1,0 +1,756 @@
+# macOS Native Foundation CI and Release Verifiers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one credential-free Apple Silicon foundation workflow and the two fail-closed RC verifiers already wired into `build-rc.yml`, while leaving real release approvals and hardware evidence blocked.
+
+**Architecture:** Two focused Node ES modules validate product acceptance evidence and final native signatures using the repository's existing manifest, hashing, architecture, and signing-command contracts. A single `macos-15` workflow compiles/tests the real Swift helper and N-API addon, stages one unsigned macOS bundle, and uploads only a bounded CI receipt.
+
+**Tech Stack:** Node.js 24.17.0 ESM and `node:test`, Swift Package Manager 6, GitHub Actions YAML, existing package/release manifest helpers, macOS `codesign`/`lipo`, Windows Authenticode command adapter.
+
+## Global Constraints
+
+- The normal workflow has exactly one `macos-15` arm64 job; do not add `macos-14-compat`, Windows, nightly, or self-hosted matrices.
+- Ordinary PR CI must not import credentials, sign/notarize artifacts, start After Effects, publish a product, or run the intentionally blocked real native-coverage policy.
+- Build the helper/runtime once; do not add byte-for-byte double-build reproducibility.
+- Keep `packaging/native-coverage-approvals.json` and `packaging/product-acceptance-coverage.json` blocked and empty.
+- Product-owned native helper, addon, native plug-in, and Windows launcher files require the protected product signer. The current macOS shell launcher is manifest/mode verified and must not be represented as a codesigned Mach-O file. Third-party runtime binaries require a valid signature but not the product signer.
+- `finalRootSha256` is computed once in the final RC verifier only; do not add routine source/runtime/full-tree hashing.
+- `reviewedBy` may identify a Subagent review task or receipt; this single-maintainer project does not require a second human maintainer.
+- Do not add PID, start-token, process restart census, pairing, hostile same-user defenses, installer lifecycle, ScreenCaptureKit, AE hardware work, or generalized runner infrastructure.
+- Every implementation task uses red-green-refactor and ends with a focused commit.
+
+## File and Interface Map
+
+- `scripts/release/verify-product-acceptance-coverage.mjs`
+  - Owns product coverage CLI parsing, policy/evidence validation, and canonical result writing.
+- `scripts/release/test/verify-product-acceptance-coverage.test.mjs`
+  - Owns approved/blocked/stale/incomplete product coverage fixtures.
+- `scripts/package/verify-final-native-signatures.mjs`
+  - Owns final signed-root discovery, platform signature adapters, signer classification, and canonical result writing.
+- `scripts/package/test/verify-final-native-signatures.test.mjs`
+  - Owns signed-root fixture coverage and injected signature-adapter rejection cases.
+- `scripts/release/artifact-manifest.mjs` and focused fixture/tests
+  - Consume only real native-signature records; macOS requires helper/addon coverage while Windows also requires its native launcher.
+- `.github/workflows/platform-foundation-ci.yml`
+  - Owns the single credential-free Apple Silicon build/test/stage job and CI receipt.
+- `native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs`
+  - Owns the minimal real N-API module-load contract after the macOS addon is built.
+- `scripts/release/test/signing-plan.test.mjs`
+  - Owns the workflow boundary contract and removal of the superseded macOS 14 compatibility assertion.
+- `scripts/release/test/native-coverage-gate.test.mjs`
+  - Remains the integration contract proving the RC workflow calls both verifiers before consuming their evidence.
+- `docs/RELEASE.md`
+  - Describes that verifier implementation is present while real policy/evidence remains blocked.
+
+---
+
+### Task 1: Product acceptance coverage verifier
+
+**Files:**
+- Create: `scripts/release/verify-product-acceptance-coverage.mjs`
+- Create: `scripts/release/test/verify-product-acceptance-coverage.test.mjs`
+
+**Interfaces:**
+- Consumes: `canonicalJson`, `assertPortableRelativePath`, `readJsonFile`, and
+  `writeCanonicalJson` from `scripts/package/lib/manifest.mjs`, plus
+  `readRegularFileSnapshot` and `sha256File` from
+  `scripts/package/lib/files.mjs`.
+- Produces:
+  - `PRODUCT_ACCEPTANCE_SCENARIOS: readonly string[]`
+  - `parseProductAcceptanceArgs(argv: string[]): { candidateSha: string, coveragePath: string, outPath: string }`
+  - `verifyProductAcceptanceCoverage(input: { candidateSha: string, coveragePath: string }): Promise<{ schemaVersion: 1, candidateSha: string, result: "PASS", coverage: Array<{ id: string, result: "PASS", evidenceSha256: string }> }>`
+  - `writeProductAcceptanceCoverageEvidence(input: { candidateSha: string, coveragePath: string, outPath: string }): Promise<{ schemaVersion: 1, candidateSha: string, result: "PASS", coverage: Array<{ id: string, result: "PASS", evidenceSha256: string }> }>`
+
+- [ ] **Step 1: Write the failing argument and approved-fixture tests**
+
+Create a temporary fixture with this exact approved selector:
+
+```js
+const scenarioIds = [
+  'clean-install-and-upgrade-rollback',
+  'permission-denial-and-recovery',
+  'persistence',
+  'provider-header-routing',
+  'tool-library',
+];
+
+const selector = {
+  evidence: scenarioIds.map((id) => ({
+    id,
+    candidateSha,
+    result: 'PASS',
+    evidencePath: `packaging/evidence/product-acceptance/${id}.json`,
+    evidenceSha256: evidenceDigests.get(id),
+    owner: 'JUNKDOGE-JOE',
+    reviewedBy: 'subagent:issue68-product-coverage-review',
+  })),
+  requiredScenarios: scenarioIds,
+  schemaVersion: 1,
+  status: 'approved',
+};
+```
+
+Each referenced evidence file is bounded canonical JSON and contains at least:
+
+```js
+{
+  schemaVersion: 1,
+  candidateSha,
+  result: 'PASS',
+  scenario: id,
+}
+```
+
+Assert that:
+
+```js
+const result = await verifyProductAcceptanceCoverage({
+  candidateSha,
+  coveragePath: fixture.coveragePath,
+});
+assert.deepEqual(result, {
+  schemaVersion: 1,
+  candidateSha,
+  result: 'PASS',
+  coverage: scenarioIds.map((id) => ({
+    id,
+    result: 'PASS',
+    evidenceSha256: fixture.evidenceDigests.get(id),
+  })),
+});
+```
+
+Also assert that the parser rejects missing, duplicate, unknown, non-absolute
+`--coverage`/`--out`, and malformed candidate SHA arguments.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node --test scripts/release/test/verify-product-acceptance-coverage.test.mjs
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for
+`verify-product-acceptance-coverage.mjs`.
+
+- [ ] **Step 3: Implement the minimal parser and successful verifier**
+
+Implement exact top-level selector keys:
+
+```js
+const SELECTOR_KEYS = ['evidence', 'requiredScenarios', 'schemaVersion', 'status'];
+const ENTRY_KEYS = [
+  'candidateSha',
+  'evidencePath',
+  'evidenceSha256',
+  'id',
+  'owner',
+  'result',
+  'reviewedBy',
+];
+```
+
+Resolve evidence paths relative to the repository root inferred from the
+canonical selector location. Reject paths that are absolute, escape that root,
+are symbolic/hard linked, exceed 8 MiB, or do not match their recorded SHA-256.
+Require the exact ordered scenario list, one exact-shaped entry per scenario,
+matching candidate SHA, `PASS`, and non-empty `owner`/`reviewedBy`. Do not
+require a second human reviewer or add an approval identity service.
+
+The CLI error boundary is:
+
+```js
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  writeProductAcceptanceCoverageEvidence(parseProductAcceptanceArgs(process.argv.slice(2)))
+    .catch((error) => {
+      process.stderr.write(
+        `PRODUCT_ACCEPTANCE_COVERAGE_FAILED: ${error.message}\n`,
+      );
+      process.exitCode = 1;
+    });
+}
+```
+
+- [ ] **Step 4: Add rejection tests**
+
+Add one focused test for each concrete invalid release state:
+
+```text
+blocked selector
+empty evidence array
+missing/extra/duplicate/unsorted scenario
+wrong candidate SHA
+non-PASS selector entry
+empty owner or reviewedBy
+absolute or escaping evidence path
+missing/symlink/hard-linked/oversized evidence file
+evidence digest mismatch
+evidence JSON candidate/result mismatch
+pre-existing output path
+```
+
+Do not add process, lock, PID, retry, or approval-workflow tests.
+
+- [ ] **Step 5: Run focused tests and existing consumers**
+
+Run:
+
+```bash
+node --test scripts/release/test/verify-product-acceptance-coverage.test.mjs
+node --test scripts/release/test/artifact-manifest.test.mjs
+node --test scripts/release/test/native-coverage-gate.test.mjs
+```
+
+Expected: all PASS. The checked-in blocked selector remains unchanged.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add \
+  scripts/release/verify-product-acceptance-coverage.mjs \
+  scripts/release/test/verify-product-acceptance-coverage.test.mjs
+git commit -m "feat(release): verify product acceptance coverage"
+```
+
+---
+
+### Task 2: Final native signature verifier
+
+**Files:**
+- Create: `scripts/package/verify-final-native-signatures.mjs`
+- Create: `scripts/package/test/verify-final-native-signatures.test.mjs`
+- Modify: `scripts/release/artifact-manifest.mjs`
+- Modify: `scripts/release/test/artifact-manifest.test.mjs`
+- Modify: `scripts/release/test/helpers/artifact-manifest-fixture.mjs`
+- Modify: `scripts/release/test/verify-release-inputs.test.mjs`
+
+**Interfaces:**
+- Consumes:
+  - `verifyPlatformBundle()` from `scripts/package/verify-platform-bundle.mjs`
+  - `validateBundleManifest`, `readCanonicalJsonFile`, `sha256File`, `writeCanonicalJson` from `scripts/package/lib/manifest.mjs`
+  - `detectBinaryArchitectureFile` from `scripts/package/lib/binary-arch.mjs`
+  - `sha256Directory` from `scripts/package/lib/files.mjs`
+  - product-owned paths declared by helper/native-plugin manifests
+- Produces:
+  - `parseFinalNativeSignatureArgs(argv: string[]): { platform: "macos-arm64"|"windows-x64", candidateSha: string, signedRoot: string, zxpPath: string, dmgPath?: string, outPath: string }`
+  - `verifyFinalNativeSignatures(input: { platform: string, candidateSha: string, signedRoot: string, zxpPath: string, dmgPath?: string }, dependencies?: { inspectSignature?: Function }): Promise<object>`
+  - `writeFinalNativeSignatureEvidence(input: { platform: string, candidateSha: string, signedRoot: string, zxpPath: string, dmgPath?: string, outPath: string }, dependencies?: { inspectSignature?: Function }): Promise<object>`
+  - dependency seam `inspectSignature({ platform, filePath, requireProductIdentity, expectedFingerprint }): Promise<{ verified: true, signerFingerprint: string }>`
+
+- [ ] **Step 1: Write the failing success-path fixture test**
+
+Use `makeStageHarness()` plus the existing `machoArm64Bytes()`, `peX64Bytes()`,
+`writeFixtureFile()`, and `rewriteStageManifests()` exports from
+`scripts/package/test/helpers/platform-bundle-fixture.mjs`. The harness already
+contains native helper, runtime, and platform-specific launcher fixtures.
+After staging, add the missing addon to the staged helper fixture and rewrite
+its two manifests:
+
+```js
+const addonRelative = platform === 'macos-arm64'
+  ? 'lib/ae-mcp-platform-helper-transport.node'
+  : 'lib/ae-mcp-platform-helper-transport.node';
+const addonBytes = platform === 'macos-arm64'
+  ? machoArm64Bytes()
+  : peX64Bytes();
+await writeFixtureFile(
+  join(h.outDir, 'platform', platform),
+  addonRelative,
+  addonBytes,
+  platform === 'macos-arm64' ? 0o755 : 0o644,
+);
+const helperManifestPath = join(
+  h.outDir,
+  'platform',
+  platform,
+  'helper-manifest.json',
+);
+const helperManifest = JSON.parse(await readFile(helperManifestPath, 'utf8'));
+helperManifest.files.push({
+  path: addonRelative,
+  architecture: platform === 'macos-arm64' ? 'macho-arm64' : 'pe-x64',
+  sha256: sha256Bytes(addonBytes),
+});
+await writeFile(helperManifestPath, `${JSON.stringify(helperManifest, null, 2)}\n`);
+await rewriteStageManifests(h, { helper: true });
+```
+
+Create temporary ZXP and, for macOS, DMG files.
+
+Inject:
+
+```js
+const inspections = [];
+const inspectSignature = async (input) => {
+  inspections.push(input);
+  return {
+    verified: true,
+    signerFingerprint: input.requireProductIdentity
+      ? expectedProductFingerprint
+      : thirdPartyFingerprint,
+  };
+};
+```
+
+Assert the result has exactly:
+
+```js
+[
+  'artifacts',
+  'candidateSha',
+  'discoveredNativeCount',
+  'files',
+  'finalRootSha256',
+  'platform',
+  'result',
+  'schemaVersion',
+  'signedBundleManifestSha256',
+]
+```
+
+Assert `files` are UTF-8 byte sorted, every discovered native file is present,
+product-owned records use the protected fingerprint, and the artifact list is
+`[{ name, sha256 }]` for ZXP plus macOS DMG.
+
+Add a consumer regression test proving the macOS shell launcher is not
+fabricated as a native signature:
+
+```js
+assert.doesNotMatch(
+  JSON.stringify(nativeSignatureEvidence.files),
+  /platform\/macos-arm64\/bin\/ae-mcp"/,
+);
+assert.ok(nativeSignatureEvidence.files.some(
+  (item) => item.path.endsWith('/bin/ae-mcp-platform-helper'),
+));
+assert.ok(nativeSignatureEvidence.files.some(
+  (item) => item.path.endsWith(
+    '/lib/ae-mcp-platform-helper-transport.node',
+  ),
+));
+```
+
+For Windows, retain required helper, addon, and native launcher records.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node --test scripts/package/test/verify-final-native-signatures.test.mjs
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for
+`verify-final-native-signatures.mjs`.
+
+- [ ] **Step 3: Implement manifest validation and native discovery**
+
+Read the signed manifest, then call:
+
+```js
+await verifyPlatformBundle({
+  root: signedRoot,
+  platform,
+  version: manifest.version,
+  sourceCommitSha: candidateSha,
+  verificationProfile: 'release-audit',
+});
+```
+
+Discover native files only among manifest-declared regular files by calling
+`detectBinaryArchitectureFile()` and accepting:
+
+```js
+platform === 'macos-arm64'
+  ? ['macho-arm64', 'macho-universal-arm64']
+  : ['pe-x64']
+```
+
+Derive product-owned paths from the helper manifest plus the optional native
+plug-in manifest. Include the launcher in signature discovery only when its
+declared architecture is native; the current macOS `script` launcher remains
+covered by `verifyPlatformBundle()` hash/mode checks. Do not classify all
+runtime files as product-owned and do not invent an extension-based native
+list.
+
+Narrow `assertNativeSignatureEvidence()` in
+`scripts/release/artifact-manifest.mjs` to require:
+
+```text
+macos-arm64 -> ae-mcp-platform-helper + ae-mcp-platform-helper-transport.node
+windows-x64 -> ae-mcp-platform-helper.exe + ae-mcp-platform-helper-transport.node + ae-mcp.exe
+```
+
+Update only the corresponding test fixtures. Do not change the evidence
+schema, launcher implementation, or signing plan.
+
+- [ ] **Step 4: Implement the real platform signature adapters**
+
+For macOS:
+
+```text
+/usr/bin/codesign --verify --strict --verbose=4 <file>
+/usr/bin/codesign -d --verbose=4 <file>
+/usr/bin/codesign -d --extract-certificates <temporary-prefix> <file>
+/usr/bin/shasum -a 256 <leaf-certificate>
+```
+
+For product-owned files, require the extracted certificate SHA-256 to equal
+`AE_MCP_APPLE_CERT_FINGERPRINT_SHA256`. For third-party files, require
+`codesign --verify` and record the extracted signer fingerprint without
+requiring equality.
+
+For Windows, invoke a bounded PowerShell command that calls
+`Get-AuthenticodeSignature -LiteralPath <file>` and emits compact JSON with
+`Status` and `SignerCertificate.Thumbprint`. Require `Status == "Valid"`; for
+product-owned files require the thumbprint to equal
+`AE_MCP_WINDOWS_SIGNING_CERT_SHA1`.
+
+The adapter must inspect only the file requested by the verifier. It must not
+enumerate processes, certificate stores, or unrelated filesystem roots.
+
+- [ ] **Step 5: Implement artifact and canonical evidence writing**
+
+Require:
+
+```text
+macos-arm64 -> exactly one --zxp and one --dmg
+windows-x64 -> exactly one --zxp and no --dmg
+```
+
+Compute `signedBundleManifestSha256`, artifact digests, and exactly one
+`sha256Directory(signedRoot)` call for `finalRootSha256`. Write the canonical
+schema already validated by `scripts/release/artifact-manifest.mjs`.
+
+The CLI failure boundary is:
+
+```js
+process.stderr.write(`FINAL_NATIVE_SIGNATURES_FAILED: ${error.message}\n`);
+process.exitCode = 1;
+```
+
+- [ ] **Step 6: Add concrete rejection tests**
+
+Add focused cases for:
+
+```text
+missing launcher/helper or a manifest-declared native file
+manifest/file digest mismatch
+wrong native architecture
+unsigned/invalid signature adapter result
+wrong product signer fingerprint
+third-party valid signer accepted without product-fingerprint equality
+missing or extra final artifact
+wrong platform/candidate identity
+pre-existing output
+```
+
+Use the injected adapter for signature cases. Do not create test certificates,
+run real notarization, or build an adversarial security harness.
+
+- [ ] **Step 7: Run focused and consumer tests**
+
+Run:
+
+```bash
+node --test scripts/package/test/verify-final-native-signatures.test.mjs
+node --test scripts/release/test/artifact-manifest.test.mjs
+node --test scripts/release/test/native-coverage-gate.test.mjs
+node --test scripts/release/test/signing-plan.test.mjs
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add \
+  scripts/package/verify-final-native-signatures.mjs \
+  scripts/package/test/verify-final-native-signatures.test.mjs \
+  scripts/release/artifact-manifest.mjs \
+  scripts/release/test/artifact-manifest.test.mjs \
+  scripts/release/test/helpers/artifact-manifest-fixture.mjs \
+  scripts/release/test/verify-release-inputs.test.mjs
+git commit -m "feat(package): verify final native signatures"
+```
+
+---
+
+### Task 3: Focused Apple Silicon foundation workflow
+
+**Files:**
+- Create: `.github/workflows/platform-foundation-ci.yml`
+- Create: `native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs`
+- Modify: `scripts/release/test/signing-plan.test.mjs`
+- Modify: `docs/RELEASE.md`
+
+**Interfaces:**
+- Consumes: existing helper/runtime builders, `stage-platform-bundle.mjs`,
+  `verify-platform-bundle.mjs`, Task 1/2 tests, and the pinned action SHAs
+  already used by `build-rc.yml`.
+- Produces: one `macos-15` arm64 required CI job and one bounded
+  `platform-foundation-receipt.json` artifact.
+
+- [ ] **Step 1: Replace the stale workflow-boundary test with the approved contract**
+
+Change the existing `macos-14-compat` test to require:
+
+```js
+test('foundation CI is one credential-free Apple Silicon job', async () => {
+  const workflow = await readFile(
+    '.github/workflows/platform-foundation-ci.yml',
+    'utf8',
+  );
+  assert.match(workflow, /runs-on:\s*macos-15/);
+  assert.match(workflow, /\[\[ "\$\(uname -m\)" == 'arm64' \]\]/);
+  assert.match(workflow, /swift test[\s\S]*native\/platform-helper\/macos/);
+  assert.match(workflow, /build-platform-helper\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /stage-platform-bundle\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /verify-platform-bundle\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /platform-foundation-receipt\.json/);
+  assert.doesNotMatch(workflow, /macos-14-compat|windows-2025|schedule:/);
+  assert.doesNotMatch(
+    workflow,
+    /AE_MCP_APPLE_CERT_P12_BASE64|notarytool|package-macos-dmg|build-rc/,
+  );
+});
+```
+
+Also assert all `uses:` references are immutable 40-hex SHAs and the workflow
+does not execute `native-coverage-gate.mjs`.
+
+- [ ] **Step 2: Run the boundary test and verify RED**
+
+Run:
+
+```bash
+node --test scripts/release/test/signing-plan.test.mjs
+```
+
+Expected: FAIL because
+`.github/workflows/platform-foundation-ci.yml` does not exist.
+
+- [ ] **Step 3: Add the minimal workflow skeleton**
+
+Create:
+
+```yaml
+name: macOS native foundation
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-foundation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-arm64:
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      AE_MCP_RUNTIME_LICENSE_APPROVAL: ${{ github.workspace }}/packaging/runtime-license-approvals.json
+```
+
+Use the existing immutable action SHAs:
+
+```text
+actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+```
+
+Pin Node `24.17.0`, uv `0.11.7`, and Python `3.13.13`. Assert
+`uname -m == arm64` before native work.
+
+- [ ] **Step 4: Add focused tests and one real helper/runtime build**
+
+Run in this order:
+
+```bash
+swift test --package-path native/platform-helper/macos
+node --test native/platform-helper/protocol/protocol.test.mjs
+node --test native/platform-helper/macos/Tests/*.test.mjs
+node --test \
+  plugin/host/platform-helper-registration.test.js \
+  plugin/host/platform-helper-transport.test.js \
+  plugin/panel/test/runtimeManager.test.js
+node --test scripts/package/test/verify-final-native-signatures.test.mjs
+node --test scripts/release/test/verify-product-acceptance-coverage.test.mjs
+```
+
+Download only the locked Node headers URL/digest from
+`packaging/runtime-lock.json` through the existing
+`downloadLockedAsset()` helper into `$RUNNER_TEMP`; export that absolute path as
+`AE_MCP_NODE_HEADERS_ARCHIVE`.
+
+Then run once:
+
+```bash
+node scripts/package/build-portable-runtime.mjs \
+  --platform macos-arm64 \
+  --out build/runtime/macos-arm64
+node scripts/package/build-platform-helper.mjs \
+  --platform macos-arm64 \
+  --out build/helper/macos-arm64
+AE_MCP_MACOS_ADDON_PATH="$GITHUB_WORKSPACE/build/helper/macos-arm64/lib/ae-mcp-platform-helper-transport.node" \
+  node --test native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs
+```
+
+Do not repeat the build for a reproducibility comparison.
+
+The new live test contains only the N-API load contract:
+
+```js
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const addonPath = process.env.AE_MCP_MACOS_ADDON_PATH || '';
+
+test('macOS helper addon loads and exposes createTransport', {
+  skip: process.platform !== 'darwin' || process.arch !== 'arm64' || !addonPath,
+}, () => {
+  const addon = createRequire(import.meta.url)(addonPath);
+  assert.equal(typeof addon.createTransport, 'function');
+});
+```
+
+It does not start the helper, mutate Keychain state, open an XPC service, or
+add a process-lifecycle test.
+
+- [ ] **Step 5: Stage and verify one unsigned bundle**
+
+Use the checked-out commit and current release version:
+
+```bash
+export AE_MCP_SOURCE_COMMIT_SHA="$(git rev-parse HEAD)"
+node scripts/package/stage-platform-bundle.mjs \
+  --platform macos-arm64 \
+  --profile release-audit \
+  --version 0.9.2 \
+  --out build/stage/macos-arm64
+node scripts/package/verify-platform-bundle.mjs \
+  --root build/stage/macos-arm64 \
+  --platform macos-arm64 \
+  --profile release-audit \
+  --version 0.9.2
+```
+
+This is an unsigned stage. Do not call signing, DMG, ZXP, notarization, AE, or
+release workflows.
+
+- [ ] **Step 6: Write and upload the bounded CI receipt**
+
+Write canonical JSON at
+`build/evidence/platform-foundation-receipt.json` with exact fields:
+
+```js
+{
+  schemaVersion: 1,
+  sourceCommitSha,
+  runner: { os: process.platform, architecture: process.arch },
+  toolchain: { node, swift, xcode },
+  runtimeManifestSha256,
+  stagedBundleManifestSha256,
+  stagedRootSha256,
+  afterEffectsEvidence: {
+    produced: false,
+    reason: 'credential-free-foundation-ci',
+  },
+}
+```
+
+Upload only this JSON as `macos-foundation-receipt-${{ github.sha }}` with
+`retention-days: 14`. Do not upload `build/stage`, runtime, helper, ZXP, or DMG
+files.
+
+- [ ] **Step 7: Update release documentation**
+
+In both Chinese and English sections of `docs/RELEASE.md`, state:
+
+```text
+The macOS foundation workflow and both RC verifier implementations are
+present. The approval and product-acceptance selectors intentionally remain
+blocked; a credentialed RC cannot pass until separately reviewed real
+signature and AE/Windows hardware evidence is supplied.
+```
+
+Do not claim the RC or hardware matrix is complete.
+
+- [ ] **Step 8: Run Task 3 tests**
+
+Run:
+
+```bash
+node --test scripts/release/test/signing-plan.test.mjs
+node --test scripts/release/test/native-coverage-gate.test.mjs
+node --test scripts/package/test/verify-final-native-signatures.test.mjs
+node --test scripts/release/test/verify-product-acceptance-coverage.test.mjs
+git diff --check
+```
+
+Expected: all PASS.
+
+- [ ] **Step 9: Commit Task 3**
+
+```bash
+git add \
+  .github/workflows/platform-foundation-ci.yml \
+  native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs \
+  scripts/release/test/signing-plan.test.mjs \
+  docs/RELEASE.md
+git commit -m "ci(macos): add native foundation workflow"
+```
+
+---
+
+## Integrated Verification and Review Gate
+
+After all three task commits:
+
+1. Run:
+
+   ```bash
+   node --test scripts/package/test/*.test.mjs
+   node --test scripts/release/test/*.test.mjs
+   git diff --check origin/main...HEAD
+   ```
+
+2. On macOS arm64, run the focused Swift/protocol tests:
+
+   ```bash
+   swift test --package-path native/platform-helper/macos
+   node --test native/platform-helper/protocol/protocol.test.mjs
+   node --test native/platform-helper/macos/Tests/*.test.mjs
+   ```
+
+3. Dispatch one concentrated Subagent spec-compliance review. The reviewer must
+   check:
+   - ordinary PR CI has no credentialed/release/AE path;
+   - only one `macos-15` arm64 job exists;
+   - blocked policy JSON files are byte unchanged;
+   - product and third-party signer identities are classified separately;
+   - final root hashing occurs only in the RC verifier;
+   - no process/runtime/general security infrastructure was added.
+
+4. Fix only a reproduced current-path blocker. Classify other findings as
+   follow-up or out of scope under `AGENTS.md` section 5. Use at most two
+   concentrated review rounds.
+
+5. Push the branch and require the focused macOS foundation job plus existing
+   required CI. No AE HDEV/T5/T6 is required for this Issue.
+
+6. After merge, verify the relevant automated suites from clean `main`, publish
+   the implementation/CI/review receipt in #68, and close it with an explicit
+   note that real release evidence remains blocked.

--- a/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
+++ b/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
@@ -1,0 +1,273 @@
+# macOS Native Foundation CI and Release Verifier Design
+
+Date: 2026-07-31
+
+Issue: #68
+
+Status: User-approved scope; written-spec review
+
+## Goal
+
+Complete the missing macOS native build signal and the two release verifiers
+that the existing RC workflow already calls:
+
+1. a focused Apple Silicon CI workflow that proves the macOS helper/addon and
+   unsigned package graph can be built and checked without release credentials;
+2. a final-native-signature verifier that inspects the signed delivery graph;
+3. a product-acceptance-coverage verifier that rejects empty, incomplete, or
+   stale release evidence.
+
+This Issue implements the gates. It does not manufacture or approve the real
+release evidence that later macOS/Windows hardware and release Issues must
+produce.
+
+## Current Observed State
+
+- `.github/workflows/ci.yml` runs Windows and Linux jobs but does not compile
+  the Swift helper or the macOS N-API addon on Apple Silicon.
+- `.github/workflows/build-rc.yml` already invokes
+  `verify-product-acceptance-coverage.mjs` before candidate lock and
+  `verify-final-native-signatures.mjs` after each platform signing plan.
+- `scripts/release/native-coverage-gate.mjs` already declares the macOS
+  workflow, both verifiers, and their tests as required implementation files.
+- Those five files are absent on `origin/main`.
+- `scripts/release/artifact-manifest.mjs` already defines the canonical output
+  shapes consumed from both verifiers.
+- `packaging/native-coverage-approvals.json` and
+  `packaging/product-acceptance-coverage.json` intentionally remain
+  `status: "blocked"` with no approvals or evidence.
+
+## Considered Approaches
+
+### Chosen: one focused implementation PR
+
+Add the missing macOS workflow and both verifiers with focused tests. Keep the
+real approval/evidence policies blocked. This completes the implementation
+surface without pretending that downstream release acceptance has occurred.
+
+### Rejected: split workflow and verifiers into separate PRs
+
+The files are already one dependency set in `native-coverage-gate.mjs` and
+`build-rc.yml`. Splitting them would duplicate review and CI while leaving the
+same release path partially missing between merges.
+
+### Rejected: make the complete release gate green in this PR
+
+That would require real AE 25/26 macOS and Windows evidence, signed final
+artifacts, credentialed release work, and downstream acceptance owned by
+#69/#70/#80/#81 and Windows follow-up work. Pulling those into #68 would be
+scope expansion or fabricated evidence.
+
+## Design Decisions
+
+### 1. Focused Apple Silicon workflow
+
+Create `.github/workflows/platform-foundation-ci.yml` with:
+
+- `pull_request`, `push` to `main`, and manual dispatch triggers;
+- read-only repository permission and ordinary branch concurrency;
+- one `macos-15` job that asserts `uname -m` is `arm64`;
+- the repository's pinned Node version and macOS deployment target;
+- Swift package tests for `native/platform-helper/macos`;
+- the existing helper build, protocol, static, and N-API contract tests needed
+  to falsify the macOS production build;
+- one credential-free macOS helper/runtime build followed by unsigned
+  stage-and-verify; and
+- one small uploaded JSON receipt for this CI run, not a distributable product
+  artifact.
+
+The workflow will not:
+
+- run on a nightly schedule;
+- import signing or notarization credentials;
+- install or launch After Effects;
+- publish a release artifact;
+- build twice merely to compare byte-for-byte output; or
+- add another macOS compatibility or Windows matrix.
+
+The unsigned stage already provides file-set, manifest, architecture, runtime,
+and package-path checks. The final signed graph remains an RC responsibility.
+
+An existing historical assertion in
+`scripts/release/test/signing-plan.test.mjs` requires a `macos-14-compat` job as
+soon as this workflow exists. That assertion will be narrowed to the newly
+approved single `macos-15` arm64 boundary. The implementation must not add the
+old compatibility or Windows matrix merely to satisfy the stale test.
+
+### 2. Final native signature verifier
+
+Create `scripts/package/verify-final-native-signatures.mjs` with the CLI already
+used by `build-rc.yml`:
+
+```text
+--platform <macos-arm64|windows-x64>
+--candidate-sha <40-hex>
+--signed-root <absolute path>
+--zxp <absolute path>
+[--dmg <absolute path on macOS>]
+--out <absolute path>
+```
+
+The verifier will:
+
+1. run the existing `verifyPlatformBundle(..., verificationProfile:
+   "release-audit")` contract against the signed root, which already validates
+   the frozen bundle/runtime/helper manifests, actual file graph, digests, and
+   native architecture;
+2. require the manifest platform and source commit to match the CLI identity;
+3. discover the actual native executables/addons by file magic and require
+   exact correspondence with the frozen manifest;
+4. verify every discovered native file with the platform's existing signing
+   tool;
+5. require product-owned launcher/helper/addon/plugin files to match the
+   release job's expected product signer identity, while third-party
+   runtime-native files require a valid signature without pretending they use
+   the product certificate;
+6. record the signer fingerprint, native architecture result, and current file
+   hash;
+7. require the product launcher and platform helper to be present;
+8. hash the already-produced ZXP and macOS DMG, when applicable; and
+9. write the canonical evidence shape already consumed by
+   `artifact-manifest.mjs`.
+
+This is a post-signing RC verifier. It will not participate in routine local
+startup, hash a source checkout, re-sign files, inspect processes, or create a
+new identity/pairing system.
+
+The expected macOS and Windows product signer fingerprints come from the
+release job's existing protected environment. The test seam will inject
+signing-command results so Linux contract CI can cover success and rejection
+behavior without real certificates. Ordinary platform CI does not create a
+fake release identity.
+
+`finalRootSha256` requires one final directory digest because it is already a
+hard contract of `artifact-manifest.mjs`. That single post-signing RC digest
+must not be reused as a reason to hash a source checkout, routine runtime
+startup, or AE validation fixture.
+
+### 3. Product acceptance coverage verifier
+
+Create `scripts/release/verify-product-acceptance-coverage.mjs` with the CLI
+already used by `build-rc.yml`:
+
+```text
+--candidate-sha <40-hex>
+--coverage <absolute path>
+--out <absolute path>
+```
+
+The verifier will require:
+
+- `status: "approved"` before it can emit `PASS`;
+- the exact required scenario set already declared by
+  `packaging/product-acceptance-coverage.json`;
+- one input entry per scenario with exactly `id`, `candidateSha`, `result`,
+  `evidencePath`, `evidenceSha256`, `owner`, and `reviewedBy`;
+- repository-relative evidence paths, a non-empty owner and reviewer identity,
+  and a reviewer different from the owner;
+- one bounded, regular evidence JSON file per scenario whose top-level
+  `candidateSha` and `result` identify the same passing candidate; and
+- the evidence digest recorded in the policy to match the supplied bytes.
+
+Its output will be the canonical `schemaVersion`, `candidateSha`, `result`, and
+sorted `coverage` array expected by `artifact-manifest.mjs`.
+
+The verifier only validates evidence. It does not start AE, generate acceptance
+records, approve a policy, or infer that one scenario covers another.
+
+### 4. Minimal rejection tests
+
+Tests will prove that the new code rejects only concrete release-invalidating
+states:
+
+- missing required launcher/helper or another discovered native file;
+- signed-manifest/file hash mismatch;
+- wrong architecture;
+- missing, invalid, or wrong signer identity;
+- missing or unexpected final artifact;
+- blocked, empty, incomplete, duplicate, or unsorted acceptance coverage;
+- acceptance evidence for another candidate; and
+- acceptance evidence digest mismatch.
+
+These are verifier correctness tests, not a generalized security-hardening
+program. No PID census, start token, process restart, hostile same-user
+simulation, runner lifecycle, power-loss, installer, or concurrency framework
+is added.
+
+### 5. Evidence boundary
+
+The macOS CI job will write and upload one bounded JSON receipt containing the
+source commit, runner OS/architecture, Node/Swift/Xcode versions, runtime
+manifest digest, staged bundle manifest digest, and staged root digest. It will
+record that AE evidence was not produced by this credential-free foundation
+job; it must not claim an AE version. The receipt is CI evidence only and is
+not a signed or distributable product artifact.
+
+The checked-in approval and product-coverage policies remain blocked. Normal PR
+CI proves the verifier implementations with fixtures and an unsigned macOS
+build. It does not run the real blocked `native-coverage-gate` CLI expecting
+success. A credentialed RC remains blocked until separately reviewed real
+evidence is supplied.
+
+## Expected Change Surface
+
+- `.github/workflows/platform-foundation-ci.yml`
+- `scripts/package/verify-final-native-signatures.mjs`
+- `scripts/package/test/verify-final-native-signatures.test.mjs`
+- `scripts/release/verify-product-acceptance-coverage.mjs`
+- `scripts/release/test/verify-product-acceptance-coverage.test.mjs`
+- narrowly required existing workflow/schema contract tests
+- `scripts/release/test/signing-plan.test.mjs` to remove the superseded
+  `macos-14-compat` workflow requirement
+- `docs/RELEASE.md` only if needed to describe the now-implemented but still
+  blocked gate
+
+The exact list may contract during test-first implementation. Expansion into
+runtime helper behavior, signing scripts, installer behavior, AE acceptance,
+or Windows product implementation requires a reproduced blocker and explicit
+scope review.
+
+## Verification
+
+Implementation follows red-green-refactor:
+
+1. focused argument/schema/unit tests for each verifier;
+2. focused signature-command adapter tests;
+3. existing native-coverage, artifact-manifest, signing-plan, and workflow
+   contract tests;
+4. Swift helper tests and existing macOS helper/protocol/static tests;
+5. one credential-free macOS helper/runtime build and unsigned stage/verify;
+6. the affected packaging/release suites; and
+7. required GitHub CI.
+
+No AE hardware run is required because #68 does not change an AE capability,
+installed runtime behavior, GUI state, or project state.
+
+## Review and Scope Control
+
+Use one concentrated Subagent review by default and no more than two rounds.
+Classify findings under `AGENTS.md` section 5:
+
+- only a reproduced failure in the new CI or release-verifier path is a current
+  blocker;
+- credible release hardening outside that path is a follow-up; and
+- hypothetical runner/process/security infrastructure is out of scope.
+
+The review must explicitly check that no credentialed behavior is reachable
+from ordinary PR CI and that the blocked evidence policies were not relaxed.
+
+## Completion and Issue Closure
+
+#68 is implementation-complete when:
+
+- the Apple Silicon workflow passes its focused build/test/stage path;
+- both verifiers and their rejection tests pass;
+- the existing RC workflow consumes their canonical outputs;
+- required CI and concentrated review have no unresolved blocker;
+- the PR is merged and the relevant clean-`main` automated checks pass; and
+- the Issue closure comment states that real signed/hardware evidence remains
+  blocked and owned by downstream release/Windows Issues.
+
+Closing #68 does not mean the RC is releasable. It means the previously missing
+gate implementations now exist and correctly prevent release without the
+separately required evidence.

--- a/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
+++ b/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
@@ -163,8 +163,10 @@ The verifier will require:
   `packaging/product-acceptance-coverage.json`;
 - one input entry per scenario with exactly `id`, `candidateSha`, `result`,
   `evidencePath`, `evidenceSha256`, `owner`, and `reviewedBy`;
-- repository-relative evidence paths, a non-empty owner and reviewer identity,
-  and a reviewer different from the owner;
+- repository-relative evidence paths plus non-empty owner and reviewer
+  identities; `reviewedBy` may identify the Subagent review task/receipt used
+  by this single-maintainer project and does not require a second human
+  maintainer;
 - one bounded, regular evidence JSON file per scenario whose top-level
   `candidateSha` and `result` identify the same passing candidate; and
 - the evidence digest recorded in the policy to match the supplied bytes.

--- a/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
+++ b/docs/superpowers/specs/2026-07-31-macos-native-foundation-ci-design.md
@@ -119,13 +119,15 @@ The verifier will:
    exact correspondence with the frozen manifest;
 4. verify every discovered native file with the platform's existing signing
    tool;
-5. require product-owned launcher/helper/addon/plugin files to match the
-   release job's expected product signer identity, while third-party
-   runtime-native files require a valid signature without pretending they use
-   the product certificate;
+5. require product-owned native helper/addon/plugin files, plus the Windows
+   native launcher, to match the release job's expected product signer
+   identity, while third-party runtime-native files require a valid signature
+   without pretending they use the product certificate;
 6. record the signer fingerprint, native architecture result, and current file
    hash;
-7. require the product launcher and platform helper to be present;
+7. require the product launcher and platform helper to be present; the current
+   macOS shell launcher is protected by the frozen manifest hash and executable
+   mode rather than being falsely reported as a codesigned Mach-O file;
 8. hash the already-produced ZXP and macOS DMG, when applicable; and
 9. write the canonical evidence shape already consumed by
    `artifact-manifest.mjs`.
@@ -216,6 +218,9 @@ evidence is supplied.
 - `.github/workflows/platform-foundation-ci.yml`
 - `scripts/package/verify-final-native-signatures.mjs`
 - `scripts/package/test/verify-final-native-signatures.test.mjs`
+- `native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs`
+- `scripts/release/artifact-manifest.mjs` and its fixtures/tests, narrowly
+  correcting the old assumption that the macOS shell launcher is native code
 - `scripts/release/verify-product-acceptance-coverage.mjs`
 - `scripts/release/test/verify-product-acceptance-coverage.test.mjs`
 - narrowly required existing workflow/schema contract tests

--- a/native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs
+++ b/native/platform-helper/macos/Tests/platform-helper-addon-live.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const addonPath = process.env.AE_MCP_MACOS_ADDON_PATH || '';
+
+test('macOS helper addon loads and exposes createTransport', {
+  skip: process.platform !== 'darwin' || process.arch !== 'arm64' || !addonPath,
+}, () => {
+  const addon = createRequire(import.meta.url)(addonPath);
+  assert.equal(typeof addon.createTransport, 'function');
+});

--- a/scripts/package/test/verify-final-native-signatures.test.mjs
+++ b/scripts/package/test/verify-final-native-signatures.test.mjs
@@ -453,3 +453,107 @@ test('CLI reports the bounded final-signature failure prefix', async () => {
     },
   );
 });
+
+test('Windows adapter binds the requested file through an explicit PowerShell parameter', async () => {
+  const module = await import('../verify-final-native-signatures.mjs');
+  assert.equal(typeof module.inspectWindowsSignature, 'function');
+  const requestedFile = 'C:\\RC files\\ae-mcp-platform-helper.exe';
+  let temporaryScriptPath;
+
+  const result = await module.inspectWindowsSignature({
+    filePath: requestedFile,
+    requireProductIdentity: true,
+    expectedFingerprint: 'A'.repeat(40),
+  }, {
+    executeFile: async (command, args, options) => {
+      assert.equal(command, 'powershell.exe');
+      assert.equal(options.timeout, 30_000);
+      const fileSwitch = args.indexOf('-File');
+      const pathParameter = args.indexOf('-FilePath');
+      assert.ok(fileSwitch >= 0);
+      assert.ok(pathParameter > fileSwitch);
+      assert.equal(args[pathParameter + 1], requestedFile);
+      assert.equal(args.filter((item) => item === requestedFile).length, 1);
+      temporaryScriptPath = args[fileSwitch + 1];
+      const script = await readFile(temporaryScriptPath, 'utf8');
+      assert.match(script, /^param\(/u);
+      assert.match(
+        script,
+        /Get-AuthenticodeSignature -LiteralPath \$FilePath/u,
+      );
+      return {
+        stdout: JSON.stringify({
+          Status: 'Valid',
+          SignerCertificate: { Thumbprint: 'A'.repeat(40) },
+        }),
+      };
+    },
+  });
+
+  assert.deepEqual(result, {
+    verified: true,
+    signerFingerprint: 'A'.repeat(40),
+  });
+  await assert.rejects(readFile(temporaryScriptPath), { code: 'ENOENT' });
+});
+
+test('third-party native with a required suffix cannot replace missing product coverage', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'macos-arm64');
+  const helperRoot = join(h.outDir, 'platform', 'macos-arm64');
+  const helperManifestPath = join(helperRoot, 'helper-manifest.json');
+  const helperManifest = JSON.parse(await readFile(helperManifestPath, 'utf8'));
+  helperManifest.files = helperManifest.files.filter(
+    ({ path }) => path !== 'lib/ae-mcp-platform-helper-transport.node',
+  );
+  await writeFile(helperManifestPath, `${JSON.stringify(helperManifest, null, 2)}\n`);
+  await rm(join(helperRoot, 'lib', 'ae-mcp-platform-helper-transport.node'));
+  await writeFixtureFile(
+    join(h.outDir, 'runtime', 'macos-arm64'),
+    'third-party/lib/ae-mcp-platform-helper-transport.node',
+    machoArm64Bytes(),
+    0o755,
+  );
+  await rewriteStageManifests(h, { helper: true });
+
+  await assert.rejects(
+    withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures({
+      platform: 'macos-arm64',
+      candidateSha: h.input.sourceCommitSha,
+      signedRoot: h.outDir,
+      zxpPath: h.zxpPath,
+      dmgPath: h.dmgPath,
+    }, { inspectSignature: validInspector('macos-arm64') })),
+    /product native signature coverage is missing/u,
+  );
+});
+
+test('writer rejects the signed root and its descendants before hashing', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'windows-x64');
+  let inspections = 0;
+
+  for (const outPath of [
+    h.outDir,
+    join(h.outDir, 'evidence', 'native-signatures.json'),
+  ]) {
+    await assert.rejects(
+      withProtectedFingerprint('windows-x64', () => writeFinalNativeSignatureEvidence({
+        platform: 'windows-x64',
+        candidateSha: h.input.sourceCommitSha,
+        signedRoot: h.outDir,
+        zxpPath: h.zxpPath,
+        outPath,
+      }, {
+        inspectSignature: async (input) => {
+          inspections += 1;
+          return validInspector('windows-x64')(input);
+        },
+      })),
+      /output path must be outside the signed root/u,
+    );
+  }
+  assert.equal(inspections, 0);
+  await assert.rejects(
+    readFile(join(h.outDir, 'evidence', 'native-signatures.json')),
+    { code: 'ENOENT' },
+  );
+});

--- a/scripts/package/test/verify-final-native-signatures.test.mjs
+++ b/scripts/package/test/verify-final-native-signatures.test.mjs
@@ -1,0 +1,455 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+import { canonicalJson } from '../lib/manifest.mjs';
+import { stagePlatformBundle } from '../stage-platform-bundle.mjs';
+import {
+  parseFinalNativeSignatureArgs,
+  verifyFinalNativeSignatures,
+  writeFinalNativeSignatureEvidence,
+} from '../verify-final-native-signatures.mjs';
+import {
+  machoArm64Bytes,
+  machoX64Bytes,
+  makeStageHarness,
+  peX64Bytes,
+  rewriteStageManifests,
+  sha256Bytes,
+  writeFixtureFile,
+} from './helpers/platform-bundle-fixture.mjs';
+
+const execFileAsync = promisify(execFile);
+
+async function makeFinalSignatureHarness(t, platform) {
+  const h = await makeStageHarness(t, platform);
+  await stagePlatformBundle(h.input);
+  const addonRelative = 'lib/ae-mcp-platform-helper-transport.node';
+  const addonBytes = platform === 'macos-arm64' ? machoArm64Bytes() : peX64Bytes();
+  await writeFixtureFile(
+    join(h.outDir, 'platform', platform),
+    addonRelative,
+    addonBytes,
+    platform === 'macos-arm64' ? 0o755 : 0o644,
+  );
+  const helperManifestPath = join(
+    h.outDir,
+    'platform',
+    platform,
+    'helper-manifest.json',
+  );
+  const helperManifest = JSON.parse(await readFile(helperManifestPath, 'utf8'));
+  helperManifest.files.push({
+    path: addonRelative,
+    architecture: platform === 'macos-arm64' ? 'macho-arm64' : 'pe-x64',
+    sha256: sha256Bytes(addonBytes),
+  });
+  await writeFile(helperManifestPath, `${JSON.stringify(helperManifest, null, 2)}\n`);
+  await rewriteStageManifests(h, { helper: true });
+
+  const zxpPath = join(h.root, `${platform}.zxp`);
+  const dmgPath = platform === 'macos-arm64' ? join(h.root, `${platform}.dmg`) : undefined;
+  await writeFile(zxpPath, `${platform} zxp\n`);
+  if (dmgPath) await writeFile(dmgPath, `${platform} dmg\n`);
+  return { ...h, zxpPath, dmgPath };
+}
+
+function fingerprints(platform) {
+  return platform === 'macos-arm64'
+    ? { product: 'a'.repeat(64), thirdParty: 'b'.repeat(64) }
+    : { product: 'A'.repeat(40), thirdParty: 'B'.repeat(40) };
+}
+
+async function withProtectedFingerprint(platform, callback) {
+  const name = platform === 'macos-arm64'
+    ? 'AE_MCP_APPLE_CERT_FINGERPRINT_SHA256'
+    : 'AE_MCP_WINDOWS_SIGNING_CERT_SHA1';
+  const previous = process.env[name];
+  process.env[name] = fingerprints(platform).product;
+  try {
+    return await callback();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+}
+
+function validInspector(platform) {
+  const { product, thirdParty } = fingerprints(platform);
+  return async ({ requireProductIdentity }) => ({
+    verified: true,
+    signerFingerprint: requireProductIdentity ? product : thirdParty,
+  });
+}
+
+for (const platform of ['macos-arm64', 'windows-x64']) {
+  test(`${platform} verifies every manifest-declared native and preserves signer ownership`, async (t) => {
+    const h = await makeFinalSignatureHarness(t, platform);
+    const {
+      product: expectedProductFingerprint,
+      thirdParty: thirdPartyFingerprint,
+    } = fingerprints(platform);
+    const inspections = [];
+    const inspectSignature = async (input) => {
+      inspections.push(input);
+      return {
+        verified: true,
+        signerFingerprint: input.requireProductIdentity
+          ? expectedProductFingerprint
+          : thirdPartyFingerprint,
+      };
+    };
+
+    const result = await withProtectedFingerprint(platform, () => (
+      verifyFinalNativeSignatures({
+        platform,
+        candidateSha: h.input.sourceCommitSha,
+        signedRoot: h.outDir,
+        zxpPath: h.zxpPath,
+        dmgPath: h.dmgPath,
+      }, { inspectSignature })
+    ));
+
+    assert.deepEqual(Object.keys(result).sort(), [
+      'artifacts',
+      'candidateSha',
+      'discoveredNativeCount',
+      'files',
+      'finalRootSha256',
+      'platform',
+      'result',
+      'schemaVersion',
+      'signedBundleManifestSha256',
+    ]);
+    assert.deepEqual(
+      result.files.map(({ path }) => path),
+      result.files.map(({ path }) => path)
+        .toSorted((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right))),
+    );
+    const expectedNativePaths = platform === 'macos-arm64'
+      ? [
+        'platform/macos-arm64/bin/ae-mcp-platform-helper',
+        'platform/macos-arm64/lib/ae-mcp-platform-helper-transport.node',
+        'runtime/macos-arm64/node/bin/node',
+        'runtime/macos-arm64/node/sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude',
+        'runtime/macos-arm64/python/bin/python3.13',
+      ]
+      : [
+        'platform/windows-x64/bin/ae-mcp-platform-helper.exe',
+        'platform/windows-x64/bin/ae-mcp.exe',
+        'platform/windows-x64/lib/ae-mcp-platform-helper-transport.node',
+        'runtime/windows-x64/node/node.exe',
+        'runtime/windows-x64/node/sidecar/node_modules/@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe',
+        'runtime/windows-x64/python/python.exe',
+      ];
+    expectedNativePaths.sort((left, right) => (
+      Buffer.compare(Buffer.from(left), Buffer.from(right))
+    ));
+    assert.deepEqual(result.files.map(({ path }) => path), expectedNativePaths);
+    assert.equal(result.discoveredNativeCount, inspections.length);
+    assert.equal(result.files.length, inspections.length);
+    assert.ok(inspections.every(({ filePath }) => (
+      result.files.some(({ path }) => filePath === join(h.outDir, ...path.split('/')))
+    )));
+    for (const [index, inspection] of inspections.entries()) {
+      assert.equal(
+        result.files.find(({ path }) => (
+          join(h.outDir, ...path.split('/')) === inspection.filePath
+        )).signerFingerprint,
+        inspection.requireProductIdentity
+          ? expectedProductFingerprint
+          : thirdPartyFingerprint,
+        `signer ownership mismatch at inspection ${index}`,
+      );
+      assert.equal(
+        inspection.expectedFingerprint,
+        inspection.requireProductIdentity ? expectedProductFingerprint : undefined,
+      );
+    }
+    assert.ok(inspections.some(({ requireProductIdentity }) => requireProductIdentity));
+    assert.ok(inspections.some(({ requireProductIdentity }) => !requireProductIdentity));
+    assert.deepEqual(result.artifacts, [
+      { name: `${platform}.zxp`, sha256: sha256Bytes(Buffer.from(`${platform} zxp\n`)) },
+      ...(platform === 'macos-arm64'
+        ? [{ name: `${platform}.dmg`, sha256: sha256Bytes(Buffer.from(`${platform} dmg\n`)) }]
+        : []),
+    ]);
+
+    if (platform === 'macos-arm64') {
+      assert.doesNotMatch(
+        JSON.stringify(result.files),
+        /platform\/macos-arm64\/bin\/ae-mcp"/,
+      );
+      assert.ok(result.files.some(
+        (item) => item.path.endsWith('/bin/ae-mcp-platform-helper'),
+      ));
+      assert.ok(result.files.some(
+        (item) => item.path.endsWith('/lib/ae-mcp-platform-helper-transport.node'),
+      ));
+    } else {
+      for (const suffix of [
+        '/bin/ae-mcp-platform-helper.exe',
+        '/lib/ae-mcp-platform-helper-transport.node',
+        '/bin/ae-mcp.exe',
+      ]) {
+        assert.ok(result.files.some((item) => item.path.endsWith(suffix)), suffix);
+      }
+    }
+  });
+}
+
+test('argument parser enforces the exact platform artifact cardinality', () => {
+  const common = [
+    '--candidate-sha', 'a'.repeat(40),
+    '--signed-root', '/tmp/signed',
+    '--zxp', '/tmp/panel.zxp',
+    '--out', '/tmp/native-signatures.json',
+  ];
+  assert.deepEqual(
+    parseFinalNativeSignatureArgs([
+      '--platform', 'macos-arm64',
+      ...common,
+      '--dmg', '/tmp/panel.dmg',
+    ]),
+    {
+      platform: 'macos-arm64',
+      candidateSha: 'a'.repeat(40),
+      signedRoot: '/tmp/signed',
+      zxpPath: '/tmp/panel.zxp',
+      dmgPath: '/tmp/panel.dmg',
+      outPath: '/tmp/native-signatures.json',
+    },
+  );
+  assert.deepEqual(
+    parseFinalNativeSignatureArgs(['--platform', 'windows-x64', ...common]),
+    {
+      platform: 'windows-x64',
+      candidateSha: 'a'.repeat(40),
+      signedRoot: '/tmp/signed',
+      zxpPath: '/tmp/panel.zxp',
+      outPath: '/tmp/native-signatures.json',
+    },
+  );
+  assert.throws(
+    () => parseFinalNativeSignatureArgs(['--platform', 'macos-arm64', ...common]),
+    /--dmg is required/u,
+  );
+  assert.throws(
+    () => parseFinalNativeSignatureArgs([
+      '--platform', 'windows-x64',
+      ...common,
+      '--dmg', '/tmp/panel.dmg',
+    ]),
+    /--dmg is forbidden/u,
+  );
+  assert.throws(
+    () => parseFinalNativeSignatureArgs([
+      '--platform', 'windows-x64',
+      ...common,
+      '--zxp', '/tmp/extra.zxp',
+    ]),
+    /invalid argument/u,
+  );
+});
+
+test('missing launcher, helper, or manifest-declared native file is rejected', async (t) => {
+  for (const relative of [
+    'platform/macos-arm64/bin/ae-mcp',
+    'platform/macos-arm64/bin/ae-mcp-platform-helper',
+    'runtime/macos-arm64/node/bin/node',
+  ]) {
+    await t.test(relative, async (child) => {
+      const h = await makeFinalSignatureHarness(child, 'macos-arm64');
+      await rm(join(h.outDir, ...relative.split('/')));
+      await assert.rejects(
+        withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures({
+          platform: 'macos-arm64',
+          candidateSha: h.input.sourceCommitSha,
+          signedRoot: h.outDir,
+          zxpPath: h.zxpPath,
+          dmgPath: h.dmgPath,
+        }, { inspectSignature: validInspector('macos-arm64') })),
+        /bundle file set|declared helper payload|missing|mismatch/iu,
+      );
+    });
+  }
+});
+
+test('manifest digest mismatch and wrong native architecture are rejected', async (t) => {
+  await t.test('digest mismatch', async (child) => {
+    const h = await makeFinalSignatureHarness(child, 'macos-arm64');
+    await h.flipByte('platform/macos-arm64/bin/ae-mcp-platform-helper');
+    await assert.rejects(
+      withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures({
+        platform: 'macos-arm64',
+        candidateSha: h.input.sourceCommitSha,
+        signedRoot: h.outDir,
+        zxpPath: h.zxpPath,
+        dmgPath: h.dmgPath,
+      }, { inspectSignature: validInspector('macos-arm64') })),
+      /mismatch/iu,
+    );
+  });
+  await t.test('wrong architecture', async (child) => {
+    const h = await makeFinalSignatureHarness(child, 'macos-arm64');
+    await writeFile(
+      join(h.outDir, 'platform/macos-arm64/bin/ae-mcp-platform-helper'),
+      machoX64Bytes(),
+    );
+    await rewriteStageManifests(h, { helper: true });
+    await assert.rejects(
+      withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures({
+        platform: 'macos-arm64',
+        candidateSha: h.input.sourceCommitSha,
+        signedRoot: h.outDir,
+        zxpPath: h.zxpPath,
+        dmgPath: h.dmgPath,
+      }, { inspectSignature: validInspector('macos-arm64') })),
+      { code: 'BUNDLE_ARCH_MISMATCH' },
+    );
+  });
+});
+
+test('invalid signatures and wrong product fingerprint are rejected', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'windows-x64');
+  const input = {
+    platform: 'windows-x64',
+    candidateSha: h.input.sourceCommitSha,
+    signedRoot: h.outDir,
+    zxpPath: h.zxpPath,
+  };
+  await assert.rejects(
+    withProtectedFingerprint('windows-x64', () => verifyFinalNativeSignatures(
+      input,
+      {
+        inspectSignature: async () => ({
+          verified: false,
+          signerFingerprint: fingerprints('windows-x64').thirdParty,
+        }),
+      },
+    )),
+    /adapter rejected/u,
+  );
+  await assert.rejects(
+    withProtectedFingerprint('windows-x64', () => verifyFinalNativeSignatures(
+      input,
+      {
+        inspectSignature: async ({ requireProductIdentity }) => ({
+          verified: true,
+          signerFingerprint: requireProductIdentity
+            ? fingerprints('windows-x64').thirdParty
+            : fingerprints('windows-x64').product,
+        }),
+      },
+    )),
+    /product signer fingerprint mismatch/u,
+  );
+});
+
+test('third-party valid signer does not need the product fingerprint', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'windows-x64');
+  const inspections = [];
+  const result = await withProtectedFingerprint('windows-x64', () => (
+    verifyFinalNativeSignatures({
+      platform: 'windows-x64',
+      candidateSha: h.input.sourceCommitSha,
+      signedRoot: h.outDir,
+      zxpPath: h.zxpPath,
+    }, {
+      inspectSignature: async (input) => {
+        inspections.push(input);
+        return {
+          verified: true,
+          signerFingerprint: input.requireProductIdentity
+            ? fingerprints('windows-x64').product
+            : fingerprints('windows-x64').thirdParty,
+        };
+      },
+    })
+  ));
+  assert.ok(inspections.some(({ requireProductIdentity }) => !requireProductIdentity));
+  assert.ok(result.files.some(({ signerFingerprint }) => (
+    signerFingerprint === fingerprints('windows-x64').thirdParty
+  )));
+});
+
+test('missing artifacts and wrong signed identity are rejected', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'macos-arm64');
+  const base = {
+    platform: 'macos-arm64',
+    candidateSha: h.input.sourceCommitSha,
+    signedRoot: h.outDir,
+    zxpPath: h.zxpPath,
+    dmgPath: h.dmgPath,
+  };
+  await rm(h.zxpPath);
+  await assert.rejects(
+    withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures(
+      base,
+      { inspectSignature: validInspector('macos-arm64') },
+    )),
+    /ENOENT|no such file/iu,
+  );
+  await assert.rejects(
+    withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures(
+      { ...base, platform: 'windows-x64', dmgPath: undefined },
+      { inspectSignature: validInspector('windows-x64') },
+    )),
+    /platform|identity|mismatch/iu,
+  );
+  await assert.rejects(
+    withProtectedFingerprint('macos-arm64', () => verifyFinalNativeSignatures(
+      { ...base, candidateSha: 'f'.repeat(40) },
+      { inspectSignature: validInspector('macos-arm64') },
+    )),
+    /candidate|source commit|identity|mismatch/iu,
+  );
+});
+
+test('canonical evidence writer refuses a pre-existing output', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'windows-x64');
+  const outPath = join(h.root, 'native-signatures.json');
+  await writeFile(outPath, 'existing\n');
+  await assert.rejects(
+    withProtectedFingerprint('windows-x64', () => writeFinalNativeSignatureEvidence({
+      platform: 'windows-x64',
+      candidateSha: h.input.sourceCommitSha,
+      signedRoot: h.outDir,
+      zxpPath: h.zxpPath,
+      outPath,
+    }, { inspectSignature: validInspector('windows-x64') })),
+    /already exists/u,
+  );
+  assert.equal(await readFile(outPath, 'utf8'), 'existing\n');
+});
+
+test('canonical evidence writer creates the final artifact once', async (t) => {
+  const h = await makeFinalSignatureHarness(t, 'windows-x64');
+  const outPath = join(h.root, 'native-signatures.json');
+  const result = await withProtectedFingerprint('windows-x64', () => (
+    writeFinalNativeSignatureEvidence({
+      platform: 'windows-x64',
+      candidateSha: h.input.sourceCommitSha,
+      signedRoot: h.outDir,
+      zxpPath: h.zxpPath,
+      outPath,
+    }, { inspectSignature: validInspector('windows-x64') })
+  ));
+  assert.equal(await readFile(outPath, 'utf8'), canonicalJson(result));
+});
+
+test('CLI reports the bounded final-signature failure prefix', async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      join(import.meta.dirname, '..', 'verify-final-native-signatures.mjs'),
+    ]),
+    (error) => {
+      assert.match(error.stderr, /^FINAL_NATIVE_SIGNATURES_FAILED: /u);
+      assert.equal(error.code, 1);
+      return true;
+    },
+  );
+});

--- a/scripts/package/verify-final-native-signatures.mjs
+++ b/scripts/package/verify-final-native-signatures.mjs
@@ -131,36 +131,59 @@ async function inspectMacSignature({
   }
 }
 
-async function inspectWindowsSignature({
+export async function inspectWindowsSignature({
   filePath,
   requireProductIdentity,
   expectedFingerprint,
-}) {
-  const command = [
-    '$signature = Get-AuthenticodeSignature -LiteralPath $args[0];',
-    '[PSCustomObject]@{',
-    'Status = [string]$signature.Status;',
-    'SignerCertificate = if ($null -eq $signature.SignerCertificate) { $null }',
-    'else { [PSCustomObject]@{',
-    'Thumbprint = [string]$signature.SignerCertificate.Thumbprint',
-    '} }',
-    '} | ConvertTo-Json -Compress',
-  ].join(' ');
-  const { stdout } = await execFileAsync(
-    'powershell.exe',
-    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command, filePath],
-    COMMAND_OPTIONS,
+}, dependencies = {}) {
+  const temporary = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'ae-mcp-authenticode-'),
   );
-  const inspected = JSON.parse(stdout);
-  const signerFingerprint = inspected?.SignerCertificate?.Thumbprint;
-  if (inspected?.Status !== 'Valid' || !/^[A-F0-9]{40}$/.test(signerFingerprint ?? '')) {
-    throw new Error(`Authenticode signature is invalid: ${filePath}`);
+  try {
+    const scriptPath = path.join(temporary, 'inspect-authenticode.ps1');
+    await fs.promises.writeFile(scriptPath, [
+      'param(',
+      '  [Parameter(Mandatory = $true)]',
+      '  [string]$FilePath',
+      ')',
+      '$signature = Get-AuthenticodeSignature -LiteralPath $FilePath',
+      '[PSCustomObject]@{',
+      '  Status = [string]$signature.Status',
+      '  SignerCertificate = if ($null -eq $signature.SignerCertificate) { $null } else {',
+      '    [PSCustomObject]@{',
+      '      Thumbprint = [string]$signature.SignerCertificate.Thumbprint',
+      '    }',
+      '  }',
+      '} | ConvertTo-Json -Compress',
+      '',
+    ].join('\n'), { flag: 'wx', mode: 0o600 });
+    const executeFile = dependencies.executeFile ?? execFileAsync;
+    const { stdout } = await executeFile(
+      'powershell.exe',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-File',
+        scriptPath,
+        '-FilePath',
+        filePath,
+      ],
+      COMMAND_OPTIONS,
+    );
+    const inspected = JSON.parse(stdout);
+    const signerFingerprint = inspected?.SignerCertificate?.Thumbprint;
+    if (inspected?.Status !== 'Valid' || !/^[A-F0-9]{40}$/.test(signerFingerprint ?? '')) {
+      throw new Error(`Authenticode signature is invalid: ${filePath}`);
+    }
+    if (requireProductIdentity
+        && signerFingerprint.toUpperCase() !== expectedFingerprint.toUpperCase()) {
+      throw new Error(`product signer fingerprint mismatch: ${filePath}`);
+    }
+    return { verified: true, signerFingerprint };
+  } finally {
+    await fs.promises.rm(temporary, { recursive: true, force: true });
   }
-  if (requireProductIdentity
-      && signerFingerprint.toUpperCase() !== expectedFingerprint.toUpperCase()) {
-    throw new Error(`product signer fingerprint mismatch: ${filePath}`);
-  }
-  return { verified: true, signerFingerprint };
 }
 
 async function defaultInspectSignature(input) {
@@ -218,6 +241,7 @@ export async function verifyFinalNativeSignatures(input, dependencies = {}) {
   const expectedFingerprint = protectedFingerprint(platform);
   const inspectSignature = dependencies.inspectSignature ?? defaultInspectSignature;
   const files = [];
+  const productVerifiedPaths = new Set();
   for (const record of manifest.files) {
     if (record.type !== 'file') continue;
     const filePath = resolveManifestFile(signedRoot, record.path);
@@ -238,6 +262,7 @@ export async function verifyFinalNativeSignatures(input, dependencies = {}) {
         && inspected.signerFingerprint.toLowerCase() !== expectedFingerprint.toLowerCase()) {
       throw new Error(`product signer fingerprint mismatch: ${record.path}`);
     }
+    if (requireProductIdentity) productVerifiedPaths.add(record.path);
     files.push({
       path: record.path,
       sha256: record.sha256,
@@ -248,18 +273,18 @@ export async function verifyFinalNativeSignatures(input, dependencies = {}) {
   }
   files.sort((left, right) => compareUtf8(left.path, right.path));
 
-  const requiredProductSuffixes = platform === 'macos-arm64'
+  const requiredProductPaths = platform === 'macos-arm64'
     ? [
-      '/bin/ae-mcp-platform-helper',
-      '/lib/ae-mcp-platform-helper-transport.node',
+      'platform/macos-arm64/bin/ae-mcp-platform-helper',
+      'platform/macos-arm64/lib/ae-mcp-platform-helper-transport.node',
     ]
     : [
-      '/bin/ae-mcp-platform-helper.exe',
-      '/lib/ae-mcp-platform-helper-transport.node',
-      '/bin/ae-mcp.exe',
+      'platform/windows-x64/bin/ae-mcp-platform-helper.exe',
+      'platform/windows-x64/lib/ae-mcp-platform-helper-transport.node',
+      'platform/windows-x64/bin/ae-mcp.exe',
     ];
-  if (requiredProductSuffixes.some((suffix) => (
-    !files.some(({ path: relative }) => relative.endsWith(suffix))
+  if (requiredProductPaths.some((requiredPath) => (
+    !owned.has(requiredPath) || !productVerifiedPaths.has(requiredPath)
   ))) {
     throw new Error('final product native signature coverage is missing');
   }
@@ -288,6 +313,14 @@ export async function verifyFinalNativeSignatures(input, dependencies = {}) {
 export async function writeFinalNativeSignatureEvidence(input, dependencies = {}) {
   const resolvedOut = path.resolve(String(input?.outPath ?? ''));
   if (input?.outPath !== resolvedOut) throw new Error('output path must be absolute');
+  const resolvedSignedRoot = path.resolve(String(input?.signedRoot ?? ''));
+  const relativeOutput = path.relative(resolvedSignedRoot, resolvedOut);
+  if (relativeOutput === ''
+      || (!path.isAbsolute(relativeOutput)
+        && relativeOutput !== '..'
+        && !relativeOutput.startsWith(`..${path.sep}`))) {
+    throw new Error('output path must be outside the signed root');
+  }
   try {
     await fs.promises.lstat(resolvedOut);
     throw new Error(`output already exists: ${resolvedOut}`);

--- a/scripts/package/verify-final-native-signatures.mjs
+++ b/scripts/package/verify-final-native-signatures.mjs
@@ -1,0 +1,355 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+import { detectBinaryArchitectureFile } from './lib/binary-arch.mjs';
+import { sha256Directory } from './lib/files.mjs';
+import {
+  readCanonicalJsonFile,
+  sha256File,
+  validateBundleManifest,
+  writeCanonicalJson,
+} from './lib/manifest.mjs';
+import { verifyPlatformBundle } from './verify-platform-bundle.mjs';
+
+const execFileAsync = promisify(execFile);
+const PLATFORMS = new Set(['macos-arm64', 'windows-x64']);
+const SOURCE_SHA = /^[a-f0-9]{40}$/;
+const SIGNER_FINGERPRINT = /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i;
+const COMMAND_OPTIONS = Object.freeze({
+  encoding: 'utf8',
+  maxBuffer: 1024 * 1024,
+  timeout: 30_000,
+});
+
+function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+}
+
+function signatureKind(platform) {
+  return platform === 'macos-arm64' ? 'codesign' : 'authenticode';
+}
+
+function protectedFingerprint(platform) {
+  const name = platform === 'macos-arm64'
+    ? 'AE_MCP_APPLE_CERT_FINGERPRINT_SHA256'
+    : 'AE_MCP_WINDOWS_SIGNING_CERT_SHA1';
+  const value = process.env[name];
+  const expected = platform === 'macos-arm64' ? /^[a-f0-9]{64}$/ : /^[A-F0-9]{40}$/;
+  if (!expected.test(value ?? '')) {
+    throw new Error(`${name} is required for final native signature verification`);
+  }
+  return value;
+}
+
+function resolveManifestFile(root, relative) {
+  const absolute = path.resolve(root, ...String(relative).split('/'));
+  const remainder = path.relative(root, absolute);
+  if (!relative || relative.includes('\\')
+      || remainder === '..' || remainder.startsWith(`..${path.sep}`)
+      || path.isAbsolute(remainder)) {
+    throw new Error(`manifest path escapes the signed root: ${String(relative)}`);
+  }
+  return absolute;
+}
+
+async function readJson(pathname) {
+  return JSON.parse(await fs.promises.readFile(pathname, 'utf8'));
+}
+
+async function productOwnedPaths(root, platform, manifest) {
+  const helperManifestPath = path.join(
+    root,
+    'platform',
+    platform,
+    'helper-manifest.json',
+  );
+  const helper = await readJson(helperManifestPath);
+  if (helper?.platform !== platform || !Array.isArray(helper.files)) {
+    throw new Error('signed helper manifest identity mismatch');
+  }
+  const owned = new Set(helper.files.map((record) => (
+    `platform/${platform}/${String(record?.path)}`
+  )));
+  if (manifest.nativePlugin) {
+    const nativeManifest = await readJson(resolveManifestFile(
+      root,
+      manifest.nativePlugin.manifestPath,
+    ));
+    const executablePath = nativeManifest?.artifact?.executablePath;
+    if (typeof executablePath !== 'string' || executablePath.length === 0) {
+      throw new Error('signed native plug-in manifest executable identity is missing');
+    }
+    owned.add(`${path.posix.dirname(manifest.nativePlugin.manifestPath)}/${executablePath}`);
+  }
+  return owned;
+}
+
+async function inspectMacSignature({
+  filePath,
+  requireProductIdentity,
+  expectedFingerprint,
+}) {
+  await execFileAsync(
+    '/usr/bin/codesign',
+    ['--verify', '--strict', '--verbose=4', filePath],
+    COMMAND_OPTIONS,
+  );
+  await execFileAsync(
+    '/usr/bin/codesign',
+    ['-d', '--verbose=4', filePath],
+    COMMAND_OPTIONS,
+  );
+  const temporary = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'ae-mcp-final-signature-'),
+  );
+  try {
+    const certificatePrefix = path.join(temporary, 'certificate');
+    await execFileAsync(
+      '/usr/bin/codesign',
+      ['-d', '--extract-certificates', certificatePrefix, filePath],
+      COMMAND_OPTIONS,
+    );
+    const { stdout } = await execFileAsync(
+      '/usr/bin/shasum',
+      ['-a', '256', `${certificatePrefix}0`],
+      COMMAND_OPTIONS,
+    );
+    const signerFingerprint = stdout.trim().split(/\s+/u)[0];
+    if (!/^[a-f0-9]{64}$/.test(signerFingerprint)) {
+      throw new Error(`codesign certificate fingerprint is invalid: ${filePath}`);
+    }
+    if (requireProductIdentity && signerFingerprint !== expectedFingerprint) {
+      throw new Error(`product signer fingerprint mismatch: ${filePath}`);
+    }
+    return { verified: true, signerFingerprint };
+  } finally {
+    await fs.promises.rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function inspectWindowsSignature({
+  filePath,
+  requireProductIdentity,
+  expectedFingerprint,
+}) {
+  const command = [
+    '$signature = Get-AuthenticodeSignature -LiteralPath $args[0];',
+    '[PSCustomObject]@{',
+    'Status = [string]$signature.Status;',
+    'SignerCertificate = if ($null -eq $signature.SignerCertificate) { $null }',
+    'else { [PSCustomObject]@{',
+    'Thumbprint = [string]$signature.SignerCertificate.Thumbprint',
+    '} }',
+    '} | ConvertTo-Json -Compress',
+  ].join(' ');
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', command, filePath],
+    COMMAND_OPTIONS,
+  );
+  const inspected = JSON.parse(stdout);
+  const signerFingerprint = inspected?.SignerCertificate?.Thumbprint;
+  if (inspected?.Status !== 'Valid' || !/^[A-F0-9]{40}$/.test(signerFingerprint ?? '')) {
+    throw new Error(`Authenticode signature is invalid: ${filePath}`);
+  }
+  if (requireProductIdentity
+      && signerFingerprint.toUpperCase() !== expectedFingerprint.toUpperCase()) {
+    throw new Error(`product signer fingerprint mismatch: ${filePath}`);
+  }
+  return { verified: true, signerFingerprint };
+}
+
+async function defaultInspectSignature(input) {
+  return input.platform === 'macos-arm64'
+    ? inspectMacSignature(input)
+    : inspectWindowsSignature(input);
+}
+
+function validateInput({ platform, candidateSha, signedRoot, zxpPath, dmgPath }) {
+  if (!PLATFORMS.has(platform)) throw new Error(`unsupported platform: ${platform}`);
+  if (!SOURCE_SHA.test(candidateSha ?? '')) throw new Error('candidate SHA is invalid');
+  if (path.resolve(String(signedRoot ?? '')) !== signedRoot) {
+    throw new Error('signed root must be absolute');
+  }
+  if (path.resolve(String(zxpPath ?? '')) !== zxpPath) {
+    throw new Error('exactly one absolute ZXP path is required');
+  }
+  if (platform === 'macos-arm64') {
+    if (path.resolve(String(dmgPath ?? '')) !== dmgPath) {
+      throw new Error('macOS requires exactly one absolute DMG path');
+    }
+  } else if (dmgPath !== undefined) {
+    throw new Error('Windows final signature evidence must not include a DMG');
+  }
+}
+
+export async function verifyFinalNativeSignatures(input, dependencies = {}) {
+  validateInput(input);
+  const {
+    platform,
+    candidateSha,
+    signedRoot,
+    zxpPath,
+    dmgPath,
+  } = input;
+  const bundleManifestPath = path.join(signedRoot, 'bundle-manifest.json');
+  const manifest = validateBundleManifest(
+    await readCanonicalJsonFile(bundleManifestPath),
+  );
+  if (manifest.platform !== platform || manifest.sourceCommitSha !== candidateSha) {
+    throw new Error('signed bundle platform or candidate identity mismatch');
+  }
+  await verifyPlatformBundle({
+    root: signedRoot,
+    platform,
+    version: manifest.version,
+    sourceCommitSha: candidateSha,
+    verificationProfile: 'release-audit',
+  });
+
+  const acceptedArchitectures = platform === 'macos-arm64'
+    ? new Set(['macho-arm64', 'macho-universal-arm64'])
+    : new Set(['pe-x64']);
+  const owned = await productOwnedPaths(signedRoot, platform, manifest);
+  const expectedFingerprint = protectedFingerprint(platform);
+  const inspectSignature = dependencies.inspectSignature ?? defaultInspectSignature;
+  const files = [];
+  for (const record of manifest.files) {
+    if (record.type !== 'file') continue;
+    const filePath = resolveManifestFile(signedRoot, record.path);
+    const architecture = await detectBinaryArchitectureFile(filePath);
+    if (!acceptedArchitectures.has(architecture)) continue;
+    const requireProductIdentity = owned.has(record.path);
+    const inspected = await inspectSignature({
+      platform,
+      filePath,
+      requireProductIdentity,
+      expectedFingerprint: requireProductIdentity ? expectedFingerprint : undefined,
+    });
+    if (inspected?.verified !== true
+        || !SIGNER_FINGERPRINT.test(inspected.signerFingerprint ?? '')) {
+      throw new Error(`native signature adapter rejected: ${record.path}`);
+    }
+    if (requireProductIdentity
+        && inspected.signerFingerprint.toLowerCase() !== expectedFingerprint.toLowerCase()) {
+      throw new Error(`product signer fingerprint mismatch: ${record.path}`);
+    }
+    files.push({
+      path: record.path,
+      sha256: record.sha256,
+      signatureKind: signatureKind(platform),
+      signerFingerprint: inspected.signerFingerprint,
+      verified: true,
+    });
+  }
+  files.sort((left, right) => compareUtf8(left.path, right.path));
+
+  const requiredProductSuffixes = platform === 'macos-arm64'
+    ? [
+      '/bin/ae-mcp-platform-helper',
+      '/lib/ae-mcp-platform-helper-transport.node',
+    ]
+    : [
+      '/bin/ae-mcp-platform-helper.exe',
+      '/lib/ae-mcp-platform-helper-transport.node',
+      '/bin/ae-mcp.exe',
+    ];
+  if (requiredProductSuffixes.some((suffix) => (
+    !files.some(({ path: relative }) => relative.endsWith(suffix))
+  ))) {
+    throw new Error('final product native signature coverage is missing');
+  }
+
+  const artifactPaths = [zxpPath, ...(dmgPath === undefined ? [] : [dmgPath])];
+  const artifacts = [];
+  for (const artifactPath of artifactPaths) {
+    artifacts.push({
+      name: path.basename(artifactPath),
+      sha256: await sha256File(artifactPath),
+    });
+  }
+  return {
+    schemaVersion: 1,
+    platform,
+    candidateSha,
+    result: 'PASS',
+    signedBundleManifestSha256: await sha256File(bundleManifestPath),
+    finalRootSha256: await sha256Directory(signedRoot),
+    discoveredNativeCount: files.length,
+    files,
+    artifacts,
+  };
+}
+
+export async function writeFinalNativeSignatureEvidence(input, dependencies = {}) {
+  const resolvedOut = path.resolve(String(input?.outPath ?? ''));
+  if (input?.outPath !== resolvedOut) throw new Error('output path must be absolute');
+  try {
+    await fs.promises.lstat(resolvedOut);
+    throw new Error(`output already exists: ${resolvedOut}`);
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+  const evidence = await verifyFinalNativeSignatures(input, dependencies);
+  await writeCanonicalJson(resolvedOut, evidence);
+  return evidence;
+}
+
+export function parseFinalNativeSignatureArgs(argv) {
+  const allowed = new Set([
+    '--platform',
+    '--candidate-sha',
+    '--signed-root',
+    '--zxp',
+    '--dmg',
+    '--out',
+  ]);
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const item = argv[index];
+    const equal = item.indexOf('=');
+    const key = equal === -1 ? item : item.slice(0, equal);
+    const value = equal === -1 ? argv[++index] : item.slice(equal + 1);
+    if (!allowed.has(key) || !value || values.has(key)) {
+      throw new Error(`invalid argument: ${String(item)}`);
+    }
+    values.set(key, value);
+  }
+  for (const required of ['--platform', '--candidate-sha', '--signed-root', '--zxp', '--out']) {
+    if (!values.has(required)) throw new Error(`${required} is required`);
+  }
+  const platform = values.get('--platform');
+  const dmgPath = values.get('--dmg');
+  if (platform === 'macos-arm64' && !dmgPath) throw new Error('--dmg is required for macOS');
+  if (platform === 'windows-x64' && dmgPath) throw new Error('--dmg is forbidden for Windows');
+  const parsed = {
+    platform,
+    candidateSha: values.get('--candidate-sha'),
+    signedRoot: values.get('--signed-root'),
+    zxpPath: values.get('--zxp'),
+    ...(dmgPath ? { dmgPath } : {}),
+    outPath: values.get('--out'),
+  };
+  validateInput(parsed);
+  if (path.resolve(parsed.outPath) !== parsed.outPath) {
+    throw new Error('--out must be absolute');
+  }
+  return parsed;
+}
+
+async function main() {
+  await writeFinalNativeSignatureEvidence(
+    parseFinalNativeSignatureArgs(process.argv.slice(2)),
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`FINAL_NATIVE_SIGNATURES_FAILED: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release/artifact-manifest.mjs
+++ b/scripts/release/artifact-manifest.mjs
@@ -124,7 +124,7 @@ function untrustedFile(message, cause) {
 }
 
 function canonicalEvidenceJson(field, value) {
-  return ['nativeSignatureEvidence', 'productAcceptanceEvidence', 'signingReport'].includes(field)
+  return ['productAcceptanceEvidence', 'signingReport'].includes(field)
     ? canonicalStringify(value)
     : canonicalJson(value);
 }
@@ -225,8 +225,15 @@ function assertNativeSignatureEvidence(record, platform, candidateSha, artifacts
   const finalFiles = new Map(record.signedBundleManifest.files.map((item) => [item.path, item]));
   const expectedKind = platform === 'macos-arm64' ? 'codesign' : 'authenticode';
   const requiredSuffixes = platform === 'macos-arm64'
-    ? ['/bin/ae-mcp', '/bin/ae-mcp-platform-helper']
-    : ['/bin/ae-mcp.exe', '/bin/ae-mcp-platform-helper.exe'];
+    ? [
+      '/bin/ae-mcp-platform-helper',
+      '/lib/ae-mcp-platform-helper-transport.node',
+    ]
+    : [
+      '/bin/ae-mcp-platform-helper.exe',
+      '/lib/ae-mcp-platform-helper-transport.node',
+      '/bin/ae-mcp.exe',
+    ];
   let previous = '';
   const seen = new Set();
   for (const item of value.files) {
@@ -244,7 +251,7 @@ function assertNativeSignatureEvidence(record, platform, candidateSha, artifacts
     previous = item.path;
   }
   if (requiredSuffixes.some((suffix) => ![...seen].some((item) => item.endsWith(suffix)))) {
-    throw new Error('final helper or launcher signature coverage is missing');
+    throw new Error('final product native signature coverage is missing');
   }
   const expectedArtifacts = expectedSigningOutputs(artifacts, platform)
     .map(({ name, sha256 }) => ({ name, sha256 }));

--- a/scripts/release/test/artifact-manifest.test.mjs
+++ b/scripts/release/test/artifact-manifest.test.mjs
@@ -102,14 +102,18 @@ async function writeEvidence(root, candidateSha, artifacts) {
           manifestSha256: '5'.repeat(64),
         },
         files: [
-          {
-            path: `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
-            sha256: '9'.repeat(64), size: 1,
-            mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
-          },
+          ...(platform === 'windows-x64' ? [{
+            path: `platform/${platform}/bin/ae-mcp.exe`,
+            sha256: '9'.repeat(64), size: 1, mode: '0644', type: 'file',
+          }] : []),
           {
             path: `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
             sha256: 'a'.repeat(64), size: 1,
+            mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
+          },
+          {
+            path: `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
+            sha256: 'b'.repeat(64), size: 1,
             mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
           },
           {
@@ -167,10 +171,13 @@ async function writeEvidence(root, candidateSha, artifacts) {
       }),
     );
     const nativePaths = [
-      `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
+      ...(platform === 'windows-x64'
+        ? [`platform/${platform}/bin/ae-mcp.exe`]
+        : []),
       `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
+      `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
     ].sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
-    await writeFile(files.nativeSignatureEvidence, canonicalStringify({
+    await writeFile(files.nativeSignatureEvidence, canonicalJson({
       schemaVersion: 1,
       platform,
       candidateSha,
@@ -180,7 +187,9 @@ async function writeEvidence(root, candidateSha, artifacts) {
       discoveredNativeCount: nativePaths.length,
       files: nativePaths.map((itemPath, index) => ({
         path: itemPath,
-        sha256: itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
+        sha256: itemPath.endsWith('.node')
+          ? 'b'.repeat(64)
+          : itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
         signatureKind: platform === 'macos-arm64' ? 'codesign' : 'authenticode',
         signerFingerprint: platform === 'macos-arm64' ? '6'.repeat(64) : 'f'.repeat(40),
         verified: true,
@@ -257,6 +266,19 @@ test('manifest is canonical and binds exact artifact bytes', async (t) => {
   assert.equal(MAX_EVIDENCE_JSON_BYTES, 8 * 1024 * 1024);
   assert.ok(manifest.evidence.every((record) => record.signedBundleManifest));
   assert.ok(manifest.evidence.every((record) => record.nativeSignatureEvidence));
+  const macNativeSignatureEvidence = manifest.evidence.find(
+    ({ platform }) => platform === 'macos-arm64',
+  ).nativeSignatureEvidence;
+  assert.doesNotMatch(
+    JSON.stringify(macNativeSignatureEvidence.files),
+    /platform\/macos-arm64\/bin\/ae-mcp"/,
+  );
+  assert.ok(macNativeSignatureEvidence.files.some(
+    (item) => item.path.endsWith('/bin/ae-mcp-platform-helper'),
+  ));
+  assert.ok(macNativeSignatureEvidence.files.some(
+    (item) => item.path.endsWith('/lib/ae-mcp-platform-helper-transport.node'),
+  ));
   assert.equal(manifest.productAcceptanceEvidence.candidateSha, fixture.candidateSha);
   assert.match(manifest.artifacts[0].sha256, /^[a-f0-9]{64}$/);
   assert.equal(

--- a/scripts/release/test/helpers/artifact-manifest-fixture.mjs
+++ b/scripts/release/test/helpers/artifact-manifest-fixture.mjs
@@ -92,14 +92,18 @@ async function writeEvidence(root, candidateSha, artifacts) {
           manifestSha256: '5'.repeat(64),
         },
         files: [
-          {
-            path: `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
-            sha256: '9'.repeat(64), size: 1,
-            mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
-          },
+          ...(platform === 'windows-x64' ? [{
+            path: `platform/${platform}/bin/ae-mcp.exe`,
+            sha256: '9'.repeat(64), size: 1, mode: '0644', type: 'file',
+          }] : []),
           {
             path: `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
             sha256: 'a'.repeat(64), size: 1,
+            mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
+          },
+          {
+            path: `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
+            sha256: 'b'.repeat(64), size: 1,
             mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
           },
           {
@@ -157,10 +161,13 @@ async function writeEvidence(root, candidateSha, artifacts) {
       }),
     );
     const nativePaths = [
-      `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
+      ...(platform === 'windows-x64'
+        ? [`platform/${platform}/bin/ae-mcp.exe`]
+        : []),
       `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
+      `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
     ].sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
-    await writeFile(files.nativeSignatureEvidence, canonicalStringify({
+    await writeFile(files.nativeSignatureEvidence, canonicalJson({
       schemaVersion: 1,
       platform,
       candidateSha,
@@ -170,7 +177,9 @@ async function writeEvidence(root, candidateSha, artifacts) {
       discoveredNativeCount: nativePaths.length,
       files: nativePaths.map((itemPath) => ({
         path: itemPath,
-        sha256: itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
+        sha256: itemPath.endsWith('.node')
+          ? 'b'.repeat(64)
+          : itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
         signatureKind: platform === 'macos-arm64' ? 'codesign' : 'authenticode',
         signerFingerprint: platform === 'macos-arm64' ? '6'.repeat(64) : 'f'.repeat(40),
         verified: true,

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -1096,6 +1096,9 @@ test('foundation CI is one credential-free Apple Silicon job', async () => {
   );
   assert.match(workflow, /runs-on:\s*macos-15/);
   assert.match(workflow, /\[\[ "\$\(uname -m\)" == 'arm64' \]\]/);
+  assert.match(workflow, /uv python install 3\.13\.13/);
+  assert.match(workflow, /uv python find 3\.13\.13/);
+  assert.doesNotMatch(workflow, /\$\(python --version\)/);
   assert.match(workflow, /swift test[\s\S]*native\/platform-helper\/macos/);
   assert.match(workflow, /build-platform-helper\.mjs[\s\S]*macos-arm64/);
   assert.match(workflow, /stage-platform-bundle\.mjs[\s\S]*macos-arm64/);

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -1089,19 +1089,27 @@ test('fast CI runs the release contract suite without adding a native release ma
   assert.doesNotMatch(workflow, /macos-15|macos-14-compat|windows-2025/);
 });
 
-test('foundation CI retains the required minimum-macOS job once its gated task lands', async (t) => {
-  let workflow;
-  try {
-    workflow = await readFile('.github/workflows/platform-foundation-ci.yml', 'utf8');
-  } catch (error) {
-    if (error?.code !== 'ENOENT') throw error;
-    t.todo('platform foundation Task 16 remains blocked on the separately approved helper work');
-    return;
+test('foundation CI is one credential-free Apple Silicon job', async () => {
+  const workflow = await readFile(
+    '.github/workflows/platform-foundation-ci.yml',
+    'utf8',
+  );
+  assert.match(workflow, /runs-on:\s*macos-15/);
+  assert.match(workflow, /\[\[ "\$\(uname -m\)" == 'arm64' \]\]/);
+  assert.match(workflow, /swift test[\s\S]*native\/platform-helper\/macos/);
+  assert.match(workflow, /build-platform-helper\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /stage-platform-bundle\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /verify-platform-bundle\.mjs[\s\S]*macos-arm64/);
+  assert.match(workflow, /platform-foundation-receipt\.json/);
+  assert.doesNotMatch(workflow, /macos-14-compat|windows-2025|schedule:/);
+  assert.doesNotMatch(
+    workflow,
+    /AE_MCP_APPLE_CERT_P12_BASE64|notarytool|package-macos-dmg|build-rc/,
+  );
+  assert.doesNotMatch(workflow, /native-coverage-gate\.mjs/);
+  for (const match of workflow.matchAll(/uses:\s*([^\s]+)/g)) {
+    assert.match(match[1], /@[0-9a-f]{40}$/, `mutable action reference: ${match[1]}`);
   }
-
-  assert.match(workflow, /macos-14-compat:/);
-  assert.match(workflow, /runs-on: macos-14|runs-on: \[self-hosted, macOS, ARM64, ae-mcp-macos-14\]/);
-  assert.doesNotMatch(workflow, /macos-14-compat:[\s\S]*?continue-on-error:\s*true/);
 });
 
 test('foundation notarization explicitly consumes the temporary keychain path once fixed', async (t) => {

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -1104,6 +1104,15 @@ test('foundation CI is one credential-free Apple Silicon job', async () => {
   assert.match(workflow, /stage-platform-bundle\.mjs[\s\S]*macos-arm64/);
   assert.match(workflow, /verify-platform-bundle\.mjs[\s\S]*macos-arm64/);
   assert.match(workflow, /platform-foundation-receipt\.json/);
+  const evidenceDirectoryCreation = workflow.indexOf(
+    'mkdir -p "$GITHUB_WORKSPACE/build/evidence"',
+  );
+  const receiptWrite = workflow.indexOf('await writeCanonicalJson(');
+  assert.ok(evidenceDirectoryCreation >= 0, 'foundation CI must create the evidence directory');
+  assert.ok(
+    receiptWrite >= 0 && evidenceDirectoryCreation < receiptWrite,
+    'foundation CI must create the evidence directory before writing the receipt',
+  );
   assert.doesNotMatch(workflow, /macos-14-compat|windows-2025|schedule:/);
   assert.doesNotMatch(
     workflow,

--- a/scripts/release/test/verify-product-acceptance-coverage.test.mjs
+++ b/scripts/release/test/verify-product-acceptance-coverage.test.mjs
@@ -210,7 +210,7 @@ test('selector entry candidate SHA and result must match the requested PASS cand
   }));
 });
 
-test('selector entries require non-empty owner and reviewer identities', async (t) => {
+test('selector entries require non-blank owner and reviewer identities', async (t) => {
   const owner = await makeFixture(t, {
     mutateSelector: (selector) => { selector.evidence[0].owner = ''; },
   });
@@ -225,6 +225,22 @@ test('selector entries require non-empty owner and reviewer identities', async (
   await expectRejected(() => verifyProductAcceptanceCoverage({
     candidateSha: CANDIDATE_SHA,
     coveragePath: reviewer.coveragePath,
+  }));
+
+  const whitespaceOwner = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].owner = '   '; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: whitespaceOwner.coveragePath,
+  }));
+
+  const whitespaceReviewer = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].reviewedBy = '\t'; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: whitespaceReviewer.coveragePath,
   }));
 });
 

--- a/scripts/release/test/verify-product-acceptance-coverage.test.mjs
+++ b/scripts/release/test/verify-product-acceptance-coverage.test.mjs
@@ -1,0 +1,352 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  canonicalJson,
+  sha256Bytes,
+} from '../../package/lib/manifest.mjs';
+import {
+  PRODUCT_ACCEPTANCE_SCENARIOS,
+  parseProductAcceptanceArgs,
+  verifyProductAcceptanceCoverage,
+  writeProductAcceptanceCoverageEvidence,
+} from '../verify-product-acceptance-coverage.mjs';
+
+const CANDIDATE_SHA = 'a'.repeat(40);
+const SCENARIO_IDS = [
+  'clean-install-and-upgrade-rollback',
+  'permission-denial-and-recovery',
+  'persistence',
+  'provider-header-routing',
+  'tool-library',
+];
+
+function digest(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function evidenceDocument(id, candidateSha = CANDIDATE_SHA, result = 'PASS') {
+  return {
+    candidateSha,
+    result,
+    scenario: id,
+    schemaVersion: 1,
+  };
+}
+
+async function makeFixture(t, options = {}) {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ae-mcp-product-coverage-'));
+  t.after(() => fs.promises.rm(root, { force: true, recursive: true }));
+
+  const coveragePath = path.join(root, 'packaging', 'product-acceptance-coverage.json');
+  const evidenceDigests = new Map();
+  for (const id of SCENARIO_IDS) {
+    const evidencePath = path.join(root, 'packaging', 'evidence', 'product-acceptance', `${id}.json`);
+    const bytes = Buffer.from(canonicalJson(evidenceDocument(id)), 'utf8');
+    await fs.promises.mkdir(path.dirname(evidencePath), { recursive: true });
+    await fs.promises.writeFile(evidencePath, bytes);
+    evidenceDigests.set(id, digest(bytes));
+  }
+
+  const selector = {
+    evidence: SCENARIO_IDS.map((id) => ({
+      id,
+      candidateSha: CANDIDATE_SHA,
+      result: 'PASS',
+      evidencePath: `packaging/evidence/product-acceptance/${id}.json`,
+      evidenceSha256: evidenceDigests.get(id),
+      owner: 'JUNKDOGE-JOE',
+      reviewedBy: 'subagent:issue68-product-coverage-review',
+    })),
+    requiredScenarios: SCENARIO_IDS,
+    schemaVersion: 1,
+    status: 'approved',
+  };
+  options.mutateSelector?.(selector, evidenceDigests);
+  await fs.promises.mkdir(path.dirname(coveragePath), { recursive: true });
+  await fs.promises.writeFile(coveragePath, canonicalJson(selector));
+
+  return { coveragePath, evidenceDigests, root, selector };
+}
+
+async function rewriteSelector(fixture) {
+  await fs.promises.writeFile(fixture.coveragePath, canonicalJson(fixture.selector));
+}
+
+async function writeEvidence(fixture, id, value) {
+  const evidencePath = path.join(
+    fixture.root,
+    'packaging',
+    'evidence',
+    'product-acceptance',
+    `${id}.json`,
+  );
+  const bytes = Buffer.from(canonicalJson(value), 'utf8');
+  await fs.promises.writeFile(evidencePath, bytes);
+  fixture.evidenceDigests.set(id, sha256Bytes(bytes));
+  fixture.selector.evidence.find((entry) => entry.id === id).evidenceSha256 = sha256Bytes(bytes);
+  await rewriteSelector(fixture);
+  return evidencePath;
+}
+
+function expectRejected(action) {
+  return assert.rejects(action, (error) => error instanceof Error);
+}
+
+test('approved selector returns the exact ordered product acceptance coverage', async (t) => {
+  const fixture = await makeFixture(t);
+
+  assert.deepEqual(PRODUCT_ACCEPTANCE_SCENARIOS, SCENARIO_IDS);
+  const result = await verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+  });
+  assert.deepEqual(result, {
+    schemaVersion: 1,
+    candidateSha: CANDIDATE_SHA,
+    result: 'PASS',
+    coverage: SCENARIO_IDS.map((id) => ({
+      id,
+      result: 'PASS',
+      evidenceSha256: fixture.evidenceDigests.get(id),
+    })),
+  });
+});
+
+test('argument parser requires exactly one absolute candidate selector and output', () => {
+  const coveragePath = path.join(os.tmpdir(), 'coverage.json');
+  const outPath = path.join(os.tmpdir(), 'out.json');
+  const argv = ['--candidate-sha', CANDIDATE_SHA, '--coverage', coveragePath, '--out', outPath];
+  assert.deepEqual(parseProductAcceptanceArgs(argv), {
+    candidateSha: CANDIDATE_SHA,
+    coveragePath,
+    outPath,
+  });
+
+  for (const invalid of [
+    [],
+    ['--candidate-sha', CANDIDATE_SHA, '--candidate-sha', CANDIDATE_SHA, '--coverage', coveragePath, '--out', outPath],
+    ['--candidate-sha', CANDIDATE_SHA, '--coverage', coveragePath, '--out', outPath, '--unknown', 'x'],
+    ['--candidate-sha', CANDIDATE_SHA, '--coverage', 'coverage.json', '--out', outPath],
+    ['--candidate-sha', CANDIDATE_SHA, '--coverage', coveragePath, '--out', 'out.json'],
+    ['--candidate-sha', 'not-a-sha', '--coverage', coveragePath, '--out', outPath],
+  ]) {
+    assert.throws(() => parseProductAcceptanceArgs(invalid));
+  }
+});
+
+test('blocked selector cannot produce product acceptance coverage', async (t) => {
+  const fixture = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.status = 'blocked'; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+  }));
+});
+
+test('empty evidence array cannot produce product acceptance coverage', async (t) => {
+  const fixture = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence = []; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+  }));
+});
+
+for (const [name, mutate] of [
+  ['missing', (selector) => { selector.evidence.pop(); }],
+  ['extra', (selector) => { selector.evidence.push({ ...selector.evidence[0], id: 'extra' }); }],
+  ['duplicate', (selector) => { selector.evidence[4] = { ...selector.evidence[4], id: selector.evidence[0].id }; }],
+  ['unsorted', (selector) => { [selector.evidence[0], selector.evidence[1]] = [selector.evidence[1], selector.evidence[0]]; }],
+]) {
+  test(`${name} scenario coverage is rejected`, async (t) => {
+    const fixture = await makeFixture(t, { mutateSelector: mutate });
+    await expectRejected(() => verifyProductAcceptanceCoverage({
+      candidateSha: CANDIDATE_SHA,
+      coveragePath: fixture.coveragePath,
+    }));
+  });
+}
+
+test('selector and entries must retain their exact schema keys', async (t) => {
+  const selectorFixture = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.unexpected = true; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: selectorFixture.coveragePath,
+  }));
+
+  const entryFixture = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].unexpected = true; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: entryFixture.coveragePath,
+  }));
+});
+
+test('selector entry candidate SHA and result must match the requested PASS candidate', async (t) => {
+  const wrongSha = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].candidateSha = 'b'.repeat(40); },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: wrongSha.coveragePath,
+  }));
+
+  const nonPass = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].result = 'FAIL'; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: nonPass.coveragePath,
+  }));
+});
+
+test('selector entries require non-empty owner and reviewer identities', async (t) => {
+  const owner = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].owner = ''; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: owner.coveragePath,
+  }));
+
+  const reviewer = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].reviewedBy = ''; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: reviewer.coveragePath,
+  }));
+});
+
+test('absolute and escaping evidence paths are rejected', async (t) => {
+  const absolute = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].evidencePath = '/tmp/evidence.json'; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: absolute.coveragePath,
+  }));
+
+  const escaping = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].evidencePath = '../evidence.json'; },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: escaping.coveragePath,
+  }));
+});
+
+test('missing, symbolic, hard-linked, and oversized evidence files are rejected', async (t) => {
+  const missing = await makeFixture(t);
+  const missingPath = path.join(missing.root, 'packaging', 'evidence', 'product-acceptance', `${SCENARIO_IDS[0]}.json`);
+  await fs.promises.rm(missingPath);
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: missing.coveragePath,
+  }));
+
+  const symbolic = await makeFixture(t);
+  const symbolicPath = path.join(symbolic.root, 'packaging', 'evidence', 'product-acceptance', `${SCENARIO_IDS[0]}.json`);
+  const symbolicTarget = path.join(symbolic.root, 'symbolic-target.json');
+  await fs.promises.rename(symbolicPath, symbolicTarget);
+  await fs.promises.symlink(symbolicTarget, symbolicPath);
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: symbolic.coveragePath,
+  }));
+
+  const linked = await makeFixture(t);
+  const linkedPath = path.join(linked.root, 'packaging', 'evidence', 'product-acceptance', `${SCENARIO_IDS[0]}.json`);
+  const linkedTarget = path.join(linked.root, 'hardlink-target.json');
+  await fs.promises.rename(linkedPath, linkedTarget);
+  await fs.promises.link(linkedTarget, linkedPath);
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: linked.coveragePath,
+  }));
+
+  const oversized = await makeFixture(t);
+  const oversizedPath = path.join(oversized.root, 'packaging', 'evidence', 'product-acceptance', `${SCENARIO_IDS[0]}.json`);
+  await fs.promises.writeFile(oversizedPath, Buffer.alloc(8 * 1024 * 1024 + 1));
+  oversized.selector.evidence[0].evidenceSha256 = await digest(await fs.promises.readFile(oversizedPath));
+  await rewriteSelector(oversized);
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: oversized.coveragePath,
+  }));
+});
+
+test('selector evidence digest must match the bounded evidence bytes', async (t) => {
+  const fixture = await makeFixture(t, {
+    mutateSelector: (selector) => { selector.evidence[0].evidenceSha256 = 'b'.repeat(64); },
+  });
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+  }));
+});
+
+test('evidence JSON must be canonical and match its candidate and PASS result', async (t) => {
+  const candidate = await makeFixture(t);
+  await writeEvidence(candidate, SCENARIO_IDS[0], evidenceDocument(SCENARIO_IDS[0], 'b'.repeat(40)));
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: candidate.coveragePath,
+  }));
+
+  const result = await makeFixture(t);
+  await writeEvidence(result, SCENARIO_IDS[0], evidenceDocument(SCENARIO_IDS[0], CANDIDATE_SHA, 'FAIL'));
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: result.coveragePath,
+  }));
+
+  const noncanonical = await makeFixture(t);
+  const noncanonicalPath = path.join(
+    noncanonical.root,
+    'packaging',
+    'evidence',
+    'product-acceptance',
+    `${SCENARIO_IDS[0]}.json`,
+  );
+  const bytes = Buffer.from('{"schemaVersion":1,"scenario":"clean-install-and-upgrade-rollback","candidateSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","result":"PASS"}\n', 'utf8');
+  await fs.promises.writeFile(noncanonicalPath, bytes);
+  noncanonical.selector.evidence[0].evidenceSha256 = digest(bytes);
+  await rewriteSelector(noncanonical);
+  await expectRejected(() => verifyProductAcceptanceCoverage({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: noncanonical.coveragePath,
+  }));
+});
+
+test('writer refuses a pre-existing output path', async (t) => {
+  const fixture = await makeFixture(t);
+  const outPath = path.join(fixture.root, 'product-acceptance-evidence.json');
+  await fs.promises.writeFile(outPath, 'already present\n');
+  await expectRejected(() => writeProductAcceptanceCoverageEvidence({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+    outPath,
+  }));
+});
+
+test('writer produces canonical product acceptance evidence only after verification', async (t) => {
+  const fixture = await makeFixture(t);
+  const outPath = path.join(fixture.root, 'product-acceptance-evidence.json');
+  const result = await writeProductAcceptanceCoverageEvidence({
+    candidateSha: CANDIDATE_SHA,
+    coveragePath: fixture.coveragePath,
+    outPath,
+  });
+  assert.equal(await fs.promises.readFile(outPath, 'utf8'), canonicalJson(result));
+});

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -785,14 +785,18 @@ test('unsigned local rehearsal binds both platform bytes and rejects tamper or l
         manifestSha256: '5'.repeat(64),
       },
       files: [
-        {
-          path: `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
-          sha256: '9'.repeat(64), size: 1,
-          mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
-        },
+        ...(platform === 'windows-x64' ? [{
+          path: `platform/${platform}/bin/ae-mcp.exe`,
+          sha256: '9'.repeat(64), size: 1, mode: '0644', type: 'file',
+        }] : []),
         {
           path: `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
           sha256: 'a'.repeat(64), size: 1,
+          mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
+        },
+        {
+          path: `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
+          sha256: 'b'.repeat(64), size: 1,
           mode: platform === 'macos-arm64' ? '0755' : '0644', type: 'file',
         },
         {
@@ -843,10 +847,13 @@ test('unsigned local rehearsal binds both platform bytes and rejects tamper or l
     }));
     const nativeSignatureEvidencePath = join(root, `${platform}-native-signatures.json`);
     const nativePaths = [
-      `platform/${platform}/bin/ae-mcp${platform === 'windows-x64' ? '.exe' : ''}`,
+      ...(platform === 'windows-x64'
+        ? [`platform/${platform}/bin/ae-mcp.exe`]
+        : []),
       `platform/${platform}/bin/ae-mcp-platform-helper${platform === 'windows-x64' ? '.exe' : ''}`,
+      `platform/${platform}/lib/ae-mcp-platform-helper-transport.node`,
     ].sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
-    await writeFile(nativeSignatureEvidencePath, canonicalStringify({
+    await writeFile(nativeSignatureEvidencePath, canonicalJson({
       schemaVersion: 1,
       platform,
       candidateSha,
@@ -856,7 +863,9 @@ test('unsigned local rehearsal binds both platform bytes and rejects tamper or l
       discoveredNativeCount: nativePaths.length,
       files: nativePaths.map((itemPath) => ({
         path: itemPath,
-        sha256: itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
+        sha256: itemPath.endsWith('.node')
+          ? 'b'.repeat(64)
+          : itemPath.includes('platform-helper') ? 'a'.repeat(64) : '9'.repeat(64),
         signatureKind: platform === 'macos-arm64' ? 'codesign' : 'authenticode',
         signerFingerprint: platform === 'macos-arm64' ? '6'.repeat(64) : 'f'.repeat(40),
         verified: true,

--- a/scripts/release/verify-product-acceptance-coverage.mjs
+++ b/scripts/release/verify-product-acceptance-coverage.mjs
@@ -106,8 +106,8 @@ function validateSelector(selector, candidateSha) {
         || entry.result !== 'PASS'
         || typeof entry.evidencePath !== 'string'
         || !EVIDENCE_SHA256.test(entry.evidenceSha256 ?? '')
-        || typeof entry.owner !== 'string' || entry.owner.length === 0
-        || typeof entry.reviewedBy !== 'string' || entry.reviewedBy.length === 0) {
+        || typeof entry.owner !== 'string' || entry.owner.trim().length === 0
+        || typeof entry.reviewedBy !== 'string' || entry.reviewedBy.trim().length === 0) {
       throw coverageError('product acceptance selector entry is invalid');
     }
     try {

--- a/scripts/release/verify-product-acceptance-coverage.mjs
+++ b/scripts/release/verify-product-acceptance-coverage.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  assertPortableRelativePath,
+  canonicalJson,
+  readJsonFile,
+  writeCanonicalJson,
+} from '../package/lib/manifest.mjs';
+import {
+  readRegularFileSnapshot,
+  sha256File,
+} from '../package/lib/files.mjs';
+
+const CANDIDATE_SHA = /^[a-f0-9]{40}$/;
+const EVIDENCE_SHA256 = /^[a-f0-9]{64}$/;
+const MAX_EVIDENCE_BYTES = 8 * 1024 * 1024;
+const SELECTOR_KEYS = ['evidence', 'requiredScenarios', 'schemaVersion', 'status'];
+const ENTRY_KEYS = [
+  'candidateSha',
+  'evidencePath',
+  'evidenceSha256',
+  'id',
+  'owner',
+  'result',
+  'reviewedBy',
+];
+
+export const PRODUCT_ACCEPTANCE_SCENARIOS = Object.freeze([
+  'clean-install-and-upgrade-rollback',
+  'permission-denial-and-recovery',
+  'persistence',
+  'provider-header-routing',
+  'tool-library',
+]);
+
+function coverageError(message) {
+  return new Error(message);
+}
+
+function hasExactKeys(value, expected) {
+  return Boolean(value)
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...expected].sort());
+}
+
+function sameOrderedValues(actual, expected) {
+  return Array.isArray(actual)
+    && actual.length === expected.length
+    && actual.every((value, index) => value === expected[index]);
+}
+
+function isInside(root, target) {
+  const relative = path.relative(root, target);
+  return relative !== ''
+    && relative !== '..'
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+function repositoryRootForCoveragePath(coveragePath) {
+  const resolvedCoveragePath = path.resolve(coveragePath);
+  const packagingDirectory = path.dirname(resolvedCoveragePath);
+  if (path.basename(resolvedCoveragePath) !== 'product-acceptance-coverage.json'
+      || path.basename(packagingDirectory) !== 'packaging') {
+    throw coverageError('coverage selector must use the canonical packaging location');
+  }
+  return path.dirname(packagingDirectory);
+}
+
+async function assertSafeDirectoryChain(root, relative) {
+  let current = root;
+  for (const segment of relative.split('/').slice(0, -1)) {
+    current = path.join(current, segment);
+    let stats;
+    try {
+      stats = await fs.promises.lstat(current);
+    } catch {
+      throw coverageError(`evidence parent directory is missing: ${relative}`);
+    }
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw coverageError(`evidence parent directory is unsafe: ${relative}`);
+    }
+  }
+}
+
+function validateSelector(selector, candidateSha) {
+  if (!hasExactKeys(selector, SELECTOR_KEYS)
+      || selector.schemaVersion !== 1
+      || selector.status !== 'approved'
+      || !sameOrderedValues(selector.requiredScenarios, PRODUCT_ACCEPTANCE_SCENARIOS)
+      || !Array.isArray(selector.evidence)
+      || selector.evidence.length !== PRODUCT_ACCEPTANCE_SCENARIOS.length) {
+    throw coverageError('product acceptance selector is invalid');
+  }
+
+  return selector.evidence.map((entry, index) => {
+    if (!hasExactKeys(entry, ENTRY_KEYS)
+        || entry.id !== PRODUCT_ACCEPTANCE_SCENARIOS[index]
+        || entry.candidateSha !== candidateSha
+        || !CANDIDATE_SHA.test(entry.candidateSha)
+        || entry.result !== 'PASS'
+        || typeof entry.evidencePath !== 'string'
+        || !EVIDENCE_SHA256.test(entry.evidenceSha256 ?? '')
+        || typeof entry.owner !== 'string' || entry.owner.length === 0
+        || typeof entry.reviewedBy !== 'string' || entry.reviewedBy.length === 0) {
+      throw coverageError('product acceptance selector entry is invalid');
+    }
+    try {
+      assertPortableRelativePath(entry.evidencePath, 'PRODUCT_ACCEPTANCE_EVIDENCE_PATH_INVALID');
+    } catch {
+      throw coverageError('product acceptance evidence path is invalid');
+    }
+    return entry;
+  });
+}
+
+async function verifyEvidence({ entry, root, realRoot, candidateSha }) {
+  const evidencePath = path.resolve(root, ...entry.evidencePath.split('/'));
+  if (!isInside(root, evidencePath)) {
+    throw coverageError(`product acceptance evidence path escapes repository: ${entry.evidencePath}`);
+  }
+  await assertSafeDirectoryChain(root, entry.evidencePath);
+
+  let stats;
+  try {
+    stats = await fs.promises.lstat(evidencePath);
+  } catch {
+    throw coverageError(`product acceptance evidence is missing: ${entry.evidencePath}`);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1
+      || stats.size <= 0 || stats.size > MAX_EVIDENCE_BYTES) {
+    throw coverageError(`product acceptance evidence is not one bounded regular file: ${entry.evidencePath}`);
+  }
+
+  let realEvidencePath;
+  try {
+    realEvidencePath = await fs.promises.realpath(evidencePath);
+  } catch {
+    throw coverageError(`product acceptance evidence cannot be resolved: ${entry.evidencePath}`);
+  }
+  if (!isInside(realRoot, realEvidencePath)) {
+    throw coverageError(`product acceptance evidence escapes repository: ${entry.evidencePath}`);
+  }
+
+  let bytes;
+  let evidenceSha256;
+  try {
+    bytes = await readRegularFileSnapshot(evidencePath, {
+      expectedStats: stats,
+      maxBytes: MAX_EVIDENCE_BYTES,
+    });
+    evidenceSha256 = await sha256File(evidencePath, { expectedStats: stats });
+  } catch {
+    throw coverageError(`product acceptance evidence cannot be read safely: ${entry.evidencePath}`);
+  }
+  if (evidenceSha256 !== entry.evidenceSha256) {
+    throw coverageError(`product acceptance evidence digest mismatch: ${entry.evidencePath}`);
+  }
+
+  let evidence;
+  try {
+    evidence = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw coverageError(`product acceptance evidence is not JSON: ${entry.evidencePath}`);
+  }
+  if (!bytes.equals(Buffer.from(canonicalJson(evidence), 'utf8'))
+      || !evidence || typeof evidence !== 'object' || Array.isArray(evidence)
+      || evidence.schemaVersion !== 1
+      || evidence.candidateSha !== candidateSha
+      || evidence.result !== 'PASS'
+      || evidence.scenario !== entry.id) {
+    throw coverageError(`product acceptance evidence contract is invalid: ${entry.evidencePath}`);
+  }
+
+  return {
+    id: entry.id,
+    result: 'PASS',
+    evidenceSha256,
+  };
+}
+
+export function parseProductAcceptanceArgs(argv) {
+  if (!Array.isArray(argv) || argv.length !== 6) {
+    throw coverageError('expected --candidate-sha, --coverage, and --out exactly once');
+  }
+  const values = new Map();
+  const allowed = new Set(['--candidate-sha', '--coverage', '--out']);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(key) || values.has(key) || typeof value !== 'string' || value.length === 0) {
+      throw coverageError('expected --candidate-sha, --coverage, and --out exactly once');
+    }
+    values.set(key, value);
+  }
+  const candidateSha = values.get('--candidate-sha');
+  const coveragePath = values.get('--coverage');
+  const outPath = values.get('--out');
+  if (!CANDIDATE_SHA.test(candidateSha)
+      || !path.isAbsolute(coveragePath)
+      || !path.isAbsolute(outPath)) {
+    throw coverageError('candidate SHA and coverage/output paths are invalid');
+  }
+  return { candidateSha, coveragePath, outPath };
+}
+
+export async function verifyProductAcceptanceCoverage({ candidateSha, coveragePath } = {}) {
+  if (!CANDIDATE_SHA.test(candidateSha ?? '') || typeof coveragePath !== 'string'
+      || !path.isAbsolute(coveragePath)) {
+    throw coverageError('candidate SHA and coverage path are invalid');
+  }
+  const root = repositoryRootForCoveragePath(coveragePath);
+  let realRoot;
+  try {
+    realRoot = await fs.promises.realpath(root);
+  } catch {
+    throw coverageError('repository root cannot be resolved');
+  }
+
+  let selector;
+  try {
+    selector = await readJsonFile(coveragePath, 'PRODUCT_ACCEPTANCE_COVERAGE_INVALID');
+  } catch {
+    throw coverageError('product acceptance selector cannot be read safely');
+  }
+  const entries = validateSelector(selector, candidateSha);
+  const coverage = [];
+  for (const entry of entries) {
+    coverage.push(await verifyEvidence({ entry, root, realRoot, candidateSha }));
+  }
+  return {
+    schemaVersion: 1,
+    candidateSha,
+    result: 'PASS',
+    coverage,
+  };
+}
+
+export async function writeProductAcceptanceCoverageEvidence({ candidateSha, coveragePath, outPath } = {}) {
+  if (!CANDIDATE_SHA.test(candidateSha ?? '') || typeof coveragePath !== 'string'
+      || !path.isAbsolute(coveragePath) || typeof outPath !== 'string' || !path.isAbsolute(outPath)) {
+    throw coverageError('candidate SHA and coverage/output paths are invalid');
+  }
+  try {
+    await fs.promises.lstat(outPath);
+    throw coverageError(`output path already exists: ${outPath}`);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const result = await verifyProductAcceptanceCoverage({ candidateSha, coveragePath });
+  await writeCanonicalJson(outPath, result);
+  return result;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  writeProductAcceptanceCoverageEvidence(parseProductAcceptanceArgs(process.argv.slice(2)))
+    .catch((error) => {
+      process.stderr.write(
+        `PRODUCT_ACCEPTANCE_COVERAGE_FAILED: ${error.message}\n`,
+      );
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## What changed

- add one credential-free Apple Silicon foundation job on `macos-15`
- build and test the macOS platform helper/runtime once, load the built N-API addon, stage the unsigned product artifact, and upload only a bounded machine-readable receipt
- add the product acceptance coverage verifier with exact five-scenario, candidate, digest, owner, and Subagent reviewer binding
- add the final native signature verifier for macOS and Windows artifact graphs, including product-owned helper/addon/launcher coverage and third-party signer handling
- add focused negative tests and document the intentionally narrow CI boundary

## Why

Issue #68 had fail-closed release gates that referenced a missing hosted macOS foundation workflow and two missing verifiers. This PR supplies those concrete entry points without widening the ordinary development path into signing, notarization, AE hardware validation, nightly matrices, or generalized runner infrastructure.

## Validation

- Subagent whole-branch review plus one scoped fix re-review: approved, no remaining code blocker
- `node --test scripts/package/test/*.test.mjs`: 434 pass, 6 existing skips, 0 fail
- `node --test scripts/release/test/*.test.mjs`: 141 pass, 0 fail
- `git diff --check origin/main...HEAD`: pass

The hosted `macos-15` job is the remaining merge gate and will provide the real Swift build/addon-load/stage/receipt evidence.

Closes #68