### PR TITLE
docs(release): record v0.9.5 macOS supplemental assets

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -33,6 +33,10 @@ v0.9.5 的发布资产是：
 
 内置/离线 Python、一体化安装器、自动 AEX 部署、Windows RuntimeManager、升级/修复/回滚/卸载生命周期不属于 v0.9.5 Windows 发布范围。
 
+### macOS arm64 补传资产（2026-08-12）
+
+v0.9.5 发布后按 v0.9.4 先例（#214）补传了 macOS arm64 资产：`ae-mcp-platform-bundle-v0.9.5-macos-arm64-unsigned.zip`（完整平台包，未签名，通过 `verify-platform-bundle` 校验）、`AeMcpNative-v0.9.5-macos-arm64.plugin.zip`（原生 AEGP 插件，ad-hoc 签名）与 `SHA256SUMS-v0.9.5-macos-arm64.txt`，均构建自干净 `636d6f6`。本次补传不含 macOS ZXP；自签名 ZXP 待签名环境可用后补传。原生插件安装方式与 v0.9.4 相同：校验 SHA-256 → 完全退出 AE → 解压后把完整的 `AeMcpNative.plugin` 放到 `~/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/AeMcpNative.plugin` → 重启 AE。平台包面向测试与手动部署（开发者/进阶用户），未经 AE 真机验收，使用前先核对 SHA-256。
+
 ### 可选 AI 通道依赖
 
 核心 MCP/AE 能力不依赖 AI CLI。只有选择相应面板通道时，才需要以下可选依赖：
@@ -136,6 +140,10 @@ Do not substitute a source archive, locally rebuilt package, or public PyPI name
 On Windows, the Panel starts Platform Helper when it opens; the installer does not prestart a resident Helper. Closing and reopening the Panel reconnects within the same AE session. Platform Helper exits when its authenticated AE process exits or crashes. Startup, handshake, or credential-store failures remain fail-closed and never fall back to plaintext provider configuration.
 
 Bundled/offline Python, an integrated installer, automatic AEX deployment, Windows RuntimeManager, and upgrade/repair/rollback/uninstall lifecycle are outside the v0.9.5 Windows release.
+
+### macOS arm64 Supplemental Assets (2026-08-12)
+
+Following the v0.9.4 precedent (#214), macOS arm64 assets were added to the v0.9.5 release after publication: `ae-mcp-platform-bundle-v0.9.5-macos-arm64-unsigned.zip` (full platform bundle, unsigned, `verify-platform-bundle` verified), `AeMcpNative-v0.9.5-macos-arm64.plugin.zip` (native AEGP plug-in, ad-hoc signed), and `SHA256SUMS-v0.9.5-macos-arm64.txt`, all built from clean `636d6f6`. No macOS ZXP is included yet; a self-signed ZXP will follow once the signing environment is available. The native plug-in installs as in v0.9.4: verify the SHA-256, quit AE completely, unzip, place the complete `AeMcpNative.plugin` at `~/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/AeMcpNative.plugin`, and restart AE. The platform bundle targets testing and manual deployment (developers/advanced users), has not passed on-host AE acceptance, and should be checksum-verified before use.
 
 ### Optional AI Channel Dependencies
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -47,6 +47,10 @@ v0.9.5 不是离线、零依赖或只装 ZXP 即用的发布。
 升级/修复/回滚/卸载生命周期、macOS 资产或 Windows ARM。ZXP installer 不会把 AEX
 安装到 AE 原生插件目录。自签名只能证明签名后的字节未变化，不建立系统默认信任的公开发布者。
 
+> 补充（2026-08-12）：按 v0.9.4 先例（#214）向 v0.9.5 Release 补传了未签名 macOS arm64
+> 平台包与 ad-hoc 签名原生插件（见 INSTALL）。该补传不改变上述发布契约；macOS ZXP 与
+> 正式签名资产仍在非目标内，待签名环境可用后另行处理。
+
 ## English
 
 ### Fixed assets
@@ -96,3 +100,8 @@ This release adds no bundled/offline runtime, Windows RuntimeManager, integrated
 automatic AEX deployment, upgrade/repair/rollback/uninstall lifecycle, macOS asset, or Windows ARM
 support. A ZXP installer does not install the AEX in AE's native plug-in directory. Self-signing
 does not establish a publicly trusted publisher.
+
+> Supplement (2026-08-12): following the v0.9.4 precedent (#214), an unsigned macOS arm64
+> platform bundle and an ad-hoc-signed native plug-in were added to the v0.9.5 release (see
+> INSTALL). This does not change the release contract above; the macOS ZXP and formally signed
+> assets remain non-goals until a signing environment is available.


### PR DESCRIPTION
Documents the 2026-08-12 post-release upload of macOS arm64 assets to the [v0.9.5 release](https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.9.5): the unsigned platform bundle, the ad-hoc-signed native plug-in, and `SHA256SUMS-v0.9.5-macos-arm64.txt`, following the v0.9.4 precedent (#214).

- INSTALL.md (zh/en): new supplemental-assets section with install steps for the native plug-in and the audience/caveats for the unsigned platform bundle.
- RELEASE.md (zh/en): a dated supplement note under the non-goals section; the frozen v0.9.5 release contract itself is unchanged, and the macOS ZXP stays deferred until a signing environment is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)