### PR TITLE
docs(approval): write down why the two gates default in opposite directions (#243)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -181,6 +181,28 @@ CAS 晋升；没有自动过期或清理。已有 candidates 保持不变。
 两者都必填；同一 key 只能绑定规范化后完全相同的 program。一个写 program 使用
 一个真实 AE Undo group，但不承诺原子性，也不会在部分失败后静默回滚。
 
+### 审批模型
+
+两个工具面，分别把关，**默认方向相反，这是刻意的**。
+
+| | 动词面（`ae_exec`、`ae_previewFrame` 等） | 存储程序面（`ae_toolUse`、`ae_skillUse`） |
+|---|---|---|
+| 环境变量 | `AE_MCP_APPROVAL_TIER_FILE` | `AE_MCP_TOOL_APPROVAL_TIER_FILE` |
+| 变量未设置 | 不设门禁——由客户端自己弹审批 | `manual`——由 ae-mcp 弹审批 |
+| 文件缺失或不可读 | `manual` | `manual` |
+| 档位 | `readonly` / `manual` / `auto` / `none` | 同左 |
+
+档位文件由面板写入，你拨动审批 chip 时面板会改写它。变量未设置时，调用方是别的
+MCP 客户端，把关的是它自己的权限系统——面板对 Codex adapter 就是**故意不设**这个
+变量的，因为 Codex 自己会弹审批。把动词面默认改成 `manual` 反而会让所有不支持
+elicitation 的客户端完全无法写入。
+
+存储程序面默认相反，因为它执行的是调用方当轮没有写的代码，配置缺失是"该问一句"
+的理由，而不是"可以继续"的理由。**风险更高的那一面才是 fail-closed 的那一面。**
+
+两个门禁都不是认证边界。`/exec` 要求 `~/.ae-mcp/auth-token` 里的共享密钥（首次
+运行生成），面板的 kill switch 和 per-client 黑名单也在这两个门禁之前。
+
 ### Readback、失败与 Undo
 
 - 写入前读取基线，写入后用新的独立请求读取结果。
@@ -391,6 +413,32 @@ Read programs omit `operationKey` and `undoGroup`. A program containing any
 write requires both; one key binds one canonical program. A write program uses
 one real AE Undo group, is not atomic, and never silently rolls back partial
 execution.
+
+### Approval model
+
+Two surfaces, gated separately, defaulting in opposite directions on purpose.
+
+| | verbs (`ae_exec`, `ae_previewFrame`, …) | stored programs (`ae_toolUse`, `ae_skillUse`) |
+|---|---|---|
+| env var | `AE_MCP_APPROVAL_TIER_FILE` | `AE_MCP_TOOL_APPROVAL_TIER_FILE` |
+| variable unset | no gate — the client prompts | `manual` — ae-mcp prompts |
+| file missing or unreadable | `manual` | `manual` |
+| tiers | `readonly` / `manual` / `auto` / `none` | same |
+
+The panel writes the tier file and rewrites it when you move the approval chip.
+When the variable is unset, the caller is another MCP client whose own
+permission system is the gate — which is why the panel deliberately leaves it
+unset for its Codex adapter, since Codex prompts on its own. Defaulting the verb
+surface to `manual` instead would leave any client that cannot prompt unable to
+write at all.
+
+Stored programs default the other way because they run code the caller did not
+write in that turn, so an absent configuration is a reason to ask rather than to
+proceed. **The higher-risk surface is the fail-closed one.**
+
+Neither gate is the authentication boundary. `/exec` requires a shared secret at
+`~/.ae-mcp/auth-token`, generated on first run, and the panel's kill switch and
+per-client block list sit in front of both gates.
 
 ### Readback, failures, and Undo
 

--- a/packages/core/ae_mcp/approval_gate.py
+++ b/packages/core/ae_mcp/approval_gate.py
@@ -1,9 +1,38 @@
-"""Opt-in approval gate driven by a tier file (panel-controlled).
+"""Approval gates for the two tool surfaces.
 
-Activated only when AE_MCP_APPROVAL_TIER_FILE is set: the embedding UI
-(panel Codex adapter) writes one of readonly/manual/auto/none into that
-file and flips it when the user changes the approval chip. Decisions
-come from VERB_ANNOTATIONS (the same source as the Claude backend's
+There are two, with **opposite defaults**, and the difference is deliberate. It
+has been read from the source as a fail-open bug (#243), so it is written down
+here rather than left to be rediscovered.
+
+**Verb surface** -- ae_exec, ae_previewFrame, and the rest. Gated by
+`enforce()`, active only when AE_MCP_APPROVAL_TIER_FILE is set: the embedding
+UI writes one of readonly/manual/auto/none into that file and flips it when the
+user changes the approval chip. With the variable unset the gate is a no-op,
+because the caller is then some other MCP client whose own permission system is
+the gate. The panel deliberately does not set the variable for its Codex
+adapter for exactly that reason -- asserted in
+plugin/panel/test/codexBackend.test.js. Defaulting this to `manual` instead is
+not a safe one-line change: a client with no elicitation capability would hit
+_NO_PROMPT_API on every write and be unable to do anything at all.
+
+**Tool Library and skill surface** -- ae_toolUse, ae_skillUse. These execute
+stored programs rather than a verb the caller just wrote, so they are excluded
+from `enforce()` at the dispatch site and gated by `plan_decision()` /
+`authorize_plan()` instead, which fall back to `manual` when
+AE_MCP_TOOL_APPROVAL_TIER_FILE is absent. **The higher-risk surface is the
+fail-closed one.**
+
+A missing or unreadable tier *file* falls back to `manual` on both surfaces
+(see `read_tier`). Only the absence of the environment variable separates them,
+and it means different things in the two places: "no UI is driving this gate,
+and the client has its own", versus "no UI is driving this gate, so assume
+nothing".
+
+Neither gate is the authentication boundary. /exec requires a shared secret
+(plugin/host/auth-token.js) and the panel has a kill switch and per-client
+block list in front of both.
+
+Decisions come from VERB_ANNOTATIONS (the same source as the Claude backend's
 canUseTool tiers), so semantics match across backends.
 """
 from __future__ import annotations
@@ -98,6 +127,12 @@ def gate_decision(tier: str, verb_name: str) -> Decision:
 
 
 def current_tool_tier() -> Tier:
+    """Tier for the Tool Library surface, which runs stored programs.
+
+    Unset means `manual`, the opposite of `enforce()`. That asymmetry is the
+    point: this surface executes code the caller did not write in this turn, so
+    an absent configuration is a reason to ask, not a reason to proceed.
+    """
     path = os.environ.get("AE_MCP_TOOL_APPROVAL_TIER_FILE")
     if not path:
         return "manual"
@@ -195,7 +230,12 @@ async def authorize_plan(
 
 
 async def enforce(name: str, ctx: Any) -> dict[str, Any] | None:
-    """Apply the configured approval tier before a tool executes."""
+    """Apply the configured approval tier before a verb executes.
+
+    Returns None to allow. See the module docstring for why an unset variable
+    allows here while `current_tool_tier` denies: this gate exists so the panel
+    UI can drive it, and its absence means another client owns the prompt.
+    """
     path = os.environ.get("AE_MCP_APPROVAL_TIER_FILE")
     if not path:
         return None

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -1358,6 +1358,11 @@ def build_server() -> Server:
         except LookupError:
             ctx = None
 
+        # toolUse and skillUse are excluded here because they are gated harder
+        # elsewhere, not because they are exempt: they run stored programs, so
+        # they go through plan_decision/authorize_plan, which falls back to
+        # `manual` when unconfigured. See the approval_gate module docstring —
+        # the two surfaces default in opposite directions on purpose.
         if not panel_private and canonical not in {"ae.toolUse", "ae.skillUse"}:
             gated = await approval_gate.enforce(canonical, ctx)
             if gated is not None:

--- a/packages/core/tests/test_approval_gate.py
+++ b/packages/core/tests/test_approval_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -335,3 +336,54 @@ async def test_server_gate_allows_execution_in_none_tier(monkeypatch, tmp_path):
 
     assert result.isError is False
     assert json.loads(result.content[0].text) == {"ok": True, "ran": True}
+
+
+# ---------------------------------------------------------------------------
+# The two surfaces default in opposite directions (#243)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_two_surfaces_default_in_opposite_directions_on_purpose(monkeypatch):
+    """Pins the asymmetry that reads as a fail-open bug from the source.
+
+    Both behaviours are covered individually above, which is exactly the
+    problem: nothing said they disagree, or why, so an audit reasonably
+    concluded one of them was wrong. If a later change "fixes" the
+    inconsistency, this is the test that should stop it and explain the cost.
+
+    The verb surface allows when unconfigured because the caller is then an MCP
+    client with its own permission prompt, and denying would leave clients that
+    cannot elicit unable to write at all. The Tool Library surface denies when
+    unconfigured because it executes stored programs -- code the caller did not
+    write this turn -- so an absent configuration is a reason to ask.
+    """
+    monkeypatch.delenv("AE_MCP_APPROVAL_TIER_FILE", raising=False)
+    monkeypatch.delenv("AE_MCP_TOOL_APPROVAL_TIER_FILE", raising=False)
+
+    assert await approval_gate.enforce("ae.exec", None) is None
+    assert current_tool_tier() == "manual"
+    assert plan_decision(current_tool_tier(), "write") == "elicit"
+    assert plan_decision(current_tool_tier(), "destructive") == "elicit"
+
+
+def test_a_missing_tier_file_fails_closed_on_both_surfaces(monkeypatch, tmp_path):
+    """Only the *variable* differs. An unreadable file is manual everywhere."""
+    missing = tmp_path / "gone.tier"
+    assert read_tier(str(missing)) == "manual"
+
+    monkeypatch.setenv("AE_MCP_TOOL_APPROVAL_TIER_FILE", str(missing))
+    assert current_tool_tier() == "manual"
+
+
+def test_stored_program_surfaces_skip_the_verb_gate_by_name():
+    """The exclusion at dispatch is what makes the model coherent.
+
+    ae.toolUse and ae.skillUse bypass enforce() because plan authorization
+    covers them harder. Adding a third stored-program verb without adding it
+    here would leave it on the weaker gate.
+    """
+    source = (
+        Path(approval_gate.__file__).resolve().parent / "server.py"
+    ).read_text(encoding="utf-8")
+    assert 'canonical not in {"ae.toolUse", "ae.skillUse"}' in source


### PR DESCRIPTION
Closes #243 item 5. **No behaviour changes.**

## The actual defect is the silence

A read-only audit of the source concluded the approval gate fails open, because `enforce()` returns `None` when `AE_MCP_APPROVAL_TIER_FILE` is unset while `current_tool_tier()` returns `manual` when *its* variable is unset.

Both behaviours were already tested — individually, with nothing anywhere saying they disagree or why. Two passing tests asserting opposite postures, and no explanation between them. Anyone auditing this reaches the same conclusion @tomaszteee did.

## The model is coherent

| | verbs | stored programs |
|---|---|---|
| gate | `enforce()` | `plan_decision` / `authorize_plan` |
| env var | `AE_MCP_APPROVAL_TIER_FILE` | `AE_MCP_TOOL_APPROVAL_TIER_FILE` |
| variable unset | no gate — the client prompts | `manual` — ae-mcp prompts |
| file missing | `manual` | `manual` |

The verb surface allows when unconfigured because the caller is then an MCP client whose own permission system is the gate — which is why the panel deliberately leaves the variable unset for its Codex adapter (asserted in `plugin/panel/test/codexBackend.test.js`).

`ae_toolUse` and `ae_skillUse` are excluded from `enforce()` at the dispatch site — not because they are exempt, but because they are gated harder: they run stored programs, code the caller did not write that turn, and their gate falls back to `manual`. **The higher-risk surface is the fail-closed one.**

## Why not just align them

Defaulting the verb surface to `manual` is not a safe one-line hardening. A client with no elicitation capability would hit `approval required but this client cannot prompt` on every write and be unable to do anything at all. The asymmetry is load-bearing.

## What changed

The model is written down: the `approval_gate` module docstring, both call sites, the dispatch-site exclusion, and `docs/REFERENCE.md` — where these environment variables appeared **nowhere at all** until now, in either language.

Three tests pin it:

- the two surfaces disagree on purpose, with the reasoning in the docstring so a future "consistency fix" has to argue with it;
- only the *variable* differs — a missing or unreadable tier *file* fails closed on both;
- the stored-program exclusion list still exists, since adding a third such verb without listing it would silently leave it on the weaker gate.

## Credit

**@tomaszteee**, whose reading of the source is the evidence that this needed documenting. Carried as a `Co-authored-by:` trailer.

## Verification (macOS)

`pytest`: 930 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)