### PR TITLE
fix(panel): stop the composer latching shut at 8px (#243)

### DIFF
--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -36,8 +36,8 @@
                     <Type>Panel</Type>
                     <Menu>ae-mcp</Menu>
                     <Geometry>
-                        <Size><Height>200</Height><Width>320</Width></Size>
-                        <MinSize><Height>120</Height><Width>240</Width></MinSize>
+                        <Size><Height>480</Height><Width>420</Width></Size>
+                        <MinSize><Height>300</Height><Width>280</Width></MinSize>
                         <MaxSize><Height>800</Height><Width>800</Width></MaxSize>
                     </Geometry>
                     <Icons>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -24866,12 +24866,13 @@
 
   // src/lib/composerResize.js
   init_cep_runtime_inject();
-  var COMPOSER_MIN_HEIGHT = 72;
+  var COMPOSER_MIN_HEIGHT = 96;
   var COMPOSER_DEFAULT_HEIGHT = 96;
   var COMPOSER_KEYBOARD_STEP = 24;
   var MIN_TRANSCRIPT_HEIGHT = 120;
   var MAX_COMPOSER_RATIO = 0.6;
   var FALLBACK_MAX_HEIGHT = 320;
+  var MIN_LAYOUT_HEIGHT = MIN_TRANSCRIPT_HEIGHT + COMPOSER_MIN_HEIGHT;
   function finitePositive(value) {
     return Number.isFinite(value) && value > 0;
   }
@@ -24912,8 +24913,12 @@
       maxHeight
     };
   }
