### PR TITLE
fix(snapshot): stop defaulting the capture path to the working directory (#243)

### DIFF
--- a/packages/core/ae_mcp/snapshot/base.py
+++ b/packages/core/ae_mcp/snapshot/base.py
@@ -1,13 +1,48 @@
 """Abstract Snapshotter — capture AE viewer/main window pixels."""
 from __future__ import annotations
 
+import tempfile
+import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
 
 
+SNAPSHOT_ROOT = Path(tempfile.gettempdir()) / "ae_mcp_snapshots"
+
+
+def resolve_snapshot_path(out_path: Optional[Path]) -> Path:
+    """Turn a caller's optional out_path into a real, writable, unique file.
+
+    The default has to be absolute. A bare filename resolves against the MCP
+    server process's working directory -- whatever launched it, often somewhere
+    the process cannot write. That produces `[Errno 13] Permission denied:
+    'ae_viewer_....png'`, with no directory in the message because there was
+    never a directory in the path. It works on a developer machine for exactly
+    the reason it fails on a user's: where the process happened to start.
+
+    The name is a UUID rather than a millisecond timestamp, which two
+    concurrent captures can collide on.
+
+    This lives on the base class so every backend inherits it. The macOS
+    ScreenCaptureKit backend does not exist yet; when it does, it should not be
+    able to reintroduce this by writing the same three lines.
+    """
+    resolved = (
+        Path(out_path)
+        if out_path is not None
+        else SNAPSHOT_ROOT / f"ae_viewer_{uuid.uuid4().hex}.png"
+    )
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
 class Snapshotter(ABC):
     name: str
+
+    def resolve_out_path(self, out_path: Optional[Path]) -> Path:
+        """Resolve and prepare the destination. Backends must call this."""
+        return resolve_snapshot_path(out_path)
 
     @abstractmethod
     async def capture(

--- a/packages/core/tests/test_snapshot_base.py
+++ b/packages/core/tests/test_snapshot_base.py
@@ -1,0 +1,59 @@
+"""Destination resolution shared by every snapshot backend (#243)."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ae_mcp.snapshot.base import SNAPSHOT_ROOT, Snapshotter, resolve_snapshot_path
+
+
+def test_default_destination_is_absolute_and_not_the_working_directory(tmp_path):
+    """The reported failure was a bare filename resolved against the CWD.
+
+    Asserting "absolute" is not enough on its own -- a relative default would
+    still look fine from a writable CWD, which is exactly why this shipped. The
+    check that matters is that the result does not depend on where the process
+    was started.
+    """
+    original = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        first = resolve_snapshot_path(None)
+    finally:
+        os.chdir(original)
+
+    assert first.is_absolute()
+    assert tmp_path not in first.parents
+    assert Path(tempfile.gettempdir()) in first.parents
+    assert first.parent.is_dir()
+
+
+def test_default_destinations_do_not_collide():
+    """A millisecond timestamp is shared by two captures in the same tick."""
+    names = {resolve_snapshot_path(None).name for _ in range(50)}
+    assert len(names) == 50
+
+
+def test_an_explicit_destination_is_honoured_and_its_parent_created(tmp_path):
+    requested = tmp_path / "nested" / "shot.png"
+    resolved = resolve_snapshot_path(requested)
+    assert resolved == requested
+    assert resolved.parent.is_dir()
+
+
+def test_backends_inherit_the_resolver_rather_than_reimplementing_it(tmp_path):
+    class _Backend(Snapshotter):
+        name = "probe"
+
+        def supports_platform(self) -> bool:
+            return True
+
+        async def capture(self, out_path, **kwargs) -> dict:
+            return {"ok": True, "path": str(self.resolve_out_path(out_path))}
+
+    resolved = Path(_Backend().resolve_out_path(None))
+    assert resolved.is_absolute()
+    assert resolved.parent == SNAPSHOT_ROOT

--- a/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
+++ b/packages/snapshot-mss/ae_mcp_snapshot_mss/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 from typing import Optional
 
@@ -27,11 +26,7 @@ class MssSnapshotter(Snapshotter):
         main_window: bool = False,
         method: str = "auto",
     ) -> dict:
-        if out_path is None:
-            ts = int(time.time() * 1000)
-            out_path = Path(f"ae_viewer_{ts}.png")
-        out_path = Path(out_path)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path = self.resolve_out_path(out_path)
 
         # Resolve target rect. An explicit hwnd wins; otherwise we always
         # locate the real After Effects window (by owning AfterFX.exe process)


### PR DESCRIPTION
Closes the `ae.snapshot` half of #243 item 4.

## The bug

`ae.snapshot` without an explicit `out_path` built its destination as `Path(f"ae_viewer_{ts}.png")` — a bare filename, resolved against the **MCP server process's working directory**. That is whatever launched the process, frequently somewhere it cannot write:

```
[Errno 13] Permission denied: 'ae_viewer_1786639644493.png'
```

The message carries no directory because the path never had one. That is also how it was identified: only this branch can produce a bare filename.

## It is not intermittent

The report described it as occasional. It is deterministic — two call paths simply have different defaults. `ae.snapshot` without `out_path` lands here; `previewFrame`'s viewer fallback passes an explicit path under the preview temp root and therefore always works. Same bug, two exit codes.

## The fix, and where it lives

Resolution moves to `ae_mcp.snapshot.base` as `resolve_snapshot_path`, with a concrete `Snapshotter.resolve_out_path` in front of it, so it is **inherited rather than restated per backend**. The macOS ScreenCaptureKit backend (#67) does not exist yet; when it does, it should not be able to reintroduce this by writing the same three lines.

Default is an absolute path under the system temp directory, named with a UUID — a millisecond timestamp is shared by two captures landing in the same tick.

## The test that matters

Not "the path is absolute". A relative default still looks absolutely fine from a writable working directory, which is precisely why this shipped and why it only ever hurt users. The test changes the process's working directory and asserts the resolved path **does not depend on where the process started**.

## Credit

Reported by **@tomaszteee**, carried as a `Co-authored-by:` trailer.

## Verification (macOS)

`pytest`: 931 passed, 5 skipped. The mss backend itself is Windows-only, so the capture path needs a re-test on Windows — @tomaszteee, once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)