### PR TITLE
fix(release): restore Windows Helper in v0.9.4 ZXP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [0.9.4] — 2026-08-04
+
+#### 修复
+
+- 恢复 v0.9.3 ZXP 误删的 Windows Platform Helper，使 Provider 管理器重新使用 Windows Credential Manager 保存凭据；Helper manifest 与三个声明二进制在签名前逐项校验。
+- 新增 Windows 最小 ZXP 契约测试：必须保留生产 Host 依赖、Helper 与现有在线 `uv tool install` 首跑向导，同时拒绝 bundled Python/Node、Windows RuntimeManager manifest 与嵌套 AEX。
+- 修正文档：外部 Python runtime 不在 ZXP 内，但清洁环境可通过面板首跑向导联网安装；AEX 仍作为独立 Release 资产手动安装。
+
 ### [0.9.3] — 2026-08-03
 
 #### 发布范围
@@ -251,6 +259,14 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [0.9.4] — 2026-08-04
+
+#### Fixed
+
+- Restore Windows Platform Helper, which was mistakenly omitted from the v0.9.3 ZXP, so Provider Manager again stores credentials through Windows Credential Manager. Packaging verifies the Helper manifest and all three declared binaries before signing.
+- Add a minimal Windows ZXP contract test that requires production Host dependencies, Helper, and the existing online `uv tool install` first-run wizard while rejecting bundled Python/Node, Windows RuntimeManager manifests, and nested AEX files.
+- Correct the installation docs: the external Python runtime is not inside the ZXP, but a clean environment can install it online through the Panel's first-run wizard. The AEX remains a separate manual-install Release asset.
 
 ### [0.9.3] — 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ ae-mcp is a backend-agnostic automation tool that keeps Adobe After Effects and 
 
 The MCP server is the core. Outside the MCP layer, ae-mcp also ships a CEP panel that wraps built-in agent chat, backend configuration, approval controls, diagnostics, and first-run setup. You can use ae-mcp from an external agent backend through MCP, or configure Claude / Codex / ZCode directly inside the AE panel.
 
-**v0.9.3 is a Windows x64 release with two separately installed assets.** Install the signed ZXP for the CEP panel and manually copy the signed AEX into the selected After Effects plug-in directory. This release retains the existing external runtime/launcher requirement; it is not a zero-environment or ZXP-only installation.
+**v0.9.4 is the corrective Windows x64 release.** The signed ZXP contains the CEP panel and Windows Platform Helper; the signed AEX remains a separate manual install. The Panel's first-run wizard can install the external Python runtime online, so a pre-existing runtime is not required, but this is not an offline or ZXP-only installation.
 
-## v0.9.3 Target Support Matrix
+## v0.9.4 Target Support Matrix
 
-The published v0.9.3 assets target this release scope:
+The published v0.9.4 assets target this release scope:
 
 - Windows 11 24H2 (11.0.26100) or newer on x64. Windows on ARM is not supported.
 - After Effects 2025 is the packaged acceptance host. The CEP manifest remains `[25.0,26.9]`; this release contains no macOS asset.
@@ -29,28 +29,29 @@ Embedded panel chat or external MCP client
 
 `ae_previewFrame` remains the AE-internal `CompItem.saveFrameToPng` path for rendering real comp pixels, with viewer snapshot only as a fallback. `packages/snapshot-mss` provides Windows `ae_snapshot` screen capture through the `mss` backend.
 
-The MCP core is backend-agnostic: external clients can talk to AE through the stdio server, while the CEP panel can also host built-in agent chat. The existing panel layer handles backend setup, approvals, diagnostics, and activity history. The v0.9.3 Windows release retains the existing external runtime/launcher setup and does not activate a bundled Windows RuntimeManager. Claude, Codex, and ZCode are built-in panel backends; OpenCode and other tools can still connect as external MCP clients.
+The MCP core is backend-agnostic: external clients can talk to AE through the stdio server, while the CEP panel can also host built-in agent chat. The existing panel layer handles backend setup, approvals, diagnostics, and activity history. The v0.9.4 ZXP restores the Windows Platform Helper used by Provider Manager and protected Credential Manager storage. It does not bundle Python or activate a Windows RuntimeManager. Claude, Codex, and ZCode are built-in panel backends; OpenCode and other tools can still connect as external MCP clients.
 
-## v0.9.3 Release Scope
+## v0.9.4 Release Scope
 
 - One final protected-`main` SHA produces the ZXP and AEX; changed source requires new artifacts and checksums.
+- The ZXP includes the existing Windows Platform Helper and validates its manifest and binaries before signing.
 - The AEX is distributed separately because a ZXP installer does not place nested files in After Effects' native plug-in directory.
-- An integrated installer, automatic AEX deployment, Windows RuntimeManager, zero-environment onboarding, repair/rollback/uninstall lifecycle, macOS assets, and Windows ARM are outside this release.
+- The first-run wizard installs `uv` and the tag-pinned external runtime over the network when they are missing. Bundled/offline Python, an integrated installer, automatic AEX deployment, Windows RuntimeManager, repair/rollback/uninstall lifecycle, macOS assets, and Windows ARM are outside this release.
 - Both signatures use newly created self-signed identities and therefore do not establish a publicly trusted publisher.
 
 ## Install and First Run
 
-Download the three named files from the v0.9.3 GitHub Release. Do not use source archives as substitutes for the signed assets:
+Download the three named files from the v0.9.4 GitHub Release. Do not use source archives as substitutes for the signed assets:
 
 | Role | Release asset |
 |---|---|
-| CEP panel | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
-| Native AEGP plug-in | `AeMcpNative-v0.9.3-windows-x64.aex` |
-| Integrity | `SHA256SUMS-v0.9.3.txt` |
+| CEP panel + Windows Platform Helper | `ae-mcp-panel-v0.9.4-windows-x64.zxp` |
+| Native AEGP plug-in | `AeMcpNative-v0.9.4-windows-x64.aex` |
+| Integrity | `SHA256SUMS-v0.9.4.txt` |
 
-Install the ZXP with a supported ZXP installer. With After Effects closed, copy the AEX to the selected host's `Support Files\Plug-ins\Extensions\AeMcpNative.aex` path using administrator permission, then restart After Effects and open `Window -> Extensions -> ae-mcp`. Keep the existing external runtime/launcher configured.
+Install the ZXP with a supported ZXP installer. With After Effects closed, copy the AEX to the selected host's `Support Files\Plug-ins\Extensions\AeMcpNative.aex` path using administrator permission, then restart After Effects and open `Window -> Extensions -> ae-mcp`. If `uv` or `ae-mcp` is missing, use the first-run wizard to install them online; it runs a tag-pinned `uv tool install` for v0.9.4. Existing compatible launchers are reused.
 
-Verify both binaries with `SHA256SUMS-v0.9.3.txt`. See [Install](docs/INSTALL.md) and [Release](docs/RELEASE.md).
+Verify both binaries with `SHA256SUMS-v0.9.4.txt`. See [Install](docs/INSTALL.md) and [Release](docs/RELEASE.md).
 
 ## Built-in Backends
 
@@ -79,20 +80,20 @@ Claude Code CLI is separate from Claude Desktop. Claude Desktop MCP configuratio
 
 <table>
   <tr><td><img src="docs/images/en/settings-provider-manager-collapsed.png" width="380"><br>Settings: backend channels and compact Provider Manager rows</td><td><img src="docs/images/en/settings-provider-manager-expanded.png" width="380"><br>Settings: expanded provider editor with local API key storage</td></tr>
-  <tr><td><img src="docs/images/en/settings-general-language.png" width="380"><br>Settings: general options, language switch, logs, and About</td><td><img src="docs/images/en/wizard-install.png" width="380"><br>Historical v0.9.0 development wizard: online `uv` and PATH launcher; not the v0.9.3 release path</td></tr>
+  <tr><td><img src="docs/images/en/settings-general-language.png" width="380"><br>Settings: general options, language switch, logs, and About</td><td><img src="docs/images/en/wizard-install.png" width="380"><br>First-run wizard: online `uv` and tag-pinned external runtime installation</td></tr>
   <tr><td><img src="docs/images/en/wizard-connect-clients.png" width="380"><br>First-run wizard: built-in chat and external MCP client setup</td><td><img src="docs/images/en/chat-home.png" width="380"><br>Chat home: starter suggestions and composer controls</td></tr>
   <tr><td><img src="docs/images/en/chat-approval.png" width="380"><br>Tool approval card for gated high-risk operations</td><td><img src="docs/images/en/activity-stream.png" width="380"><br>Activity stream: agent operation history</td></tr>
 </table>
 
 ## External MCP Clients
 
-For Windows v0.9.3, an existing external launcher config has this shape after replacing `<USER>` with the actual account name:
+For a default Windows `uv tool install`, the generated external launcher config has this shape after replacing `<USER>` with the actual account name:
 
 ```json
 {
   "mcpServers": {
     "ae": {
-      "command": "C:\\Users\\<USER>\\.ae-mcp\\bin\\ae-mcp.exe",
+      "command": "C:\\Users\\<USER>\\.local\\bin\\ae-mcp.exe",
       "env": {
         "AE_MCP_BACKEND": "ae-mcp",
         "AE_MCP_PLUGIN_URL": "http://127.0.0.1:11488"
@@ -102,7 +103,7 @@ For Windows v0.9.3, an existing external launcher config has this shape after re
 }
 ```
 
-Keep the expanded absolute path shown above; do not rely on a bare PATH command. The three Release assets do not install or activate that launcher. See [Install](docs/INSTALL.md).
+Copy the config generated by the Panel because `UV_TOOL_BIN_DIR` may change the launcher location. The runtime remains external to the ZXP, but the first-run wizard can install it online. See [Install](docs/INSTALL.md).
 
 External clients must run on the same machine as After Effects, or otherwise be able to reach `127.0.0.1:11488` on the AE machine. This matters for long-running or Dockerized IM-bot frameworks such as OpenClaw and AstrBot.
 
@@ -329,7 +330,7 @@ node scripts/live-model-matrix.mjs
 
 ## Package and Release
 