+  function isMeasurableLayout(availableHeight) {
+    return Number.isFinite(availableHeight) && availableHeight >= MIN_LAYOUT_HEIGHT;
+  }
   function reduceComposerHeight(state, action) {
     if ((action == null ? void 0 : action.type) === "measure") {
+      if (!isMeasurableLayout(action.availableHeight)) return state;
       const maxHeight = composerMaxHeight(action.availableHeight);
       return { height: clampComposerHeight(state.height, maxHeight), maxHeight };
     }

--- a/plugin/panel/src/lib/composerResize.js
+++ b/plugin/panel/src/lib/composerResize.js
@@ -1,9 +1,20 @@
-export const COMPOSER_MIN_HEIGHT = 72;
+// The composer is three stacked rows -- attachment pond, chips/status, textarea.
+// The first two plus padding and gaps occupy about 64px, so a 72px floor left
+// the textarea roughly 8px tall: present, and impossible to type in. 96 is the
+// smallest height that leaves the textarea a full line. That makes the floor
+// equal to the default, so the composer can be dragged taller, never shorter.
+export const COMPOSER_MIN_HEIGHT = 96;
 export const COMPOSER_DEFAULT_HEIGHT = 96;
 export const COMPOSER_KEYBOARD_STEP = 24;
 export const MIN_TRANSCRIPT_HEIGHT = 120;
 export const MAX_COMPOSER_RATIO = 0.6;
 export const FALLBACK_MAX_HEIGHT = 320;
+
+// Below this the layout cannot seat a usable composer and a readable transcript
+// at the same time. The CSXS manifest's MinSize keeps the panel above it, so a
+// measurement under this is not a small panel -- it is a measurement taken
+// before layout settled. Believing one is what used to pin the composer shut.
+export const MIN_LAYOUT_HEIGHT = MIN_TRANSCRIPT_HEIGHT + COMPOSER_MIN_HEIGHT;
 
 function finitePositive(value) {
   return Number.isFinite(value) && value > 0;
@@ -50,8 +61,19 @@ export function createComposerHeightState(availableHeight) {
   };
 }
 
+// A measured shrink is honoured and does not spring back when the panel grows
+// again -- resurrecting a height the user last saw at a different size is worse
+// than leaving it where they left it. That only holds for measurements the
+// layout could actually produce, though. Anything under MIN_LAYOUT_HEIGHT is
+// startup noise, and clamping to it is permanent precisely because of the
+// no-resurrect rule, so those are dropped before they can reach state.
+export function isMeasurableLayout(availableHeight) {
+  return Number.isFinite(availableHeight) && availableHeight >= MIN_LAYOUT_HEIGHT;
+}
+
 export function reduceComposerHeight(state, action) {
   if (action?.type === 'measure') {
+    if (!isMeasurableLayout(action.availableHeight)) return state;
     const maxHeight = composerMaxHeight(action.availableHeight);
     return { height: clampComposerHeight(state.height, maxHeight), maxHeight };
   }

--- a/plugin/panel/test/composerResize.test.js
+++ b/plugin/panel/test/composerResize.test.js
@@ -3,40 +3,80 @@ import assert from 'node:assert/strict';
 import {
   COMPOSER_DEFAULT_HEIGHT,
   COMPOSER_KEYBOARD_STEP,
+  COMPOSER_MIN_HEIGHT,
   FALLBACK_MAX_HEIGHT,
+  MIN_LAYOUT_HEIGHT,
+  MIN_TRANSCRIPT_HEIGHT,
   clampComposerHeight,
   composerAvailableHeight,
   composerKeyboardRequest,
   composerMaxHeight,
   createComposerHeightState,
   createComposerDragSession,
+  isMeasurableLayout,
   reduceComposerHeight,
 } from '../src/lib/composerResize.js';
 
 test('composer bounds preserve the transcript in compact and tall panels', () => {
   assert.equal(composerMaxHeight(null), FALLBACK_MAX_HEIGHT);
-  assert.equal(composerMaxHeight(160), 72);
-  assert.equal(composerMaxHeight(200), 80);
+  assert.equal(composerMaxHeight(MIN_LAYOUT_HEIGHT), COMPOSER_MIN_HEIGHT);
+  assert.equal(composerMaxHeight(400), 240);
   assert.equal(composerMaxHeight(800), 480);
   assert.equal(clampComposerHeight(Number.NaN, 480), COMPOSER_DEFAULT_HEIGHT);
-  assert.equal(clampComposerHeight(20, 480), 72);
+  assert.equal(clampComposerHeight(20, 480), COMPOSER_MIN_HEIGHT);
   assert.equal(clampComposerHeight(900, 480), 480);
 });
 
-test('a measured panel shorter than fixed footer chrome clamps to the minimum', () => {
+test('the floor seats a full textarea line and equals the default', () => {
+  // Regression for the ~8px composer: 72px could not hold the third row, and
+  // a floor below the default would let the panel re-open at an unusable size.
+  assert.equal(COMPOSER_MIN_HEIGHT, 96);
+  assert.equal(COMPOSER_DEFAULT_HEIGHT, COMPOSER_MIN_HEIGHT);
+  assert.equal(MIN_LAYOUT_HEIGHT, MIN_TRANSCRIPT_HEIGHT + COMPOSER_MIN_HEIGHT);
+});
+
+test('measurements the settled layout cannot produce are dropped, not clamped to', () => {
+  // Taken while the footer is still taller than the container, which happens on
+  // mount before layout settles. Acting on it is what pinned the composer shut.
   const availableHeight = composerAvailableHeight({
     containerHeight: 80,
     footerHeight: 160,
-    composerHeight: 72,
+    composerHeight: 96,
   });
-  assert.equal(availableHeight, 0);
-  assert.equal(composerMaxHeight(availableHeight), 72);
+  // Small and positive, which is the dangerous shape: it looks like a real
+  // measurement, so every guard that only rejects zero and NaN lets it through.
+  assert.equal(availableHeight, 16);
+  assert.equal(isMeasurableLayout(availableHeight), false);
+  assert.equal(isMeasurableLayout(MIN_LAYOUT_HEIGHT - 1), false);
+  assert.equal(isMeasurableLayout(MIN_LAYOUT_HEIGHT), true);
+  assert.equal(isMeasurableLayout(null), false);
 
-  const measured = reduceComposerHeight(
-    { height: 300, maxHeight: FALLBACK_MAX_HEIGHT },
-    { type: 'measure', availableHeight },
+  const before = { height: 300, maxHeight: FALLBACK_MAX_HEIGHT };
+  assert.equal(
+    reduceComposerHeight(before, { type: 'measure', availableHeight }),
+    before,
   );
-  assert.deepEqual(measured, { height: 72, maxHeight: 72 });
+});
+
+test('a degenerate startup measurement does not latch the composer shut', () => {
+  // The reported failure: mount measures before layout settles, the composer
+  // clamps to the floor, and every later measurement re-clamps that floor
+  // because a shrink is never resurrected. It must never reach state at all.
+  let state = createComposerHeightState();
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 30 });
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: null });
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 800 });
+  assert.deepEqual(state, { height: COMPOSER_DEFAULT_HEIGHT, maxHeight: 480 });
+});
+
+test('a height the user dragged to survives a transient bad measurement', () => {
+  let state = createComposerHeightState(800);
+  state = reduceComposerHeight(state, { type: 'request', height: 300 });
+  assert.equal(state.height, 300);
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 12 });
+  assert.equal(state.height, 300);
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 800 });
+  assert.equal(state.height, 300);
 });
 
 test('footer chrome is removed from the shared transcript and input allocation', () => {
@@ -57,10 +97,11 @@ test('session reducer clamps on shrink and does not resurrect an old height', ()
   assert.deepEqual(state, { height: 96, maxHeight: 320 });
   state = reduceComposerHeight(state, { type: 'request', height: 300 });
   assert.equal(state.height, 300);
-  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 200 });
-  assert.deepEqual(state, { height: 80, maxHeight: 80 });
+  // A real shrink -- the user dragged the panel smaller, not a startup artifact.
+  state = reduceComposerHeight(state, { type: 'measure', availableHeight: 400 });
+  assert.deepEqual(state, { height: 240, maxHeight: 240 });
   state = reduceComposerHeight(state, { type: 'measure', availableHeight: 800 });
-  assert.deepEqual(state, { height: 80, maxHeight: 480 });
+  assert.deepEqual(state, { height: 240, maxHeight: 480 });
   state = reduceComposerHeight(state, { type: 'reset' });
   assert.equal(state.height, COMPOSER_DEFAULT_HEIGHT);
   assert.equal(createComposerHeightState().height, COMPOSER_DEFAULT_HEIGHT);


### PR DESCRIPTION
Closes the first item of #243.

## Two defects, one symptom

**The floor was structurally too small.** The composer stacks three rows — attachment pond, chips/status, textarea — and the first two plus padding take ~64px. At the 72px floor the textarea got roughly 8px, measured on real hardware as `582×8`. Present, and impossible to type in; clicks near it landed in the FilePond drop area instead.

**The floor was also reachable by accident, and then permanent.** `ChatScreen` measures on mount, before layout settles, and a small-but-positive `availableHeight` bottoms `composerMaxHeight` out at the floor. Every later measurement re-clamps that floor, because the reducer deliberately does not resurrect a height after a shrink — a rule that is right for a real shrink and catastrophic for a bogus one.

Either defect alone makes the input unusable, which is why this needed both halves.

## Approach

Floor raised to 96, equal to the default: the composer can be dragged taller, never shorter than one full line.

For the latch, rather than loosen the no-resurrect rule, measurements the settled layout *cannot produce* are rejected — below `MIN_TRANSCRIPT_HEIGHT + COMPOSER_MIN_HEIGHT` the panel could not seat both a usable composer and a readable transcript, so such a value is startup noise, not a small panel.

`MinSize` goes to `300×280` to make that guarantee real. At the old `120px` minimum the panel could legitimately be dragged smaller than its own contents — the case that would have kept the bug alive under a guard alone. Default `Size` follows to `480×420`; `200px` tall was below the new floor.

## Why it survived this long

The old suite asserted the latch as intended behaviour — *"a measured panel shorter than fixed footer chrome clamps to the minimum"*. It is replaced by its inverse, plus the reported startup sequence and a check that a user-dragged height survives a transient bad measurement. The genuine no-resurrect case keeps its coverage, with values the layout can actually produce.

## Credit

Reported, diagnosed and verified by **@tomaszteee** on Windows 11 / AE 2026, who measured the broken state through live CEP DevTools rather than describing it, and confirmed the 96px floor restores typing, Polish characters, backspace and clipboard paste. Carried as a `Co-authored-by:` trailer.

## Verification (macOS)

| suite | result |
|---|---|
| `plugin/panel` | 1136 passed, 2 skipped |
| `plugin/host` | 108 passed |
| `plugin/sidecar` | 37 passed |
| `pytest` | 922 passed, 5 skipped |
| `scripts/package/test/*` | 490 passed, 7 skipped |
| `scripts/release/test/*` | 144 passed |
| `check-repository-governance` | passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)