### PR TITLE
fix(previewFrame): report the pixels that were written, once they are (#242)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -137,6 +137,19 @@ CAS 晋升；没有自动过期或清理。已有 candidates 保持不变。
 随后使用独立读取验证状态。需要画面判断时再调用 `ae_previewFrame`；写入表达式
 后先调用 `ae_validateExpressions`。
 
+### `ae_previewFrame` 的帧元数据
+
+`width` / `height` 永远是**写出的 PNG 的真实像素尺寸**，从文件读回。
+`saveFrameToPng` 遵循视图的 Resolution 设置，所以 Half 分辨率下写出的是半张帧；
+合成自身的尺寸单独报为 `compWidth` / `compHeight`，并附带 `resolutionFactor`。
+
+抓到的画面小于合成时，该帧带 `downsampled: true`，结果里带一条 `note` 说明。
+降采样的预览只能当作"看一眼"，不能当作证据——细节已经丢了。要用某一帧证明视觉
+改动生效，先把视图切回 Full 分辨率。
+
+`times` 最多 8 个。每一帧都要一次 After Effects 往返，加上渲染落盘的时间，
+采样较长的区间请分多次调用。
+
 ### `ae_nativeExec`
 
 原生入口接受一个最多 64 个 operation 的线性 program：
@@ -330,6 +343,23 @@ expiration or cleanup. Existing candidates are unchanged.
 End reads with `JSON.stringify(...)`. Give writes a recognizable Undo label
 and verify them with an independent read. Use `ae_previewFrame` when visual
 correctness matters, and validate expressions before preview.
+
+### `ae_previewFrame` frame metadata
+
+`width` and `height` are always the **written PNG's real pixel size**, read back
+from the file. `saveFrameToPng` honours the viewer's Resolution setting, so a
+Half-resolution viewer writes half a frame; the composition's own size is
+reported separately as `compWidth` and `compHeight`, with `resolutionFactor`
+alongside it.
+
+When the capture is smaller than the composition, the frame carries
+`downsampled: true` and the result carries a `note` saying so. Treat a
+downsampled preview as a look, not as proof: fine detail is gone. Set the viewer
+to Full resolution before using a frame as evidence that a visual change landed.
+
+`times` accepts at most 8 entries. Each frame costs a round-trip to After
+Effects plus however long the render takes to reach disk, so sample a longer
+range across more than one call.
 
 ### `ae_nativeExec`
 

--- a/packages/core/ae_mcp/handlers/core.py
+++ b/packages/core/ae_mcp/handlers/core.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import io
 import json
 import logging
 import os
@@ -49,6 +50,24 @@ _PREVIEW_SESSION_ID = uuid.uuid4().hex[:10]
 _PREVIEW_ROOT = Path(tempfile.gettempdir()) / "ae_mcp_previews"
 _PREVIEW_CLEANUP_DONE = False
 _PREVIEW_CLEANUP_AGE_SEC = 24 * 60 * 60
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_PNG_TRAILER = b"IEND\xaeB`\x82"
+
+# One frame costs a 15s JSX round-trip plus the write-completion budget below,
+# so a flat outer timeout fails on frame counts that are each succeeding. The
+# budget grows per frame and still stops: a timeout bounded only by caller input
+# is its own failure mode.
+_PREVIEW_BASE_TIMEOUT_SEC = 45.0
+_PREVIEW_PER_FRAME_TIMEOUT_SEC = 35.0
+_PREVIEW_MAX_TIMEOUT_SEC = 300.0
+
+_DOWNSAMPLED_NOTE = (
+    "One or more frames are marked downsampled: they were captured at the "
+    "viewer's resolution setting, not the composition's full size, so fine "
+    "detail may be missing. Set the viewer to Full resolution before treating "
+    "a preview as proof that a visual change landed."
+)
 
 
 def _load_jsx(name: str) -> Template:
@@ -636,19 +655,51 @@ def _downscale_png(path: Path, scale: float) -> Optional[tuple[int, int]]:
         return None
 
 
-async def _wait_for_png(path: Path, timeout_sec: float = 5.0) -> bool:
-    deadline = asyncio.get_running_loop().time() + timeout_sec
-    png_sig = b"\x89PNG\r\n\x1a\n"
+async def _await_written_png(
+    path: Path, timeout_sec: float = 15.0
+) -> Optional[tuple[int, int]]:
+    """Wait for `path` to become a complete PNG and return its real pixel size.
+
+    `saveFrameToPng` does not block. The file is absent, then empty, then grows,
+    and only the final bytes make it a valid image. Accepting it once the 8-byte
+    signature matches hands Pillow a truncated file — the "frame is not a
+    decodable image" failure, intermittent only because it depends on how long
+    the frame takes to write.
+
+    Three conditions have to hold together: the IEND trailer is present, the
+    size stopped changing between two polls, and the bytes actually decode. The
+    last is not redundant with the first two. It is the same check the caller
+    runs when packaging the image, so failing it here reports a file that never
+    finished rather than an image that cannot be read.
+
+    Returns the decoded (width, height), or None if the deadline passed. The
+    dimensions come from the file because they are the only trustworthy source:
+    `saveFrameToPng` honours the viewer's Resolution setting, so the
+    composition's own width and height describe a different image.
+    """
+    from PIL import Image
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_sec
+    minimum_size = len(_PNG_SIGNATURE) + len(_PNG_TRAILER)
+    previous_size = -1
     while True:
         try:
-            if path.exists() and path.stat().st_size >= len(png_sig):
-                with path.open("rb") as fh:
-                    if fh.read(len(png_sig)) == png_sig:
-                        return True
+            size = path.stat().st_size
+            if size >= minimum_size and size == previous_size:
+                data = path.read_bytes()
+                if data.startswith(_PNG_SIGNATURE) and data.endswith(_PNG_TRAILER):
+                    with Image.open(io.BytesIO(data)) as image:
+                        image.load()
+                        return image.size
+            previous_size = size
         except OSError:
-            pass
-        if asyncio.get_running_loop().time() >= deadline:
-            return False
+            previous_size = -1
+        except Exception:  # noqa: BLE001 - Pillow raises broadly on truncation
+            log.debug("preview PNG at %s not decodable yet", path, exc_info=True)
+            previous_size = -1
+        if loop.time() >= deadline:
+            return None
         await asyncio.sleep(0.05)
 
 
@@ -688,10 +739,14 @@ async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
             comp_name = prepared.get("compName")
 
             if prepared.get("source") == "comp" or prepared.get("method") == "saveFrameToPng":
-                frame_w = prepared.get("width")
-                frame_h = prepared.get("height")
                 snap_path = prepared.get("path") or str(frame_request["path"])
-                if snap_path and await _wait_for_png(Path(str(snap_path))):
+                captured = (
+                    await _await_written_png(Path(str(snap_path)))
+                    if snap_path
+                    else None
+                )
+                if captured is not None:
+                    frame_w, frame_h = captured
                     new_dims = _downscale_png(Path(str(snap_path)), args.scale)
                     if new_dims is not None:
                         frame_w, frame_h = new_dims
@@ -707,11 +762,27 @@ async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
                         "method": "saveFrameToPng",
                         "compId": comp_id,
                     }
