### PR TITLE
docs(issue-86): freeze Windows x64 Native EXEC host spec and plan

### DIFF
--- a/docs/superpowers/plans/2026-07-31-windows-native-exec-host.md
+++ b/docs/superpowers/plans/2026-07-31-windows-native-exec-host.md
@@ -1,0 +1,251 @@
+# Windows x64 Native EXEC Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Windows x64 `.aex` host from shared product source and validate the existing unified `ae_nativeExec` chain on real Windows AE 25/26, with one read-only public acceptance program.
+
+**Architecture:** A new `src/platform/windows/` adapter (entry export, PiPL resource, same-user named-pipe endpoint registry) plugs into the unchanged shared core (`rpc_codec`, `native_rpc_connection`, `host_dispatcher`, Native EXEC registry). A build/verify script pair mirrors `build-macos.mjs`/`verify-macos.mjs`; a reversible dev-install script places the artifact in the Windows Common Plug-ins topology. The CEP client reuses `net.createConnection({ path })` with Windows pipe endpoint discovery.
+
+**Tech Stack:** MSVC x64 C++ (pinned Windows AE SDK from #71), Node.js 24.17.0 ESM and `node:test`, PowerShell or Node driver scripts, existing `scripts/package/ae-sdk-input.mjs` policy, Windows named pipes, real Windows AE 25/26 hardware.
+
+**Execution venue:** Tasks 1-3 can be prepared anywhere but their build/test steps require a Windows machine with MSVC and the pinned SDK. Tasks 4-5 require the real Windows AE 25/26 host. Continue execution from a Windows-host fork/clone of this branch.
+
+## Global Constraints
+
+- No new native primitives or capabilities; the existing Native EXEC registry is the acceptance surface.
+- No transport authentication, pairing, tokens, peer-process validation, or cross-user/session defenses (#88 closed NOT_PLANNED; PR #197 boundary). Same-user pipe ACL only.
+- No Authenticode signing, production installer, upgrade/rollback, or uninstall lifecycle — that is #80.
+- No write tools, Undo claims, or release-matrix claims — that is #81.
+- Do not vendor or redistribute Adobe SDK headers, samples, documentation, PiPLtool, or extraction utilities.
+- Shared `src/core` and `src/aegp` sources must compile identically on macOS and Windows; platform seams follow the existing `src/platform/<os>/` header pattern, not scattered `#ifdef` blocks in shared logic.
+- Fail fast on every locked external input before compiling (pinned SDK, MSVC, Windows SDK, output ownership) per AGENTS.md section 7.
+- One artifact per build; no byte-for-byte double-build reproducibility.
+- Use a dedicated disposable AE project for any AE-state validation; never the user's production project.
+- T5/T6 hardware budget: roughly 5-7 public `ae_nativeExec` calls per run.
+- Every implementation task uses red-green-refactor and ends with a focused commit.
+
+## File and Interface Map
+
+- `native/ae-plugin/src/platform/windows/endpoint_registry_windows.{hpp,cpp}`
+  - Owns pipe naming (`\\.\pipe\aemcp-n1-` + UUID-v4 instance scope), metadata bounds, stale-endpoint cleanup, and the accept loop feeding `native_rpc_connection`.
+- `native/ae-plugin/src/platform/windows/plugin_entry_windows.cpp`
+  - Owns `DllMain` and the AEGP entry export, delegating to the existing `plugin_entry.cpp` dispatch.
+- `native/ae-plugin/resources/AeMcpNative_PiPL.win.rc`
+  - Owns the Windows resource carrying the same PiPL values as `AeMcpNative_PiPL.r`.
+- `native/ae-plugin/build-windows.mjs` (or `.ps1`)
+  - Owns prerequisite fail-fast checks, the MSVC compile/link, and the build receipt.
+- `native/ae-plugin/verify-windows.mjs`
+  - Owns PE architecture/export/resource verification and the canonical receipt shape.
+- `native/ae-plugin/install-dev-windows.mjs` (or `.ps1`)
+  - Owns the reversible Common Plug-ins development install and its receipt.
+- `plugin/host/native-aegp-client.js`
+  - Narrowly owns Windows endpoint discovery; protocol flow unchanged.
+- `native/ae-plugin/tests/*windows*_test.cpp` and focused `.mjs` contract tests
+  - Own registry naming/ACL-boundary and PE-verifier falsification without real AE.
+
+---
+
+### Task 1: Windows build prerequisites, PiPL resource, and entry point
+
+**Files:**
+- Create: `native/ae-plugin/src/platform/windows/plugin_entry_windows.cpp`
+- Create: `native/ae-plugin/src/platform/windows/endpoint_registry_windows.hpp` (interface only at this step)
+- Create: `native/ae-plugin/resources/AeMcpNative_PiPL.win.rc`
+- Create: `native/ae-plugin/build-windows.mjs`
+- Create: `scripts/package/test/native-aegp-build-contract.test.mjs` (extend existing contract coverage narrowly for the Windows script)
+
+**Interfaces:**
+- Consumes: `loadAeSdkPolicy`, `verifyAeSdkInput` from `scripts/package/ae-sdk-input.mjs`.
+- Produces:
+  - `checkWindowsBuildPrerequisites(input: { sdkArchive?: string, sdkRoot?: string }): Promise<{ sdkRoot: string, msvcVersion: string, windowsSdkVersion: string }>`
+  - `buildWindowsAex(input: { sdkRoot: string, outputPath: string }): Promise<{ artifactPath: string, sha256: string, receipt: object }>`
+- Entry export must resolve to the same `plugin_entry.cpp` dispatch table used by the macOS build.
+
+- [ ] **Step 1: Write failing prerequisite tests**
+
+Cover: missing SDK archive/root, unpinned SDK version, missing MSVC, missing
+Windows SDK headers, and a non-owned output path. Each must fail before any
+compile starts with an `AE_*`-prefixed structured error, mirroring the macOS
+build error taxonomy.
+
+- [ ] **Step 2: Implement the prerequisite check and build skeleton**
+
+Implement `checkWindowsBuildPrerequisites` and the compile/link invocation
+producing a single `.aex`. Run on the Windows machine: confirm fail-fast
+behavior for each missing input, then a successful compile against the
+pinned SDK.
+
+- [ ] **Step 3: Author the PiPL resource and entry export**
+
+Port the PiPL values (name, match name, category, entry point) from
+`resources/AeMcpNative_PiPL.r` into the Windows resource, keeping the product
+version token substitution identical to `build-macos.mjs`. Wire
+`DllMain`/entry export to the existing dispatch. macOS sources remain
+untouched.
+
+- [ ] **Step 4: Commit**
+
+Commit the resource, entry source, build script, and tests.
+
+### Task 2: PE verifier and build receipt
+
+**Files:**
+- Create: `native/ae-plugin/verify-windows.mjs`
+- Create: `scripts/package/test/verify-windows-aex.test.mjs` (new focused test file; do not overload the macOS verifier tests)
+
+**Interfaces:**
+- Produces:
+  - `verifyWindowsAex(input: { artifactPath: string, expectedCommit: string }): Promise<{ result: "PASS", artifactSha256: string, architecture: "x64", entryExport: string, receipt: object }>`
+- CLI mirrors `verify-macos.mjs` conventions: explicit `--artifact`,
+  `--output`, and pinned-SDK identity flags.
+
+- [ ] **Step 1: Write failing verifier tests with PE fixtures**
+
+Cover: wrong architecture (x86/arm64 fixture rejected), missing entry
+export, missing/altered AE resource, unexpected extra executable entry
+surface, and hash/receipt consistency. Use small synthetic PE fixtures; do
+not require a real `.aex` in unit tests.
+
+- [ ] **Step 2: Implement the verifier**
+
+Parse PE headers (architecture, export table, resource section) without
+third-party dependencies, emit the canonical receipt (commit, artifact
+hash, SDK identity, compiler version), and fail closed on every mismatch.
+
+- [ ] **Step 3: Verify the real artifact**
+
+On the Windows machine, run the verifier against the Task 1 artifact and
+record the receipt.
+
+- [ ] **Step 4: Commit**
+
+Commit verifier, tests, and the recorded receipt schema.
+
+### Task 3: Same-user named-pipe endpoint adapter and client discovery
+
+**Files:**
+- Create: `native/ae-plugin/src/platform/windows/endpoint_registry_windows.cpp`
+- Create: `native/ae-plugin/tests/endpoint_registry_windows_test.cpp`
+- Modify: `plugin/host/native-aegp-client.js` (Windows endpoint discovery only)
+- Modify: `plugin/host/native-aegp-client.test.js` (discovery-path cases)
+
+**Interfaces:**
+- Mirrors `endpoint_registry_macos.cpp` semantics:
+  - one pipe per host instance, name `\\.\pipe\aemcp-n1-<uuid-v4>`;
+  - bounded descriptor/metadata (same 1024-byte bound as macOS);
+  - stale-endpoint cleanup on start; restart invalidates old endpoints;
+  - same-user ACL on pipe creation; no peer authentication beyond the OS
+    same-user boundary.
+- Client: `discoverWindowsEndpoints(registryRoot): Array<{ pipePath: string, instanceId: string }>` feeding the existing
+  `net.createConnection({ path })` flow.
+
+- [ ] **Step 1: Write failing registry contract tests**
+
+Cover naming scheme, UUID validation, metadata bounds, stale-entry cleanup,
+and ACL creation flags. Mark the same-user ACL boundary explicitly so a
+future reviewer cannot mistake its absence of peer authentication for an
+oversight — record the #88 NOT_PLANNED disposition in the test comment.
+
+- [ ] **Step 2: Implement the pipe endpoint registry and accept loop**
+
+Implement creation, registration, accept, framing handoff to
+`native_rpc_connection`, and cleanup. Shared codec/connection code must not
+change.
+
+- [ ] **Step 3: Implement Windows client discovery**
+
+Add the discovery path to `native-aegp-client.js`; prove with unit tests
+that discovery picks the current instance's pipe and ignores stale names.
+Protocol, deadlines, cancellation, and admission remain unchanged.
+
+- [ ] **Step 4: Commit**
+
+Commit adapter, client discovery, and tests.
+
+### Task 4: Reversible development install and lifecycle smoke (Windows AE host)
+
+**Files:**
+- Create: `native/ae-plugin/install-dev-windows.mjs` (or `.ps1`)
+- Create: install receipt schema alongside the macOS dev-install receipt conventions
+
+**Interfaces:**
+- Produces:
+  - `installDevWindowsAex(input: { artifactPath: string }): Promise<{ installedPath: string, receipt: object }>`
+  - `removeDevWindowsAex(input: { receiptPath: string }): Promise<{ removed: true }>`
+- Installs into the supported Windows Common Plug-ins topology for AE
+  25/26; records canonical path, hash, size, mtime; removes exactly what it
+  installed.
+
+- [ ] **Step 1: Zero-evidence hardware preflight**
+
+Per AGENTS.md section 4: prove the Windows host, AE 25/26 install paths,
+GUI access, fixture location, and log directories in one preflight. Create
+or reset, save, and reopen one disposable fixture from inside AE. No
+acceptance evidence is produced here.
+
+- [ ] **Step 2: Install and T4 native-novelty smoke**
+
+Install the `.aex`, launch AE, and run the narrowest smoke: plug-in loads,
+pipe endpoint registers, one IdleHook-dispatched no-op/read-only registry
+probe succeeds, plug-in unloads on removal, AE quits cleanly. This is the
+single allowed native-novelty smoke for the package.
+
+- [ ] **Step 3: Restart invalidation check**
+
+Restart AE; prove the old endpoint is stale and a fresh instance registers.
+
+- [ ] **Step 4: Commit**
+
+Commit the install script and receipt schema.
+
+### Task 5: Public acceptance — T5 candidate and T6 clean-main
+
+**Files:**
+- Create: `scripts/hardware/issue86_windows_native_exec_acceptance.py` (and spec file, following the `issue190_*` acceptance-driver pattern)
+- Evidence directory per the project's evidence conventions, outside Adobe scan roots
+
+**Interfaces:**
+- Acceptance calls only the public MCP surface: `ae_nativeExec` with one
+  real read-only program; typed result cross-checked against independently
+  read AE state through the same public surface.
+- Budget: roughly 5-7 public calls for T5 and again for T6.
+
+- [ ] **Step 1: Freeze the candidate**
+
+After concentrated review has no unresolved blocker and all sources/tests
+are committed, designate the candidate. Run T3 (relevant full regression +
+required CI) once before any acceptance evidence.
+
+- [ ] **Step 2: T5 candidate acceptance**
+
+On real Windows AE 25/26 with the candidate build receipts: run the
+read-only `ae_nativeExec` program, cross-check the typed result against AE
+state, record load/IdleHook/unload/quit/restart evidence, and bind commit,
+artifact hash, SDK identity, AE build, and Windows version/arch.
+
+- [ ] **Step 3: Merge and T6 clean-main revalidation**
+
+Merge, rebuild/reinstall from a clean `main`, and replay the same public
+acceptance once. Touch the same read-only path; verify restart freshness.
+
+- [ ] **Step 4: Close #86 with the completion report**
+
+Report per AGENTS.md section 9, including the fixture lifecycle counts,
+build receipts, and the explicit statement that signing/installer belongs
+to #80 and write/Undo/release-matrix coverage belongs to #81.
+
+---
+
+## Integrated Verification and Review Gate
+
+1. All focused unit/contract tests (registry, verifier, client discovery,
+   build prerequisites) green.
+2. Existing macOS native compile tests, protocol conformance, and required
+   GitHub CI green — proving the Windows adapter changed no shared behavior.
+3. One concentrated Subagent review (at most two rounds), explicitly
+   checking: macOS/shared protocol unchanged, no authentication/pairing
+   leaked into the pipe path, no signing/installer scope leaked from #80,
+   and no new primitives.
+4. T4 smoke, T5 candidate acceptance, and T6 clean-`main` revalidation on
+   real Windows AE 25/26 within the frozen call budgets.
+5. Stop conditions of AGENTS.md section 10 apply before #80 begins.

--- a/docs/superpowers/specs/2026-07-31-windows-native-exec-host-design.md
+++ b/docs/superpowers/specs/2026-07-31-windows-native-exec-host-design.md
@@ -65,8 +65,11 @@ install. Validate through the public MCP surface only.
 
 ### Rejected: port the retired standalone tool or add a Windows-specific capability
 
-`ae.project.summary` no longer exists as a tool. A Windows-only capability
-would fork the capability contract and violate the Issue's non-goals. The
+`ae.project.summary` no longer exists as a tool (the string survives only as
+an internal negotiated native capability/contract ID in
+`packages/core/ae_mcp/backends/native.py`, never as a public MCP tool). A
+Windows-only capability would fork the capability contract and violate the
+Issue's non-goals. The
 existing read-only Native EXEC registry already contains programs sufficient
 for acceptance.
 
@@ -223,7 +226,8 @@ Classify findings under `AGENTS.md` section 5:
 - only a reproduced failure in the Windows build/adapter/acceptance path is
   a current blocker;
 - credible Windows hardening beyond the single-user boundary is a follow-up
-  recorded against #80/#81 or a new issue;
+  recorded as a new issue (or against #80/#81 only when it directly concerns
+  their packaging/release-matrix scope);
 - reviving #88-style authentication, pairing, or process defenses is out of
   scope by product decision.
 

--- a/docs/superpowers/specs/2026-07-31-windows-native-exec-host-design.md
+++ b/docs/superpowers/specs/2026-07-31-windows-native-exec-host-design.md
@@ -1,0 +1,249 @@
+# Windows x64 Native EXEC Host Design
+
+Date: 2026-07-31
+
+Issue: #86
+
+Status: User-approved frozen scope; written-spec review
+
+## Goal
+
+Build the Windows x64 After Effects `.aex` host from shared product-owned
+source, and validate the existing unified Native EXEC chain end to end on a
+real Windows AE 25/26 host:
+
+1. an MSVC x64 build of the existing native plug-in source with the pinned
+   developer-supplied SDK from #71;
+2. a Windows platform adapter: PiPL/resource, entry export, and a same-user
+   named-pipe endpoint mirroring the macOS Unix-socket registry;
+3. a reversible development install in the Windows Common Plug-ins topology;
+4. real-host lifecycle validation (load, IdleHook, unload, quit, restart);
+5. one real read-only program executed through the public `ae_nativeExec`
+   tool, cross-checked against actual AE state.
+
+This Issue proves the existing registry on Windows. It does not extend the
+capability set, does not add transport authentication, and does not produce
+a signed or installable product.
+
+## Current Observed State
+
+- #71 (pinned SDK inputs), #72 (versioned RPC contract), #73 (macOS host and
+  main-thread dispatcher), and #76 (MCP/Core-to-AEGP broker bridge) are all
+  closed and merged.
+- #88 (Windows named-pipe mutual authentication) was closed NOT_PLANNED on
+  2026-07-28 after PR #197 established the trusted single-user same-host
+  product boundary. Peer authentication, pairing, endpoint-substitution, and
+  cross-user/session defenses are unsupported product goals, not deferred
+  implementation work.
+- `native/ae-plugin` contains no Windows code: no `_WIN32` guards, no
+  `src/platform/windows/`, and no named-pipe implementation. The only
+  platform adapter is `src/platform/macos/`.
+- The macOS transport is a Unix domain socket registry
+  (`src/platform/macos/endpoint_registry_macos.cpp`, socket directory
+  `aemcp-n1`, UUID-v4-scoped endpoint names) plus `src/core/transport_auth.cpp`,
+  `src/core/native_rpc_connection.cpp`, and `src/core/rpc_codec.cpp`.
+- The CEP/host client (`plugin/host/native-aegp-client.js`) connects with
+  `net.createConnection({ path })`, which on Windows accepts `\\.\pipe\`
+  paths; the client-side adaptation is endpoint discovery and naming, not a
+  new protocol.
+- The macOS build is `native/ae-plugin/build-macos.mjs` with pinned-SDK
+  policy from `scripts/package/ae-sdk-input.mjs`, Rez PiPL source at
+  `resources/AeMcpNative_PiPL.r`, and verification in `verify-macos.mjs`.
+- The old standalone `ae.project.summary` tool referenced by the original
+  Issue text was retired in PR #200; the unified public surface is
+  `ae_nativeExec`.
+
+## Considered Approaches
+
+### Chosen: minimal platform adapter on the shared execution plane
+
+Add `src/platform/windows/` with the smallest adapter that lets the existing
+registry/dispatcher/protocol run unchanged: entry export, PiPL compiled into
+a `.rc`/resource, and a named-pipe endpoint server with the same registry
+semantics as macOS. One build script, one verifier, one reversible dev
+install. Validate through the public MCP surface only.
+
+### Rejected: port the retired standalone tool or add a Windows-specific capability
+
+`ae.project.summary` no longer exists as a tool. A Windows-only capability
+would fork the capability contract and violate the Issue's non-goals. The
+existing read-only Native EXEC registry already contains programs sufficient
+for acceptance.
+
+### Rejected: implement the #88 authenticated transport first
+
+#88 was closed NOT_PLANNED as a product-scope decision. Implementing it now
+would contradict PR #197's boundary and expand #86 far beyond its approved
+scope. The Windows pipe uses same-user ACL/filesystem protection only,
+consistent with the AGENTS.md local development trust model.
+
+### Rejected: Authenticode signing or production installer in this Issue
+
+Those belong to #80, which consumes the real `.aex` this Issue produces.
+Signing here would block the package on release credentials and installer
+lifecycle work that has its own acceptance matrix.
+
+## Design Decisions
+
+### 1. Windows platform adapter layout
+
+Create `native/ae-plugin/src/platform/windows/` containing:
+
+- the AEGP entry-point export (`PF_Cmd`-style entry / `DllMain`) wired to the
+  existing `plugin_entry.cpp` dispatch, with no behavior change on macOS;
+- a named-pipe endpoint registry (`endpoint_registry_windows.cpp`) mirroring
+  the macOS semantics: one pipe per host instance, UUID-v4-scoped pipe names
+  under `\\.\pipe\aemcp-n1-`, bounded descriptor/metadata, stale-endpoint
+  cleanup on start, and restart invalidation;
+- the pipe server accept loop feeding the existing
+  `native_rpc_connection`/`rpc_codec` framing unchanged.
+
+The adapter compiles only under `_WIN32`. Shared sources in `src/core` and
+`src/aegp` must build identically on both platforms; any required seam uses
+the existing platform-header pattern rather than scattered `#ifdef` blocks
+inside shared logic.
+
+### 2. PiPL and resource
+
+Add `resources/AeMcpNative_PiPL.win.rc` (or the closest equivalent accepted
+by the pinned SDK's resource flow) carrying the same PiPL values as the
+macOS Rez source: plug-in name, match name, category, and entry point. The
+Windows build must not invent a second identity; match name and version
+tokens come from the same product manifest substitution used by
+`build-macos.mjs`.
+
+### 3. Build and verification scripts
+
+Create `native/ae-plugin/build-windows.ps1` or `build-windows.mjs` (matching
+the chosen Windows toolchain driver) and `verify-windows.mjs`:
+
+- fail fast before compiling on every locked external input per AGENTS.md
+  section 7: pinned SDK archive/root from `ae-sdk-input.mjs`, MSVC toolchain
+  presence and version, Windows SDK headers, Node headers if needed, and
+  output-path ownership;
+- produce exactly one x64 `.aex` PE artifact;
+- the verifier asserts PE architecture (x64), the expected entry export and
+  AE resource, and the absence of unexpected executable entry surface, and
+  records the artifact hash, SDK identity, compiler version, and source
+  commit as a build receipt;
+- no byte-for-byte double-build reproducibility requirement.
+
+### 4. Same-user named-pipe transport
+
+The pipe endpoint is protected at the Windows ACL level for the current
+user/session only. Consistent with the #88 disposition, the adapter will
+not:
+
+- validate peer process identity, signer, session, or architecture beyond
+  what the OS same-user pipe ACL already enforces;
+- add pairing, tokens, fingerprints, or a connection-code ceremony;
+- write secrets, raw audit tokens, or request payloads to world-readable
+  locations.
+
+`plugin/host/native-aegp-client.js` gains a Windows endpoint-discovery path
+that enumerates the same registry naming scheme and calls the existing
+`net.createConnection({ path })` flow; the protocol, deadlines, cancellation,
+and admission rules are untouched.
+
+### 5. Reversible development install
+
+Create `native/ae-plugin/install-dev-windows.ps1` (or `.mjs`) that copies the
+built `.aex` into the supported Windows Common Plug-ins topology for AE
+25/26, records an install receipt (canonical path, hash, size, mtime), and
+removes exactly what it installed. It does not touch the production
+installer, registry-based upgrade/rollback, or signing; those are #80.
+
+### 6. Real-host lifecycle validation
+
+On a real Windows AE 25/26 host, validate through observable AE behavior:
+
+- deterministic load and endpoint registration;
+- IdleHook/main-thread dispatch of the read-only acceptance program;
+- unload/DeathHook on plug-in removal;
+- AE quit without hanging the host;
+- restart invalidating stale endpoints and establishing a fresh instance.
+
+All AE suite calls must run on the approved AE thread/IdleHook context.
+
+### 7. Public acceptance surface
+
+Acceptance uses only the public MCP tool a model would call:
+
+- `ae_nativeExec` executing one real read-only program against a disposable
+  fixture, with the typed result cross-checked against independently read AE
+  state;
+- T5 (candidate) and T6 (clean-`main`) hardware budgets of roughly 5-7
+  public calls each, per the frozen brief;
+- evidence binds commit, artifact hash, SDK identity, AE version/build,
+  Windows version/architecture, public request/result, and sanitized
+  lifecycle logs.
+
+No write tool, Undo claim, Authenticode claim, or installer claim is made in
+this Issue.
+
+## Expected Change Surface
+
+- `native/ae-plugin/src/platform/windows/` (new adapter sources/headers)
+- `native/ae-plugin/resources/AeMcpNative_PiPL.win.rc` or equivalent
+- `native/ae-plugin/build-windows.*` and `verify-windows.mjs`
+- `native/ae-plugin/install-dev-windows.*`
+- `plugin/host/native-aegp-client.js` narrowly: Windows endpoint discovery
+- focused contract tests for the Windows registry naming/ACL boundary and
+  the PE verifier, runnable without real AE
+- `docs/INSTALL.md`/`docs/REFERENCE.md` only if needed to describe the
+  development install path
+
+The exact list may contract during test-first implementation. Expansion into
+transport authentication, signing, installer lifecycle, new primitives, or
+process guardrails requires a reproduced blocker and explicit scope review.
+
+## Verification
+
+Implementation follows red-green-refactor:
+
+1. focused unit/contract tests for the endpoint registry naming, metadata
+   bounds, and stale-entry cleanup;
+2. focused PE-verifier tests (architecture, export, resource, receipt);
+3. existing native compile tests and protocol conformance suites unchanged
+   and green on macOS;
+4. one fresh external Windows build producing the verified `.aex`;
+5. reversible development install with receipt;
+6. T4 native-novelty smoke (first Windows load + IdleHook dispatch);
+7. T5 candidate acceptance on real Windows AE 25/26; and
+8. T6 clean-`main` revalidation.
+
+T5/T6 run on the Windows host; the macOS acceptance loop must remain green
+without re-running beyond the normal clean-`main` check.
+
+## Review and Scope Control
+
+Use one concentrated Subagent review by default and no more than two rounds.
+Classify findings under `AGENTS.md` section 5:
+
+- only a reproduced failure in the Windows build/adapter/acceptance path is
+  a current blocker;
+- credible Windows hardening beyond the single-user boundary is a follow-up
+  recorded against #80/#81 or a new issue;
+- reviving #88-style authentication, pairing, or process defenses is out of
+  scope by product decision.
+
+The review must explicitly check that macOS/shared protocol behavior is
+unchanged and that no authentication or signing claim leaked into the
+Windows path.
+
+## Completion and Issue Closure
+
+#86 is complete when:
+
+- a fresh external build produces the verified PE x64 `.aex` with a build
+  receipt;
+- the reversible development install works on the real host;
+- real Windows AE 25/26 load/IdleHook/unload/quit/restart evidence exists;
+- the public `ae_nativeExec` read-only acceptance passed at T5 and T6 within
+  the frozen call budget;
+- required CI and concentrated review have no unresolved blocker;
+- the closure comment records that Authenticode/installer lifecycle remains
+  with #80 and write/Undo/release-matrix coverage remains with #81.
+
+Closing #86 means the Windows host runs the existing Native EXEC chain. It
+does not mean the Windows product is signed, installable, or releasable.


### PR DESCRIPTION
## Summary

Frozen design spec and implementation plan for #86, re-scoped per the owner-approved 2026-07-31 boundary:

- Acceptance target is the unified public `ae_nativeExec` chain (the original `ae.project.summary` standalone tool was retired in PR #200).
- Verified during planning that #88 was closed NOT_PLANNED after PR #197's single-user same-host boundary — the authenticated Windows named-pipe transport was never implemented, and `native/ae-plugin` contains no Windows code at all. The frozen scope therefore includes a plain same-user named-pipe endpoint mirroring `endpoint_registry_macos.cpp` semantics; pairing/peer-auth/cross-user defenses are explicitly descoped.
- Scope: MSVC x64 `.aex` build with the pinned SDK from #71, PiPL/resource + entry export, reversible dev install, real Windows AE 25/26 lifecycle validation, one read-only `ae_nativeExec` program cross-checked against AE state.
- Non-goals recorded in both documents: no new primitives, no transport authentication, no Authenticode/installer (#80), no writes/Undo/release matrix (#81).
- T5/T6 budget ~5-7 public calls per run; execution continues from a Windows-host fork of this branch.

Docs-only change; no code touched. Issue #86 body and freeze/correction comments updated to match these documents.

Refs #86