### PR TITLE
release: prepare Windows v0.9.3 minimal assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.9.3] — 2026-08-03
+
+#### 发布范围
+
+- 新增 Windows x64 原生执行宿主的正式发布资产；ZXP 与 AEX 均从最终 `main` 提交重新构建，并分别使用本次新建的自签名身份签名。
+- 固定资产为 `ae-mcp-panel-v0.9.3-windows-x64.zxp`、`AeMcpNative-v0.9.3-windows-x64.aex` 与 `SHA256SUMS-v0.9.3.txt`。
+- AEX 由用户在关闭 AE 后手动复制到所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`。本版继续使用现有外部 runtime/launcher，不提供零环境安装、一体化安装器、Windows RuntimeManager 或自动升级/修复/回滚/卸载。
+
 ### [0.9.2] — 2026-07-13
 
 #### ✨ 新增
@@ -243,6 +251,14 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.9.3] — 2026-08-03
+
+#### Release scope
+
+- Publish the Windows x64 native execution host as a release asset. The ZXP and AEX are rebuilt from the final `main` commit and signed with newly created self-signed identities.
+- Fixed assets are `ae-mcp-panel-v0.9.3-windows-x64.zxp`, `AeMcpNative-v0.9.3-windows-x64.aex`, and `SHA256SUMS-v0.9.3.txt`.
+- With AE closed, users manually copy the AEX to the selected host as `Support Files\Plug-ins\Extensions\AeMcpNative.aex`. The existing external runtime/launcher remains required; this release has no zero-environment install, integrated installer, Windows RuntimeManager, or automatic upgrade/repair/rollback/uninstall lifecycle.
 
 ### [0.9.2] — 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ ae-mcp is a backend-agnostic automation tool that keeps Adobe After Effects and 
 
 The MCP server is the core. Outside the MCP layer, ae-mcp also ships a CEP panel that wraps built-in agent chat, backend configuration, approval controls, diagnostics, and first-run setup. You can use ae-mcp from an external agent backend through MCP, or configure Claude / Codex / ZCode directly inside the AE panel.
 
-**v0.9.2 is the Windows x64 release.** macOS compatibility, bundled RuntimeManager, the production cross-platform signing chain, and the complete AE 25/26 hardware matrix move to v0.9.3.
+**v0.9.3 is a Windows x64 release with two separately installed assets.** Install the signed ZXP for the CEP panel and manually copy the signed AEX into the selected After Effects plug-in directory. This release retains the existing external runtime/launcher requirement; it is not a zero-environment or ZXP-only installation.
 
-## v0.9.2 Target Support Matrix
+## v0.9.3 Target Support Matrix
 
-The published v0.9.2 asset targets this verified release scope:
+The published v0.9.3 assets target this release scope:
 
 - Windows 11 24H2 (11.0.26100) or newer on x64. Windows on ARM is not supported.
-- After Effects 25.x is hardware-validated. The CEP manifest remains `[25.0,26.9]`; complete AE 26 and macOS acceptance is deferred to v0.9.3.
+- After Effects 2025 is the packaged acceptance host. The CEP manifest remains `[25.0,26.9]`; this release contains no macOS asset.
 
 ## Architecture
 
@@ -29,26 +29,28 @@ Embedded panel chat or external MCP client
 
 `ae_previewFrame` remains the AE-internal `CompItem.saveFrameToPng` path for rendering real comp pixels, with viewer snapshot only as a fallback. `packages/snapshot-mss` provides Windows `ae_snapshot` screen capture through the `mss` backend.
 
-The MCP core is backend-agnostic: external clients can talk to AE through the stdio server, while the CEP panel can also host built-in agent chat. The existing panel layer handles backend setup, approvals, diagnostics, and activity history. The published v0.9.2 Windows asset predates bundled-runtime activation; current v0.9.3 macOS development includes a panel RuntimeManager that verifies, installs, atomically activates, repairs, rolls back, and uninstalls the packaged runtime without using an online package manager. Claude, Codex, and ZCode are built-in panel backends; OpenCode and other tools can still connect as external MCP clients.
+The MCP core is backend-agnostic: external clients can talk to AE through the stdio server, while the CEP panel can also host built-in agent chat. The existing panel layer handles backend setup, approvals, diagnostics, and activity history. The v0.9.3 Windows release retains the existing external runtime/launcher setup and does not activate a bundled Windows RuntimeManager. Claude, Codex, and ZCode are built-in panel backends; OpenCode and other tools can still connect as external MCP clients.
 
-## v0.9.2 Release Candidate Scope
+## v0.9.3 Release Scope
 
-- One protected `main` candidate SHA produces both native platform payloads; a failed or changed candidate must be rebuilt under a new SHA.
-- Core operation is designed to be offline and self-contained in the signed release payload. System Python, system Node, `uv`, PyPI, and npm resolution are development inputs, not normal-user install prerequisites.
-- Provider, Tool Library, and Platform Helper implementation is complete, including Windows AE 2025 hardware validation. v0.9.2 ships a self-signed Windows ZXP whose certificate is valid until 2037; the asset has no TSA timestamp, and its native Helper binaries are not Authenticode-signed. Bundled RuntimeManager, production native signing, macOS, and the remaining hardware cells are v0.9.3 work.
-- UXP, Intel Mac, Windows ARM, provider-config export, and ZCode desktop captcha/runtime-header bridging are outside the v0.9.2 support scope.
+- One final protected-`main` SHA produces the ZXP and AEX; changed source requires new artifacts and checksums.
+- The AEX is distributed separately because a ZXP installer does not place nested files in After Effects' native plug-in directory.
+- An integrated installer, automatic AEX deployment, Windows RuntimeManager, zero-environment onboarding, repair/rollback/uninstall lifecycle, macOS assets, and Windows ARM are outside this release.
+- Both signatures use newly created self-signed identities and therefore do not establish a publicly trusted publisher.
 
 ## Install and First Run
 
-Normal users install one immutable asset from the v0.9.2 release set. Do not use source archives or an online `uv`/PyPI install as a substitute for a signed release asset:
+Download the three named files from the v0.9.3 GitHub Release. Do not use source archives as substitutes for the signed assets:
 
-| Platform | Install asset | Auditable payload |
-|---|---|---|
-| Windows 11 24H2+ x64 | `ae-mcp-panel-v0.9.2-windows-x64.zxp` | same ZXP |
+| Role | Release asset |
+|---|---|
+| CEP panel | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
+| Native AEGP plug-in | `AeMcpNative-v0.9.3-windows-x64.aex` |
+| Integrity | `SHA256SUMS-v0.9.3.txt` |
 
-Install `ae-mcp-panel-v0.9.2-windows-x64.zxp` with a supported ZXP installer, restart After Effects, and open `Window -> Extensions -> ae-mcp`. This release retains the existing external runtime setup; the bundled offline RuntimeManager is deferred to v0.9.3.
+Install the ZXP with a supported ZXP installer. With After Effects closed, copy the AEX to the selected host's `Support Files\Plug-ins\Extensions\AeMcpNative.aex` path using administrator permission, then restart After Effects and open `Window -> Extensions -> ae-mcp`. Keep the existing external runtime/launcher configured.
 
-The GitHub Release publishes the exact Windows asset and its SHA-256 digest. See [Install](docs/INSTALL.md) and [Release](docs/RELEASE.md).
+Verify both binaries with `SHA256SUMS-v0.9.3.txt`. See [Install](docs/INSTALL.md) and [Release](docs/RELEASE.md).
 
 ## Built-in Backends
 
@@ -77,20 +79,20 @@ Claude Code CLI is separate from Claude Desktop. Claude Desktop MCP configuratio
 
 <table>
   <tr><td><img src="docs/images/en/settings-provider-manager-collapsed.png" width="380"><br>Settings: backend channels and compact Provider Manager rows</td><td><img src="docs/images/en/settings-provider-manager-expanded.png" width="380"><br>Settings: expanded provider editor with local API key storage</td></tr>
-  <tr><td><img src="docs/images/en/settings-general-language.png" width="380"><br>Settings: general options, language switch, logs, and About</td><td><img src="docs/images/en/wizard-install.png" width="380"><br>Historical v0.9.0 development wizard: online `uv` and PATH launcher setup; not the v0.9.2 bundled-runtime UX</td></tr>
+  <tr><td><img src="docs/images/en/settings-general-language.png" width="380"><br>Settings: general options, language switch, logs, and About</td><td><img src="docs/images/en/wizard-install.png" width="380"><br>Historical v0.9.0 development wizard: online `uv` and PATH launcher; not the v0.9.3 release path</td></tr>
   <tr><td><img src="docs/images/en/wizard-connect-clients.png" width="380"><br>First-run wizard: built-in chat and external MCP client setup</td><td><img src="docs/images/en/chat-home.png" width="380"><br>Chat home: starter suggestions and composer controls</td></tr>
   <tr><td><img src="docs/images/en/chat-approval.png" width="380"><br>Tool approval card for gated high-risk operations</td><td><img src="docs/images/en/activity-stream.png" width="380"><br>Activity stream: agent operation history</td></tr>
 </table>
 
 ## External MCP Clients
 
-The v0.9.3 macOS panel-generated MCP config for external clients has this shape:
+For Windows v0.9.3, an existing external launcher config has this shape after replacing `<USER>` with the actual account name:
 
 ```json
 {
   "mcpServers": {
     "ae": {
-      "command": "/Users/<USER>/.ae-mcp/bin/ae-mcp",
+      "command": "C:\\Users\\<USER>\\.ae-mcp\\bin\\ae-mcp.exe",
       "env": {
         "AE_MCP_BACKEND": "ae-mcp",
         "AE_MCP_PLUGIN_URL": "http://127.0.0.1:11488"
@@ -100,7 +102,7 @@ The v0.9.3 macOS panel-generated MCP config for external clients has this shape:
 }
 ```
 
-This is the stable-launcher contract. On macOS the Panel now emits the expanded absolute launcher path and never resolves `ae-mcp` from bare PATH; the RuntimeManager verifies and activates the packaged runtime before the launcher is used. Windows v0.9.2 behavior remains unchanged in this implementation. See [RuntimeManager](docs/RUNTIME_MANAGER.md).
+Keep the expanded absolute path shown above; do not rely on a bare PATH command. The three Release assets do not install or activate that launcher. See [Install](docs/INSTALL.md).
 
 External clients must run on the same machine as After Effects, or otherwise be able to reach `127.0.0.1:11488` on the AE machine. This matters for long-running or Dockerized IM-bot frameworks such as OpenClaw and AstrBot.
 
@@ -327,7 +329,7 @@ node scripts/live-model-matrix.mjs
 
 ## Package and Release
 
-Maintainers create v0.9.2 artifacts only through the protected `build-rc.yml` workflow. The exact Mac arm64 and Windows x64 bytes are bound to `artifact-manifest-v0.9.2.json`, validated by `macos-rc-attestation` and `windows-rc-attestation`, then promoted by `release.yml` without rebuilding. Signing credentials, redistribution approvals, AE 25/26 installations, and a Windows x64 verifier are external prerequisites; see [docs/RELEASE.md](docs/RELEASE.md).
+Maintainers merge release metadata first, then build the v0.9.3 Windows ZXP and AEX from the final clean protected-`main` commit. They sign and verify both assets, generate `SHA256SUMS-v0.9.3.txt`, run the After Effects 2025 public-path smoke, and upload those exact bytes without rebuilding. See [docs/RELEASE.md](docs/RELEASE.md).
 
 ## Implementation Notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,14 +6,14 @@ ae-mcp 是一个**后端无关**的 After Effects 自动化工具，用来让 AE
 
 MCP server 是核心。在 MCP 本体之外，ae-mcp 还包装了一套 CEP 面板插件，提供面板内对话、后端配置、审批、诊断和首跑安装。你可以根据自己的工作流选择：在外部 agent 后端里通过 MCP 使用 ae-mcp，或者直接在 AE 面板内配置 Claude / Codex / ZCode 后端进行对话。
 
-**v0.9.2 是 Windows x64 正式版本。** macOS 兼容、包内 RuntimeManager、正式跨平台签名链以及完整 AE 25/26 实机矩阵转入 v0.9.3。
+**v0.9.3 是包含两个独立安装资产的 Windows x64 版本。** ZXP 用于 CEP 面板，签名 AEX 需手动复制到所选 After Effects 的原生插件目录。本版继续依赖现有外部 runtime/launcher，不是零环境或只装 ZXP 即用的安装包。
 
-## v0.9.2 目标支持矩阵
+## v0.9.3 目标支持矩阵
 
-v0.9.2 已发布资产面向以下已验证范围：
+v0.9.3 发布资产面向以下范围：
 
 - Windows 11 24H2（11.0.26100）或更新版本，运行于 x64；不支持 Windows ARM。
-- After Effects 25.x 已完成实机验证。CEP manifest 仍为 `[25.0,26.9]`；完整 AE 26 与 macOS 验收延后至 v0.9.3。
+- After Effects 2025 是本次打包验收宿主。CEP manifest 仍为 `[25.0,26.9]`；本版不包含 macOS 资产。
 
 ## 架构
 
@@ -29,26 +29,28 @@ v0.9.2 已发布资产面向以下已验证范围：
 
 `ae_previewFrame` 仍是 AE 内部的 `CompItem.saveFrameToPng` 路径，用于渲染真实合成像素，viewer snapshot 只作为 fallback。`packages/snapshot-mss` 通过 `mss` backend 提供 Windows `ae_snapshot` 屏幕捕获。
 
-MCP core 本身保持后端无关：外部客户端可以通过 stdio server 与 AE 对话，CEP 面板也可以在 AE 内承载内嵌 agent 对话。现有面板层负责后端配置、审批、诊断和活动历史。已发布的 v0.9.2 Windows 资产早于包内 runtime 激活能力；当前 v0.9.3 macOS 开发版本已经实现 Panel RuntimeManager，可在不调用在线包管理器的情况下校验、安装、原子激活、修复、回滚和卸载包内 runtime。Claude、Codex、ZCode 是面板内置后端；OpenCode 和其他工具仍可以作为外部 MCP 客户端接入。
+MCP core 本身保持后端无关：外部客户端可以通过 stdio server 与 AE 对话，CEP 面板也可以在 AE 内承载内嵌 agent 对话。现有面板层负责后端配置、审批、诊断和活动历史。v0.9.3 Windows 版本继续使用既有外部 runtime/launcher，不会激活 Windows 包内 RuntimeManager。Claude、Codex、ZCode 是面板内置后端；OpenCode 和其他工具仍可以作为外部 MCP 客户端接入。
 
-## v0.9.2 候选范围
+## v0.9.3 发布范围
 
-- protected `main` 上的同一个候选 SHA 同时生成两个平台原生载荷；候选失败或发生任何变化，都必须以新 SHA 重新构建。
-- 核心能力按离线、自包含发布包设计。系统 Python、系统 Node、`uv`、PyPI 和 npm 解析只属于开发环境，不是普通用户安装前提。
-- Provider、Tool Library 与 Platform Helper 已完成实现，并通过 Windows AE 2025 实机验证。v0.9.2 发布使用有效至 2037 年证书的自签名 Windows ZXP；本次资产没有 TSA 时间戳，其中原生 Helper 二进制也尚未做 Authenticode。包内 RuntimeManager、正式原生签名、macOS 和其余实机矩阵转入 v0.9.3。
-- UXP、Intel Mac、Windows ARM、provider 配置导出以及 ZCode 桌面 captcha/runtime-header 桥接不属于 v0.9.2 支持范围。
+- ZXP 与 AEX 必须来自最终受保护 `main` 的同一个 SHA；源码变化后必须重新生成资产和校验值。
+- ZXP installer 不会把包内文件复制到 AE 原生插件目录，因此 AEX 单独发布并手动安装。
+- 一体化安装器、自动 AEX 部署、Windows RuntimeManager、零环境首跑、修复/回滚/卸载生命周期、macOS 资产和 Windows ARM 不属于本版范围。
+- 两类签名均使用本次新建的自签名身份，不代表公开可信的软件发布者。
 
 ## 安装和首次启动
 
-普通用户只安装 v0.9.2 发布组中的一个不可变平台资产。不要用源码归档或在线 `uv`/PyPI 安装替代签名发布资产：
+从 v0.9.3 GitHub Release 下载以下三个固定文件，不要用源码归档替代签名资产：
 
-| 平台 | 安装资产 | 可审计载荷 |
-|---|---|---|
-| Windows 11 24H2+ x64 | `ae-mcp-panel-v0.9.2-windows-x64.zxp` | 同一个 ZXP |
+| 用途 | 发布资产 |
+|---|---|
+| CEP 面板 | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
+| 原生 AEGP 插件 | `AeMcpNative-v0.9.3-windows-x64.aex` |
+| 完整性校验 | `SHA256SUMS-v0.9.3.txt` |
 
-使用受支持的 ZXP installer 安装 `ae-mcp-panel-v0.9.2-windows-x64.zxp`，重启 After Effects，再打开 `Window -> Extensions -> ae-mcp`。本版继续使用现有外部 runtime 配置；包内离线 RuntimeManager 延后至 v0.9.3。
+用受支持的 ZXP installer 安装 ZXP。关闭 After Effects 后，以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`，再重启 AE 并打开 `Window -> Extensions -> ae-mcp`。继续保留现有外部 runtime/launcher 配置。
 
-GitHub Release 会发布精确的 Windows 资产及其 SHA-256。详见[安装文档](docs/INSTALL.md)和[发布文档](docs/RELEASE.md)。
+用 `SHA256SUMS-v0.9.3.txt` 校验两个二进制。详见[安装文档](docs/INSTALL.md)和[发布文档](docs/RELEASE.md)。
 
 ## 选择并登录后端
 
@@ -110,7 +112,7 @@ Tools 标签页管理本地生成的 JSX、表达式、提示词 skill、recipe 
 
 <table>
   <tr><td><img src="docs/images/zh-CN/settings-provider-manager-collapsed.png" width="380"><br>设置页：后端通道与收起状态的 Provider 管理器</td><td><img src="docs/images/zh-CN/settings-provider-manager-expanded.png" width="380"><br>设置页：展开编辑 provider，本地保存 API key</td></tr>
-  <tr><td><img src="docs/images/zh-CN/settings-general-language.png" width="380"><br>设置页：通用选项、界面语言、日志与关于</td><td><img src="docs/images/zh-CN/wizard-install.png" width="380"><br>历史 v0.9.0 开发向导：在线 `uv` 与 PATH launcher 安装；不能代表 v0.9.2 包内 runtime UX</td></tr>
+  <tr><td><img src="docs/images/zh-CN/settings-general-language.png" width="380"><br>设置页：通用选项、界面语言、日志与关于</td><td><img src="docs/images/zh-CN/wizard-install.png" width="380"><br>历史 v0.9.0 开发向导：在线 `uv` 与 PATH launcher；不是 v0.9.3 发布路径</td></tr>
   <tr><td><img src="docs/images/zh-CN/wizard-connect-clients.png" width="380"><br>首跑向导：选择面板内对话或外部 MCP 客户端</td><td><img src="docs/images/zh-CN/chat-home.png" width="380"><br>聊天首页：启动建议与 composer 快捷选择条</td></tr>
   <tr><td><img src="docs/images/zh-CN/chat-approval.png" width="380"><br>工具审批卡片：高风险操作确认</td><td><img src="docs/images/zh-CN/activity-stream.png" width="380"><br>活动流：agent 操作历史</td></tr>
 </table>
@@ -119,13 +121,13 @@ Tools 标签页管理本地生成的 JSX、表达式、提示词 skill、recipe 
 
 面板内对话覆盖 Claude、Codex、ZCode 三类后端。如果你使用 Cursor、Claude Desktop、Claude Code、OpenCode、OpenClaw、AstrBot、Gemini Antigravity、ZCode 等外部客户端，可以通过面板生成的 MCP config 接入。
 
-v0.9.3 macOS Panel 生成的最小配置形态如下：
+Windows v0.9.3 应在把 `<USER>` 替换为实际账户名后，按下面的形态配置既有外部 launcher：
 
 ```json
 {
   "mcpServers": {
     "ae": {
-      "command": "/Users/<USER>/.ae-mcp/bin/ae-mcp",
+      "command": "C:\\Users\\<USER>\\.ae-mcp\\bin\\ae-mcp.exe",
       "env": {
         "AE_MCP_BACKEND": "ae-mcp",
         "AE_MCP_PLUGIN_URL": "http://127.0.0.1:11488"
@@ -135,7 +137,7 @@ v0.9.3 macOS Panel 生成的最小配置形态如下：
 }
 ```
 
-这是稳定 launcher 契约。macOS Panel 现在会输出展开后的绝对 launcher 路径，且不会再从裸 PATH 解析 `ae-mcp`；RuntimeManager 会在使用 launcher 前校验并激活包内 runtime。本项实现保持 Windows v0.9.2 行为不变。详见 [RuntimeManager](docs/RUNTIME_MANAGER.md)。
+保留上面展开后的绝对路径，不要依赖裸 PATH 命令；三个 Release 资产不会安装或激活该 launcher。详见[安装文档](docs/INSTALL.md)。
 
 关键限制：ae-mcp 默认通过 `127.0.0.1:11488` 连到 AE 面板，所以外部客户端必须和 After Effects 在同一台机器上，或者能访问 AE 所在机器的这个端口。OpenClaw、AstrBot 这类常驻或 Docker 化的 IM-bot 框架尤其要注意。
 
@@ -336,7 +338,7 @@ node scripts/live-model-matrix.mjs
 
 ## 打包与发布
 
-维护者只能通过受保护的 `build-rc.yml` 工作流生成 v0.9.2 资产。Mac arm64 与 Windows x64 的精确字节由 `artifact-manifest-v0.9.2.json` 绑定，通过 `macos-rc-attestation` 与 `windows-rc-attestation` 后，再由 `release.yml` 原样提升且不重新构建。签名凭据、再分发批准、AE 25/26 安装和 Windows x64 验证机都是外部前置条件；完整流程见 [docs/RELEASE.md](docs/RELEASE.md)。
+维护者先合并发布元数据，再从最终干净的受保护 `main` 提交构建 v0.9.3 Windows ZXP 与 AEX。两个资产分别签名、复验并生成 `SHA256SUMS-v0.9.3.txt`，通过 After Effects 2025 公开路径 smoke 后原样上传，不重新构建。完整流程见 [docs/RELEASE.md](docs/RELEASE.md)。
 
 ## 实现说明
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,34 +2,36 @@
 
 ## 中文
 
-### v0.9.2 状态与支持矩阵
+### v0.9.3 状态与支持矩阵
 
-v0.9.2 是 Windows x64 正式版本。Provider、Tool Library 与 Platform Helper 已完成实现，并通过 Windows AE 2025 实机验证。macOS、包内 RuntimeManager、正式跨平台签名链和完整 AE 25/26 实机矩阵转入 v0.9.3。
+v0.9.3 是 Windows x64 版本，CEP 面板与原生 AEX 作为两个独立签名资产发布。AEX 需要手动安装，本版继续使用现有外部 runtime/launcher；它不是零环境或只装 ZXP 即用的安装包。
 
 支持范围固定为：
 
 - Windows 11 24H2 或更高版本，x64；不支持 Windows ARM。
-- After Effects 25.x 已完成实机验证；AE 26 完整验收转入 v0.9.3。
+- After Effects 2025 是本次打包验收宿主；CEP manifest 仍允许 `[25.0,26.9]`。
 
 ### 普通用户：安装离线发布资产
 
-v0.9.2 的平台资产是：
+v0.9.3 的发布资产是：
 
-| 平台 | 安装资产 | 同组审计资产 |
-|---|---|---|
-| Windows x64 | `ae-mcp-panel-v0.9.2-windows-x64.zxp` | 同一个 ZXP |
+| 用途 | 发布资产 |
+|---|---|
+| CEP 面板 | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
+| 原生 AEGP 插件 | `AeMcpNative-v0.9.3-windows-x64.aex` |
+| 完整性校验 | `SHA256SUMS-v0.9.3.txt` |
 
-GitHub Release 同时给出 Windows ZXP 的 SHA-256。不要用源码归档、本地重建包、公共 PyPI 同名包或在线依赖安装替代它。
+不要用源码归档、本地重建包或公共 PyPI 同名包替代这些固定发布资产。
 
-1. 从 GitHub Release 下载 Windows ZXP，并对照发布说明校验 SHA-256。
-2. 使用受支持的 ZXP installer 安装下载的 ZXP。
-3. 重启 After Effects，打开 `Window -> Extensions -> ae-mcp`。
-4. 继续使用现有外部 runtime/launcher 配置；包内离线 RuntimeManager 转入 v0.9.3。
-5. 先运行 `ae_ping` / `ae_status`，再在测试工程执行只读与预览 smoke。
+1. 下载 ZXP、AEX 与 `SHA256SUMS-v0.9.3.txt`，先校验两个二进制。
+2. 使用受支持的 ZXP installer 安装 ZXP。
+3. 关闭全部 After Effects 实例。以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`。
+4. 保留并使用现有外部 runtime/launcher 配置；本版没有 Windows RuntimeManager。
+5. 重启 After Effects，打开 `Window -> Extensions -> ae-mcp`，先运行 `ae_ping` / `ae_status`，再在测试工程执行只读 smoke。
 
 在 Windows 上，平台 Helper 由 Panel 打开时自动启动，不由安装器预先常驻启动。关闭并重开 Panel 时，同一个 AE 会话可以重新连接现有 Helper；AE 正常退出或闪退后，Helper 随已认证的 AE 进程退出。启动、握手或凭据库失败时 Provider 凭据保持 fail-closed，不回退读取明文配置。
 
-升级会先把新 runtime 安装到独立版本目录并完成校验，成功后才原子切换 `current` pointer。失败时继续使用旧 runtime；回滚只切回已验证的 `previous` pointer，不在线重装依赖。
+一体化安装器、自动 AEX 部署、升级/修复/回滚/卸载生命周期与零环境首跑不属于 v0.9.3 Windows 发布范围。
 
 ### 可选 AI 通道依赖
 
@@ -62,7 +64,7 @@ GitHub Release 同时给出 Windows ZXP 的 SHA-256。不要用源码归档、�
 
 macOS 请把 `<USER>` 替换为实际账户名。Windows 请把 `command` 改成 `%USERPROFILE%\.ae-mcp\bin\ae-mcp.exe` 展开后的绝对路径。Panel 端口若有修改，也要同步修改 `AE_MCP_PLUGIN_URL`。
 
-上例是稳定 launcher 契约。v0.9.3 macOS Panel 会输出展开后的绝对路径，在启动 core 前由 RuntimeManager 离线校验并激活包内 runtime；它不会回退到裸 PATH 或在线 Homebrew/uv。Windows v0.9.2 行为保持不变。
+上例是稳定 launcher 契约。Windows v0.9.3 继续使用外部 runtime/launcher，不会从 ZXP 自动激活包内 runtime，也不会回退到在线安装器。
 
 ### 开发安装
 
@@ -96,42 +98,44 @@ Windows 开发机在完成相同依赖同步后运行：
 
 - Panel 不在菜单中：确认安装的是正确平台资产，重启 AE；开发模式才重新运行开发安装脚本。
 - Panel 未监听：检查 Panel 日志及 `127.0.0.1:11488` 端口占用。
-- launcher 不存在：重新运行首跑向导的离线修复，或查看诊断中的 RuntimeManager 错误；不要改用公共 PyPI 或临时系统 Python 旁路。
+- launcher 不存在：v0.9.3 三项资产不提供 runtime bootstrap；先恢复一套受支持的既有外部 runtime/launcher，再把本次安装视为完成。
 - CLI 通道不可用：检查对应的 Claude Code、Codex 或 ZCode CLI/app-server；这不应影响 core。
 - macOS 截图权限不足：按系统提示授权签名 helper 的 Screen Recording；`ae_previewFrame` 的 AE 原生路径应独立诊断。
-- 升级失败：保持旧 `current`，保存校验报告与日志，再回滚到 `previous`。
+- 需要回退发布资产：本版没有自动回滚状态；关闭 AE 后仅恢复用户自己保留且校验过的上一版 ZXP/AEX。
 - provider 配置、凭据与 Tool Library 属于用户数据；卸载或回滚不得静默删除它们。
 
 ## English
 
-### v0.9.2 Status and Support Matrix
+### v0.9.3 Status and Support Matrix
 
-v0.9.2 is the Windows x64 release. Provider, Tool Library, and Platform Helper implementation is complete and has passed Windows AE 2025 hardware validation. macOS, bundled RuntimeManager, the production cross-platform signing chain, and the complete AE 25/26 hardware matrix move to v0.9.3.
+v0.9.3 is a Windows x64 release with a separately signed CEP panel and native AEX. The AEX requires manual installation and the existing external runtime/launcher remains required. This is not a zero-environment or ZXP-only installation.
 
 The supported matrix is fixed to:
 
 - Windows 11 24H2 or newer on x64; no Windows ARM support.
-- After Effects 25.x is hardware-validated; complete AE 26 acceptance moves to v0.9.3.
+- After Effects 2025 is the packaged acceptance host; the CEP manifest remains `[25.0,26.9]`.
 
 ### Normal Users: Install an Offline Release Asset
 
-The v0.9.2 platform assets are:
+The v0.9.3 release assets are:
 
-| Platform | Install asset | Same-set audit asset |
-|---|---|---|
-| Windows x64 | `ae-mcp-panel-v0.9.2-windows-x64.zxp` | the same ZXP |
+| Role | Release asset |
+|---|---|
+| CEP panel | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
+| Native AEGP plug-in | `AeMcpNative-v0.9.3-windows-x64.aex` |
+| Integrity | `SHA256SUMS-v0.9.3.txt` |
 
-The GitHub Release lists the Windows ZXP SHA-256. Do not substitute a source archive, locally rebuilt package, public PyPI namesake, or online dependency install.
+Do not substitute a source archive, locally rebuilt package, or public PyPI namesake for these fixed assets.
 
-1. Download the Windows ZXP and verify its SHA-256 against the GitHub Release notes.
-2. Install it with a supported ZXP installer.
-3. Restart After Effects and open `Window -> Extensions -> ae-mcp`.
-4. Continue using the existing external runtime/launcher setup; bundled offline RuntimeManager moves to v0.9.3.
-5. Run `ae_ping` / `ae_status` first, followed by read-only and preview smoke in a test project.
+1. Download the ZXP, AEX, and `SHA256SUMS-v0.9.3.txt`; verify both binaries first.
+2. Install the ZXP with a supported ZXP installer.
+3. Close every After Effects instance. With administrator permission, copy the AEX to the selected host as `Support Files\Plug-ins\Extensions\AeMcpNative.aex`.
+4. Keep the existing external runtime/launcher configured; this release has no Windows RuntimeManager.
+5. Restart After Effects, open `Window -> Extensions -> ae-mcp`, and run `ae_ping` / `ae_status` followed by a read-only smoke in a test project.
 
 On Windows, the Panel starts Platform Helper when it opens; the installer does not prestart a resident Helper. Closing and reopening the Panel reconnects within the same AE session. Platform Helper exits when its authenticated AE process exits or crashes. Startup, handshake, or credential-store failures remain fail-closed and never fall back to plaintext provider configuration.
 
-An upgrade installs the new runtime into a separate version directory and verifies it before atomically switching the `current` pointer. Failure leaves the old runtime active; rollback switches to the verified `previous` pointer without downloading dependencies.
+An integrated installer, automatic AEX deployment, upgrade/repair/rollback/uninstall lifecycle, and zero-environment onboarding are outside the v0.9.3 Windows release.
 
 ### Optional AI Channel Dependencies
 
@@ -164,7 +168,7 @@ Use the installed stable launcher:
 
 On macOS, replace `<USER>` with the actual account name. On Windows, replace `command` with the expanded absolute path to `%USERPROFILE%\.ae-mcp\bin\ae-mcp.exe`. If the Panel port changes, update `AE_MCP_PLUGIN_URL` too.
 
-This is the stable-launcher contract. The v0.9.3 macOS Panel emits the expanded absolute path and asks RuntimeManager to verify and activate the bundled runtime offline before starting core; it never falls back to bare PATH or online Homebrew/uv. Windows v0.9.2 behavior is unchanged.
+This is the stable-launcher contract. Windows v0.9.3 continues to use an external runtime/launcher; the ZXP does not automatically activate a bundled runtime or fall back to an online installer.
 
 ### Developer Install
 
@@ -223,8 +227,8 @@ Retention keeps the newest three migration backups within the 30-day policy wind
 
 - Panel missing: confirm the correct platform asset was installed and restart AE; rerun a dev installer only in development mode.
 - Panel not listening: inspect Panel logs and the process using `127.0.0.1:11488`.
-- Launcher missing: rerun the first-run wizard's offline repair or inspect the RuntimeManager diagnostic; do not bypass it with a public PyPI package or ad-hoc system Python.
+- Launcher missing: the three v0.9.3 assets do not bootstrap a runtime. Restore a supported existing external runtime/launcher before treating this installation as complete.
 - Optional channel unavailable: inspect the corresponding Claude Code, Codex, or ZCode CLI/app-server; core should remain usable.
 - macOS capture permission missing: grant Screen Recording to the signed helper when prompted; diagnose the AE-native `ae_previewFrame` path separately.
-- Upgrade failure: keep the old `current`, retain verification evidence and logs, then roll back to `previous`.
+- To revert release assets: this release has no automatic rollback state. Close AE and restore only a user-retained, checksum-verified previous ZXP/AEX.
 - Provider settings, credentials, and Tool Library data are user data; uninstall or rollback must not silently delete them.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -10,11 +10,13 @@
 | Preview 输出 | 默认位于操作系统临时目录的 `ae_mcp_previews/<session>/...png`，可用 `out_dir` 覆盖 |
 | Checkpoint 存储 | 操作系统临时目录下的 `ae_mcp_checkpoints/<basename>/<id>.aep + .json` |
 
-### v0.9.2 平台与分发契约
+### v0.9.3 平台与分发契约
 
-v0.9.2 是 Windows x64 正式版本，安装资产为
-`ae-mcp-panel-v0.9.2-windows-x64.zxp`。macOS、包内 RuntimeManager、
-正式跨平台签名链和完整 AE 25/26 实机矩阵转入 v0.9.3。
+v0.9.3 是 Windows x64 版本。固定发布资产为
+`ae-mcp-panel-v0.9.3-windows-x64.zxp`、
+`AeMcpNative-v0.9.3-windows-x64.aex` 与 `SHA256SUMS-v0.9.3.txt`。
+AEX 需手动复制到所选 AE 插件目录；现有外部 runtime/launcher 仍是前置条件。
+本版不提供一体化安装器、Windows RuntimeManager 或零环境首跑。
 
 Claude Code CLI、Codex CLI 与 ZCode CLI/app-server 都只是对应 AI 通道的
 **可选**依赖，不是 Core 或两个执行入口的前置条件。
@@ -201,12 +203,14 @@ uv run python scripts/generate_native_exec.py --check
 | Preview output | `ae_mcp_previews/<session>/...png` in the operating-system temporary directory unless `out_dir` is set |
 | Checkpoint store | `ae_mcp_checkpoints/<basename>/<id>.aep + .json` under the operating-system temporary directory |
 
-### v0.9.2 platform and distribution contract
+### v0.9.3 platform and distribution contract
 
-v0.9.2 is the Windows x64 release. Its install asset is
-`ae-mcp-panel-v0.9.2-windows-x64.zxp`. macOS, bundled RuntimeManager,
-the production cross-platform signing chain, and the complete AE 25/26
-hardware matrix move to v0.9.3.
+v0.9.3 is a Windows x64 release. Its fixed assets are
+`ae-mcp-panel-v0.9.3-windows-x64.zxp`,
+`AeMcpNative-v0.9.3-windows-x64.aex`, and `SHA256SUMS-v0.9.3.txt`.
+Install the AEX manually in the selected AE plug-in directory and retain the
+existing external runtime/launcher. This release has no integrated installer,
+Windows RuntimeManager, or zero-environment onboarding.
 
 Claude Code CLI, Codex CLI, and the ZCode CLI/app-server are **optional**
 dependencies for their corresponding AI channels, not prerequisites for Core

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,214 +1,100 @@
-# v0.9.2 Windows 发布与后续双平台设计 / Windows Release and Deferred Dual-Platform Design
-
-> **2026-07-13 范围调整 / Scope override:** v0.9.2 只发布 Windows 11 x64 ZXP；macOS、包内 RuntimeManager、正式跨平台签名链与完整四格实机矩阵转入 v0.9.3。下方双平台流程保留为后续硬化设计记录，不是本次 v0.9.2 发布声明。Windows ZXP 使用有效至 2037 年的自签名证书，但没有 TSA 时间戳；包内 Helper 二进制尚未进行 Authenticode 签名。
+# v0.9.3 Windows 最小发布 / Minimal Windows Release
 
 ## 中文
 
-### 1. 状态与原则
+### 固定资产
 
-v0.9.2 按上方范围调整发布 Windows-only 资产。以下不可变双平台 RC 流程不用于本次 tag；它作为 v0.9.3 跨平台签名、硬件矩阵与 no-rebuild 晋级流程的设计基线保留。
-
-固定发布资产：
+v0.9.3 只发布以下三个文件：
 
 ```text
-ae-mcp-panel-v0.9.2-macos-arm64.zxp
-ae-mcp-panel-v0.9.2-macos-arm64.dmg
-ae-mcp-panel-v0.9.2-windows-x64.zxp
-artifact-manifest-v0.9.2.json
+ae-mcp-panel-v0.9.3-windows-x64.zxp
+AeMcpNative-v0.9.3-windows-x64.aex
+SHA256SUMS-v0.9.3.txt
 ```
 
-两个平台资产来自同一个 candidate SHA。任一平台失败、候选代码变化、依赖/签名变化或 artifact 不一致时，当前候选永久拒绝；修复必须产生新 SHA、新 build run、新 artifact 和两份新 attestation。
-
-### 2. 外部前置条件
-
-macOS foundation workflow 与两项 RC verifier 实现现已存在。approval 与 product-acceptance selector 仍有意保持 `blocked`；在另行评审的真实签名证据和 AE/Windows 硬件证据提供之前，credentialed RC 无法通过。
-
-触发签名 RC 前必须逐项确认：
-
-- revised “条件式 A→B” signed-helper architecture 已取得明确批准，并完成其 Phase 0 签名/可行性证据；未批准时不得实现或声称 helper、Tool Library、provider route 已闭环。
-- `packaging/native-coverage-approvals.json` 当前保持 `blocked`。未来即使 helper build 单独落地，也必须另行提供并批准逐文件 Mac/Windows 原生签名复验、AE 25/26 双平台实机矩阵，以及 `provider-header-routing`、Tool Library、持久化、升级回滚和权限恢复的完整验收覆盖；缺少任一项时 build guard 在不可逆 candidate lock 之前失败。
-- 所有 helper-gated provider route 与 Tool Library 实现、测试、凭据防泄露评审和发布完整性评审已经在 candidate 中完成；版本文档不能替代实现证据。
-- protected `main`、required checks、allowlisted attestation 身份、protected Environment reviewer 和一次性 candidate build lock 已配置并验证。
-- GitHub 标签规则集（tag ruleset）必须阻止除晋级身份外创建、更新或删除 `v*` tag；从 mutation-adjacent 复核开始到公开后审计结束，maintainer 必须对 `main` 执行外部合并冻结。workflow 的 API 重读只能检测竞态，不能原子化替代标签规则集或合并冻结。
-- 仓库已启用 GitHub Immutable Releases；protected `release-promotion` Environment 提供仅具 repository administration-read 的 `AE_MCP_RELEASE_ADMIN_TOKEN`，用于在 tag/publish 前读取该设置，不能用普通 contents token 或布尔占位替代。
-- attestation Check 的 `details_url` 必须指向处理 active comment 的精确 `actions/runs/<run-id>/attempts/<attempt>`。promotion 会复核 run ID、attempt、`.github/workflows/attestation.yml` path、candidate head SHA 与 workflow blob；在 attestation writer 尚未提供这份 provenance 前必须 fail closed。
-- Adobe ZXP 证书、Apple Developer ID/notary 凭据、Windows Authenticode 证书只存在 protected CI environment；本地文档或日志中不得出现 secret。
-- repository variable `AE_MCP_ZXP_CERT_FINGERPRINT_SHA256` 已设为实际 Adobe ZXP 签名证书 DER 编码的 64 位小写 SHA-256 指纹；它不是占位值，且必须与两个平台 ZXP 内嵌证书一致。
-- 便携 Node、CPython、原生 helper、npm/Python 依赖及 Windows runtime 的许可证与再分发依据已经审计并获准；缺失或受限证据必须 fail closed。
-- Mac arm64 上可用 AE 25.x、26.x；Windows 11 24H2 x64 验证机上可用 AE 25.x、26.x。
-- `ZXPSignCmd`、Apple 公证工具、Windows SignTool/PowerShell 以及签名 runner 架构满足锁定版本与平台要求。
-- Windows Codex 可读取候选与指定 build artifact，并以 allowlisted GitHub 身份在 release coordination PR 下评论。
-- Claude Code CLI、Codex CLI、ZCode CLI/app-server 只用于各自的可选通道 smoke；缺少某个可选 CLI 不改变核心离线包的定义，但若 release scope 承诺该通道就必须提供对应测试环境。
-
-任何前置条件缺失都可以继续做无关单元工作，但不得创建最终 tag 或公开任一平台资产。
-
-### 3. 候选前检查
-
-1. release coordination PR 按正常评审合入 protected `main`；合入后的 40 位小写 SHA 才是 candidate。
-2. 确认所有 active package、lock、Panel 与 CEP manifest 版本为 `0.9.2`，Host range 精确为 `[25.0,26.9]`。
-3. 在干净 checkout 运行：
-
-   ```bash
-   node --test scripts/release/test/version-consistency.test.mjs
-   uv run pytest -q
-   (cd plugin/host && npm test)
-   (cd plugin/panel && npm test)
-   (cd plugin/sidecar && npm test)
-   ```
-
-4. 确认 runtime lock、SBOM、license inventory、bundle manifest、signing plan 与 Phase 0 evidence 都绑定该 SHA；restricted/unknown license 不得用占位批准绕过。
-5. 合入后不再 squash、rebase 或修改 candidate；任何修复走新 PR。
-
-### 4. 一次构建两个签名平台包
-
-从 protected 默认分支手动触发 `.github/workflows/build-rc.yml`，输入精确 `candidate_sha` 与 `version=0.9.2`。workflow 必须：
-
-- 验证 candidate 可达 protected `main`、trusted workflow revision 和 runner 架构；
-- 为 candidate 获取一次性 build lock；失败或取消也不得重用该 SHA；
-- 在原生 Mac arm64 与 Windows x64 job 中验证 deterministic stage，完成 nested signing、ZXP 签名和平台验证；
-- 在 Mac job 生成、签名、公证并 staple DMG；
-- 生成 `artifact-manifest-v0.9.2.json`，同时内嵌未签名 source bundle manifest 与签名后的 final bundle manifest，以及 runtime/SBOM/license/signing evidence，并记录 run ID、artifact ID 与 SHA-256；
-- 上传上方四个固定名字的 RC 资产；另有两个固定名字、保留 30 天的内部 signer preflight artifact，用于覆盖 protected Environment 审批延迟；它们不属于 Release 资产，即使过期、清理或缺失也不影响四个晋级资产的有效性与下载。
-
-签名 job 不从开放版本范围执行在线 `npm install`/`pip install`，也不接受 fork、未保护 branch 或本地重建的 payload。
-
-### 5. 下载精确 artifact 并完成四格验收
-
-所有验证者记录 build workflow run ID 与 artifact ID，从该 run 下载资产，先按 `artifact-manifest-v0.9.2.json` 校验 digest。禁止在验证机重建被测包。
-
-Mac 验证者向 `scripts/release/verify-rc-macos.sh` 提供另行安装的受支持 ZXP installer；wrapper 校验 DMG/ZXP hash、nested codesign、Gatekeeper、公证/staple、精确安装载荷与稳定 launcher。Mac 和 Windows wrapper 随后分别在 AE 25.x、26.x 中运行六项 installed-runtime 检查：`initialize`、`tools/list`、`ae.status`、`ae.diagnose`、`ae.previewFrame`、`ae.snapshot`，并生成各自 canonical attestation。
-
-这组 wrapper 检查不是完整产品验收。独立的 product-acceptance policy 当前仍为 `blocked`；`packaging/product-acceptance-coverage.json` 必须另行、逐项提供全新安装/升级回滚、权限拒绝/恢复、持久化、provider header routing 与 Tool Library 证据。build guard 会在不可逆 candidate lock 前拒绝缺失覆盖。只有 wrapper 两个 AE major 的精确载荷 smoke、独立产品覆盖和相应 GUI/实机证据全部满足，才算四格验收完成。
-
-Windows 验证者使用 [固定 Codex 提示词](WINDOWS_CODEX_RC_PROMPT.md) 与 `scripts/release/verify-rc-windows.ps1`，生成 canonical `windows-attestation.json`，并在当前 PR 留下人类可读结果和机器 marker。Windows Codex 只测试与评论，不修改代码；它不得把六项 wrapper smoke 描述成 provider/Tool Library/升级回滚已经验收。
-
-### 6. 双 attestation Check
-
-`.github/workflows/attestation.yml` 只接受与 candidate、build run、artifact ID/name/digest 完全一致的 canonical report，并在 protected Environment 审批后维护两个 Check：
+ZXP 安装 CEP 面板；AEX 由用户在关闭全部 AE 实例后，手动复制为所选宿主的
+`Support Files\Plug-ins\Extensions\AeMcpNative.aex`。After Effects 2025 的典型完整路径是：
 
 ```text
-macos-rc-attestation
-windows-rc-attestation
+C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\Extensions\AeMcpNative.aex
 ```
 
-Check 必须绑定 candidate SHA。Windows 评论作者必须在 allowlist 中；评论编辑/删除或同一身份后续有效 `FAIL` 会立即使旧 PASS 失效。任一 Check 缺失、非 success、绑定错误或 evidence 不完整，都不得进入 promotion。
+此 Release 仅适用于已经配置好受支持外部 `ae-mcp` runtime/launcher 的 Windows 环境。
+三个发布文件不包含外部 runtime 的 bootstrap；清洁环境仅安装这些文件不能完整使用产品。
 
-### 7. No-rebuild 原样提升
+### 构建与发布顺序
 
-只有两个 attestation Check 都有效时，才触发 `.github/workflows/release.yml`，输入 `candidate_sha`、`build_run_id` 与 `version=0.9.2`。promotion job 必须：
+1. 将 0.9.3 版本、范围和安装说明合并到受保护 `main`。
+2. 只从最终干净 `main` 提交构建 Windows x64 ZXP 与 AEX；不得把旧 0.9.2 二进制改名。
+3. 使用锁定 Adobe SDK 输入构建 AEX，并验证 PE x64、`AeMcpNativeMain`、版本和源码提交。
+4. 为本次发布新建自签名身份，分别签名并复验 ZXP 与 AEX；AEX 使用 RFC 3161 时间戳。
+5. 生成 `SHA256SUMS-v0.9.3.txt`，绑定两个最终签名二进制。
+6. 在 After Effects 2025 上安装最终资产并通过公开 MCP 路径运行只读实机 smoke。
+7. 创建 `v0.9.3` tag 与 GitHub Release，上传已验证的原始字节；发布阶段不重新构建。
 
-1. 从指定 build run 下载原始 RC artifacts，不运行 build 或签名步骤。
-2. 重新校验 manifest 的 version、candidate SHA、workflow run/artifact ID、平台、文件名与 SHA-256。
-3. 验证两个 attestation Check 仍为 success 且绑定相同 SHA/digest。
-4. 创建指向 candidate 的 annotated `v0.9.2` tag；若 tag 已指向其他 SHA则失败。
-5. 先创建 draft GitHub Release，上传精确三个安装/载荷资产及 manifest，再从 release 下载并复算 SHA-256。
-6. 所有复核通过后才公开 Release；失败时保持 draft/失败状态，不发布部分平台。
+### 明确非目标
 
-晋级 workflow 固定使用 Node `24.17.0` 与完整 commit SHA 的 Actions，并在 protected `release-promotion` Environment 中运行。两个内部 preflight artifact 可已过期或被 GitHub 清理而缺失；四个固定 RC artifact 必须唯一、未过期、ID/大小有效，且晋级只下载这四个精确 artifact ID。若 preflight artifact 仍在 inventory 中，只允许两个锁定名称各出现一次；任何未知或重复 artifact 都 fail closed。仅凭 artifact 名、Check 名或绿色状态不足以放行。
+本版不是零环境安装，不新增一体化安装器、自动 AEX 部署、Windows RuntimeManager、
+新 CI/runner 拓扑、私有制品服务、升级/修复/回滚/卸载生命周期、macOS 资产或 Windows ARM。
+ZXP installer 不会把 AEX 安装到 AE 原生插件目录。
 
-创建 tag 前，workflow 会解析两个 deterministic Check 的 external ID、GitHub Actions App ID、canonical state、`candidateRejected=false`、active artifact ID/digest 与 active comment ID。GitHub Actions App ID 是共享身份，不能单独证明来源，因此还必须复核 Check 绑定的 workflow run ID、attempt、path 与 SHA。随后按该 comment ID 重新读取当前 PR 评论，并重新验证 `updated_at`、作者 allowlist、正文 marker、canonical PASS report、PR 归属和完整 candidate/run/artifact 身份；它会分页读取该 PR 的全部 canonical attestation 评论，并用与 attestation workflow 相同的 reconciliation 规则独立重算两个平台状态。对 candidate SHA 的每个 attestation workflow run，latest attempt 必须是 `completed+success`；queued/running/cancelled/failure/timed-out/action-required/stale 都会阻断，直至成功重跑同一 run。任何匹配当前 candidate/artifact 的有效 `FAIL` 也会阻断。评论不存在、被编辑、作者变化或正文不再匹配时立即失败。创建 tag reference 与公开 draft 紧前会再次读取 main/tag、同一评论、完整评论历史、Check/provenance、build lock、release/asset inventory 与 immutable-releases gate；tag 已创建不构成发布授权。
+ZXP 与 AEX 的自签名可证明签名后字节未变化，但不建立操作系统默认信任的公开发布者；
+安装时可能显示未知或不受信任发布者提示。
 
-失败后的重复晋级只允许使用完全相同的 candidate、build run 和 bytes，且 candidate 仍须是 current protected `main`：正确的 annotated tag 可复用；workflow 通过 `listReleases` 找到唯一 draft/published 并持久绑定 release ID，之后只按 release/asset ID 操作。已存在 draft 中每个资产必须先下载并匹配摘要，workflow 只追加缺失资产，绝不删除、替换或 `--clobber`。上传后记录 asset ID/name/size/更新时间，重新下载四个资产（包括 manifest）并逐一复算摘要，且在公开前再次确认该 inventory 未变化。公开动作紧前会再次复核 main、tag、Check/comment/run、build lock、release identity、asset inventory 与 immutable-releases 设置；公开后会重新读取并证明 tag 仍指向 candidate、main 未移动、同一证据仍有效、资产 inventory 未变化且 Release 为 `immutable=true`。若 Release 已公开，重复触发仅执行同一套只读一致性审计。任何缺失或差异都 fail closed。
+校验示例：
 
-tag 后不得修改 candidate 文件。文档修订进入后续版本，不能改写已经 attested 的 v0.9.2 字节。
-
-### 8. 失败、撤销与证据
-
-- build、签名、公证、license、四格 AE、provider/Tool Library、attestation 或 promotion 任一步失败，candidate 都不能发布。
-- 保存 canonical manifest、Mac/Windows reports、Check URL、workflow run/artifact ID、签名/许可证证据和最终 release digest。
-- provider 配置和凭据不可导出；诊断/attestation 只记录脱敏元数据。
-- issue/PR 关闭评论必须链接实际测试与 artifact 证据，不能用“自动化已过”代替 AE 实机结果。
+```powershell
+Get-FileHash .\ae-mcp-panel-v0.9.3-windows-x64.zxp -Algorithm SHA256
+Get-FileHash .\AeMcpNative-v0.9.3-windows-x64.aex -Algorithm SHA256
+```
 
 ## English
 
-### 1. Status and Invariant
+### Fixed assets
 
-v0.9.2 publishes the Windows-only asset under the scope override above. The immutable dual-platform RC flow below is not used for this tag; it remains the design baseline for v0.9.3 cross-platform signing, hardware acceptance, and no-rebuild promotion.
-
-Fixed assets:
+v0.9.3 publishes exactly these files:
 
 ```text
-ae-mcp-panel-v0.9.2-macos-arm64.zxp
-ae-mcp-panel-v0.9.2-macos-arm64.dmg
-ae-mcp-panel-v0.9.2-windows-x64.zxp
-artifact-manifest-v0.9.2.json
+ae-mcp-panel-v0.9.3-windows-x64.zxp
+AeMcpNative-v0.9.3-windows-x64.aex
+SHA256SUMS-v0.9.3.txt
 ```
 
-Both platforms come from one candidate SHA. Any platform failure, source change, dependency/signing change, or artifact mismatch permanently rejects that candidate. A fix requires a new SHA, build run, artifact set, and dual attestations.
-
-### 2. External Prerequisites
-
-The macOS foundation workflow and both RC verifier implementations are present. The approval and product-acceptance selectors intentionally remain `blocked`; a credentialed RC cannot pass until separately reviewed real signature and AE/Windows hardware evidence is supplied.
-
-Before a signed RC is triggered, verify all of the following:
-
-- The revised conditional A→B signed-helper architecture has explicit approval and Phase 0 signing/feasibility evidence. Until then, no helper, Tool Library, or provider-route closure may be implemented or claimed through release documentation.
-- `packaging/native-coverage-approvals.json` intentionally remains `blocked`. Landing the helper build alone never unlocks an RC: separately approved per-file Mac/Windows native-signature verification, the AE 25/26 hardware matrix, and complete provider-header-routing, Tool Library, persistence, upgrade/rollback, and permission-recovery acceptance coverage are all required before the irreversible candidate lock.
-- All approved helper-gated provider route and Tool Library implementation, tests, credential-leak review, and release-integrity review are present in the candidate; version metadata is not implementation evidence.
-- Protected `main`, required checks, allowlisted attestation identities, protected Environment reviewers, and the one-build-per-candidate lock are configured and tested.
-- A GitHub tag ruleset blocks every identity except promotion from creating, updating, or deleting `v*` tags, and maintainers enforce an external `main` merge freeze from mutation-adjacent revalidation through the post-publication audit. API rereads detect races but cannot atomically replace the tag ruleset or merge freeze.
-- GitHub Immutable Releases is enabled. The protected `release-promotion` Environment supplies `AE_MCP_RELEASE_ADMIN_TOKEN` with repository administration-read only so the workflow can read that setting before tag and publish; a contents token or boolean placeholder is not sufficient.
-- Each attestation Check `details_url` points to the exact `actions/runs/<run-id>/attempts/<attempt>` that processed its active comment. Promotion revalidates the run ID, attempt, `.github/workflows/attestation.yml` path, candidate head SHA, and workflow blob; until the attestation writer emits that provenance, promotion fails closed.
-- Adobe ZXP, Apple Developer ID/notary, and Windows Authenticode credentials exist only in protected CI environments.
-- Repository variable `AE_MCP_ZXP_CERT_FINGERPRINT_SHA256` is the 64-character lowercase SHA-256 fingerprint of the real Adobe ZXP signing certificate's DER encoding. It is not a placeholder and must match the embedded certificate in both platform ZXP files.
-- Redistribution evidence for portable Node, CPython, the native helper, npm/Python dependencies, and Windows runtimes is audited and approved; missing or restricted evidence fails closed.
-- AE 25.x and 26.x are available on both a Mac arm64 verifier and a Windows 11 24H2 x64 verifier.
-- Locked `ZXPSignCmd`, Apple notarization tools, Windows SignTool/PowerShell, and native signing runner architectures are available.
-- Windows Codex can read the exact candidate/artifact and comment through an allowlisted GitHub identity on the release coordination PR.
-- Claude Code CLI, Codex CLI, and the ZCode CLI/app-server are optional channel dependencies. A promised channel still needs its corresponding smoke environment, but the core offline package must not depend on these CLIs.
-
-A missing prerequisite may leave unrelated unit work in progress, but it forbids a final tag or public platform asset.
-
-### 3. Candidate Preflight
-
-1. Merge the reviewed release coordination PR into protected `main`; the resulting 40-lowercase-hex commit is the candidate.
-2. Confirm all active package, lock, Panel, and CEP manifest versions are `0.9.2`, with exact host range `[25.0,26.9]`.
-3. Run the version, Python, host, Panel, and sidecar suites from a clean checkout.
-4. Confirm runtime locks, SBOM, license inventory, bundle manifest, signing plan, and Phase 0 evidence are bound to that SHA. Never replace restricted/unknown license approval with a placeholder.
-5. Do not squash, rebase, or mutate the candidate after merge; fixes use a new PR.
-
-### 4. Build Both Signed Platforms Once
-
-Dispatch `.github/workflows/build-rc.yml` from the protected default branch with exact `candidate_sha` and `version=0.9.2`. It verifies candidate/trusted-workflow identity and native runner architecture, acquires the one-time build lock, signs native Mac/Windows payloads, creates the notarized/stapled DMG, embeds both the unsigned source and frozen final bundle manifests with the remaining supply-chain/signing evidence, and uploads the four fixed RC artifact names above. Two separately named, 30-day signer-preflight artifacts cover protected Environment approval delays and are not Release assets; their expiry or absence does not affect the four promotion assets or their download.
-
-Signing jobs consume locked offline inputs. They do not resolve open npm/Python ranges, accept fork/unprotected payloads, or substitute locally rebuilt files.
-
-### 5. Download Exact Artifacts and Run the Four Cells
-
-Each verifier downloads the named artifact from the recorded workflow run/artifact ID and verifies it against `artifact-manifest-v0.9.2.json`; the verification machine never rebuilds the package under test.
-
-The Mac verifier supplies a separately installed supported ZXP installer to `scripts/release/verify-rc-macos.sh`. The wrapper verifies the DMG/ZXP digest, nested signatures, Gatekeeper/notarization/staple, exact installed payload, and stable launcher. Both platform wrappers then run exactly six installed-runtime checks in AE 25.x and AE 26.x: `initialize`, `tools/list`, `ae.status`, `ae.diagnose`, `ae.previewFrame`, and `ae.snapshot`, and emit their canonical attestations.
-
-Those wrapper checks are not full product acceptance. The separate product-acceptance policy remains `blocked`; `packaging/product-acceptance-coverage.json` must independently supply clean-install/upgrade/rollback, permission denial/recovery, persistence, provider-header routing, and Tool Library evidence. The build guard rejects missing coverage before the irreversible candidate lock. A four-cell result requires the exact-payload wrapper smoke for both AE majors plus that independent product and GUI/hardware evidence.
-
-The Windows verifier uses [the fixed Codex prompt](WINDOWS_CODEX_RC_PROMPT.md) and `scripts/release/verify-rc-windows.ps1` on Windows 11 24H2 x64. It emits canonical `windows-attestation.json` and posts the human plus machine-readable result to the current PR. Windows Codex tests and comments only; it must not describe the six-check wrapper as provider/Tool Library/upgrade acceptance.
-
-### 6. Dual Attestation Checks
-
-`.github/workflows/attestation.yml` accepts only canonical reports that exactly match candidate, build run, artifact ID/name, and digest. Protected approval maintains:
+The ZXP installs the CEP panel. With every AE instance closed, copy the AEX manually to the
+selected host as `Support Files\Plug-ins\Extensions\AeMcpNative.aex`. A typical complete
+After Effects 2025 path is:
 
 ```text
-macos-rc-attestation
-windows-rc-attestation
+C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\Extensions\AeMcpNative.aex
 ```
 
-Checks bind to the candidate SHA. The Windows author must be allowlisted, and comment edit/delete or a later valid FAIL invalidates the old PASS. A missing, stale, non-success, or mismatched Check blocks promotion.
+This Release applies only to Windows environments that already have a supported external
+`ae-mcp` runtime/launcher configured. The three assets do not bootstrap that external runtime;
+a clean environment cannot obtain full product operation by installing only these files.
 
-### 7. No-Rebuild Promotion
+### Build and publication order
 
-Only after both Checks succeed, dispatch `.github/workflows/release.yml` with `candidate_sha`, `build_run_id`, and `version=0.9.2`. It downloads the original RC artifacts, revalidates manifest identity and hashes, confirms both Checks, creates `v0.9.2` at the candidate, uploads a draft Release, downloads the published assets for another digest comparison, and publishes only after all comparisons pass. It contains no build or signing step.
+1. Merge the 0.9.3 version, scope, and installation documentation into protected `main`.
+2. Build the Windows x64 ZXP and AEX only from the final clean `main` commit; never rename a 0.9.2 binary.
+3. Build the AEX from locked Adobe SDK inputs and verify PE x64, `AeMcpNativeMain`, version, and source commit.
+4. Create new self-signed identities for this release, then sign and reverify the ZXP and AEX separately; use an RFC 3161 timestamp for the AEX.
+5. Generate `SHA256SUMS-v0.9.3.txt` over the two final signed binaries.
+6. Install the final assets in After Effects 2025 and run a read-only smoke through the public MCP surface.
+7. Create the `v0.9.3` tag and GitHub Release and upload the verified bytes without rebuilding.
 
-Promotion runs behind the protected `release-promotion` Environment with Node `24.17.0` and commit-pinned Actions. The two internal preflight artifacts may be expired or already purged; all four fixed RC artifacts must remain unique, unexpired, and valid, and only their four exact IDs are downloaded. If preflight artifacts remain in the run inventory, only the two locked names are allowed once each; any duplicate or unknown artifact fails closed. A matching name, Check name, or green conclusion alone is never sufficient.
+### Explicit non-goals
 
-Before creating the tag, the workflow validates each deterministic Check's external ID, GitHub Actions App ID, canonical state, `candidateRejected=false`, active artifact ID/digest, and active comment ID. The GitHub Actions App ID is shared and is not sufficient provenance by itself, so the bound workflow run ID, attempt, path, and SHA are also revalidated. It then fetches the current PR comment by ID and revalidates its `updated_at`, allowlisted author, body marker, canonical PASS report, PR ownership, and full candidate/run/artifact identity. It paginates every current canonical attestation comment and independently recomputes both platform states with the attestation workflow's reconciliation rule. For every attestation workflow run at the candidate SHA, the latest attempt must be `completed+success`; queued, running, cancelled, failed, timed-out, action-required, or stale attempts block until that run is rerun successfully. Any valid `FAIL` for the candidate/artifact also blocks promotion. A missing, edited, re-authored, or mismatched comment fails closed. Immediately before the tag reference and draft publication calls, it rechecks protected main/tag, the active and complete comment history, Check/run provenance, build lock, release/asset inventory, and immutable-releases gate; an already-created tag is not release authorization.
+This is not a zero-environment release. It adds no integrated installer, automatic AEX deployment,
+Windows RuntimeManager, new CI/runner topology, private artifact service, upgrade/repair/rollback/uninstall
+lifecycle, macOS asset, or Windows ARM support. A ZXP installer does not install the AEX in AE's native
+plug-in directory.
 
-A failed promotion may resume only with the identical candidate, build run, and bytes while that candidate remains current protected `main`. A correct annotated tag is reusable. The workflow discovers exactly one draft/published release with `listReleases`, persists its release ID, and thereafter operates only by release/asset ID. Every asset already present in a draft is downloaded and digest-checked first; the workflow may append missing assets but never deletes, replaces, or uses `--clobber`. After upload it snapshots every asset ID/name/size/update time, downloads all four assets including the manifest, and recalculates every digest. Immediately before publication it revalidates main, tag, Check/comment/run evidence, the build lock, release identity, asset inventory, and immutable-releases setting. After publication it rereads the same evidence and proves that the tag still targets the candidate, main has not moved, assets are unchanged, and the Release is `immutable=true`. Re-dispatching an already-published release performs the same read-only audit; any missing or changed state fails closed.
+The self-signed ZXP and AEX signatures prove that the bytes have not changed since signing, but they
+do not establish a publicly trusted publisher. Installation may show an unknown or untrusted publisher warning.
 
-Files at the attested tag are immutable. Later documentation corrections belong to a later version.
+Verification example:
 
-### 8. Failure and Evidence
-
-- Any build, signing, notarization, license, four-cell AE, provider/Tool Library, attestation, or promotion failure blocks both platforms.
-- Retain the canonical manifest, Mac/Windows reports, Check URLs, workflow run/artifact IDs, signing/license evidence, and final release digests.
-- Provider configuration and credentials are not exportable; diagnostics and attestations contain redacted metadata only.
-- Issue/PR closure links concrete tests and artifact evidence. Automated green status never substitutes for AE hardware acceptance.
+```powershell
+Get-FileHash .\ae-mcp-panel-v0.9.3-windows-x64.zxp -Algorithm SHA256
+Get-FileHash .\AeMcpNative-v0.9.3-windows-x64.aex -Algorithm SHA256
+```

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -2,21 +2,16 @@
 
 ## 中文
 
-这份文档描述 v0.9.2 的执行工作流。Windows x64 安装资产是
-`ae-mcp-panel-v0.9.2-windows-x64.zxp`；使用受支持的 ZXP installer 安装。
+这份文档描述 v0.9.3 的执行工作流。Windows x64 发布资产是
+`ae-mcp-panel-v0.9.3-windows-x64.zxp`、
+`AeMcpNative-v0.9.3-windows-x64.aex` 与 `SHA256SUMS-v0.9.3.txt`。
+使用受支持的 ZXP installer 安装面板，并手动把 AEX 复制到所选 AE 插件目录。
 Claude Code CLI、Codex CLI 与 ZCode CLI/app-server 都是相应 AI 通道的
 **可选**依赖，不是 Core 或 AE 执行的前置条件。
 
-稳定 launcher 配置使用展开后的绝对路径
-`/Users/<USER>/.ae-mcp/bin/ae-mcp`。v0.9.3 macOS RuntimeManager 在启动 Core
-前校验并激活包内 runtime，且不会回退到裸 PATH；Windows v0.9.2 行为保持不变。
-
-### Attestation Check provenance（外部前置）
-
-GitHub Actions App 由同仓库 workflow 共享。attestation workflow 生成的 Check
-使用该 App，但共享身份不能单独证明写入来自指定 workflow。因此发布的外部前置条件是：
-仓库策略和评审必须防止不受信任的同仓库 workflow 获得 `checks:write`。无法证明
-该限制时，attestation Check 不能作为发布授权。
+Windows v0.9.3 继续使用现有外部 runtime/launcher，不提供 Windows RuntimeManager、
+一体化安装器或零环境首跑。macOS 的稳定 launcher 配置使用展开后的绝对路径
+`/Users/<USER>/.ae-mcp/bin/ae-mcp`，不会回退到裸 PATH。
 
 ### 1. 选择执行路径
 
@@ -106,25 +101,19 @@ uv run python scripts/generate_native_exec.py --check
 
 ## English
 
-This document describes the v0.9.2 execution workflow. The Windows x64 install
-asset is `ae-mcp-panel-v0.9.2-windows-x64.zxp`. Install it with a supported ZXP installer.
+This document describes the v0.9.3 execution workflow. The Windows x64 assets
+are `ae-mcp-panel-v0.9.3-windows-x64.zxp`,
+`AeMcpNative-v0.9.3-windows-x64.aex`, and `SHA256SUMS-v0.9.3.txt`.
+Install the panel with a supported ZXP installer and copy the AEX manually to
+the selected AE plug-in directory.
 Claude Code CLI, Codex CLI, and the ZCode CLI/app-server are **optional**
 dependencies for their corresponding AI channels, not prerequisites for Core
 or AE execution.
 
-The stable launcher configuration uses the expanded absolute path
-`/Users/<USER>/.ae-mcp/bin/ae-mcp`. The v0.9.3 macOS RuntimeManager verifies and
-activates the packaged runtime before starting Core and never falls back to
-bare PATH; Windows v0.9.2 behavior is unchanged.
-
-### Attestation Check Provenance (External Prerequisite)
-
-The GitHub Actions App is shared by workflows in the same repository. Checks
-created by the attestation workflow use that App, but its shared identity alone
-cannot prove which workflow wrote a Check. A release external prerequisite is
-a repository policy and review boundary that prevents untrusted same-repository
-workflows from receiving `checks:write`. Without that restriction, an
-attestation Check is not release authorization.
+Windows v0.9.3 retains the existing external runtime/launcher and has no Windows
+RuntimeManager, integrated installer, or zero-environment onboarding. The macOS
+stable launcher uses the expanded absolute path `/Users/<USER>/.ae-mcp/bin/ae-mcp`
+and never falls back to bare PATH.
 
 ### 1. Choose the execution route
 

--- a/docs/release-notes/v0.9.3-zh-CN.md
+++ b/docs/release-notes/v0.9.3-zh-CN.md
@@ -1,0 +1,27 @@
+# ae-mcp v0.9.3 中文说明
+
+[English release →](https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.9.3)
+
+这是 Windows 11 x64 版本，发布 CEP 面板与原生 AEGP 执行宿主。它采用两个独立安装资产，不是零环境或只安装 ZXP 即用的整合安装包。
+
+## 下载文件
+
+- `ae-mcp-panel-v0.9.3-windows-x64.zxp`：CEP 面板。
+- `AeMcpNative-v0.9.3-windows-x64.aex`：原生 AEGP 插件。
+- `SHA256SUMS-v0.9.3.txt`：两个二进制的 SHA-256 校验值。
+
+## 安装
+
+1. 下载三个文件并先用 `SHA256SUMS-v0.9.3.txt` 校验 ZXP 与 AEX。
+2. 使用受支持的 ZXP installer 安装 ZXP。
+3. 关闭全部 After Effects 实例。
+4. 以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`。
+5. 保留现有外部 runtime/launcher 配置；v0.9.3 不提供 Windows RuntimeManager。
+6. 重启 AE，打开 `Window → Extensions → ae-mcp`，先执行 `ae_ping` 与 `ae_status`。
+
+## 签名与范围披露
+
+- ZXP 与 AEX 均使用本次发布新建的自签名身份。签名可验证资产未在签名后改变，但不会建立操作系统默认信任的公开发布者身份。
+- AEX 不会被 ZXP installer 自动复制到 AE 原生插件目录。
+- 本版不包含一体化安装器、自动 AEX 部署、Windows RuntimeManager、零环境首跑、升级/修复/回滚/卸载生命周期、macOS 资产或 Windows ARM 支持。
+- Claude Code CLI、Codex CLI 与 ZCode CLI/app-server 仅是相应面板 AI 通道的可选依赖；外部 MCP/Core 能力仍使用现有 runtime/launcher。

--- a/native/platform-helper/windows/CMakeLists.txt
+++ b/native/platform-helper/windows/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ae_mcp_platform_helper_windows VERSION 0.9.2 LANGUAGES CXX)
+project(ae_mcp_platform_helper_windows VERSION 0.9.3 LANGUAGES CXX)
 
 if(NOT WIN32 OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   message(FATAL_ERROR "the Windows platform helper requires a native x64 Windows host")

--- a/native/platform-helper/windows/src/main.cpp
+++ b/native/platform-helper/windows/src/main.cpp
@@ -674,7 +674,7 @@ IJsonValue Capabilities() {
   JsonObject result;
   result.Insert(L"protocolVersion", NumberValue(1));
   result.Insert(L"platform", StringValue("windows-x64"));
-  result.Insert(L"helperVersion", StringValue("0.9.2"));
+  result.Insert(L"helperVersion", StringValue("0.9.3"));
   result.Insert(L"secretBackend", StringValue("credential-manager"));
   result.Insert(L"captureBackend", StringValue("windows-graphics-capture"));
   result.Insert(L"authenticatedCaller", JsonValue::CreateBooleanValue(true));

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.9.2"
+version = "0.9.3"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.9.2"
+version = "0.9.3"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.9.2"
+version = "0.9.3"
 description = "Windows mss-based After Effects window capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packaging/ae-sdk-inputs.json
+++ b/packaging/ae-sdk-inputs.json
@@ -103,7 +103,7 @@
         "privateSelfHostedCi": "blocked-pending-scope-approval",
         "privateHostedArtifactStorage": "blocked-pending-scope-approval",
         "rawSdkRedistribution": "blocked",
-        "compiledPluginDistribution": "blocked-pending-separate-review",
+        "compiledPluginDistribution": "allowed-by-explicit-user-release-approval-2026-08-03",
         "adobeSampleDerivedCode": "blocked-pending-separate-review"
       }
     },

--- a/packaging/schemas/ae-sdk-inputs.schema.json
+++ b/packaging/schemas/ae-sdk-inputs.schema.json
@@ -162,7 +162,7 @@
                 "privateSelfHostedCi": { "const": "blocked-pending-scope-approval" },
                 "privateHostedArtifactStorage": { "const": "blocked-pending-scope-approval" },
                 "rawSdkRedistribution": { "const": "blocked" },
-                "compiledPluginDistribution": { "const": "blocked-pending-separate-review" },
+                "compiledPluginDistribution": { "const": "allowed-by-explicit-user-release-approval-2026-08-03" },
                 "adobeSampleDerivedCode": { "const": "blocked-pending-separate-review" }
               }
             }

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.9.2"
+                   ExtensionBundleVersion="0.9.3"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.9.2" />
+        <Extension Id="com.aemcp.panel" Version="0.9.3" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20262,7 +20262,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.9.2",
+    version: "0.9.3",
     private: true,
     type: "module",
     scripts: {
@@ -31995,7 +31995,7 @@
   var DEFAULT_TIMEOUT_MS2 = 3e4;
   var INITIALIZE_TIMEOUT_MS = 12e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.9.2";
+  var PANEL_VERSION = "0.9.3";
   function defaultRandomBytes2(size) {
     const cryptoImpl = globalThis.crypto;
     if (!cryptoImpl || typeof cryptoImpl.getRandomValues !== "function") {

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1045,7 +1045,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-                version: input.version || '0.9.2',
+                version: input.version || '0.9.3',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "express": "4.22.1"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -6,7 +6,7 @@ import { createRuntimeManager, hasDevelopmentRuntimeOverride } from './runtimeMa
 const DEFAULT_TIMEOUT_MS = 30000;
 const INITIALIZE_TIMEOUT_MS = 120000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.9.2';
+export const PANEL_VERSION = '0.9.3';
 
 function defaultRandomBytes(size) {
   const cryptoImpl = globalThis.crypto;

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-agent-sidecar",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-agent-sidecar",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.174"
       }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -2,7 +2,7 @@
   "name": "ae-mcp-agent-sidecar",
   "private": true,
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.174"
   },

--- a/scripts/package/ae-sdk-input.mjs
+++ b/scripts/package/ae-sdk-input.mjs
@@ -26,7 +26,7 @@ const MAX_TRACKED_BLOB_BYTES = 16 * 1024 * 1024;
 const MAX_TRACKED_BLOB_TOTAL_BYTES = 64 * 1024 * 1024;
 
 export const AE_SDK_POLICY_CANONICAL_SHA256 =
-  'e02aed46553c781d50a7a10a4c5577451cc8bbcd3713674c5f8f444af92985d6';
+  '00690979c34d23e109ca0456e9ac9df285c2a12794c492a525cbd391a064b2ed';
 
 const SDK_ONLY_PATH = new RegExp([
   String.raw`(?:^|\/)(?:AfterEffectsSDK_[^/]+|ae25\.6_61\.64bit\.AfterEffectsSDK)(?:\/|$)`,

--- a/scripts/package/test/ae-sdk-input.test.mjs
+++ b/scripts/package/test/ae-sdk-input.test.mjs
@@ -132,6 +132,10 @@ test('production policy records the operator attestation and keeps unrelated sco
     'allowed-aggregate-locks-and-minimal-layout-sentinels',
   );
   assert.equal(policy.sdk.licenseReview.scopes.privateSelfHostedCi, 'blocked-pending-scope-approval');
+  assert.equal(
+    policy.sdk.licenseReview.scopes.compiledPluginDistribution,
+    'allowed-by-explicit-user-release-approval-2026-08-03',
+  );
   assert.deepEqual(policy.sdk.platforms['macos-arm64'].archive, {
     fileNameHint: 'AfterEffectsSDK_25.6_61_mac.zip',
     bytes: 2039255,

--- a/scripts/release/test/release-promotion.test.mjs
+++ b/scripts/release/test/release-promotion.test.mjs
@@ -25,9 +25,26 @@ test('promotion queues every idempotent retry instead of replacing an older pend
   );
 });
 
+test('v0.9.3 release docs describe only the approved minimal Windows publication', async () => {
+  const docs = await readFile('docs/RELEASE.md', 'utf8');
+
+  for (const asset of [
+    'ae-mcp-panel-v0.9.3-windows-x64.zxp',
+    'AeMcpNative-v0.9.3-windows-x64.aex',
+    'SHA256SUMS-v0.9.3.txt',
+  ]) {
+    assert.match(docs, new RegExp(asset.replaceAll('.', '\\.')));
+  }
+  assert.match(docs, /(?:只发布以下三个文件|publishes exactly these files)/i);
+  assert.match(docs, /(?:新 CI\/runner 拓扑|new CI\/runner topology)/i);
+  assert.doesNotMatch(
+    docs,
+    /preflight artifact|latest attempt|tag ruleset|标签规则集|merge freeze|合并冻结|AE_MCP_RELEASE_ADMIN_TOKEN|Administration[^\n]*read|admin-read|details_url[^\n]*actions\/runs|workflow run[^\n]*provenance/i,
+  );
+});
+
 test('build inventory requires four live release artifacts and only permits two optional preflight artifacts', async () => {
   const text = await workflow();
-  const docs = await readFile('docs/RELEASE.md', 'utf8');
   const body = step(text, 'Resolve one successful build run and four exact artifact IDs');
   const tag = step(text, 'Revalidate active evidence and create or verify annotated tag');
 
@@ -50,7 +67,6 @@ test('build inventory requires four live release artifacts and only permits two 
   assert.match(tag, /if \(expectedArtifactId\)[\s\S]*artifact\.expired === true[\s\S]*releaseArtifacts\.push/);
   assert.match(tag, /else if \(!allowedPreflightNames\.has\(artifact\.name\)\)/);
   assert.doesNotMatch(tag, /JSON\.stringify\(actual\) !== JSON\.stringify\(wanted\)/);
-  assert.match(docs, /preflight artifact[^\n]*(?:过期|清理|缺失)[^\n]*(?:四个|4 个)[^\n]*(?:下载|晋级)/i);
 });
 
 test('draft promotion persists one release ID and never resolves mutable assets by tag', async () => {
@@ -108,7 +124,6 @@ test('attestation writers and promotion share the exact Actions run details URL 
 
 test('tag and publish reject every candidate attestation run whose latest attempt is not successful', async () => {
   const text = await workflow();
-  const docs = await readFile('docs/RELEASE.md', 'utf8');
   const tag = step(text, 'Revalidate active evidence and create or verify annotated tag');
   const publish = step(text, 'Revalidate comments, Checks, tag, and downloaded assets before publication');
 
@@ -121,7 +136,6 @@ test('tag and publish reject every candidate attestation run whose latest attemp
     assert.match(body, /await requireLatestAttestationAttemptsSuccessful\(/);
     assert.doesNotMatch(body, /for \(const status of \['queued', 'in_progress'/);
   }
-  assert.match(docs, /latest attempt[^\n]*(?:completed[^\n]*success|成功)[^\n]*(?:rerun|重跑)/i);
 });
 
 test('promotion and attestation enumerate deterministic Checks through check suites', async () => {
@@ -140,7 +154,6 @@ test('promotion and attestation enumerate deterministic Checks through check sui
 
 test('irreversible tag and publication mutations have adjacent full revalidation gates', async () => {
   const text = await workflow();
-  const docs = await readFile('docs/RELEASE.md', 'utf8');
   const tag = step(text, 'Revalidate active evidence and create or verify annotated tag');
   const publish = step(text, 'Revalidate comments, Checks, tag, and downloaded assets before publication');
 
@@ -166,15 +179,12 @@ test('irreversible tag and publication mutations have adjacent full revalidation
   assert.match(publish, /checks\.get/);
   assert.match(publish, /listAllWorkflowRunsForWorkflow/);
   assert.match(publish, /repos\.listReleaseAssets/);
-  assert.match(docs, /tag ruleset[\s\S]{0,240}merge freeze/i);
-  assert.match(docs, /标签规则集[\s\S]{0,240}合并冻结/);
 });
 
 test('protected admin-read token proves immutable releases before tag and publish and publication verifies immutable result', async () => {
   const text = await workflow();
   const tag = step(text, 'Revalidate active evidence and create or verify annotated tag');
   const publish = step(text, 'Revalidate comments, Checks, tag, and downloaded assets before publication');
-  const docs = await readFile('docs/RELEASE.md', 'utf8');
 
   for (const body of [tag, publish]) {
     assert.match(body, /AE_MCP_RELEASE_ADMIN_TOKEN/);
@@ -184,9 +194,6 @@ test('protected admin-read token proves immutable releases before tag and publis
   }
   assert.match(publish, /published\.immutable !== true/);
   assert.match(publish, /!release\.draft && release\.immutable !== true/);
-  assert.match(docs, /AE_MCP_RELEASE_ADMIN_TOKEN/);
-  assert.match(docs, /Administration[^\n]*read|admin-read/i);
-  assert.match(docs, /details_url[^\n]*actions\/runs|workflow run[^\n]*provenance/i);
 });
 
 test('promotion remains no-build and no-sign', async () => {

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -527,7 +527,7 @@ test('attestation workflow pins actions and binds platform checks to immutable b
   assert.doesNotMatch(workflow, /const digestFields = \[/);
 });
 
-test('attestation Check provenance is constrained and its same-App limitation is explicit', async () => {
+test('legacy attestation Check provenance stays constrained without governing v0.9.3', async () => {
   const workflow = await readFile('.github/workflows/attestation.yml', 'utf8');
   const writers = [
     workflowJob(workflow, 'preinvalidate-macos'),
@@ -537,9 +537,12 @@ test('attestation Check provenance is constrained and its same-App limitation is
   assert.equal((writers.match(/app\?\.slug !== 'github-actions'/g) || []).length, 2);
 
   const docs = await readFile('docs/WORKFLOW.md', 'utf8');
-  assert.match(docs, /GitHub Actions App[^\n]*(?:共享|shared)/i);
-  assert.match(docs, /checks:write/);
-  assert.match(docs, /外部前置|external prerequisite/i);
+  assert.doesNotMatch(docs, /GitHub Actions App[^\n]*(?:共享|shared)/i);
+  assert.doesNotMatch(docs, /checks:write/);
+  assert.doesNotMatch(docs, /外部前置|external prerequisite/i);
+  assert.match(docs, /ae-mcp-panel-v0\.9\.3-windows-x64\.zxp/);
+  assert.match(docs, /AeMcpNative-v0\.9\.3-windows-x64\.aex/);
+  assert.match(docs, /SHA256SUMS-v0\.9\.3\.txt/);
 });
 
 test('attestation workflow does not interpolate or log untrusted comment bodies', async () => {

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -5,9 +5,11 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 
 const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
-const VERSION = '0.9.2';
+const VERSION = '0.9.3';
 const PLATFORM_ASSETS = [
-  'ae-mcp-panel-v0.9.2-windows-x64.zxp',
+  'ae-mcp-panel-v0.9.3-windows-x64.zxp',
+  'AeMcpNative-v0.9.3-windows-x64.aex',
+  'SHA256SUMS-v0.9.3.txt',
 ];
 
 const PYTHON_PROJECTS = [
@@ -67,7 +69,7 @@ function panelVersion(source) {
   return source.match(/PANEL_VERSION\s*=\s*['"]([^'"]+)['"];/)?.[1];
 }
 
-test('all active package and lockfile versions are v0.9.2', async () => {
+test('all active package and lockfile versions are v0.9.3', async () => {
   for (const relativePath of PYTHON_PROJECTS) {
     assert.equal(projectVersion(await text(relativePath), relativePath), VERSION, relativePath);
   }
@@ -104,6 +106,17 @@ test('Panel source, generated bundle, and CEP manifest use the release version',
   assert.equal(manifest.match(/<Host Name="AEFT" Version="([^"]+)"/)?.[1], '[25.0,26.9]');
 });
 
+test('Windows native client and Platform Helper use the release version', async () => {
+  const [client, cmake, helper] = await Promise.all([
+    text('plugin/host/native-aegp-client.js'),
+    text('native/platform-helper/windows/CMakeLists.txt'),
+    text('native/platform-helper/windows/src/main.cpp'),
+  ]);
+  assert.ok(client.includes(`version: input.version || '${VERSION}'`));
+  assert.ok(cmake.includes(`VERSION ${VERSION} LANGUAGES CXX`));
+  assert.ok(helper.includes(`helperVersion", StringValue("${VERSION}")`));
+});
+
 test('native product version is injected from the exact repository product manifest', async () => {
   const [build, entry, infoPlist, installer, verifier] = await Promise.all([
     text('native/ae-plugin/build-macos.mjs'),
@@ -134,10 +147,10 @@ test('native product version is injected from the exact repository product manif
   }
 });
 
-test('user docs describe the v0.9.2 platform assets and optional AI channel CLIs', async () => {
+test('user docs describe the v0.9.3 platform assets and optional AI channel CLIs', async () => {
   for (const relativePath of USER_DOCS) {
     const body = await text(relativePath);
-    assert.match(body, /v?0\.9\.2/, `${relativePath} release version`);
+    assert.match(body, /v?0\.9\.3/, `${relativePath} release version`);
     for (const asset of PLATFORM_ASSETS) {
       assert.ok(body.includes(asset), `${relativePath} must name ${asset}`);
     }
@@ -159,32 +172,23 @@ test('normal install docs do not make an online uv tool install the user path', 
   }
 });
 
-test('release docs retain the hardened dual-platform design for v0.9.3 work', async () => {
+test('release docs define the approved minimal Windows v0.9.3 contract', async () => {
   const release = await text('docs/RELEASE.md');
-  for (const marker of [
-    'build-rc.yml',
-    'artifact-manifest-v0.9.2.json',
-    'macos-rc-attestation',
-    'windows-rc-attestation',
-    'release.yml',
-  ]) {
+  for (const marker of PLATFORM_ASSETS) {
     assert.ok(release.includes(marker), `docs/RELEASE.md must name ${marker}`);
   }
-  assert.match(release, /no[- ]rebuild|不重新构建|禁止重建/i);
-  assert.match(release, /prerequisite|前置条件/i);
-  assert.doesNotMatch(release, /one-day signer-preflight|保留 1 天/);
-  assert.match(release,
-    /保留 30 天[^\n]*Environment[^\n]*(?:缺失|不影响)[^\n]*四个晋级资产/);
-  assert.match(release,
-    /30-day[^\n]*Environment[^\n]*(?:missing|absence)[^\n]*four promotion assets/i);
+  assert.match(release, /manual|手动/i);
+  assert.match(release, /external runtime|外部 runtime/i);
+  assert.match(release, /not.*zero-environment|不.*零环境/i);
+  assert.match(release, /installer|安装器/i);
 
   const changelog = await text('CHANGELOG.md');
   const firstRelease = changelog.match(/^### \[([^\]]+)\].*$/m)?.[1];
   assert.equal(firstRelease, VERSION);
-  assert.match(changelog, /^### \[0\.9\.2\].*2026-07-13/mi);
+  assert.match(changelog, /^### \[0\.9\.3\].*2026-08-03/mi);
 });
 
-test('user docs distinguish the Windows v0.9.2 release from deferred v0.9.3 work', async () => {
+test('user docs distinguish the minimal Windows v0.9.3 release from deferred work', async () => {
   const [readme, readmeZh, install, reference, release, workflow] = await Promise.all([
     readFile('README.md', 'utf8'),
     readFile('README.zh-CN.md', 'utf8'),
@@ -194,8 +198,8 @@ test('user docs distinguish the Windows v0.9.2 release from deferred v0.9.3 work
     readFile('docs/WORKFLOW.md', 'utf8'),
   ]);
 
-  assert.match(readme, /v0\.9\.2 Target Support Matrix/);
-  assert.match(readmeZh, /v0\.9\.2 目标支持矩阵/);
+  assert.match(readme, /v0\.9\.3 Target Support Matrix/);
+  assert.match(readmeZh, /v0\.9\.3 目标支持矩阵/);
   assert.match(readme, /historical v0\.9\.0 development wizard[\s\S]*online `uv`/i);
   assert.match(readmeZh, /历史 v0\.9\.0 开发向导[\s\S]*在线 `uv`/);
   assert.match(readme, /install-plugin-dev-macos\.sh/);
@@ -208,9 +212,11 @@ test('user docs distinguish the Windows v0.9.2 release from deferred v0.9.3 work
   assert.doesNotMatch(workflow, /Mac 安装 DMG|install the DMG/i);
   assert.match(workflow, /受支持的 ZXP installer/);
   assert.match(workflow, /supported ZXP installer/i);
-  assert.match(release, /six installed-runtime checks/i);
-  assert.match(release, /六项 installed-runtime/);
-  assert.match(release, /product-acceptance[\s\S]{0,300}blocked/i);
+  for (const value of [readme, readmeZh, install, reference, release, workflow]) {
+    for (const asset of PLATFORM_ASSETS) assert.ok(value.includes(asset));
+  }
+  assert.match(install, /manual|手动/i);
+  assert.match(install, /external runtime|外部 runtime/i);
 
   assert.doesNotMatch(reference, /203 passed/);
   assert.doesNotMatch(reference, /24 passed/);
@@ -246,12 +252,16 @@ test('user docs distinguish the Windows v0.9.2 release from deferred v0.9.3 work
   assert.match(reference, /operating-system temporary directory/i);
   assert.match(reference, /操作系统临时目录/);
 
-  for (const value of [readme, readmeZh, workflow]) {
-    assert.match(value, /\/Users\/<USER>\/\.ae-mcp\/bin\/ae-mcp/);
+  for (const value of [readme, readmeZh]) {
+    assert.ok(value.includes('C:\\\\Users\\\\<USER>\\\\.ae-mcp\\\\bin\\\\ae-mcp.exe'));
     assert.match(value, /RuntimeManager/i);
     assert.match(value, /(?:bare PATH|裸 PATH)/i);
     assert.match(value, /(?:absolute|绝对)/i);
   }
+  assert.match(workflow, /\/Users\/<USER>\/\.ae-mcp\/bin\/ae-mcp/);
+  assert.match(workflow, /RuntimeManager/i);
+  assert.match(workflow, /(?:bare PATH|裸 PATH)/i);
+  assert.match(workflow, /(?:absolute|绝对)/i);
   assert.match(install, /\/Users\/<USER>\/\.ae-mcp\/bin\/ae-mcp/);
 });
 

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "jsonschema" },
@@ -47,7 +47,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -73,7 +73,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
## Outcome

Prepare the source and documentation for the explicitly approved Windows x64 v0.9.3 release:

- `ae-mcp-panel-v0.9.3-windows-x64.zxp`
- `AeMcpNative-v0.9.3-windows-x64.aex`
- `SHA256SUMS-v0.9.3.txt`

The AEX remains a separate manual install. The existing external runtime/launcher remains required. Both release signatures will use newly created self-signed identities and will not represent a publicly trusted publisher.

## Included

- bump active product/package/native helper identities to 0.9.3
- authorize compiled AEX distribution under the locked Adobe SDK policy while continuing to prohibit raw SDK redistribution and public SDK caching
- update version/SDK/native build contract coverage
- replace stale installer/RuntimeManager release claims with the approved three-asset Windows process
- add bilingual release notes and accurate Windows launcher examples

## Explicit non-goals

- integrated installer or automatic AEX deployment
- Windows RuntimeManager or zero-environment onboarding
- repair/rollback/uninstall lifecycle
- new CI topology or private artifact service
- macOS or Windows ARM assets

## Verification

- focused release/SDK/AEX contract suite: 45 passed, 1 Windows symlink-privilege skip, 0 failed
- panel: 1063 passed, 26 skipped, 0 failed
- sidecar: 35 passed, 0 failed
- host: 86 passed, 16 skipped, 1 local Windows symlink-privilege failure
- Python: 908 passed, 9 skipped, 13 deselected, 9 local Windows symlink-privilege failures
- independent release-document review: no remaining blocker

The local platform-only failures are existing POSIX/symlink cases on an unprivileged Windows host; required GitHub CI remains the merge gate. Final signed assets will be built from the resulting protected `main` commit, not from this PR branch.