+                    # The composition's own size is reported separately, never
+                    # as width/height: at Half resolution the viewer writes half
+                    # a frame, and a caller comparing a downsampled preview
+                    # against the comp settings would read it as full size.
+                    comp_w = prepared.get("compWidth")
+                    comp_h = prepared.get("compHeight")
+                    if isinstance(comp_w, int) and isinstance(comp_h, int):
+                        frame["compWidth"] = comp_w
+                        frame["compHeight"] = comp_h
+                        if (comp_w, comp_h) != captured:
+                            frame["downsampled"] = True
+                    resolution_factor = prepared.get("resolutionFactor")
+                    if isinstance(resolution_factor, list):
+                        frame["resolutionFactor"] = resolution_factor
                     if args.include_base64:
                         frame["base64"] = base64.b64encode(png_bytes).decode("ascii")
                     frames.append(frame)
                     continue
-                prepared["fallbackReason"] = "saveFrameToPng did not create a PNG file"
+                prepared["fallbackReason"] = (
+                    "saveFrameToPng did not finish writing a decodable PNG"
+                )
 
             if snapper is None:
                 snapper = _snap_discovery.select_snapshotter()
@@ -772,16 +843,26 @@ async def _run_preview_frame(args: schemas.AePreviewFrameArgs, ctx: Any) -> Any:
                 frame["base64"] = base64.b64encode(png_bytes).decode("ascii")
             frames.append(frame)
 