-Maintainers merge release metadata first, then build the v0.9.3 Windows ZXP and AEX from the final clean protected-`main` commit. They sign and verify both assets, generate `SHA256SUMS-v0.9.3.txt`, run the After Effects 2025 public-path smoke, and upload those exact bytes without rebuilding. See [docs/RELEASE.md](docs/RELEASE.md).
+Maintainers merge release metadata first, then build the v0.9.4 Windows Helper, ZXP, and AEX from the final clean protected-`main` commit. They validate the minimal ZXP payload, sign and verify both release assets, generate `SHA256SUMS-v0.9.4.txt`, run the After Effects 2025 Helper/Provider and public-MCP smokes, and upload those exact bytes without rebuilding. See [docs/RELEASE.md](docs/RELEASE.md).
 
 ## Implementation Notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,11 +6,11 @@ ae-mcp 是一个**后端无关**的 After Effects 自动化工具，用来让 AE
 
 MCP server 是核心。在 MCP 本体之外，ae-mcp 还包装了一套 CEP 面板插件，提供面板内对话、后端配置、审批、诊断和首跑安装。你可以根据自己的工作流选择：在外部 agent 后端里通过 MCP 使用 ae-mcp，或者直接在 AE 面板内配置 Claude / Codex / ZCode 后端进行对话。
 
-**v0.9.3 是包含两个独立安装资产的 Windows x64 版本。** ZXP 用于 CEP 面板，签名 AEX 需手动复制到所选 After Effects 的原生插件目录。本版继续依赖现有外部 runtime/launcher，不是零环境或只装 ZXP 即用的安装包。
+**v0.9.4 是 Windows x64 修复版本。** 签名 ZXP 内含 CEP 面板与 Windows Platform Helper；签名 AEX 仍需单独手动安装。面板首跑向导可以联网安装外部 Python runtime，因此不要求用户预先装好 runtime，但本版不是离线或只装 ZXP 即用的安装包。
 
-## v0.9.3 目标支持矩阵
+## v0.9.4 目标支持矩阵
 
-v0.9.3 发布资产面向以下范围：
+v0.9.4 发布资产面向以下范围：
 
 - Windows 11 24H2（11.0.26100）或更新版本，运行于 x64；不支持 Windows ARM。
 - After Effects 2025 是本次打包验收宿主。CEP manifest 仍为 `[25.0,26.9]`；本版不包含 macOS 资产。
@@ -29,28 +29,29 @@ v0.9.3 发布资产面向以下范围：
 
 `ae_previewFrame` 仍是 AE 内部的 `CompItem.saveFrameToPng` 路径，用于渲染真实合成像素，viewer snapshot 只作为 fallback。`packages/snapshot-mss` 通过 `mss` backend 提供 Windows `ae_snapshot` 屏幕捕获。
 
-MCP core 本身保持后端无关：外部客户端可以通过 stdio server 与 AE 对话，CEP 面板也可以在 AE 内承载内嵌 agent 对话。现有面板层负责后端配置、审批、诊断和活动历史。v0.9.3 Windows 版本继续使用既有外部 runtime/launcher，不会激活 Windows 包内 RuntimeManager。Claude、Codex、ZCode 是面板内置后端；OpenCode 和其他工具仍可以作为外部 MCP 客户端接入。
+MCP core 本身保持后端无关：外部客户端可以通过 stdio server 与 AE 对话，CEP 面板也可以在 AE 内承载内嵌 agent 对话。现有面板层负责后端配置、审批、诊断和活动历史。v0.9.4 ZXP 恢复 Provider 管理器和 Windows Credential Manager 所需的 Platform Helper，但不内置 Python，也不激活 Windows RuntimeManager。Claude、Codex、ZCode 是面板内置后端；OpenCode 和其他工具仍可以作为外部 MCP 客户端接入。
 
-## v0.9.3 发布范围
+## v0.9.4 发布范围
 
 - ZXP 与 AEX 必须来自最终受保护 `main` 的同一个 SHA；源码变化后必须重新生成资产和校验值。
+- ZXP 包含既有 Windows Platform Helper，并在签名前校验其 manifest、文件清单与哈希。
 - ZXP installer 不会把包内文件复制到 AE 原生插件目录，因此 AEX 单独发布并手动安装。
-- 一体化安装器、自动 AEX 部署、Windows RuntimeManager、零环境首跑、修复/回滚/卸载生命周期、macOS 资产和 Windows ARM 不属于本版范围。
+- 首跑向导会在缺少依赖时联网安装 `uv` 与按 v0.9.4 tag 固定的外部 runtime。内置/离线 Python、一体化安装器、自动 AEX 部署、Windows RuntimeManager、修复/回滚/卸载生命周期、macOS 资产和 Windows ARM 不属于本版范围。
 - 两类签名均使用本次新建的自签名身份，不代表公开可信的软件发布者。
 
 ## 安装和首次启动
 
-从 v0.9.3 GitHub Release 下载以下三个固定文件，不要用源码归档替代签名资产：
+从 v0.9.4 GitHub Release 下载以下三个固定文件，不要用源码归档替代签名资产：
 
 | 用途 | 发布资产 |
 |---|---|
-| CEP 面板 | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
-| 原生 AEGP 插件 | `AeMcpNative-v0.9.3-windows-x64.aex` |
-| 完整性校验 | `SHA256SUMS-v0.9.3.txt` |
+| CEP 面板 + Windows Platform Helper | `ae-mcp-panel-v0.9.4-windows-x64.zxp` |
+| 原生 AEGP 插件 | `AeMcpNative-v0.9.4-windows-x64.aex` |
+| 完整性校验 | `SHA256SUMS-v0.9.4.txt` |
 
-用受支持的 ZXP installer 安装 ZXP。关闭 After Effects 后，以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`，再重启 AE 并打开 `Window -> Extensions -> ae-mcp`。继续保留现有外部 runtime/launcher 配置。
+用受支持的 ZXP installer 安装 ZXP。关闭 After Effects 后，以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`，再重启 AE 并打开 `Window -> Extensions -> ae-mcp`。如果缺少 `uv` 或 `ae-mcp`，在首跑向导中联网安装；向导会执行固定到 v0.9.4 tag 的 `uv tool install`。已有兼容 launcher 会直接复用。
 
-用 `SHA256SUMS-v0.9.3.txt` 校验两个二进制。详见[安装文档](docs/INSTALL.md)和[发布文档](docs/RELEASE.md)。
+用 `SHA256SUMS-v0.9.4.txt` 校验两个二进制。详见[安装文档](docs/INSTALL.md)和[发布文档](docs/RELEASE.md)。
 
 ## 选择并登录后端
 
@@ -112,7 +113,7 @@ Tools 标签页管理本地生成的 JSX、表达式、提示词 skill、recipe 
 
 <table>
   <tr><td><img src="docs/images/zh-CN/settings-provider-manager-collapsed.png" width="380"><br>设置页：后端通道与收起状态的 Provider 管理器</td><td><img src="docs/images/zh-CN/settings-provider-manager-expanded.png" width="380"><br>设置页：展开编辑 provider，本地保存 API key</td></tr>
-  <tr><td><img src="docs/images/zh-CN/settings-general-language.png" width="380"><br>设置页：通用选项、界面语言、日志与关于</td><td><img src="docs/images/zh-CN/wizard-install.png" width="380"><br>历史 v0.9.0 开发向导：在线 `uv` 与 PATH launcher；不是 v0.9.3 发布路径</td></tr>
+  <tr><td><img src="docs/images/zh-CN/settings-general-language.png" width="380"><br>设置页：通用选项、界面语言、日志与关于</td><td><img src="docs/images/zh-CN/wizard-install.png" width="380"><br>首跑向导：在线安装 `uv` 与按版本固定的外部 runtime</td></tr>
   <tr><td><img src="docs/images/zh-CN/wizard-connect-clients.png" width="380"><br>首跑向导：选择面板内对话或外部 MCP 客户端</td><td><img src="docs/images/zh-CN/chat-home.png" width="380"><br>聊天首页：启动建议与 composer 快捷选择条</td></tr>
   <tr><td><img src="docs/images/zh-CN/chat-approval.png" width="380"><br>工具审批卡片：高风险操作确认</td><td><img src="docs/images/zh-CN/activity-stream.png" width="380"><br>活动流：agent 操作历史</td></tr>
 </table>
@@ -121,13 +122,13 @@ Tools 标签页管理本地生成的 JSX、表达式、提示词 skill、recipe 
 
 面板内对话覆盖 Claude、Codex、ZCode 三类后端。如果你使用 Cursor、Claude Desktop、Claude Code、OpenCode、OpenClaw、AstrBot、Gemini Antigravity、ZCode 等外部客户端，可以通过面板生成的 MCP config 接入。
 
-Windows v0.9.3 应在把 `<USER>` 替换为实际账户名后，按下面的形态配置既有外部 launcher：
+使用默认 `uv tool install` 时，把 `<USER>` 替换为实际账户名后的外部 launcher 配置形态如下：
 
 ```json
 {
   "mcpServers": {
     "ae": {
-      "command": "C:\\Users\\<USER>\\.ae-mcp\\bin\\ae-mcp.exe",
+      "command": "C:\\Users\\<USER>\\.local\\bin\\ae-mcp.exe",
       "env": {
         "AE_MCP_BACKEND": "ae-mcp",
         "AE_MCP_PLUGIN_URL": "http://127.0.0.1:11488"
@@ -137,7 +138,7 @@ Windows v0.9.3 应在把 `<USER>` 替换为实际账户名后，按下面的形�
 }
 ```
 
-保留上面展开后的绝对路径，不要依赖裸 PATH 命令；三个 Release 资产不会安装或激活该 launcher。详见[安装文档](docs/INSTALL.md)。
+优先复制面板生成的配置，因为 `UV_TOOL_BIN_DIR` 可能改变 launcher 位置。runtime 仍位于 ZXP 外部，但首跑向导可以联网安装它。详见[安装文档](docs/INSTALL.md)。
 
 关键限制：ae-mcp 默认通过 `127.0.0.1:11488` 连到 AE 面板，所以外部客户端必须和 After Effects 在同一台机器上，或者能访问 AE 所在机器的这个端口。OpenClaw、AstrBot 这类常驻或 Docker 化的 IM-bot 框架尤其要注意。
 
@@ -338,7 +339,7 @@ node scripts/live-model-matrix.mjs
 
 ## 打包与发布
 
-维护者先合并发布元数据，再从最终干净的受保护 `main` 提交构建 v0.9.3 Windows ZXP 与 AEX。两个资产分别签名、复验并生成 `SHA256SUMS-v0.9.3.txt`，通过 After Effects 2025 公开路径 smoke 后原样上传，不重新构建。完整流程见 [docs/RELEASE.md](docs/RELEASE.md)。
+维护者先合并发布元数据，再从最终干净的受保护 `main` 提交构建 v0.9.4 Windows Helper、ZXP 与 AEX。校验最小 ZXP 载荷后分别签名、复验并生成 `SHA256SUMS-v0.9.4.txt`，通过 After Effects 2025 Helper/Provider 与公开 MCP 路径 smoke 后原样上传，不重新构建。完整流程见 [docs/RELEASE.md](docs/RELEASE.md)。
 
 ## 实现说明
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,36 +2,36 @@
 
 ## 中文
 
