### PR TITLE
docs: credit the contributions git cannot record

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,64 @@
+# Contributors
+
+Git records who wrote a line of code. It has no way to record who spent an
+evening with a debugger and came back with the reason a bug happens, or who
+ran a build on real hardware nobody else has. Both have moved this project
+more than most patches. This file exists for the part git cannot hold.
+
+The [GitHub contributor list][gh] is generated from commits on `main` and stays
+the authoritative record for code. Where a fix originated in someone else's
+analysis, the commit that lands it carries a `Co-authored-by:` trailer, so that
+credit reaches the same place.
+
+[gh]: https://github.com/JUNKDOGE-JOE/after-effects-mcp/graphs/contributors
+
+## Code
+
+**[@Kokoro12345](https://github.com/Kokoro12345)** — After Effects 2024 on
+Windows ([#235](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/235)).
+Traced a load failure from a minidump through `std::_Mutex_base::lock` to the
+host's older `MSVCP140`, identified the static CRT (`/MT`) as the correct fix
+rather than shipping a redistributable, and renamed the five bare `require`
+calls that CEP 11 rejects. The diagnosis was the hard part and it was right;
+the merged change extends it rather than replacing it.
+
+**[@Ghz114514](https://github.com/Ghz114514)** — MCP-compliant tool names
+(`fe1a705`). Dotted verb names like `ae.ping` violate the MCP name pattern, so
+strict clients rejected the whole tool list at handshake. Fixed without
+breaking existing callers.
+
+## Analysis and root cause
+
+**[@msaworks](https://github.com/msaworks)** —
+[#242](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/242),
+`ae.previewFrame`. Separated two failures that shared one symptom: the handler
+reported the composition's nominal size while `saveFrameToPng` honours the
+viewer's resolution, and it accepted a PNG as complete on an 8-byte signature
+while After Effects was still writing the file. Verified the first by decoding
+the IHDR chunk directly, and demonstrated the second by showing `outFile.exists`
+false immediately after the call. Wrote the reproduction as a stubbed backend
+that fails against the old code and passes against the new — including the
+negative assertion, so the test cannot pass vacuously.
+
+**[@tomaszteee](https://github.com/tomaszteee)** —
+[#243](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/243), Windows
+v0.9.5 reliability. Five independent issues in one report, each separated into
+confirmed runtime fact and hypothesis. Measured the collapsed composer through
+live CEP DevTools rather than describing it (`582×8px`, with the row-by-row
+arithmetic that explains it). Recognised that a timed-out ExtendScript call is
+not a cancelled one, which is a correctness problem rather than the timeout
+tuning issue it first resembles.
+
+## Hardware validation
+
+**[@tomaszteee](https://github.com/tomaszteee)** — carried the
+[#239](https://github.com/JUNKDOGE-JOE/after-effects-mcp/issues/239) workaround
+through a real Windows install of After Effects 2026 and built a six-layer
+composition end to end, which is what established that the main execution path
+works and that everything else in that report was a separate problem.
+
+## Adding to this file
+
+Open a pull request, or say so on the issue and it will be added when the
+related change lands. Analysis and hardware validation belong here as much as
+code does — that is the point of the file.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ node scripts/live-model-matrix.mjs
 
 Maintainers merge release metadata first, then build the v0.9.5 Windows Helper, ZXP, and AEX from the final clean protected-`main` commit. They validate the minimal ZXP payload, sign and verify both release assets, generate `SHA256SUMS-v0.9.5.txt`, run the After Effects 2025 Helper/Provider and public-MCP smokes, and upload those exact bytes without rebuilding. See [docs/RELEASE.md](docs/RELEASE.md).
 
+## Contributors
+
+A bug report that arrives with a root cause, and validation on hardware the maintainers do not have, carry this project as much as patches do. Both are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ## Implementation Notes
 
 Third-party components:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -341,6 +341,10 @@ node scripts/live-model-matrix.mjs
 
 维护者先合并发布元数据，再从最终干净的受保护 `main` 提交构建 v0.9.5 Windows Helper、ZXP 与 AEX。校验最小 ZXP 载荷后分别签名、复验并生成 `SHA256SUMS-v0.9.5.txt`，通过 After Effects 2025 Helper/Provider 与公开 MCP 路径 smoke 后原样上传，不重新构建。完整流程见 [docs/RELEASE.md](docs/RELEASE.md)。
 
+## 贡献者
+
+带着根因一起来的 bug 报告，以及在维护者没有的硬件上做的验收，对这个项目的推动不亚于补丁。两者都记在 [CONTRIBUTORS.md](CONTRIBUTORS.md)。
+
 ## 实现说明
 
 第三方组件：


### PR DESCRIPTION
The GitHub contributor list is generated from commits on `main`, so it credits whoever wrote a line and nobody else. Two of the most valuable contributions this project has had fall outside that: a bug report that arrives with the root cause already isolated, and validation on hardware the maintainers do not own. Neither produces a commit.

## What this adds

`CONTRIBUTORS.md`, with three sections — **Code**, **Analysis and root cause**, **Hardware validation** — and specific detail on what each person actually did. A credits file that only lists names credits nobody.

Currently listed:

- **@Kokoro12345** — the AE 2024 Windows load failure (#235): minidump → `std::_Mutex_base::lock` → the host's older `MSVCP140`, and `/MT` as the right fix rather than shipping a redistributable. Their commit lands on `main` through #238 with authorship intact.
- **@Ghz114514** — MCP-compliant tool names (`fe1a705`).
- **@msaworks** — #242: separated two failures sharing one symptom, verified by decoding the IHDR chunk directly, and wrote the reproduction with a negative assertion so it cannot pass vacuously.
- **@tomaszteee** — #243: five issues separated into confirmed fact and hypothesis, the composer measured through live CEP DevTools rather than described, and the recognition that a timed-out ExtendScript call is not a cancelled one. Also carried the #239 workaround end to end on real Windows hardware.

## Convention it establishes

A fix originating in someone else's analysis carries a `Co-authored-by:` trailer, so that credit also reaches the generated contributor list — which matters when we rewrite a contributor's patch rather than building on their commit.

Linked from both READMEs; a credits file nobody can find is not credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)