-        return {
+        result: dict[str, Any] = {
             "ok": True,
             "compId": comp_id,
             "compName": comp_name,
             "captureId": capture_id,
             "frames": frames,
         }
+        # Say it in the text the caller actually reads. A resolutionFactor field
+        # is only useful to a caller that already knows to look for one.
+        if any(frame.get("downsampled") for frame in frames):
+            result["note"] = _DOWNSAMPLED_NOTE
+        return result
 
+    timeout_sec = min(
+        _PREVIEW_MAX_TIMEOUT_SEC,
+        _PREVIEW_BASE_TIMEOUT_SEC
+        + _PREVIEW_PER_FRAME_TIMEOUT_SEC * (len(frame_requests) - 1),
+    )
     return await progress.run_with_timeout(
-        ctx, _call(), timeout_sec=60.0, start_msg="ae.previewFrame..."
+        ctx, _call(), timeout_sec=timeout_sec, start_msg="ae.previewFrame..."
     )
 
 

--- a/packages/core/ae_mcp/jsx_templates/preview_viewer.jsx
+++ b/packages/core/ae_mcp/jsx_templates/preview_viewer.jsx
@@ -30,13 +30,19 @@
     if (typeof comp.saveFrameToPng === "function") {
       try {
         comp.saveFrameToPng(comp.time, outFile);
+        // No width/height here on purpose. saveFrameToPng honours the viewer's
+        // Resolution setting, so the composition's own size describes a
+        // different image than the one just written -- at Half it is exactly
+        // twice as large. The caller reads the real size back off the file and
+        // uses these two only to report that a preview was downsampled.
         return JSON.stringify({
           ok: true,
           compId: String(comp.id),
           compName: comp.name,
           time: comp.time,
-          width: comp.width,
-          height: comp.height,
+          compWidth: comp.width,
+          compHeight: comp.height,
+          resolutionFactor: comp.resolutionFactor,
           path: outFile.fsName,
           source: "comp",
           method: "saveFrameToPng",
@@ -54,8 +60,9 @@
       compId: String(comp.id),
       compName: comp.name,
       time: comp.time,
-      width: comp.width,
-      height: comp.height,
+      compWidth: comp.width,
+      compHeight: comp.height,
+      resolutionFactor: comp.resolutionFactor,
       source: "viewer",
       method: "ViewerCapture",
       fallbackReason: fallbackReason

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -293,7 +293,13 @@ class AePreviewFrameArgs(_StrictModel):
         None, ge=0, description="Single frame time in seconds. Ignored when times is set."
     )
     times: Optional[List[NonNegativeFloat]] = Field(
-        None, description="Render multiple frame times in seconds."
+        None,
+        max_length=8,
+        description=(
+            "Render multiple frame times in seconds. At most 8 — each frame "
+            "costs a round-trip to After Effects plus the time the render "
+            "takes to reach disk. Sample a motion range in more than one call."
+        ),
     )
     out_dir: Optional[str] = Field(
         None, description="Output directory. Default: temp ae_mcp_previews session directory."

--- a/packages/core/tests/live/test_preview_frame.py
+++ b/packages/core/tests/live/test_preview_frame.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from pathlib import Path
 
@@ -31,9 +32,31 @@ SETUP_JSX = """
 
 
 def _assert_png(path):
+    """Decode it. A signature check shares the blind spot the handler had.
+
+    saveFrameToPng writes asynchronously, so the first eight bytes are true long
+    before the file is an image -- meaning a signature-only assertion passes on
+    exactly the truncated captures it exists to catch.
+    """
+    from PIL import Image
+
     data = path.read_bytes()
     assert data[:8] == b"\x89PNG\r\n\x1a\n"
-    assert len(data) > 100
+    assert data[-8:] == b"IEND\xaeB`\x82", f"{path} has no IEND trailer"
+    with Image.open(io.BytesIO(data)) as image:
+        image.load()
+        assert image.format == "PNG"
+        return image.size
+
+
+def _assert_frame_matches_file(frame):
+    """Reported size must be the file's size, not the composition's settings."""
+    size = _assert_png(Path(frame["path"]))
+    assert (frame["width"], frame["height"]) == size, (
+        f"frame reports {(frame['width'], frame['height'])} "
+        f"but the written PNG is {size}"
+    )
+    return size
 
 
 @pytest.fixture
@@ -144,3 +167,114 @@ async def test_preview_frame_captures_different_times_distinctly(clean_project, 
         "times — the AE viewer didn't repaint between captures. Likely a "
         "regression of the repaint_delay_ms fix."
     )
+
+
+# ---------------------------------------------------------------------------
+# Real-size capture and the write race (#242)
+#
+# Every test above uses a comp of 320x180 or smaller. Those write fast enough
+# that the signature-only wait never lost the race, which is why this class of
+# failure reached users through a suite that was passing. A full-HD frame at
+# Full resolution takes long enough to reach disk for the race to be real.
+# ---------------------------------------------------------------------------
+
+
+FULL_HD_SETUP_JSX = """
+(function(){
+  try {
+    var comp = app.project.items.addComp("PreviewFullHD", 1920, 1080, 1, 2.0, 24);
+    var solid = comp.layers.addSolid([0.2,0.6,0.9], "Field", 1920, 1080, 1, 2.0);
+    solid.property("ADBE Transform Group").property("ADBE Position").setValue([960, 540, 0]);
+    comp.resolutionFactor = [1, 1];
+    comp.time = 0.25;
+    comp.openInViewer();
+    return JSON.stringify({ok:true, compId: String(comp.id)});
+  } catch (e) { return JSON.stringify({ok:false, error:String(e), line:e.line}); }
+})()
+"""
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_full_hd_capture_is_complete_and_correctly_sized(
+    clean_project, artifact_dir
+):
+    out = await clean_project.exec(code=FULL_HD_SETUP_JSX, timeout_sec=20.0)
+    parsed = json.loads(out)
+    assert parsed["ok"] is True, parsed
+
+    result = await _run_preview_frame(
+        schemas.AePreviewFrameArgs(
+            comp_id=parsed["compId"], out_dir=str(artifact_dir)
+        ),
+        ctx=None,
+    )
+    assert result["ok"] is True, result
+
+    frame = result["frames"][0]
+    assert _assert_frame_matches_file(frame) == (1920, 1080)
+    assert (frame["compWidth"], frame["compHeight"]) == (1920, 1080)
+    assert frame.get("downsampled") is None
+    assert "note" not in result
+
+
+HALF_RES_SETUP_JSX = """
+(function(){
+  try {
+    var comp = app.project.items.addComp("PreviewHalfRes", 1920, 1080, 1, 2.0, 24);
+    comp.layers.addSolid([0.9,0.4,0.1], "Field", 1920, 1080, 1, 2.0);
+    comp.resolutionFactor = [2, 2];
+    comp.time = 0.25;
+    comp.openInViewer();
+    return JSON.stringify({ok:true, compId: String(comp.id)});
+  } catch (e) { return JSON.stringify({ok:false, error:String(e), line:e.line}); }
+})()
+"""
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_half_resolution_reports_the_written_size(
+    clean_project, artifact_dir
+):
+    """The reported failure: comp says 1920x1080, the viewer writes 960x540."""
+    out = await clean_project.exec(code=HALF_RES_SETUP_JSX, timeout_sec=20.0)
+    parsed = json.loads(out)
+    assert parsed["ok"] is True, parsed
+
+    result = await _run_preview_frame(
+        schemas.AePreviewFrameArgs(
+            comp_id=parsed["compId"], out_dir=str(artifact_dir)
+        ),
+        ctx=None,
+    )
+    assert result["ok"] is True, result
+
+    frame = result["frames"][0]
+    assert _assert_frame_matches_file(frame) == (960, 540)
+    assert (frame["compWidth"], frame["compHeight"]) == (1920, 1080)
+    assert frame["resolutionFactor"] == [2, 2]
+    assert frame["downsampled"] is True
+    # The caller reads the text result; a metadata field alone is not a warning.
+    assert "downsampled" in result["note"]
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_multiple_full_hd_frames_fit_the_budget(
+    clean_project, artifact_dir
+):
+    """Three full-HD frames used to exhaust one flat 60s budget while each succeeded."""
+    out = await clean_project.exec(code=FULL_HD_SETUP_JSX, timeout_sec=20.0)
+    parsed = json.loads(out)
+    assert parsed["ok"] is True, parsed
+
+    result = await _run_preview_frame(
+        schemas.AePreviewFrameArgs(
+            comp_id=parsed["compId"],
+            times=[0.0, 0.5, 1.0],
+            out_dir=str(artifact_dir),
+        ),
+        ctx=None,
+    )
+    assert result["ok"] is True, result
+    assert len(result["frames"]) == 3
+    for frame in result["frames"]:
+        assert _assert_frame_matches_file(frame) == (1920, 1080)

--- a/packages/core/tests/test_handlers_core.py
+++ b/packages/core/tests/test_handlers_core.py
@@ -8,10 +8,17 @@ import time
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from ae_mcp import schemas as S
 from ae_mcp.handlers import HANDLERS, load_all
+from ae_mcp.handlers import core as core_handlers
 from ae_mcp.handlers.core import _run_ping
+
+
+async def _never_written(*_args, **_kwargs):
+    """Stand in for a capture whose file never becomes a complete PNG."""
+    return None
 
 
 @pytest.fixture(autouse=True)
@@ -930,3 +937,203 @@ def test_revert_open_template_substitutes_path_and_no_throw():
     # Preserves the missing-file guard and never throws.
     assert "missing" in jsx
     assert "ok: false" in jsx and "ok: true" in jsx
+
+
+# ---------------------------------------------------------------------------
+# ae.previewFrame — real PNG size vs the composition's own size (#242)
+# ---------------------------------------------------------------------------
+
+
+def _chunked_png_writer(path: Path, size: tuple[int, int]):
+    """Write a PNG the way saveFrameToPng does: late, and in pieces.
+
+    The signature lands well before the image is complete, which is what makes
+    a signature-only wait hand Pillow a truncated file. The gap is deliberate
+    and larger than the handler's 50ms poll so the race is not left to luck.
+    """
+    import io as _io
+    import threading
+    from PIL import Image
+
+    buffer = _io.BytesIO()
+    Image.new("RGB", size, (12, 34, 56)).save(buffer, "PNG")
+    payload = buffer.getvalue()
+    split = 32
+
+    def _write() -> None:
+        with open(path, "wb") as handle:
+            handle.write(payload[:split])
+            handle.flush()
+        time.sleep(0.3)
+        with open(path, "ab") as handle:
+            handle.write(payload[split:])
+            handle.flush()
+
+    threading.Timer(0.05, _write).start()
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_reports_written_pixels_not_comp_settings(
+    monkeypatch, mock_backend, tmp_path
+):
+    """A Half-resolution viewer writes half a frame; report what was written.
+
+    saveFrameToPng honours the viewer's Resolution setting, so a 1920x1080 comp
+    at [2,2] produces a 960x540 file. Reporting the composition's size instead
+    is what produced "frame 0 dimensions (960, 540) do not match (1920, 1080)".
+    """
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+
+    def _render_response(code, **kwargs):
+        import re
+
+        match = re.search(r"new File\((\".*?\")\)", code)
+        assert match, code
+        path = Path(json.loads(match.group(1)))
+        _chunked_png_writer(path, (960, 540))
+        return json.dumps({
+            "ok": True,
+            "compId": "7",
+            "compName": "Preview",
+            "time": 0.5,
+            "path": str(path),
+            "compWidth": 1920,
+            "compHeight": 1080,
+            "resolutionFactor": [2, 2],
+            "source": "comp",
+            "method": "saveFrameToPng",
+            "existsImmediately": False,
+        })
+
+    mock_backend.set_response(_render_response)
+
+    _, run_fn = HANDLERS["ae.previewFrame"]
+    result = await run_fn(
+        S.AePreviewFrameArgs(comp_id="7", time=0.5, out_dir=str(tmp_path)),
+        None,
+    )
+
+    assert result["ok"] is True
+    frame = result["frames"][0]
+    assert (frame["width"], frame["height"]) == (960, 540)
+    assert (frame["compWidth"], frame["compHeight"]) == (1920, 1080)
+    assert frame["resolutionFactor"] == [2, 2]
+    assert frame["downsampled"] is True
+    # The caller reads the text result, not the metadata fields.
+    assert "downsampled" in result["note"]
+
+    # The packaging step is the thing that used to reject this frame. It has to
+    # accept the fixed metadata, or the test proves nothing about the symptom.
+    from ae_mcp.server import _preview_frame_content
+
+    assert len(_preview_frame_content(result)) == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_full_resolution_capture_is_not_marked_downsampled(
+    monkeypatch, mock_backend, tmp_path
+):
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+
+    def _render_response(code, **kwargs):
+        import re
+
+        match = re.search(r"new File\((\".*?\")\)", code)
+        path = Path(json.loads(match.group(1)))
+        _chunked_png_writer(path, (320, 180))
+        return json.dumps({
+            "ok": True,
+            "compId": "7",
+            "compName": "Preview",
+            "time": 0.0,
+            "path": str(path),
+            "compWidth": 320,
+            "compHeight": 180,
+            "resolutionFactor": [1, 1],
+            "source": "comp",
+            "method": "saveFrameToPng",
+        })
+
+    mock_backend.set_response(_render_response)
+
+    _, run_fn = HANDLERS["ae.previewFrame"]
+    result = await run_fn(
+        S.AePreviewFrameArgs(comp_id="7", out_dir=str(tmp_path)), None
+    )
+
+    frame = result["frames"][0]
+    assert (frame["width"], frame["height"]) == (320, 180)
+    assert "downsampled" not in frame
+    assert "note" not in result
+
+
+def test_preview_frame_metadata_from_comp_settings_still_fails_packaging(tmp_path):
+    """The negative half: without the fix the same capture is still rejected.
+
+    Guards against the pair of tests above passing vacuously -- if the
+    packaging check stopped comparing dimensions at all, they would go green
+    while the original defect was untouched.
+    """
+    from PIL import Image
+    from ae_mcp.server import _preview_frame_content
+
+    path = tmp_path / "half.png"
+    Image.new("RGB", (960, 540), (12, 34, 56)).save(path, "PNG")
+    payload = path.read_bytes()
+
+    stale = {
+        "ok": True,
+        "frames": [{
+            "path": str(path),
+            "width": 1920,
+            "height": 1080,
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }],
+    }
+    with pytest.raises(ValueError, match=r"do not match"):
+        _preview_frame_content(stale)
+
+
+@pytest.mark.asyncio
+async def test_preview_frame_rejects_a_png_that_never_finishes(
+    monkeypatch, mock_backend, tmp_path
+):
+    """A truncated file is a capture that did not finish, not a broken image."""
+    monkeypatch.setattr("ae_mcp.snapshot.discovery.select_snapshotter", lambda: None)
+    monkeypatch.setattr(core_handlers, "_await_written_png", _never_written)
+
+    def _render_response(code, **kwargs):
+        import re
+
+        match = re.search(r"new File\((\".*?\")\)", code)
+        path = Path(json.loads(match.group(1)))
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        return json.dumps({
+            "ok": True,
+            "compId": "7",
+            "compName": "Preview",
+            "time": 0.0,
+            "path": str(path),
+            "compWidth": 320,
+            "compHeight": 180,
+            "source": "comp",
+            "method": "saveFrameToPng",
+        })
+
+    mock_backend.set_response(_render_response)
+
+    _, run_fn = HANDLERS["ae.previewFrame"]
+    result = await run_fn(
+        S.AePreviewFrameArgs(comp_id="7", out_dir=str(tmp_path)), None
+    )
+
+    assert result["ok"] is False
+    assert "did not finish writing" in result["fallbackReason"]
+
+
+def test_preview_frame_times_are_bounded():
+    """An outer timeout that scales with caller input has no ceiling."""
+    with pytest.raises(ValidationError):
+        S.AePreviewFrameArgs(times=[float(i) for i in range(9)])
+    assert S.AePreviewFrameArgs(times=[float(i) for i in range(8)]).times is not None


### PR DESCRIPTION
Closes #242. Also closes the `previewFrame` half of #243 item 4 — same message, same decode path, same environment, reported independently the same day.

## Three defects behind two error messages

**The reported size came from the composition, not the file.** `saveFrameToPng` honours the viewer's Resolution setting, so a 1920×1080 comp at `[2,2]` writes a 960×540 PNG — while the JSX reported `comp.width`/`comp.height` and the packaging step compared *those* against the decoded image. That is `frame 0 dimensions (960, 540) do not match (1920, 1080)`: a correct capture, rejected for a size nothing had measured.

**A frame was accepted before it finished being written.** The old wait returned as soon as the first 8 bytes matched the PNG signature, which for a large frame is true long before the image exists. Pillow got a truncated file — `frame 0 is not a decodable image`, intermittent only because it depends on how long the render takes to reach disk.

**One flat budget covered every frame.** 60s wrapped the whole loop while each frame costs a 15s round-trip plus the write budget, so three frames could time out with every capture succeeding.

## What changed

- Dimensions are read back off the file — the only trustworthy source. The composition's own size is reported separately as `compWidth`/`compHeight`, with `resolutionFactor`.
- Completion requires the `IEND` trailer, a size unchanged across two polls, **and** a successful decode. The decode is not redundant: it is the same check the caller runs, so failing it here reports a capture that never finished rather than an image that cannot be read. Budget 5s → 15s.
- The outer budget grows per frame and still stops at 300s; `times` is capped at 8. A timeout bounded only by caller input is its own failure mode.

Downsampled captures are **accepted rather than refused** — viewers sit at Half for performance, and failing there would trade one bug for another. But the warning goes in the text the caller actually reads, not only in a metadata field a caller has to know to look for.

## Why it survived a green suite

The repo already knew about the async write. The bundled `extendscript-cookbook` skill has a section titled *"File.exists() is unreliable right after saveFrameToPng"* saying the file **is** being written and not to branch on `exists`, and the JSX template reports `existsImmediately`, which nothing consumes. The handler was contradicting our own shipped guidance.

And the live tests could not have caught it: every previous `previewFrame` live test used a comp of 320×180 or smaller, which writes fast enough that the race never fires, and none asserted the reported size against the decoded file. `_assert_png` checked eight bytes — the same blind spot as the handler. All three are fixed, and coverage moves to full HD plus an explicit Half-resolution case.

## Not passing vacuously

The offline test follows @msaworks's shape, including the negative assertion that pre-patch metadata still fails packaging. Separately confirmed by replaying the old signature-only wait against the chunked fixture:

```
old wait accepted=True at size=32/2726 bytes
  -> truncated, Pillow fails: UnidentifiedImageError
```

## Credit

Reported and root-caused by **@msaworks**, who verified the size mismatch by decoding the IHDR chunk directly and demonstrated the race with `outFile.exists` false immediately after the call. Carried as a `Co-authored-by:` trailer.

## Verification (macOS)

| suite | result |
|---|---|
| `pytest` | 927 passed, 5 skipped |
| `scripts/package/test/*` | 490 passed |
| `scripts/release/test/*` | 144 passed |

Live tests are written but need real AE; they run under `AE_MCP_LIVE_TESTS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)