-### v0.9.3 状态与支持矩阵
+### v0.9.4 状态与支持矩阵
 
-v0.9.3 是 Windows x64 版本，CEP 面板与原生 AEX 作为两个独立签名资产发布。AEX 需要手动安装，本版继续使用现有外部 runtime/launcher；它不是零环境或只装 ZXP 即用的安装包。
+v0.9.4 是 Windows x64 修复版本。ZXP 内含 CEP 面板与 Windows Platform Helper；原生 AEX 作为独立签名资产手动安装。外部 runtime/launcher 可以由面板首跑向导联网安装；本版不内置离线 Python，也不是只装 ZXP 即用的安装包。
 
 支持范围固定为：
 
 - Windows 11 24H2 或更高版本，x64；不支持 Windows ARM。
 - After Effects 2025 是本次打包验收宿主；CEP manifest 仍允许 `[25.0,26.9]`。
 
-### 普通用户：安装离线发布资产
+### 普通用户：安装签名资产并准备 runtime
 
-v0.9.3 的发布资产是：
+v0.9.4 的发布资产是：
 
 | 用途 | 发布资产 |
 |---|---|
-| CEP 面板 | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
-| 原生 AEGP 插件 | `AeMcpNative-v0.9.3-windows-x64.aex` |
-| 完整性校验 | `SHA256SUMS-v0.9.3.txt` |
+| CEP 面板 + Windows Platform Helper | `ae-mcp-panel-v0.9.4-windows-x64.zxp` |
+| 原生 AEGP 插件 | `AeMcpNative-v0.9.4-windows-x64.aex` |
+| 完整性校验 | `SHA256SUMS-v0.9.4.txt` |
 
 不要用源码归档、本地重建包或公共 PyPI 同名包替代这些固定发布资产。
 
-1. 下载 ZXP、AEX 与 `SHA256SUMS-v0.9.3.txt`，先校验两个二进制。
+1. 下载 ZXP、AEX 与 `SHA256SUMS-v0.9.4.txt`，先校验两个二进制。
 2. 使用受支持的 ZXP installer 安装 ZXP。
 3. 关闭全部 After Effects 实例。以管理员权限把 AEX 复制为所选宿主的 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`。
-4. 保留并使用现有外部 runtime/launcher 配置；本版没有 Windows RuntimeManager。
+4. 重启 AE 并打开面板。若缺少 `uv` 或 `ae-mcp`，使用首跑向导联网安装；Windows 向导通过 winget（失败时使用 uv 官方 PowerShell 安装脚本）安装 `uv`，再执行固定到 `v0.9.4` tag 的 `uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.4#subdirectory=packages/core ...`。已有兼容 runtime/launcher 会被复用。
 5. 重启 After Effects，打开 `Window -> Extensions -> ae-mcp`，先运行 `ae_ping` / `ae_status`，再在测试工程执行只读 smoke。
 
 在 Windows 上，平台 Helper 由 Panel 打开时自动启动，不由安装器预先常驻启动。关闭并重开 Panel 时，同一个 AE 会话可以重新连接现有 Helper；AE 正常退出或闪退后，Helper 随已认证的 AE 进程退出。启动、握手或凭据库失败时 Provider 凭据保持 fail-closed，不回退读取明文配置。
 
-一体化安装器、自动 AEX 部署、升级/修复/回滚/卸载生命周期与零环境首跑不属于 v0.9.3 Windows 发布范围。
+内置/离线 Python、一体化安装器、自动 AEX 部署、Windows RuntimeManager、升级/修复/回滚/卸载生命周期不属于 v0.9.4 Windows 发布范围。
 
 ### 可选 AI 通道依赖
 
@@ -62,9 +62,9 @@ v0.9.3 的发布资产是：
 }
 ```
 
-macOS 请把 `<USER>` 替换为实际账户名。Windows 请把 `command` 改成 `%USERPROFILE%\.ae-mcp\bin\ae-mcp.exe` 展开后的绝对路径。Panel 端口若有修改，也要同步修改 `AE_MCP_PLUGIN_URL`。
+macOS 请把 `<USER>` 替换为实际账户名。Windows 默认 `uv tool install` 的 launcher 位于 `%USERPROFILE%\.local\bin\ae-mcp.exe`；若设置了 `UV_TOOL_BIN_DIR`，请直接复制面板生成的实际路径。Panel 端口若有修改，也要同步修改 `AE_MCP_PLUGIN_URL`。
 
-上例是稳定 launcher 契约。Windows v0.9.3 继续使用外部 runtime/launcher，不会从 ZXP 自动激活包内 runtime，也不会回退到在线安装器。
+Windows v0.9.4 继续使用 ZXP 外部的 runtime/launcher，但首跑向导会在缺失时联网安装它；ZXP 本身不携带 Python runtime。
 
 ### 开发安装
 
@@ -98,7 +98,7 @@ Windows 开发机在完成相同依赖同步后运行：
 
 - Panel 不在菜单中：确认安装的是正确平台资产，重启 AE；开发模式才重新运行开发安装脚本。
 - Panel 未监听：检查 Panel 日志及 `127.0.0.1:11488` 端口占用。
-- launcher 不存在：v0.9.3 三项资产不提供 runtime bootstrap；先恢复一套受支持的既有外部 runtime/launcher，再把本次安装视为完成。
+- launcher 不存在：重新运行面板首跑向导，联网安装 `uv` 与固定到 v0.9.4 tag 的 `ae-mcp` runtime；若自定义了 `UV_TOOL_BIN_DIR`，复制面板生成的实际路径。
 - CLI 通道不可用：检查对应的 Claude Code、Codex 或 ZCode CLI/app-server；这不应影响 core。
 - macOS 截图权限不足：按系统提示授权签名 helper 的 Screen Recording；`ae_previewFrame` 的 AE 原生路径应独立诊断。
 - 需要回退发布资产：本版没有自动回滚状态；关闭 AE 后仅恢复用户自己保留且校验过的上一版 ZXP/AEX。
@@ -106,36 +106,36 @@ Windows 开发机在完成相同依赖同步后运行：
 
 ## English
 
-### v0.9.3 Status and Support Matrix
+### v0.9.4 Status and Support Matrix
 
-v0.9.3 is a Windows x64 release with a separately signed CEP panel and native AEX. The AEX requires manual installation and the existing external runtime/launcher remains required. This is not a zero-environment or ZXP-only installation.
+v0.9.4 is the corrective Windows x64 release. The ZXP contains the CEP panel and Windows Platform Helper; the separately signed native AEX remains a manual install. The Panel's first-run wizard can install the external runtime/launcher online. Python is not bundled, and installing only the ZXP is not sufficient.
 
 The supported matrix is fixed to:
 
 - Windows 11 24H2 or newer on x64; no Windows ARM support.
 - After Effects 2025 is the packaged acceptance host; the CEP manifest remains `[25.0,26.9]`.
 
-### Normal Users: Install an Offline Release Asset
+### Normal Users: Install Signed Assets and Prepare the Runtime
 
-The v0.9.3 release assets are:
+The v0.9.4 release assets are:
 
 | Role | Release asset |
 |---|---|
-| CEP panel | `ae-mcp-panel-v0.9.3-windows-x64.zxp` |
-| Native AEGP plug-in | `AeMcpNative-v0.9.3-windows-x64.aex` |
-| Integrity | `SHA256SUMS-v0.9.3.txt` |
+| CEP panel + Windows Platform Helper | `ae-mcp-panel-v0.9.4-windows-x64.zxp` |
+| Native AEGP plug-in | `AeMcpNative-v0.9.4-windows-x64.aex` |
+| Integrity | `SHA256SUMS-v0.9.4.txt` |
 
 Do not substitute a source archive, locally rebuilt package, or public PyPI namesake for these fixed assets.
 
-1. Download the ZXP, AEX, and `SHA256SUMS-v0.9.3.txt`; verify both binaries first.
+1. Download the ZXP, AEX, and `SHA256SUMS-v0.9.4.txt`; verify both binaries first.
 2. Install the ZXP with a supported ZXP installer.
 3. Close every After Effects instance. With administrator permission, copy the AEX to the selected host as `Support Files\Plug-ins\Extensions\AeMcpNative.aex`.
-4. Keep the existing external runtime/launcher configured; this release has no Windows RuntimeManager.
+4. Restart AE and open the Panel. If `uv` or `ae-mcp` is missing, use the first-run wizard. On Windows it installs `uv` through winget (falling back to uv's official PowerShell installer), then runs a tag-pinned `uv tool install --force --from git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.4#subdirectory=packages/core ...`. An existing compatible runtime/launcher is reused.
 5. Restart After Effects, open `Window -> Extensions -> ae-mcp`, and run `ae_ping` / `ae_status` followed by a read-only smoke in a test project.
 
 On Windows, the Panel starts Platform Helper when it opens; the installer does not prestart a resident Helper. Closing and reopening the Panel reconnects within the same AE session. Platform Helper exits when its authenticated AE process exits or crashes. Startup, handshake, or credential-store failures remain fail-closed and never fall back to plaintext provider configuration.
 
-An integrated installer, automatic AEX deployment, upgrade/repair/rollback/uninstall lifecycle, and zero-environment onboarding are outside the v0.9.3 Windows release.
+Bundled/offline Python, an integrated installer, automatic AEX deployment, Windows RuntimeManager, and upgrade/repair/rollback/uninstall lifecycle are outside the v0.9.4 Windows release.
 
 ### Optional AI Channel Dependencies
 
