### PR TITLE
test/ci: unbreak the suite on macOS, then gate merges on it

### DIFF
--- a/.github/workflows/platform-foundation-ci.yml
+++ b/.github/workflows/platform-foundation-ci.yml
@@ -67,6 +67,30 @@ jobs:
             plugin/host/native-aegp-client.test.js \
             plugin/panel/test/runtimeManager.test.js
 
+      # ci.yml is the Windows gate by contract (asserted in
+      # scripts/release/test/signing-plan.test.mjs), so the macOS run of the same
+      # suites belongs here. Until this existed, nothing in any merge gate ran
+      # pytest or the full host/panel/sidecar suites on macOS, and a
+      # macOS-breaking change could merge green. Kept ahead of the native C++
+      # builds below so the cheap failures surface first.
+      - name: Run the full Python and JS suites on macOS
+        shell: bash
+        run: |
+          set -euo pipefail
+          export TMPDIR="$RUNNER_TEMP"
+
+          uv sync --frozen --group dev --python 3.13.13
+          uv run --frozen --python 3.13.13 pytest -v
+
+          for workspace in plugin/host plugin/panel plugin/sidecar; do
+            npm --prefix "$workspace" ci
+            npm --prefix "$workspace" test
+          done
+
+          # The committed panel bundle must be reproducible from either host.
+          npm --prefix plugin/panel run build
+          git diff --exit-code --stat -- plugin/client/dist
+
       - name: Build and run portable native AEGP core tests
         shell: bash
         run: |

--- a/packages/bridge/tests/test_issue86_windows_native_exec_driver.py
+++ b/packages/bridge/tests/test_issue86_windows_native_exec_driver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import hashlib
 import importlib.util
 import json
@@ -39,6 +40,46 @@ driver = _load(
     "issue86_windows_native_exec_acceptance",
     HARDWARE / "issue86_windows_native_exec_acceptance.py",
 )
+
+
+# The Windows lifecycle probes below fake `os` and `ctypes` so the pure
+# error-handling logic can be exercised on any host. Patching an attribute on
+# `driver.os` / `driver.ctypes` would reach the shared stdlib module objects and
+# leak the fake into every other caller in the process — `os.name = "nt"` alone
+# changes what `pathlib.Path()` instantiates, which on Python 3.10 turns any
+# failure in these tests into a pytest INTERNALERROR because the report
+# formatter builds a Path while the patch is still live. Replacing the module
+# *reference* inside the driver's own namespace keeps the fake local.
+class _WindowsOsProxy:
+    """`os`, seen as Windows, without mutating the real module."""
+
+    name = "nt"
+
+    def __getattr__(self, attribute):
+        return getattr(os, attribute)
+
+
+class _WindowsCtypesProxy:
+    """`ctypes` with a stubbed kernel32 loader; `WinDLL` is absent off Windows."""
+
+    def __init__(self, kernel32, last_error):
+        self._kernel32 = kernel32
+        self._last_error = last_error
+
+    def WinDLL(self, *_args, **_kwargs):  # noqa: N802 - mirrors the ctypes name
+        return self._kernel32
+
+    def get_last_error(self):
+        return self._last_error
+
+    def __getattr__(self, attribute):
+        return getattr(ctypes, attribute)
+
+
+def _fake_windows_host(monkeypatch, *, kernel32, last_error):
+    monkeypatch.setattr(driver, "os", _WindowsOsProxy())
+    monkeypatch.setattr(driver, "ctypes", _WindowsCtypesProxy(kernel32, last_error))
+
 
 OLD_HOST = "11111111-1111-4111-8111-111111111111"
 OLD_SESSION = "22222222-2222-4222-8222-222222222222"
@@ -875,7 +916,7 @@ async def test_formal_ae_launch_argv_contains_only_the_exact_executable(tmp_path
         calls.append((argv, kwargs))
         return type("SpawnedProcess", (), {"pid": 321})()
 
-    monkeypatch.setattr(driver.os, "name", "nt")
+    monkeypatch.setattr(driver, "os", _WindowsOsProxy())
     monkeypatch.setattr(driver.asyncio, "create_subprocess_exec", create_subprocess_exec)
     launch = await driver.launch_formal_after_effects(config.formal_ae_app)
 
@@ -911,9 +952,7 @@ def test_process_image_lookup_treats_access_denied_as_unmatched(monkeypatch, ope
         "GetExitCodeProcess": FakeWindowsFunction(1),
         "CloseHandle": FakeWindowsFunction(1),
     })()