@@ -166,9 +166,9 @@ Use the installed stable launcher:
 }
 ```
 
-On macOS, replace `<USER>` with the actual account name. On Windows, replace `command` with the expanded absolute path to `%USERPROFILE%\.ae-mcp\bin\ae-mcp.exe`. If the Panel port changes, update `AE_MCP_PLUGIN_URL` too.
+On macOS, replace `<USER>` with the actual account name. The default Windows `uv tool install` launcher is `%USERPROFILE%\.local\bin\ae-mcp.exe`; when `UV_TOOL_BIN_DIR` is set, copy the actual path generated by the Panel. If the Panel port changes, update `AE_MCP_PLUGIN_URL` too.
 
-This is the stable-launcher contract. Windows v0.9.3 continues to use an external runtime/launcher; the ZXP does not automatically activate a bundled runtime or fall back to an online installer.
+Windows v0.9.4 continues to use a runtime/launcher outside the ZXP, but the first-run wizard installs it online when missing. The ZXP itself does not carry a Python runtime.
 
 ### Developer Install
 
@@ -227,7 +227,7 @@ Retention keeps the newest three migration backups within the 30-day policy wind
 
 - Panel missing: confirm the correct platform asset was installed and restart AE; rerun a dev installer only in development mode.
 - Panel not listening: inspect Panel logs and the process using `127.0.0.1:11488`.
-- Launcher missing: the three v0.9.3 assets do not bootstrap a runtime. Restore a supported existing external runtime/launcher before treating this installation as complete.
+- Launcher missing: rerun the Panel's first-run wizard to install `uv` and the v0.9.4-tagged `ae-mcp` runtime online. If `UV_TOOL_BIN_DIR` is customized, copy the actual path generated by the Panel.
 - Optional channel unavailable: inspect the corresponding Claude Code, Codex, or ZCode CLI/app-server; core should remain usable.
 - macOS capture permission missing: grant Screen Recording to the signed helper when prompted; diagnose the AE-native `ae_previewFrame` path separately.
 - To revert release assets: this release has no automatic rollback state. Close AE and restore only a user-retained, checksum-verified previous ZXP/AEX.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -10,13 +10,14 @@
 | Preview 输出 | 默认位于操作系统临时目录的 `ae_mcp_previews/<session>/...png`，可用 `out_dir` 覆盖 |
 | Checkpoint 存储 | 操作系统临时目录下的 `ae_mcp_checkpoints/<basename>/<id>.aep + .json` |
 
-### v0.9.3 平台与分发契约
+### v0.9.4 平台与分发契约
 
-v0.9.3 是 Windows x64 版本。固定发布资产为
-`ae-mcp-panel-v0.9.3-windows-x64.zxp`、
-`AeMcpNative-v0.9.3-windows-x64.aex` 与 `SHA256SUMS-v0.9.3.txt`。
-AEX 需手动复制到所选 AE 插件目录；现有外部 runtime/launcher 仍是前置条件。
-本版不提供一体化安装器、Windows RuntimeManager 或零环境首跑。
+v0.9.4 是 Windows x64 修复版本。固定发布资产为
+`ae-mcp-panel-v0.9.4-windows-x64.zxp`、
+`AeMcpNative-v0.9.4-windows-x64.aex` 与 `SHA256SUMS-v0.9.4.txt`。
+ZXP 内含 Windows Platform Helper；AEX 需手动复制到所选 AE 插件目录。外部 runtime/launcher
+可由面板首跑向导通过固定到 v0.9.4 tag 的 `uv tool install` 联网安装。本版不提供
+bundled/offline runtime、一体化安装器或 Windows RuntimeManager。
 
 Claude Code CLI、Codex CLI 与 ZCode CLI/app-server 都只是对应 AI 通道的
 **可选**依赖，不是 Core 或两个执行入口的前置条件。
@@ -203,14 +204,15 @@ uv run python scripts/generate_native_exec.py --check
 | Preview output | `ae_mcp_previews/<session>/...png` in the operating-system temporary directory unless `out_dir` is set |
 | Checkpoint store | `ae_mcp_checkpoints/<basename>/<id>.aep + .json` under the operating-system temporary directory |
 
-### v0.9.3 platform and distribution contract
+### v0.9.4 platform and distribution contract
 
-v0.9.3 is a Windows x64 release. Its fixed assets are
-`ae-mcp-panel-v0.9.3-windows-x64.zxp`,
-`AeMcpNative-v0.9.3-windows-x64.aex`, and `SHA256SUMS-v0.9.3.txt`.
-Install the AEX manually in the selected AE plug-in directory and retain the
-existing external runtime/launcher. This release has no integrated installer,
-Windows RuntimeManager, or zero-environment onboarding.
+v0.9.4 is the corrective Windows x64 release. Its fixed assets are
+`ae-mcp-panel-v0.9.4-windows-x64.zxp`,
+`AeMcpNative-v0.9.4-windows-x64.aex`, and `SHA256SUMS-v0.9.4.txt`.
+The ZXP contains Windows Platform Helper. Install the AEX manually in the selected AE plug-in
+directory. The Panel's first-run wizard can install the external runtime/launcher online through
+a `uv tool install` pinned to the v0.9.4 tag. This release has no bundled/offline runtime,
+integrated installer, or Windows RuntimeManager.
 
 Claude Code CLI, Codex CLI, and the ZCode CLI/app-server are **optional**
 dependencies for their corresponding AI channels, not prerequisites for Core

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,100 +1,98 @@
-# v0.9.3 Windows 最小发布 / Minimal Windows Release
+# v0.9.4 Windows Helper 修复发布 / Windows Helper Corrective Release
 
 ## 中文
 
 ### 固定资产
 
-v0.9.3 只发布以下三个文件：
+v0.9.4 只发布以下三个文件：
 
 ```text
-ae-mcp-panel-v0.9.3-windows-x64.zxp
-AeMcpNative-v0.9.3-windows-x64.aex
-SHA256SUMS-v0.9.3.txt
+ae-mcp-panel-v0.9.4-windows-x64.zxp
+AeMcpNative-v0.9.4-windows-x64.aex
+SHA256SUMS-v0.9.4.txt
 ```
 
-ZXP 安装 CEP 面板；AEX 由用户在关闭全部 AE 实例后，手动复制为所选宿主的
+ZXP 包含 CEP 面板、生产 Host 依赖与现有 Windows Platform Helper。Helper 负责 Provider
+凭据的 Windows Credential Manager 通道和相关平台能力；签名前必须校验
+`platform/windows-x64/helper-manifest.json`、三个声明文件及其 SHA-256。ZXP 不包含
+Python、`node.exe`、Windows RuntimeManager 或 AEX。
+
+AEX 由用户在关闭全部 AE 实例后，手动复制为所选宿主的
 `Support Files\Plug-ins\Extensions\AeMcpNative.aex`。After Effects 2025 的典型完整路径是：
 
 ```text
 C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\Extensions\AeMcpNative.aex
 ```
 
-此 Release 仅适用于已经配置好受支持外部 `ae-mcp` runtime/launcher 的 Windows 环境。
-三个发布文件不包含外部 runtime 的 bootstrap；清洁环境仅安装这些文件不能完整使用产品。
+### Runtime 安装边界
+
+MCP Python runtime/launcher 位于 ZXP 外部。清洁 Windows 环境不要求预先安装它：面板首跑
+向导会联网安装 `uv`，再执行固定到 `v0.9.4` tag 的 `uv tool install`，安装 core、bridge
+与 snapshot-mss。已有兼容 runtime 会被复用。由于这个流程需要网络且 AEX 仍需单独安装，
+v0.9.4 不是离线、零依赖或只装 ZXP 即用的发布。
 
 ### 构建与发布顺序
 
-1. 将 0.9.3 版本、范围和安装说明合并到受保护 `main`。
-2. 只从最终干净 `main` 提交构建 Windows x64 ZXP 与 AEX；不得把旧 0.9.2 二进制改名。
-3. 使用锁定 Adobe SDK 输入构建 AEX，并验证 PE x64、`AeMcpNativeMain`、版本和源码提交。
-4. 为本次发布新建自签名身份，分别签名并复验 ZXP 与 AEX；AEX 使用 RFC 3161 时间戳。
-5. 生成 `SHA256SUMS-v0.9.3.txt`，绑定两个最终签名二进制。
-6. 在 After Effects 2025 上安装最终资产并通过公开 MCP 路径运行只读实机 smoke。
-7. 创建 `v0.9.3` tag 与 GitHub Release，上传已验证的原始字节；发布阶段不重新构建。
+1. 将 0.9.4 版本、Helper 恢复、打包校验和安装说明合并到受保护 `main`。
+2. 只从最终干净 `main` 提交构建 Windows x64 Helper、ZXP 与 AEX；不得修改或替换 v0.9.3 tag/资产。
+3. ZXP 签名前运行 Windows 最小载荷校验：Helper 清单/哈希、Provider 路径、在线 runtime 向导存在；bundled Python/Node、RuntimeManager manifest 与 AEX 不存在。
+4. 使用锁定 Adobe SDK 输入构建 AEX，并验证 PE x64、`AeMcpNativeMain`、版本和源码提交。
+5. 使用本版新签名身份分别签名并复验 ZXP 与 AEX；生成 `SHA256SUMS-v0.9.4.txt`。
+6. 在 After Effects 2025 上安装最终资产，验证 Helper capabilities、一次性 Provider 凭据写入/读取/删除，以及公开 MCP 只读实机路径。
+7. 所有必需 CI 与实机证据通过后创建 `v0.9.4` tag 和 GitHub Release；上传已验证字节，发布阶段不重新构建。
 
 ### 明确非目标
 
-本版不是零环境安装，不新增一体化安装器、自动 AEX 部署、Windows RuntimeManager、
-新 CI/runner 拓扑、私有制品服务、升级/修复/回滚/卸载生命周期、macOS 资产或 Windows ARM。
-ZXP installer 不会把 AEX 安装到 AE 原生插件目录。
-
-ZXP 与 AEX 的自签名可证明签名后字节未变化，但不建立操作系统默认信任的公开发布者；
-安装时可能显示未知或不受信任发布者提示。
-
-校验示例：
-
-```powershell
-Get-FileHash .\ae-mcp-panel-v0.9.3-windows-x64.zxp -Algorithm SHA256
-Get-FileHash .\AeMcpNative-v0.9.3-windows-x64.aex -Algorithm SHA256
-```
+本版不新增 bundled/offline runtime、Windows RuntimeManager、一体化安装器、自动 AEX 部署、
+升级/修复/回滚/卸载生命周期、macOS 资产或 Windows ARM。ZXP installer 不会把 AEX
+安装到 AE 原生插件目录。自签名只能证明签名后的字节未变化，不建立系统默认信任的公开发布者。
 
 ## English
 
 ### Fixed assets
 
-v0.9.3 publishes exactly these files:
+v0.9.4 publishes exactly these files:
 
 ```text