-    monkeypatch.setattr(driver.os, "name", "nt")
-    monkeypatch.setattr(driver.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32)
-    monkeypatch.setattr(driver.ctypes, "get_last_error", lambda: 5)
+    _fake_windows_host(monkeypatch, kernel32=kernel32, last_error=5)
 
     assert driver.windows_process_image_path(63208) is None
 
@@ -946,9 +985,7 @@ def test_process_image_lookup_reconciles_query_failure_with_exit_state(
         "GetExitCodeProcess": FakeExitCodeFunction(1),
         "CloseHandle": FakeWindowsFunction(1),
     })()
-    monkeypatch.setattr(driver.os, "name", "nt")
-    monkeypatch.setattr(driver.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32)
-    monkeypatch.setattr(driver.ctypes, "get_last_error", lambda: 31)
+    _fake_windows_host(monkeypatch, kernel32=kernel32, last_error=31)
 
     if expected_stopped:
         assert driver.windows_process_image_path(63208) is None


### PR DESCRIPTION
Prerequisite for the #242 / #243 fix batch: right now a macOS-breaking change can merge green, so nothing landing after this can be trusted to have been verified on both shipping targets.

## What was broken

`packages/bridge/tests/test_issue86_windows_native_exec_driver.py` faked its host by assigning through `driver.os` and `driver.ctypes`. Those names are bound to the **shared stdlib module objects**, so `os.name = "nt"` took effect process-wide — including inside `pathlib`, which picks `WindowsPath` from exactly that value.

On a non-Windows host:

- `ctypes` has no `WinDLL`, so `monkeypatch.setattr` raised `AttributeError` and the four probe tests failed;
- on Python 3.10 the failure then **killed the run** — pytest's report formatter builds a `Path` while the patch is still live and hits `NotImplementedError: cannot instantiate 'WindowsPath'`, an INTERNALERROR that took the whole `packages/bridge` suite down with it.

Nothing caught it because no merge gate ran the Python suite on macOS.

## What changed

**`test(bridge)`** — replace the module *reference* in the driver's namespace with proxies that report Windows and delegate everything else to the real modules. The fake now stops at the code under test. As a side effect these tests stop being Windows-only by accident: the access-denied / exit-state reconciliation logic they cover is pure branching, and now runs everywhere.

**`ci(macos)`** — run pytest and the full host / panel / sidecar suites on macOS in the merge gate.

This went into `platform-foundation-ci.yml`, not as a matrix on `ci.yml`. The split is deliberate and enforced — `fast PR validation keeps contracts on supported AE hosts` in `scripts/release/test/signing-plan.test.mjs` asserts `ci.yml` matches `/runs-on:\s*windows-2022/` and does **not** match `/macos-15/`. A matrix there turns that governance test red. `platform-foundation-ci.yml` also runs on `pull_request`, so it gates merges the same way.

Two details worth keeping:

- the step exports `TMPDIR="$RUNNER_TEMP"` — several packaging tests reject a build receipt that traverses a symlink, which is what a default macOS `/tmp` is;
- it asserts the committed panel bundle rebuilds byte-identically, so `plugin/client/dist` stays reproducible from either host.

## Verification

Run on macOS before wiring anything in:

| suite | result |
|---|---|
| repo-root `pytest` | **4 failed + INTERNALERROR → 922 passed, 5 skipped, 13 deselected** |
| `plugin/host` | 104 passed |
| `plugin/panel` | 1133 passed, 2 skipped |
| `plugin/sidecar` | 37 passed |
| panel dist rebuild | byte-identical to the committed dist |
| `scripts/package/test/*` | 487 passed, 7 skipped |
| `scripts/release/test/*` | 144 passed |
| `check-repository-governance.mjs` | passed |

pytest verified on both Python 3.13.13 (the CI pin) and 3.10.

## Not in scope

No product code changes. The `ae.snapshot` relative-path defect from #243 and the `previewFrame` work from #242 land separately, on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)