-ae-mcp-panel-v0.9.3-windows-x64.zxp
-AeMcpNative-v0.9.3-windows-x64.aex
-SHA256SUMS-v0.9.3.txt
+ae-mcp-panel-v0.9.4-windows-x64.zxp
+AeMcpNative-v0.9.4-windows-x64.aex
+SHA256SUMS-v0.9.4.txt
 ```
 
-The ZXP installs the CEP panel. With every AE instance closed, copy the AEX manually to the
-selected host as `Support Files\Plug-ins\Extensions\AeMcpNative.aex`. A typical complete
-After Effects 2025 path is:
+The ZXP contains the CEP Panel, production Host dependencies, and the existing Windows Platform
+Helper. The Helper provides the Windows Credential Manager channel used by Provider Manager and
+related platform capabilities. Before signing, packaging verifies
+`platform/windows-x64/helper-manifest.json`, its three declared files, and their SHA-256 values.
+The ZXP contains no Python, `node.exe`, Windows RuntimeManager, or AEX.
+
+With every AE instance closed, users copy the AEX manually to the selected host as
+`Support Files\Plug-ins\Extensions\AeMcpNative.aex`. A typical After Effects 2025 path is:
 
 ```text
 C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\Extensions\AeMcpNative.aex
 ```
 
-This Release applies only to Windows environments that already have a supported external
-`ae-mcp` runtime/launcher configured. The three assets do not bootstrap that external runtime;
-a clean environment cannot obtain full product operation by installing only these files.
+### Runtime installation boundary
+
+The MCP Python runtime/launcher remains outside the ZXP. A clean Windows environment does not need
+it preinstalled: the Panel's first-run wizard installs `uv` online and runs a `uv tool install`
+pinned to the `v0.9.4` tag for core, bridge, and snapshot-mss. An existing compatible runtime is
+reused. Because this flow needs network access and the AEX is still separate, v0.9.4 is not an
+offline, zero-dependency, or ZXP-only installation.
 
 ### Build and publication order
 
-1. Merge the 0.9.3 version, scope, and installation documentation into protected `main`.
-2. Build the Windows x64 ZXP and AEX only from the final clean `main` commit; never rename a 0.9.2 binary.
-3. Build the AEX from locked Adobe SDK inputs and verify PE x64, `AeMcpNativeMain`, version, and source commit.
-4. Create new self-signed identities for this release, then sign and reverify the ZXP and AEX separately; use an RFC 3161 timestamp for the AEX.
-5. Generate `SHA256SUMS-v0.9.3.txt` over the two final signed binaries.
-6. Install the final assets in After Effects 2025 and run a read-only smoke through the public MCP surface.
-7. Create the `v0.9.3` tag and GitHub Release and upload the verified bytes without rebuilding.
+1. Merge the 0.9.4 version, Helper restoration, packaging validation, and installation documentation into protected `main`.
+2. Build the Windows x64 Helper, ZXP, and AEX only from the final clean `main` commit. Do not mutate or replace the v0.9.3 tag or assets.
+3. Before ZXP signing, verify the minimal Windows payload: Helper manifest/hashes, Provider path, and online runtime wizard are present; bundled Python/Node, RuntimeManager manifests, and AEX are absent.
+4. Build the AEX from locked Adobe SDK inputs and verify PE x64, `AeMcpNativeMain`, version, and source commit.
+5. Sign and reverify the ZXP and AEX with new identities for this release, then generate `SHA256SUMS-v0.9.4.txt`.
+6. Install the final assets in After Effects 2025 and verify Helper capabilities, a disposable Provider credential set/get/delete round trip, and a read-only public MCP smoke.
+7. After required CI and hardware evidence pass, create the `v0.9.4` tag and GitHub Release and upload the verified bytes without rebuilding.
 
 ### Explicit non-goals
 
-This is not a zero-environment release. It adds no integrated installer, automatic AEX deployment,
-Windows RuntimeManager, new CI/runner topology, private artifact service, upgrade/repair/rollback/uninstall
-lifecycle, macOS asset, or Windows ARM support. A ZXP installer does not install the AEX in AE's native
-plug-in directory.
-
-The self-signed ZXP and AEX signatures prove that the bytes have not changed since signing, but they
-do not establish a publicly trusted publisher. Installation may show an unknown or untrusted publisher warning.
-
-Verification example:
-
-```powershell
-Get-FileHash .\ae-mcp-panel-v0.9.3-windows-x64.zxp -Algorithm SHA256
-Get-FileHash .\AeMcpNative-v0.9.3-windows-x64.aex -Algorithm SHA256
-```
+This release adds no bundled/offline runtime, Windows RuntimeManager, integrated installer,
+automatic AEX deployment, upgrade/repair/rollback/uninstall lifecycle, macOS asset, or Windows ARM
+support. A ZXP installer does not install the AEX in AE's native plug-in directory. Self-signing
+does not establish a publicly trusted publisher.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -2,15 +2,16 @@
 
 ## 中文
 
-这份文档描述 v0.9.3 的执行工作流。Windows x64 发布资产是
-`ae-mcp-panel-v0.9.3-windows-x64.zxp`、
-`AeMcpNative-v0.9.3-windows-x64.aex` 与 `SHA256SUMS-v0.9.3.txt`。
+这份文档描述 v0.9.4 的执行工作流。Windows x64 发布资产是
+`ae-mcp-panel-v0.9.4-windows-x64.zxp`、
+`AeMcpNative-v0.9.4-windows-x64.aex` 与 `SHA256SUMS-v0.9.4.txt`。
 使用受支持的 ZXP installer 安装面板，并手动把 AEX 复制到所选 AE 插件目录。
 Claude Code CLI、Codex CLI 与 ZCode CLI/app-server 都是相应 AI 通道的
 **可选**依赖，不是 Core 或 AE 执行的前置条件。
 
-Windows v0.9.3 继续使用现有外部 runtime/launcher，不提供 Windows RuntimeManager、
-一体化安装器或零环境首跑。macOS 的稳定 launcher 配置使用展开后的绝对路径
+Windows v0.9.4 的 ZXP 包含 Platform Helper；外部 runtime/launcher 可由首跑向导通过
+固定到 v0.9.4 tag 的 `uv tool install` 联网安装。本版不提供 bundled/offline runtime、
+Windows RuntimeManager 或一体化安装器。macOS 的稳定 launcher 配置使用展开后的绝对路径
 `/Users/<USER>/.ae-mcp/bin/ae-mcp`，不会回退到裸 PATH。
 
 ### 1. 选择执行路径
@@ -101,17 +102,19 @@ uv run python scripts/generate_native_exec.py --check
 
 ## English
 
-This document describes the v0.9.3 execution workflow. The Windows x64 assets
-are `ae-mcp-panel-v0.9.3-windows-x64.zxp`,
-`AeMcpNative-v0.9.3-windows-x64.aex`, and `SHA256SUMS-v0.9.3.txt`.
+This document describes the v0.9.4 execution workflow. The Windows x64 assets
+are `ae-mcp-panel-v0.9.4-windows-x64.zxp`,
+`AeMcpNative-v0.9.4-windows-x64.aex`, and `SHA256SUMS-v0.9.4.txt`.
 Install the panel with a supported ZXP installer and copy the AEX manually to
 the selected AE plug-in directory.
 Claude Code CLI, Codex CLI, and the ZCode CLI/app-server are **optional**
 dependencies for their corresponding AI channels, not prerequisites for Core
 or AE execution.
 
-Windows v0.9.3 retains the existing external runtime/launcher and has no Windows
-RuntimeManager, integrated installer, or zero-environment onboarding. The macOS
+The v0.9.4 Windows ZXP contains Platform Helper. Its external runtime/launcher can
+be installed online by the first-run wizard through a `uv tool install` pinned to
+the v0.9.4 tag. This release has no bundled/offline runtime, Windows RuntimeManager,
+or integrated installer. The macOS
 stable launcher uses the expanded absolute path `/Users/<USER>/.ae-mcp/bin/ae-mcp`
 and never falls back to bare PATH.
 

--- a/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
+++ b/native/platform-helper/macos/Tests/build-platform-helper.test.mjs
@@ -230,7 +230,7 @@ test('locked archive digest is verified before tar sees attacker-controlled byte
   const tarArgsBlock = block.slice(tarArgsStart, tarArgsEnd);
   assert.match(
     tarArgsBlock,
-    /const tarArgs = process\.platform === 'win32'\s*\?\s*\[\s*'--force-local',\s*'-xzf',\s*snapshotArchive\.replaceAll\('\\\\', '\/'\),\s*'-C',\s*extractionRoot\.replaceAll\('\\\\', '\/'\),\s*\]\s*:\s*\['-xzf', snapshotArchive, '-C', extractionRoot\];/,
+    /const tarArgs = \[\s*'-xzf',\s*snapshotArchive\.replaceAll\('\\\\', '\/'\),\s*'-C',\s*extractionRoot\.replaceAll\('\\\\', '\/'\),\s*\];/,
   );
   assert.doesNotMatch(tarArgsBlock, /\barchivePath\b/);
   assert.match(block.slice(tarArgsEnd), /^await run\(tar, tarArgs\);/);

--- a/native/platform-helper/windows/CMakeLists.txt
+++ b/native/platform-helper/windows/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(ae_mcp_platform_helper_windows VERSION 0.9.3 LANGUAGES CXX)
+project(ae_mcp_platform_helper_windows VERSION 0.9.4 LANGUAGES CXX)
 
 if(NOT WIN32 OR NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   message(FATAL_ERROR "the Windows platform helper requires a native x64 Windows host")

--- a/native/platform-helper/windows/src/main.cpp
+++ b/native/platform-helper/windows/src/main.cpp
@@ -674,7 +674,7 @@ IJsonValue Capabilities() {
   JsonObject result;
   result.Insert(L"protocolVersion", NumberValue(1));
   result.Insert(L"platform", StringValue("windows-x64"));
-  result.Insert(L"helperVersion", StringValue("0.9.3"));
+  result.Insert(L"helperVersion", StringValue("0.9.4"));
   result.Insert(L"secretBackend", StringValue("credential-manager"));
   result.Insert(L"captureBackend", StringValue("windows-graphics-capture"));
   result.Insert(L"authenticatedCaller", JsonValue::CreateBooleanValue(true));

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-bridge"
-version = "0.9.3"
+version = "0.9.4"
 description = "HTTP bridge between ae-mcp MCP server and the ae-mcp CEP plugin"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp"
-version = "0.9.3"
+version = "0.9.4"
 description = "Backend-agnostic MCP server for Adobe After Effects automation"
 readme = "../../README.md"
 requires-python = ">=3.10"

--- a/packages/snapshot-mss/pyproject.toml
+++ b/packages/snapshot-mss/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ae-mcp-snapshot-mss"
-version = "0.9.3"
+version = "0.9.4"
 description = "Windows mss-based After Effects window capture for ae-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.9.3"
+                   ExtensionBundleVersion="0.9.4"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.9.3" />
+        <Extension Id="com.aemcp.panel" Version="0.9.4" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20262,7 +20262,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.9.3",
+    version: "0.9.4",
     private: true,
     type: "module",
     scripts: {
@@ -31995,7 +31995,7 @@
   var DEFAULT_TIMEOUT_MS2 = 3e4;
   var INITIALIZE_TIMEOUT_MS = 12e4;
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.9.3";
+  var PANEL_VERSION = "0.9.4";
   function defaultRandomBytes2(size) {
     const cryptoImpl = globalThis.crypto;
     if (!cryptoImpl || typeof cryptoImpl.getRandomValues !== "function") {

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1045,7 +1045,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-                version: input.version || '0.9.3',
+        version: input.version || '0.9.4',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "express": "4.22.1"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -6,7 +6,7 @@ import { createRuntimeManager, hasDevelopmentRuntimeOverride } from './runtimeMa
 const DEFAULT_TIMEOUT_MS = 30000;
 const INITIALIZE_TIMEOUT_MS = 120000;
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.9.3';
+export const PANEL_VERSION = '0.9.4';
 
 function defaultRandomBytes(size) {
   const cryptoImpl = globalThis.crypto;

--- a/plugin/sidecar/package-lock.json
+++ b/plugin/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-agent-sidecar",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-agent-sidecar",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.174"
       }

--- a/plugin/sidecar/package.json
+++ b/plugin/sidecar/package.json
@@ -2,7 +2,7 @@
   "name": "ae-mcp-agent-sidecar",
   "private": true,
   "type": "module",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.174"
   },

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -1,9 +1,9 @@
 # Build a signed ZXP package for the ae-mcp CEP panel.
 #
 # Usage:
-#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw>
+#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw> -HelperRoot build\helper\windows-x64
 # Optional:
-#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw> -CertPath release\ae-mcp.p12
+#   .\scripts\package-zxp.ps1 -ZxpSignCmd C:\Tools\ZXPSignCmd.exe -CertPassword <pw> -HelperRoot build\helper\windows-x64 -CertPath release\ae-mcp.p12
 #
 # -CertPassword is REQUIRED (no baked-in default secret). The same password is
 # used to create the self-signed cert (if none exists) and to sign.
@@ -15,8 +15,12 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$CertPassword,
 
+    [Parameter(Mandatory=$true)]
+    [string]$HelperRoot,
+
     [string]$CertPath = "",
     [string]$OutputPath = "",
+    [string]$Version = "0.9.4",
     # Timestamp server: an untimestamped self-signed ZXP fails validation once
     # the cert expires. Timestamping pins the signature to signing time.
     [string]$Tsa = "http://timestamp.digicert.com"
@@ -32,6 +36,10 @@ $pluginSrc = Join-Path $repoRoot 'plugin'
 if (-not (Test-Path $ZxpSignCmd)) {
     throw "ZXPSignCmd not found: $ZxpSignCmd"
 }
+if (-not (Test-Path -LiteralPath $HelperRoot -PathType Container)) {
+    throw "Windows Platform Helper root not found: $HelperRoot"
+}
+$HelperRoot = (Resolve-Path -LiteralPath $HelperRoot).Path
 
 if (-not $OutputPath) {
     $OutputPath = Join-Path $releaseDir 'ae-mcp-panel.zxp'
@@ -45,7 +53,7 @@ if (Test-Path $stageDir) {
     Remove-Item -Recurse -Force $stageDir
 }
 
-Write-Host "[1/5] Staging plugin files..."
+Write-Host "[1/6] Staging plugin files..."
 Copy-Item -Recurse -Force $pluginSrc $stageDir
 if (Test-Path (Join-Path $stageDir 'host\node_modules')) {
     Remove-Item -Recurse -Force (Join-Path $stageDir 'host\node_modules')
@@ -64,7 +72,14 @@ if (Test-Path (Join-Path $stageDir 'sidecar\test')) {
 # local process attach a DevTools/Node client. Strip it before signing.
 Remove-Item -Force (Join-Path $stageDir '.debug') -ErrorAction SilentlyContinue
 
-Write-Host "[2/5] Installing production host runtime dependencies..."
+Write-Host "[2/6] Staging the Windows Platform Helper..."
+$helperStageDir = Join-Path $stageDir 'platform\windows-x64'
+New-Item -ItemType Directory -Force -Path $helperStageDir | Out-Null
+Get-ChildItem -LiteralPath $HelperRoot -Force | ForEach-Object {
+    Copy-Item -LiteralPath $_.FullName -Destination $helperStageDir -Recurse -Force
+}
+
+Write-Host "[3/6] Installing production host runtime dependencies..."
 $runtimeHostDir = Join-Path $stageDir 'runtime\windows-x64\node\host'
 New-Item -ItemType Directory -Force -Path $runtimeHostDir | Out-Null
 Copy-Item -LiteralPath (Join-Path $stageDir 'host\package.json') -Destination $runtimeHostDir
@@ -84,7 +99,7 @@ foreach ($requiredHostFile in @('package.json', 'node_modules\express\package.js
     }
 }
 
-Write-Host "[3/5] Installing sidecar production dependencies..."
+Write-Host "[4/6] Installing sidecar production dependencies..."
 Push-Location (Join-Path $stageDir 'sidecar')
 try {
     npm ci --omit=dev
@@ -95,14 +110,19 @@ try {
     Pop-Location
 }
 
-if (-not (Test-Path $CertPath)) {
-    Write-Host "[4/5] Creating self-signed ZXP certificate..."
-    & $ZxpSignCmd -selfSignedCert US CA ae-mcp ae-mcp $CertPassword $CertPath
-} else {
-    Write-Host "[4/5] Using existing certificate $CertPath"
+& node (Join-Path $repoRoot 'scripts\package\verify-windows-zxp-stage.mjs') --stage $stageDir --version $Version
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows ZXP stage validation failed"
 }
 
-Write-Host "[5/5] Signing package..."
+if (-not (Test-Path $CertPath)) {
+    Write-Host "[5/6] Creating self-signed ZXP certificate..."
+    & $ZxpSignCmd -selfSignedCert US CA ae-mcp ae-mcp $CertPassword $CertPath
+} else {
+    Write-Host "[5/6] Using existing certificate $CertPath"
+}
+
+Write-Host "[6/6] Signing package..."
 if (Test-Path $OutputPath) {
     Remove-Item -Force $OutputPath
 }

--- a/scripts/package/build-platform-helper.mjs
+++ b/scripts/package/build-platform-helper.mjs
@@ -243,18 +243,15 @@ async function extractNodeHeaders(archivePath, scratchRoot) {
   const snapshotArchive = await snapshotNodeHeadersArchive({ archivePath, scratchRoot });
   await validateNodeHeadersArchive({ archivePath: snapshotArchive });
   const tar = process.platform === 'win32' ? 'tar.exe' : '/usr/bin/tar';
-  // bsdtar on Windows mis-parses drive-letter paths as remote hosts
-  // ("Cannot connect to C:") and rejects backslash -C targets; keep
-  // archive paths local and POSIX-shaped for the extraction.
-  const tarArgs = process.platform === 'win32'
-    ? [
-        '--force-local',
-        '-xzf',
-        snapshotArchive.replaceAll('\\', '/'),
-        '-C',
-        extractionRoot.replaceAll('\\', '/'),
-      ]
-    : ['-xzf', snapshotArchive, '-C', extractionRoot];
+  // Windows tar rejects backslash -C targets and some builds do not support
+  // --force-local. POSIX-shaped paths keep drive-letter inputs local without
+  // depending on implementation-specific flags.
+  const tarArgs = [
+    '-xzf',
+    snapshotArchive.replaceAll('\\', '/'),
+    '-C',
+    extractionRoot.replaceAll('\\', '/'),
+  ];
   await run(tar, tarArgs);
   return validateNodeHeadersArchive({ archivePath: snapshotArchive, extractedRoot: extractionRoot });
 }

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { verifyWindowsZxpStage } from '../verify-windows-zxp-stage.mjs';
+
+const VERSION = '0.9.4';
+const HELPER_FILES = [
+  'bin/ae-mcp-platform-helper.exe',
+  'bin/ae-mcp.exe',
+  'lib/ae-mcp-platform-helper-transport.node',
+];
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function write(root, relativePath, value) {
+  const destination = path.join(root, ...relativePath.split('/'));
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, value);
+}
+
+async function fixture(t) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ae-mcp-zxp-contract-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const records = [];
+  for (const [index, relativePath] of HELPER_FILES.entries()) {
+    const bytes = Buffer.from(`helper-${index}`);
+    await write(root, `platform/windows-x64/${relativePath}`, bytes);
+    records.push({ path: relativePath, architecture: 'pe-x64', sha256: sha256(bytes) });
+  }
+  await write(root, 'platform/windows-x64/helper-manifest.json', `${JSON.stringify({
+    schemaVersion: 1,
+    platform: 'windows-x64',
+    helperId: 'com.junkdoge.ae-mcp.platform-helper',
+    entrypoints: {
+      helper: HELPER_FILES[0],
+      launcher: HELPER_FILES[1],
+    },
+    files: records,
+  })}\n`);
+  await write(root, 'runtime/windows-x64/node/host/package.json', '{}\n');
+  await write(root, 'runtime/windows-x64/node/host/node_modules/express/package.json', '{}\n');
+  await write(root, 'host/platform-helper-transport.js', HELPER_FILES.join('\n'));
+  await write(root, 'client/dist/app.js', [
+    `var PANEL_VERSION = "${VERSION}";`,
+    'astral.sh/uv/install.ps1',
+    '"tool", "install", "--force", "--from"',
+    '#subdirectory=packages/${sub}',
+    'src("core")',
+    'src("bridge")',
+    'src("snapshot-mss")',
+  ].join('\n'));
+  return { root, records };
+}
+
+test('accepts the minimal Windows ZXP contract with Helper and online runtime wizard', async (t) => {
+  const { root } = await fixture(t);
+  assert.deepEqual(verifyWindowsZxpStage({ stageRoot: root, version: VERSION }), {
+    platform: 'windows-x64',
+    version: VERSION,
+    helperFiles: HELPER_FILES,
+  });
+});
+
+test('rejects a missing or modified Helper payload', async (t) => {
+  const missing = await fixture(t);
+  await fs.rm(path.join(missing.root, 'platform/windows-x64/bin/ae-mcp.exe'));
+  assert.throws(
+    () => verifyWindowsZxpStage({ stageRoot: missing.root, version: VERSION }),
+    { code: 'WINDOWS_ZXP_CONTRACT_INVALID' },
+  );
+
+  const modified = await fixture(t);
+  await fs.writeFile(
+    path.join(modified.root, 'platform/windows-x64/bin/ae-mcp-platform-helper.exe'),
+    'modified',
+  );
+  assert.throws(
+    () => verifyWindowsZxpStage({ stageRoot: modified.root, version: VERSION }),
+    /hash mismatch/,
+  );
+});
+
+test('rejects bundled runtime executables and nested AEX files', async (t) => {
+  const runtime = await fixture(t);
+  await write(runtime.root, 'runtime/windows-x64/node/node.exe', 'node');
+  assert.throws(
+    () => verifyWindowsZxpStage({ stageRoot: runtime.root, version: VERSION }),
+    /forbidden bundled runtime path/,
+  );
+
+  const aex = await fixture(t);
+  await write(aex.root, 'native/AeMcpNative.aex', 'aex');
+  assert.throws(
+    () => verifyWindowsZxpStage({ stageRoot: aex.root, version: VERSION }),
+    /separate release asset/,
+  );
+});
+
+test('rejects a compiled Panel without the matching online runtime wizard', async (t) => {
+  const { root } = await fixture(t);
+  await fs.writeFile(path.join(root, 'client/dist/app.js'), 'PANEL_VERSION="0.9.3"\n');
+  assert.throws(
+    () => verifyWindowsZxpStage({ stageRoot: root, version: VERSION }),
+    /compiled Panel contract is missing/,
+  );
+});

--- a/scripts/package/verify-windows-zxp-stage.mjs
+++ b/scripts/package/verify-windows-zxp-stage.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const HELPER_FILES = Object.freeze([
+  'bin/ae-mcp-platform-helper.exe',
+  'bin/ae-mcp.exe',
+  'lib/ae-mcp-platform-helper-transport.node',
+]);
+const FORBIDDEN_RUNTIME_PATHS = Object.freeze([
+  'runtime/windows-x64/node/node.exe',
+  'runtime/windows-x64/python',
+  'runtime/windows-x64/runtime-manifest.json',
+  'runtime/windows-x64/bundle-manifest.json',
+]);
+
+function contractError(message) {
+  const error = new Error(message);
+  error.code = 'WINDOWS_ZXP_CONTRACT_INVALID';
+  return error;
+}
+
+function regularFile(filePath) {
+  let stats;
+  try {
+    stats = fs.lstatSync(filePath);
+  } catch (cause) {
+    throw contractError(`required ZXP file is missing: ${filePath}`);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw contractError(`ZXP path is not a regular file: ${filePath}`);
+  }
+  return filePath;
+}
+
+function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function relativeFiles(root) {
+  const result = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw contractError(`ZXP stage contains a symbolic link: ${absolute}`);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile()) result.push(path.relative(root, absolute).split(path.sep).join('/'));
+      else throw contractError(`ZXP stage contains an unsupported path: ${absolute}`);
+    }
+  };
+  visit(root);
+  return result.sort();
+}
+
+function exactSet(actual, expected, message) {
+  const left = [...actual].sort();
+  const right = [...expected].sort();
+  if (JSON.stringify(left) !== JSON.stringify(right)) throw contractError(message);
+}
+
+function validateHelper(stageRoot) {
+  const helperRoot = path.join(stageRoot, 'platform', 'windows-x64');
+  const manifestPath = regularFile(path.join(helperRoot, 'helper-manifest.json'));
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    throw contractError('Windows Platform Helper manifest is invalid JSON');
+  }
+  const records = Array.isArray(manifest.files) ? manifest.files : [];
+  if (manifest.schemaVersion !== 1
+      || manifest.platform !== 'windows-x64'
+      || manifest.helperId !== 'com.junkdoge.ae-mcp.platform-helper'
+      || manifest.entrypoints?.helper !== HELPER_FILES[0]
+      || manifest.entrypoints?.launcher !== HELPER_FILES[1]) {
+    throw contractError('Windows Platform Helper manifest identity is invalid');
+  }
+  exactSet(records.map((record) => record?.path), HELPER_FILES,
+    'Windows Platform Helper manifest inventory is invalid');
+  exactSet(relativeFiles(helperRoot), ['helper-manifest.json', ...HELPER_FILES],
+    'Windows Platform Helper directory contains missing or unexpected files');
+  for (const record of records) {
+    if (!record || typeof record.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(record.sha256)) {
+      throw contractError('Windows Platform Helper manifest hash is invalid');
+    }
+    const filePath = regularFile(path.join(helperRoot, ...record.path.split('/')));
+    if (sha256File(filePath) !== record.sha256) {
+      throw contractError(`Windows Platform Helper hash mismatch: ${record.path}`);
+    }
+  }
+}
+
+function validateRuntimeBoundary(stageRoot) {
+  for (const relativePath of FORBIDDEN_RUNTIME_PATHS) {
+    if (fs.existsSync(path.join(stageRoot, ...relativePath.split('/')))) {
+      throw contractError(`forbidden bundled runtime path is present: ${relativePath}`);
+    }
+  }
+  const aex = relativeFiles(stageRoot).find((relativePath) => relativePath.toLowerCase().endsWith('.aex'));
+  if (aex) throw contractError(`native AEX must remain a separate release asset: ${aex}`);
+  regularFile(path.join(stageRoot, 'runtime', 'windows-x64', 'node', 'host', 'package.json'));
+  regularFile(path.join(
+    stageRoot,
+    'runtime',
+    'windows-x64',
+    'node',
+    'host',
+    'node_modules',
+    'express',
+    'package.json',
+  ));
+}
+
+function validatePanelContracts(stageRoot, version) {
+  const bundle = fs.readFileSync(regularFile(path.join(stageRoot, 'client', 'dist', 'app.js')), 'utf8');
+  if (!new RegExp(`PANEL_VERSION\\s*=\\s*["']${version.replaceAll('.', '\\.') }["']`).test(bundle)) {
+    throw contractError(`compiled Panel contract is missing release version ${version}`);
+  }
+  for (const marker of [
+    'astral.sh/uv/install.ps1',
+    '#subdirectory=packages/${sub}',
+    'src("core")',
+    'src("bridge")',
+    'src("snapshot-mss")',
+  ]) {
+    if (!bundle.includes(marker)) throw contractError(`compiled Panel contract is missing: ${marker}`);
+  }
+  if (!/["']tool["']\s*,\s*["']install["']\s*,\s*["']--force["']\s*,\s*["']--from["']/.test(bundle)) {
+    throw contractError('compiled Panel contract is missing the uv tool install command');
+  }
+  const transport = fs.readFileSync(
+    regularFile(path.join(stageRoot, 'host', 'platform-helper-transport.js')),
+    'utf8',
+  );
+  for (const marker of HELPER_FILES) {
+    if (!transport.includes(marker)) throw contractError(`Host Helper contract is missing: ${marker}`);
+  }
+}
+
+export function verifyWindowsZxpStage({ stageRoot, version }) {
+  const resolved = path.resolve(stageRoot);
+  if (!/^0\.\d+\.\d+$/.test(version || '')) throw contractError('release version is invalid');
+  if (!fs.existsSync(resolved) || !fs.lstatSync(resolved).isDirectory()) {
+    throw contractError('Windows ZXP stage root is missing');
+  }
+  validateHelper(resolved);
+  validateRuntimeBoundary(resolved);
+  validatePanelContracts(resolved, version);
+  return Object.freeze({ platform: 'windows-x64', version, helperFiles: [...HELPER_FILES] });
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!['--stage', '--version'].includes(key) || value === undefined || values.has(key)) {
+      throw contractError(`invalid argument: ${String(key)}`);
+    }
+    values.set(key, value);
+  }
+  if (!values.has('--stage') || !values.has('--version')) {
+    throw contractError('--stage and --version are required');
+  }
+  return { stageRoot: values.get('--stage'), version: values.get('--version') };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    const result = verifyWindowsZxpStage(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`Windows ZXP stage verified: v${result.version}\n`);
+  } catch (error) {
+    process.stderr.write(`${error?.code ?? 'WINDOWS_ZXP_CONTRACT_INVALID'}: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/test/release-promotion.test.mjs
+++ b/scripts/release/test/release-promotion.test.mjs
@@ -25,18 +25,18 @@ test('promotion queues every idempotent retry instead of replacing an older pend
   );
 });
 
-test('v0.9.3 release docs describe only the approved minimal Windows publication', async () => {
+test('v0.9.4 release docs describe only the approved corrective Windows publication', async () => {
   const docs = await readFile('docs/RELEASE.md', 'utf8');
 
   for (const asset of [
-    'ae-mcp-panel-v0.9.3-windows-x64.zxp',
-    'AeMcpNative-v0.9.3-windows-x64.aex',
-    'SHA256SUMS-v0.9.3.txt',
+    'ae-mcp-panel-v0.9.4-windows-x64.zxp',
+    'AeMcpNative-v0.9.4-windows-x64.aex',
+    'SHA256SUMS-v0.9.4.txt',
   ]) {
     assert.match(docs, new RegExp(asset.replaceAll('.', '\\.')));
   }
   assert.match(docs, /(?:只发布以下三个文件|publishes exactly these files)/i);
-  assert.match(docs, /(?:新 CI\/runner 拓扑|new CI\/runner topology)/i);
+  assert.match(docs, /Windows (?:Platform )?Helper/i);
   assert.doesNotMatch(
     docs,
     /preflight artifact|latest attempt|tag ruleset|标签规则集|merge freeze|合并冻结|AE_MCP_RELEASE_ADMIN_TOKEN|Administration[^\n]*read|admin-read|details_url[^\n]*actions\/runs|workflow run[^\n]*provenance/i,

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -527,7 +527,7 @@ test('attestation workflow pins actions and binds platform checks to immutable b
   assert.doesNotMatch(workflow, /const digestFields = \[/);
 });
 
-test('legacy attestation Check provenance stays constrained without governing v0.9.3', async () => {
+test('legacy attestation Check provenance stays constrained without governing v0.9.4', async () => {
   const workflow = await readFile('.github/workflows/attestation.yml', 'utf8');
   const writers = [
     workflowJob(workflow, 'preinvalidate-macos'),
@@ -540,9 +540,9 @@ test('legacy attestation Check provenance stays constrained without governing v0
   assert.doesNotMatch(docs, /GitHub Actions App[^\n]*(?:共享|shared)/i);
   assert.doesNotMatch(docs, /checks:write/);
   assert.doesNotMatch(docs, /外部前置|external prerequisite/i);
-  assert.match(docs, /ae-mcp-panel-v0\.9\.3-windows-x64\.zxp/);
-  assert.match(docs, /AeMcpNative-v0\.9\.3-windows-x64\.aex/);
-  assert.match(docs, /SHA256SUMS-v0\.9\.3\.txt/);
+  assert.match(docs, /ae-mcp-panel-v0\.9\.4-windows-x64\.zxp/);
+  assert.match(docs, /AeMcpNative-v0\.9\.4-windows-x64\.aex/);
+  assert.match(docs, /SHA256SUMS-v0\.9\.4\.txt/);
 });
 
 test('attestation workflow does not interpolate or log untrusted comment bodies', async () => {

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -5,11 +5,11 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 
 const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
-const VERSION = '0.9.3';
+const VERSION = '0.9.4';
 const PLATFORM_ASSETS = [
-  'ae-mcp-panel-v0.9.3-windows-x64.zxp',
-  'AeMcpNative-v0.9.3-windows-x64.aex',
-  'SHA256SUMS-v0.9.3.txt',
+  'ae-mcp-panel-v0.9.4-windows-x64.zxp',
+  'AeMcpNative-v0.9.4-windows-x64.aex',
+  'SHA256SUMS-v0.9.4.txt',
 ];
 
 const PYTHON_PROJECTS = [
@@ -69,7 +69,7 @@ function panelVersion(source) {
   return source.match(/PANEL_VERSION\s*=\s*['"]([^'"]+)['"];/)?.[1];
 }
 
-test('all active package and lockfile versions are v0.9.3', async () => {
+test('all active package and lockfile versions are v0.9.4', async () => {
   for (const relativePath of PYTHON_PROJECTS) {
     assert.equal(projectVersion(await text(relativePath), relativePath), VERSION, relativePath);
   }
@@ -147,10 +147,10 @@ test('native product version is injected from the exact repository product manif
   }
 });
 
-test('user docs describe the v0.9.3 platform assets and optional AI channel CLIs', async () => {
+test('user docs describe the v0.9.4 platform assets and optional AI channel CLIs', async () => {
   for (const relativePath of USER_DOCS) {
     const body = await text(relativePath);
-    assert.match(body, /v?0\.9\.3/, `${relativePath} release version`);
+    assert.match(body, /v?0\.9\.4/, `${relativePath} release version`);
     for (const asset of PLATFORM_ASSETS) {
       assert.ok(body.includes(asset), `${relativePath} must name ${asset}`);
     }
@@ -161,34 +161,35 @@ test('user docs describe the v0.9.3 platform assets and optional AI channel CLIs
   }
 });
 
-test('normal install docs do not make an online uv tool install the user path', async () => {
+test('normal install docs explain the online tag-pinned runtime wizard', async () => {
   for (const relativePath of INSTALL_PATH_DOCS) {
     const body = await text(relativePath);
-    assert.doesNotMatch(
-      body,
-      /^.*uv tool install.*(?:git\+https|github\.com).*$/mi,
-      `${relativePath} contains a tag/network uv tool install example`,
-    );
+    assert.match(body, /uv tool install/i, `${relativePath} must name the runtime command`);
+    assert.match(body, /online|联网|在线/i, `${relativePath} must disclose network installation`);
+    assert.match(body, /tag-pinned[^\n]*v0\.9\.4|pinned to\s+the `?v0\.9\.4`? tag|v0\.9\.4 tag|v0\.9\.4#subdirectory|固定到\s*`?v0\.9\.4`? tag|按 v0\.9\.4 tag 固定/i,
+      `${relativePath} must pin the runtime source to this release`);
   }
 });
 
-test('release docs define the approved minimal Windows v0.9.3 contract', async () => {
+test('release docs define the approved corrective Windows v0.9.4 contract', async () => {
   const release = await text('docs/RELEASE.md');
   for (const marker of PLATFORM_ASSETS) {
     assert.ok(release.includes(marker), `docs/RELEASE.md must name ${marker}`);
   }
   assert.match(release, /manual|手动/i);
-  assert.match(release, /external runtime|外部 runtime/i);
-  assert.match(release, /not.*zero-environment|不.*零环境/i);
+  assert.match(release, /Platform Helper/i);
+  assert.match(release, /Credential Manager/i);
+  assert.match(release, /bundled\/offline runtime|内置\/离线 Python/i);
   assert.match(release, /installer|安装器/i);
 
   const changelog = await text('CHANGELOG.md');
   const firstRelease = changelog.match(/^### \[([^\]]+)\].*$/m)?.[1];
   assert.equal(firstRelease, VERSION);
+  assert.match(changelog, /^### \[0\.9\.4\].*2026-08-04/mi);
   assert.match(changelog, /^### \[0\.9\.3\].*2026-08-03/mi);
 });
 
-test('user docs distinguish the minimal Windows v0.9.3 release from deferred work', async () => {
+test('user docs distinguish the corrective Windows v0.9.4 release from deferred work', async () => {
   const [readme, readmeZh, install, reference, release, workflow] = await Promise.all([
     readFile('README.md', 'utf8'),
     readFile('README.zh-CN.md', 'utf8'),
@@ -198,16 +199,15 @@ test('user docs distinguish the minimal Windows v0.9.3 release from deferred wor
     readFile('docs/WORKFLOW.md', 'utf8'),
   ]);
 
-  assert.match(readme, /v0\.9\.3 Target Support Matrix/);
-  assert.match(readmeZh, /v0\.9\.3 目标支持矩阵/);
-  assert.match(readme, /historical v0\.9\.0 development wizard[\s\S]*online `uv`/i);
-  assert.match(readmeZh, /历史 v0\.9\.0 开发向导[\s\S]*在线 `uv`/);
+  assert.match(readme, /v0\.9\.4 Target Support Matrix/);
+  assert.match(readmeZh, /v0\.9\.4 目标支持矩阵/);
+  assert.match(readme, /first-run wizard[\s\S]*online `uv`/i);
+  assert.match(readmeZh, /首跑向导[\s\S]*在线安装 `uv`/);
   assert.match(readme, /install-plugin-dev-macos\.sh/);
   assert.match(readmeZh, /install-plugin-dev-macos\.sh/);
 
   for (const value of [install, readme, readmeZh]) {
-    assert.match(value, /Windows[\s\S]{0,400}v0\.9\.3/i);
-    assert.match(value, /macOS[\s\S]{0,400}v0\.9\.3/i);
+    assert.match(value, /Windows[\s\S]{0,500}v0\.9\.4/i);
   }
   assert.doesNotMatch(workflow, /Mac 安装 DMG|install the DMG/i);
   assert.match(workflow, /受支持的 ZXP installer/);
@@ -216,7 +216,7 @@ test('user docs distinguish the minimal Windows v0.9.3 release from deferred wor
     for (const asset of PLATFORM_ASSETS) assert.ok(value.includes(asset));
   }
   assert.match(install, /manual|手动/i);
-  assert.match(install, /external runtime|外部 runtime/i);
+  assert.match(install, /uv tool install/i);
 
   assert.doesNotMatch(reference, /203 passed/);
   assert.doesNotMatch(reference, /24 passed/);
@@ -253,16 +253,23 @@ test('user docs distinguish the minimal Windows v0.9.3 release from deferred wor
   assert.match(reference, /操作系统临时目录/);
 
   for (const value of [readme, readmeZh]) {
-    assert.ok(value.includes('C:\\\\Users\\\\<USER>\\\\.ae-mcp\\\\bin\\\\ae-mcp.exe'));
+    assert.ok(value.includes('C:\\\\Users\\\\<USER>\\\\.local\\\\bin\\\\ae-mcp.exe'));
     assert.match(value, /RuntimeManager/i);
-    assert.match(value, /(?:bare PATH|裸 PATH)/i);
-    assert.match(value, /(?:absolute|绝对)/i);
+    assert.match(value, /uv tool install/i);
   }
   assert.match(workflow, /\/Users\/<USER>\/\.ae-mcp\/bin\/ae-mcp/);
   assert.match(workflow, /RuntimeManager/i);
   assert.match(workflow, /(?:bare PATH|裸 PATH)/i);
   assert.match(workflow, /(?:absolute|绝对)/i);
   assert.match(install, /\/Users\/<USER>\/\.ae-mcp\/bin\/ae-mcp/);
+});
+
+test('Windows ZXP packaging requires and validates the Platform Helper', async () => {
+  const script = await text('scripts/package-zxp.ps1');
+  assert.match(script, /\[Parameter\(Mandatory=\$true\)\]\s*\[string\]\$HelperRoot/u);
+  assert.match(script, /platform\\windows-x64/u);
+  assert.match(script, /verify-windows-zxp-stage\.mjs/u);
+  assert.match(script, /--version \$Version/u);
 });
 
 test('Windows handoff gates the outer shell to PowerShell Core 7.3 or newer', async () => {

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ dev = [
 
 [[package]]
 name = "ae-mcp"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "jsonschema" },
@@ -47,7 +47,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-bridge"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "packages/bridge" }
 dependencies = [
     { name = "ae-mcp" },
@@ -73,7 +73,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ae-mcp-snapshot-mss"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "packages/snapshot-mss" }
 dependencies = [
     { name = "ae-mcp" },


### PR DESCRIPTION
## Summary

- restore the existing Windows Platform Helper under `platform/windows-x64` in the signed ZXP
- retain the existing online first-run `uv` + tag-pinned `uv tool install` runtime setup
- add a fail-closed Windows ZXP payload validator for Helper manifest/hashes, production Host dependencies, and excluded bundled runtime/AEX paths
- bump active product components and user documentation to v0.9.4
- remove the unsupported Windows `tar --force-local` argument that blocked real Helper builds

## Scope

- no bundled/offline Python runtime
- no Windows RuntimeManager or integrated installer
- AEX remains a separate manual-install release asset
- v0.9.3 tag and assets remain unchanged

## Validation

- focused v0.9.4 packaging/version suite: 27/27 passed
- Panel: 1089 tests passed (26 skipped)
- Sidecar: 35 tests passed
- Host Windows Helper/client/transport tests passed; the only Host full-suite failure was the pre-existing macOS symlink fixture hitting Windows `EPERM`
- real Windows x64 Helper built from locked Node 24.17.0 headers/node.lib
- signed preview ZXP independently extracted and revalidated; SHA-256 `d209cee5040babe4776a1e1da9f77d3ee183a6cda2d91374809a38cdf8b7e971`
- preview signing used a new self-signed certificate without TSA after the timestamp service failed; final release assets will be rebuilt from merged `main`