### PR TITLE
docs(direction): record the two-process direction and freeze the native plane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,21 @@
 
 These rules apply to human developers and coding agents working in this repository. They exist to keep engineering effort aligned with observable After Effects functionality. When an issue plan, reviewer suggestion, or local preference conflicts with these rules, stop and resolve the conflict in favor of the user-visible acceptance outcome unless the user explicitly changes the priority.
 
+## 0.0 Read the current architecture direction first
+
+**Read [`docs/ARCHITECTURE_DIRECTION.md`](docs/ARCHITECTURE_DIRECTION.md) before planning any work.** It was approved 2026-08-15 and it changes what work is worth doing. The delivery discipline in the rest of this file — evidence, acceptance tiers, stop conditions, `.aep` lifecycle — remains fully in force. Only the *direction* moved.
+
+Three standing decisions constrain new work until the direction document says otherwise:
+
+- **The native AEGP plane is frozen.** Keep the `.aex` and its 23 primitives; add none. Do not open a new native capability package, do not extend `native-primitives.json`, and do not run the capability-package codegen pipeline. The two properties that justify the plane — exact rational time and generation-bound locators — are already built.
+- **The Python server plane is being retired this quarter.** Do not add handlers, backends, schemas, or entry points under `packages/`. Fixes to keep it working are fine; new surface there is not. The MCP server is moving into the CEP Node context (`plugin/host/`).
+- **The provider layer is collapsing to three channels** — claude CLI, codex CLI, opencode. Do not add a fourth backend adapter or extend `universalProviderRoute` / `providerCapabilityProbe` / `codexResponsesRoute`; those are scheduled for deletion.
+
+Two things are known-broken and already assigned; do not re-diagnose them from scratch:
+
+- `plugin/host/jsx-bridge.js` releases the serialization queue on timeout without cancelling the ExtendScript, opening the overlap window the queue exists to prevent. `plugin/host/jsx-bridge.test.js:59-83` currently enshrines that behavior as intended.
+- The first-run wizard detects Node but never installs it, so the built-in Claude chat cannot start on a clean Windows machine. The Python server itself installs fine there via `uv`.
+
 ## 0. User authorization is the scope boundary
 
 - The current user's explicit requested outcome and named deliverables are the authorization boundary. An Issue, Epic, milestone, checklist, review comment, repository rule, prior plan, branch, worktree, or sunk implementation is context or evidence only; none authorizes additional product work or delivery mechanisms.
@@ -32,6 +47,8 @@ These rules apply to human developers and coding agents working in this reposito
 - Workflow infrastructure must remove a measured repeated cost from the active acceptance path and is timeboxed to one working day unless the user explicitly promotes it. Otherwise record it as a follow-up and continue the capability package.
 
 ## 3. Define the public vertical-slice acceptance test first
+
+> **Scope note (2026-08-15).** The AEGP chain below now describes acceptance for the **frozen** native plane only — use it when touching existing native primitives. New capability work runs on the ExtendScript plane, where the equivalent chain is: public MCP tool -> `plugin/host/mcp` handler -> `/exec` -> `jsx-bridge` -> ExtendScript -> After Effects state -> typed result -> audit evidence. The evidence requirements are identical; only the middle layers differ. See [`docs/ARCHITECTURE_DIRECTION.md`](docs/ARCHITECTURE_DIRECTION.md).
 
 For AE-native work, write the executable acceptance path before expanding the implementation:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 English | [简体中文](README.zh-CN.md)
 
+> [!IMPORTANT]
+> **The panel's built-in chat is being rebuilt.** Until that work lands, use ae-mcp as a plain MCP server registered with your own agent client (Claude Code, Claude Desktop, Cursor, Codex, OpenCode, and similar).
+
 ae-mcp is a backend-agnostic automation tool that keeps Adobe After Effects and AI agents in the same working context. Its MCP server exposes AE project state, tool execution, previews, screenshots, and checkpoints so an agent can understand and operate the current AE project during a conversation.
 
 The MCP server is the core. Outside the MCP layer, ae-mcp also ships a CEP panel that wraps built-in agent chat, backend configuration, approval controls, diagnostics, and first-run setup. You can use ae-mcp from an external agent backend through MCP, or configure Claude / Codex / ZCode directly inside the AE panel.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,9 @@
 
 [English](README.md) | 简体中文
 
+> [!IMPORTANT]
+> **面板内对话功能正在整体重构。** 在重构落地前，请把 ae-mcp 作为纯粹的 MCP server 注册到你自己的 agent 客户端使用（Claude Code / Claude Desktop / Cursor / Codex / OpenCode 等）。
+
 ae-mcp 是一个**后端无关**的 After Effects 自动化工具，用来让 AE 与 AI agent 保持同一个工作上下文。它通过 MCP server 暴露 AE 工程状态、工具调用、预览、截图和检查点，让 agent 能在对话中理解并操作当前 AE 项目。
 
 MCP server 是核心。在 MCP 本体之外，ae-mcp 还包装了一套 CEP 面板插件，提供面板内对话、后端配置、审批、诊断和首跑安装。你可以根据自己的工作流选择：在外部 agent 后端里通过 MCP 使用 ae-mcp，或者直接在 AE 面板内配置 Claude / Codex / ZCode 后端进行对话。

--- a/docs/ARCHITECTURE_DIRECTION.md
+++ b/docs/ARCHITECTURE_DIRECTION.md
@@ -1,0 +1,280 @@
+# 架构方向（当前有效）
+
+> **状态**：2026-08-15 批准。本文件是新会话的入口，读完它就能接上工作，不需要重读拆解过程。
+> 与 `AGENTS.md` 冲突时，以本文件的**方向**为准，`AGENTS.md` 的**交付纪律**（证据、验收、停止条件）仍然有效。
+
+---
+
+## 1. 一句话
+
+从 **5 进程 / 3 条执行平面 / 16 个公开工具（无结构化读动词）** 收敛到
+**2 进程 / 1 条主执行平面 / 约 10 个工具**，把省下的产能投进三项竞品结构上做不到的差异化。
+
+---
+
+## 2. 为什么
+
+竞品 Atom 3.5.4 的 ZXP 拆解（Windows x64，静态分析）显示它用一个 CEP 扩展覆盖了我们大部分能力：
+
+| | Atom | ae-mcp 现状 |
+|---|---|---|
+| 进程 | 2（CEP 面板 + agent CLI 子进程） | 5（面板+host、sidecar、Python、.aex、platform-helper） |
+| 执行平面 | 1（`evalScript`） | 3（native-aegp / maintained-jsx / ephemeral-jsx） |
+| MCP server 位置 | 面板进程内，Node `http`，`listen(0)`，Streamable HTTP `/mcp` | 独立 Python 进程，HTTP 回打面板 `:11488`（环形） |
+| 工具 | 25，其中 **1 个能写**，**9 个结构化读** | 16，其中 1 个能写，**0 个结构化读** |
+| 写失败恢复 | 落盘可编辑脚本 + `recoveryId`，模型用自己的 Edit 工具改后重跑 | 无 |
+| 视觉验证 | 代理合成 + `saveFrameToPng` + canvas 拼对比表 | `ae.previewFrame` 已用 `saveFrameToPng`，但无对比表/采样/差分 |
+| 原生代码 | 无 | `native/` 42,457 行 + 需要受限 Adobe SDK 才能构建 |
+
+同时暴露了我们自己的三个事实，这三条是方向调整的直接依据：
+
+1. **约 100 个 verb 实现函数里只有 16 个被注册。** `handlers/native.py`（2,697 行）定义约 70 个 `_run_*` 只注册 1 个（`ae.nativeExec`）；`handlers/typed.py`（516 行）注册 1/12。Python 侧 typed-native 投影层共约 **21,743 行**，绝大部分不可达。
+2. **我们没有任何结构化读工具。** 模型想看工程只能自己写 JSX 走 `ae.exec`。这是我们**弱于**竞品的地方。
+3. **platform-helper 的 3 个截屏方法在生产代码里零调用点。** 它唯一活着的用途是用系统钥匙串存 provider API key——而这个用途正被 provider 方向调整消灭。
+
+另有一个**现存正确性 bug**（见 §6.1）。
+
+---
+
+## 3. 三个已定决策
+
+| 决策 | 内容 |
+|---|---|
+| **Python 服务端** | **全力迁移，本季度退役。** MCP server 手写进 CEP Node 上下文 |
+| **native AEGP 平面** | **冻结。** 保留 `.aex` 与 23 个 primitive，不再新增；删掉 Python 投影层 |
+| **platform-helper** | **删除。** provider 凭据由 claude/codex/opencode 各自的登录态持有 |
+
+配套（前序会话已定）：**provider 三通道**——codex CLI 与 claude CLI 各管自家模型及用户已配置环境，自定义 provider 全部经 opencode。
+
+---
+
+## 4. 目标形态
+
+```
+进程 1  AE 宿主进程
+        CEP 面板页面上下文（React）
+        + CEP Node 上下文 = plugin/host/
+            /mcp      ← 手写 Streamable HTTP MCP server（新建）
+            /exec     ← ExtendScript 平面（已有）
+            /native/* ← AEGP 平面，冻结（已有）
+        + AeMcpNative.aex 载入 AE 内（非独立进程）
+
+进程 2  agent CLI 子进程：claude / codex / opencode
+        不打包，检测 + 引导安装
+
+进程 3  任意外部 MCP 客户端（Claude Desktop / Cursor / Claude Code / IM bot）
+        直连 http://127.0.0.1:11488/mcp，一等公民
+```
+
+消失的：Python 进程、Node sidecar 进程、platform-helper 进程。
+
+**执行平面**：ExtendScript 为主。native AEGP 冻结保留，只为两个 JSX 给不了的保证——精确有理数时间、世代绑定 locator。`ae.nativeExec` 不再作为独立工具暴露，折叠进 `ae.exec({ code, locators, timeMode:'exact' })`：**模型只要保证，不该知道有几条平面。**
+
+---
+
+## 5. 我们要保住的差异化（Atom 结构上做不到）
+
+1. **32bpc / EXR / ACES 正确性。** Atom 取帧时临时把工程降到 8bpc 再还原，并给色彩一致性警告。位深 primitive 已有，`grade-stack` / `render-order` skill 已有。
+2. **精确时间与 locator 保证。** JSX 浮点漂移导致的差一帧、以及图层重排后写错目标——**这两种失效在预览图上都看不出来**，模型自我验证抓不到。这是 native 平面唯一的存在理由。
+3. **外部 MCP 客户端支持。** 用户已经在为 Claude Code / Cursor 付费，零额外花费就能控制 AE。Atom 的 server 只服务它自己 spawn 的 CLI。
+4. **Tool Library。** 可持久、可版本、扫密钥、带风险分级的用户工具。Atom 的 JSX 是一次性的。
+5. **kill switch / 客户端阻断 / `/exec` 共享密钥。** Atom 没有等价物，因为它没有外部客户端。
+
+---
+
+## 6. 分阶段执行
+
+### Phase 0 — 止血与取证（1–2 周）
+
+**6.1 修 jsx-bridge 超时（现存 P0 正确性 bug）**
+
+`plugin/host/jsx-bridge.js`（68 行）：`setTimeout` 只 reject JS Promise，**不取消 AE 里的 ExtendScript**；`queue.then(onFulfilled, onRejected)` 在 reject 路径上照样放行下一个调用。于是超时路径打开了一个重叠写入窗口——正好是串行化本身要防的那件事。模型看到超时无法区分"没跑"和"跑了"，重试即**双重写入**；checkpoint 只能还原状态，无法告诉你写了两次。
+
+不能简单地"超时不放行"——`evalScript` 无法取消，直接卡住队列会让面板静默死掉。做法：把**面向调用方的 Promise**（`timeoutMs` 到点即 reject，行为不变）与**队列尾部**拆开，队列只在以下之一发生时前进：
+
+- AE 回调真的到达（哪怕在超时之后）；或
+- 一次廉价哨兵往返（`1+1`）返回——返回即证明引擎已排空。
+
+哨兵未返回期间 `ae.status` 必须报 `degraded`，并在恢复路径关闭可能悬空的 undo group。
+
+> `plugin/host/jsx-bridge.test.js:59-83` 名为 `'timeout rejects and releases the lock for the next call'`，故意不触发第一个回调来断言锁被释放——**这个测试把 bug 固化成了预期行为，必须改写**。PR 描述里要写明，否则 review 会读成回归。
+
+**6.2 手写 MCP server spike（阻塞性）**
+
+`plugin/host/cep-runtime-compat.js:3-5` 已写明：CEP 11（AE 2023/2024）是 **Node 15.x / V8 8.8，`require('node:x')` 解析失败**。官方 `@modelcontextprotocol/sdk` 要 Node 18 + `node:` 前缀，跑不了。Atom 用裸 `require("http")` 手写，印证了唯一解。
+
+先只做 `ae.status` 一个工具，在 **AE 2023 Windows** 上打通 `initialize` / `tools/list` / `tools/call`。
+
+> **红灯预案**：若手写 server 在 CEP 11 上跑不通，两条退路——把宿主下限抬到 AE 2025（`plugin/CSXS/manifest.xml:11` 现为 `[23.0,26.9]`），或改为只支持 stdio shim。**必须在第 1 周知道，不是第 3 个月。**
+
+**6.3 给 previewFrame 打点**
+
+`handlers/core.py:_run_preview_frame`（L706-869）先走 JSX `comp.saveFrameToPng()`，失败才回落 mss 截屏。记录走了哪条分支、JSX 路径为何失败。**删 mss 之前必须先有这个数**——没人知道回落触发率，盲删是这份规划里唯一可能造成用户可见退化的动作。
+
+**退出条件**：不存在任何"上一次 ExtendScript 仍在执行时派发下一次"的代码路径；spike 在 AE 2023 Windows 真机绿；previewFrame 分支遥测已上线。
+
+---
+
+### Phase 1 — MCP server 进面板（6–8 周）
+
+新建 `plugin/host/mcp/`，挂到现有 express app 上。约束：**ES2020、零新依赖、不使用 `node:` 前缀**。
+
+**复用既有件，不要重造：**
+
+| 复用 | 位置 | 用途 |
+|---|---|---|
+| express app / activity log / kill switch | `plugin/host/server.js`（810 行） | `/mcp` 挂在这里 |
+| 共享密钥 + `timingSafeEqual` | `plugin/host/auth-token.js`（85 行） | 直接复用；**另加 Origin/Host 白名单**补 DNS-rebinding 防护 |
+| native 线协议客户端 | `plugin/host/native-aegp-client.js`（1,585 行） | native 平面不经 Python 也能活 |
+| primitive 表（JS 版） | `native/ae-plugin/protocol/native_exec.generated.mjs` | `timeMode:'exact'` 直接基于它组装 native program |
+| elicitation 对端 | `plugin/panel/src/lib/elicitationCoordinator.js` | `elicitation/create` |
+
+**移植顺序**（每步独立可验证）：
+`ae.status` → `ae.exec`（含自动 checkpoint + approval gate）→ `ae.previewFrame` → `ae.read`（新）→ `ae.checkpoint`/`ae.revert` → `ae.validateExpressions` → exact-time/locator 走 `/native/invoke`
+
+整个阶段两套 server 并行，面板里一个开关切换。
+
+**退出条件**：`packages/core/tests/live` 的等价用例在无 Python 进程下打到 `/mcp` 全绿；一个原装 Claude Code 会话指向 `http://127.0.0.1:11488/mcp`，**在没装 Python 也没装 Node 的干净 Windows 机器上**完成一次 20 步合成搭建。**这条不过，Phase 2 不启动。**
+
+---
+
+### Phase 2 — 删 Python、删 sidecar、删 helper（3–4 周）
+
+**2.1 移植 Tool Library**
+
+- 忠实移植：`tool_store.py`(1,175) + `tool_artifact.py`(753) + `tool_secrets.py`(410)——原子写、内容寻址、密钥扫描，机械工作。
+- **重新定标** `tool_execution.py`(2,233)：prepare→grant→execute→status 四步握手 + job store 是为"上百个细粒度动词"设计的，在 10 个工具的世界里过度。目标形态是「渲染模板 → approval gate → `ae.exec`」，约 300 行。**但 `plan_hash` 授权绑定必须保留**——它防的是"授权后改内容再重放"，是唯一有安全语义的部分。
+- **先移植测试再移植代码。**
+
+**2.2 claude 后端换 CLI 二进制**
+
+`claudeAgentBackend.js`(780) + `plugin/sidecar/`(989) + `plugin/shared/`(340) 的存在理由只有一个：Agent SDK 是 Node 库。换成 `claude --print --output-format stream-json --input-format stream-json --mcp-config <tmp>` 后进程 2 直接消失。`codexBackend.js` / `openCodeBackend.js` 已经是这个形状，**claude 是唯一的异类**。
+
+连带删除：`runtimeManager.js`(1,699) + 测试(937)、`build-portable-runtime.mjs`(1,080)、node/python BOM 与 runtime-lock、`stage-sidecar-payload.mjs`、以及 247 MB 的 `@anthropic-ai/` 依赖岛。
+
+> **既有暴露面**：我们**今天就在转发 `claude.exe`**——Agent SDK 的 npm 包内含它，随 `npm ci --omit=dev` 进了 ZXP。`@anthropic-ai/claude-code` 的 LICENSE 是 "All rights reserved"，不是开源许可（对照：codex 是 Apache-2.0、opencode 是 MIT）。换成"检测 + 引导安装"顺带消掉这个暴露面。
+
+**2.3 删 platform-helper**
+
+`native/platform-helper/**`、`plugin/host/platform-helper-*.js`、`.github/workflows/platform-foundation-ci.yml`、`sign-macos-nested.sh` / `sign-windows-nested.ps1`、`build-platform-helper.mjs`、`macos-helper-entitlements.mjs`、`helper-identity-policy.json`。
+
+> **顺序陷阱**：`plugin/panel/src/cep/platform/process.js`(587) 是**通用可执行文件解析**，不是 helper 专属。它**必须保留**且变得更重要——它是我们找 `claude`/`codex`/`opencode` 的方式。
+>
+> **连带**：`native/platform-helper/windows/src/launcher.cpp` 就是那个 `ae-mcp.exe` 启动器（要求 `%USERPROFILE%\.ae-mcp\runtime\<current>\python\python.exe`，否则返回 78）。Python 死了它自然一起死。
+
+**2.4 外部客户端路径**
+
+HTTP 为一等支持路径（Claude Code / Cursor 原生支持）。另附约 150 行 stdio→HTTP shim 给只会 stdio 的客户端，**文档写明 shim 需要 Node**。
+
+**退出条件**：`rg -c python .github/workflows/` 为 0；ZXP 单次签名、无嵌套原生二进制（`.aex` 除外）；ZXP 体积 < 20 MB；Claude Desktop 经 shim 跑通 `ae.exec`；macOS 与 Windows 各一次全新安装。
+
+---
+
+### Phase 3 — provider 收敛（4 周）
+
+保留三个适配器：CLI 驱动的 claude、`codexBackend.js`、`openCodeBackend.js`。自定义 provider 全部经 opencode。
+
+删除约 8,500 行 + 对应测试：`lib/agentLoop.js`(313, byokLoop)、`lib/anthropic.js`(212)、`zcodeBackend.js`(1,443)、`universalProviderRoute.js`(1,245)、`providerCapabilityProbe.js`(1,265)、`codexResponsesRoute.js`(1,089)、`providerProfile.js`(1,039)、`modelProbe.js`(303) 等。
+
+**两个静默失败必须一起处理：**
+
+- `plugin/panel/src/cep/backends/index.js:66-71` 的 `assertAttachmentBackendRegistry` 硬断言"只有 byok 可以 `attachmentTransport:'reject'`"，删 byok 会在模块加载期直接抛。
+- `plugin/panel/src/app/App.jsx:1091-1092` 的 `backendInstances[effective.backend] || byokLoop` **不会抛**，删不干净会静默路由到拒收附件的 byokLoop——用户只看到"附件不工作"，日志里什么都没有。**改成未知 id 直接抛。**
+
+> **可逆性**：Phase 3 是唯一造成**用户可见能力收缩**的阶段——支持的方言边界从我们自己定变成 opencode 定。opencode 通道与现有 `universalProviderRoute` **并存一个版本周期**收覆盖率数据，确认后再删那 3,600 行。
+>
+> **待验证风险**：opencode 的自定义 provider 依赖 `opencode.json` 里声明的 npm provider 包。若需联网拉包，内网/受限网络机器会失败——落地前必须真机验证。
+
+**退出条件**：backend map 恰好 3 个条目且未知 id 抛错；provider 层 < 2,500 行；一个既有 GLM/DeepSeek/中转 Anthropic 端点用户（即 #257 的场景）经 opencode 仍可用。
+
+---
+
+### Phase 4 — 把回收的产能投进差异化
+
+1. **`ae.exec` 恢复信封**（抄 Atom，修它两个错）：失败时落盘可编辑脚本 + 元数据，返回 `recoveryId`，模型用自己的 Edit 工具改那个文件后凭 `recoveryId` 重跑，默认先还原到失败前 checkpoint。
+   **不要放 `<projectDir>/`**——`checkpoint_store` 已按解析后工程路径做 key 存在 `%TEMP%` 并 prune 到 50 份，那个设计是对的（#10 修过碰撞）。恢复脚本放同一个 keyed 目录，返回绝对路径。
+2. **touched-path / failed-mutation 归因**：**不要抄 Atom 的原型猴子补丁**——持久引擎共享全局，会跨调用污染。用我们自己拥有的 `wrapForEvalScriptTransport`（`plugin/host/server.js:365`）装一个显式的 per-call recorder，`finally` 拆除。
+3. **previewFrame 对比表 / 区间采样 / A-B 差分**：合成与缩放在**面板的 Chromium canvas** 里做，不要引入 Node 图像库（Atom 正是这么做的，也顺带消掉 Pillow 依赖）。
+4. **32bpc / EXR / ACES 正确性面**。
+
+---
+
+## 7. 移植 vs 删除
+
+### 必须移植（语义已打磨过，不要重新发明）
+
+| 来源 | 行数 | 说明 |
+|---|---|---|
+| `checkpoint_store.py` | 234 | 按解析后路径做 key、prune 50、`AE_MCP_CHECKPOINT_KEEP`。逐条移植 |
+| `approval_gate.py` | 278 | 两个 gate、默认方向相反，**是已定决策（254a24f）**。连 docstring 一起移植——那是这个决定唯一写下来的地方 |
+| `jsx_result.py` + `jsx_prelude.py` | 105 | `"EvalScript error."` 哨兵必须与 `plugin/client/CSInterface.js:33` 和 `jsx-bridge.js` 逐字节一致 |
+| `jsx_templates/`（33 个） | 2,323 | 移到 `plugin/jsx/` 旁边。`_aemcp_prelude.jsx` 与 `plugin/jsx/runtime.jsx` 是手工同步的两份副本，靠 `test_jsx_prelude.py` 逐字节断言防漂移——**迁移后合并成一份** |
+| `handlers/core.py` 活逻辑 | ~370 | `ae.exec` 自动 checkpoint、`ae.revert` 原子替换与恢复分支、`ae.previewFrame` 的 PNG 完成轮询 |
+| `instructions.py` + `skills_bundled/` | 63 + 9 JSON | 作为数据原样发。**注意** `instructions.py:21` 和 `ae-execution-guide.json` 里嵌了 23-primitive 的模型可见说明，工具面变了要同步改 |
+| `annotations.py` | 43 | `VERB_ANNOTATIONS` 变成工具注册表元数据 |
+
+### 直接删除
+
+| 对象 | 量级 |
+|---|---|
+| `packages/`（core + bridge + snapshot-mss） | 40,296 源码 + 25,130 测试 |
+| └ 其中 typed-native 投影层 | 21,743（`backends/native*.py` 17,097 + `handlers/native.py` 2,697 + 生成物 4,373） |
+| `plugin/sidecar/` + `claudeAgentBackend.js` + `plugin/shared/` | ~2,100 + 247 MB 依赖岛 |
+| `runtimeManager.js` + 测试 + portable runtime 构建 + BOM | ~3,500 |
+| platform-helper 全套 + 专属 CI + 嵌套签名脚本 | ~5,163 + 工作流 |
+| provider 层 + zcode 适配器 | ~10,000 + 测试 |
+| `ae.snapshot` + `packages/snapshot-mss` + helper `window.*` | ~1,500 |
+
+### 保留冻结
+
+`native/ae-plugin/`（约 18,500 行 + protocol）。**不再新增 primitive**，停掉 capability package 流水线（`scripts/native_capability_codegen.py`、`packaging/native-coverage-approvals.json`）。
+
+**退役条件写在这里**：若 AE 27 破 ABI 且修复不是一天的工作量，就退役——exact-time 改为 JSX 整数帧运算（对 `comp.frameDuration` 量化），locator 改为 `(index, name, sourceId)` 三元组写前复核。严格更弱，但一周能出。
+
+---
+
+## 8. 工具面重设计：16 → ~10
+
+现存 `FINAL_PUBLIC_TOOLS`（`packages/core/ae_mcp/handlers/__init__.py:16-35`）：
+`ae.checkpoint` `ae.diagnose` `ae.exec` `ae.nativeExec` `ae.ping` `ae.previewFrame` `ae.revert` `ae.skillList` `ae.skillUse` `ae.snapshot` `ae.status` `ae.toolIndex` `ae.toolInspect` `ae.toolSearch` `ae.toolUse` `ae.validateExpressions`
+
+**里面没有任何结构化读动词。这是要补的最大缺口。**
+
+| 工具 | 变化 |
+|---|---|
+| `ae.exec` | 保留。吸收 `ae.nativeExec`：`{ code, locators, timeMode:'exact' }`。新增恢复信封 |
+| `ae.read` | **新增**。分页 + 排序 + 过滤的图层/属性/关键帧读取。读路径**绝不 checkpoint、绝不开 undo group** |
+| `ae.previewFrame` | 保留并扩展：对比表、区间采样、差分 |
+| `ae.checkpoint` / `ae.revert` | 保留 |
+| `ae.status` | 吸收 `ae.ping` 和 `ae.diagnose`，用 `depth` 参数区分 |
+| `ae.toolUse` / `ae.toolSearch` | 保留；`toolIndex` + `toolInspect` 折叠成 `toolSearch` 的模式 |
+| `ae.skillUse` | 保留；`skillList` 折叠成无参调用 |
+| `ae.validateExpressions` | 保留。表达式错误在 AE 里是静默的，不可约 |
+
+删除：`ae.snapshot`、`ae.ping`、`ae.nativeExec`、`ae.toolIndex`、`ae.toolInspect`、`ae.skillList`、`ae.diagnose`。
+
+守门测试：`FINAL_PUBLIC_TOOLS` + `packages/core/tests/test_tool_names.py`。
+同步更新：`README.md`、`README.zh-CN.md`、`docs/REFERENCE.md`、`docs/INSTALL.md`。
+
+---
+
+## 9. 明确不做
+
+- **不打包 agent CLI。** 247 MB 里绝大部分是用户很可能已经装了的二进制；打包等于把别人的发版节奏、安全修复、认证变更变成我们的发版，且结构性偏向单一厂商，与多 provider 定位矛盾。改为检测（`platform/process.js`）+ 一键安装（`WizardScreen.jsx` 已有命令预览），**并且顺手补上 Node 安装**——目前向导只检测不安装 Node，这正是 Windows 干净机上内置 Claude 聊天起不来的原因。
+  （更正一个流传的说法：Windows 干净机上 **Python 服务端本身经 uv 是能装的**，真正起不来的是内置 Claude 聊天。）
+- **不动两个 approval gate 的相反默认。** `AE_MCP_APPROVAL_TIER_FILE`（动词面，未设置即 no-op）vs `AE_MCP_TOOL_APPROVAL_TIER_FILE`（Tool Library 面，缺失即 fail closed 到 manual）。理由已在 254a24f 写下，**是已定决策，不要重新讨论**。
+- **不抄 Atom 的这些**：原型猴子补丁记录 touched props（持久引擎共享全局会污染）；checkpoint/恢复脚本落在用户工程目录旁（污染工作树、进用户的 git 和交付包）；烘焙静态效果参数库（用户装了 Trapcode/Element 3D 就过期，`inspect_property_capabilities.jsx` 反射实时属性树永远正确）；取帧时降 8bpc；`--dangerously-skip-permissions` 取消全部审批。
+- **不删 Tool Library 的存储与密钥扫描。** 只重新定标执行层，不动持久化与 `plan_hash` 授权绑定。
+- **不追求"2 进程"这个数字本身。** 进程数是症状。真正要消掉的是环形依赖、双运行时、打包闭合三件事。
+
+---
+
+## 10. 相关文档
+
+| 文件 | 关系 |
+|---|---|
+| `AGENTS.md` | 交付纪律（证据、验收、停止条件）仍全部有效。但其 §3 的 native-first 验收链路在本方向下**仅适用于冻结的 native 平面**，新能力走 ExtendScript 平面 |
+| `docs/ATOM_PARITY_ROADMAP.md` | 竞品对标项的去向，逐条并入本文件的 Phase |
+| `docs/THREAT_MODEL.md` | 产品信任边界不变；platform-helper 删除后需同步"provider 密钥由各 CLI 持有" |
+| `docs/RUNTIME_MANAGER.md` | Phase 2 后作废 |
+| `docs/CAPABILITY_PACKAGE_WORKFLOW.md` | native 冻结后暂停使用 |

--- a/docs/ATOM_PARITY_ROADMAP.md
+++ b/docs/ATOM_PARITY_ROADMAP.md
@@ -1,77 +1,103 @@
-# AEMCP -> Atom Parity: Optimization Roadmap
+# ae-mcp ↔ Atom 对标：现状与去向
 
-This roadmap is now updated to the v0.7.0 state. Earlier audits were written when ae-mcp was still mostly an MCP-only/simple-RPC chain; v0.7.0 delivered the panel product layer, multi-backend embedded chat, approval flow, diagnostics, and several core parity fixes.
+> **本文件只回答一件事：竞品有什么、我们对应怎么处置。**
+> 架构方向、阶段划分与退出条件在 [ARCHITECTURE_DIRECTION.md](ARCHITECTURE_DIRECTION.md)，本文件不重复。
+>
+> 上一版停在 v0.7.0（写着 31 个 `ae_` 工具、Python stdio 链路、三条 backend），与现状和已批方向都不符，已整体替换。
 
-## v0.7.0 Current State
+**对标基准**：`atom-ae 3.5.4 windows-x64`（2026-08-12 构建），ZXP 静态拆解，未运行该扩展。
 
-Architecture:
+---
+
+## 1. 现状（2026-08-15）
 
 ```text
-MCP client
-  -> packages/core (ae_mcp, Python stdio MCP server, 31 ae_ tools)
-  -> backend (packages/bridge, httpx)
-  -> CEP panel Node host (plugin/host, Express, 127.0.0.1:11488)
-  -> CSInterface.evalScript
-  -> ExtendScript (plugin/jsx/runtime.jsx + jsx_templates/*.jsx)
+外部 MCP 客户端 ─┐
+                 ├→ packages/core（Python stdio MCP server，16 个公开工具）
+面板 spawn agent ─┘      → packages/bridge（httpx）
+                         → CEP 面板 Node host（Express，127.0.0.1:11488）  ← 环在这里闭合
+                         → CSInterface.evalScript
+                         → ExtendScript（plugin/jsx/runtime.jsx + jsx_templates/*.jsx）
+                         → 或 /native/invoke → AeMcpNative.aex（23 个 primitive）
 ```
 
-Panel product:
+5 进程、3 条执行平面。面板产品层（内置聊天、审批、向导、诊断、activity、kill switch）已交付。
 
-- Built-in AI chat is delivered.
-- Embedded backends are Claude subscription, BYOK Anthropic, and Codex.
-- Composer controls are delivered: model with cost badges, reasoning effort, fast mode where supported, and approval mode.
-- Four approval modes are delivered: read-only, manual, auto, bypass.
-- First-run wizard is delivered: `uv`, Node, Claude CLI, and ae-mcp detection/install; command preview before execution; visible login terminal.
-- Activity stream and AI kill switch are delivered.
-- Connection diagnostics are delivered.
-- External client path is delivered for Claude Desktop, Claude Code, Cursor, OpenCode, OpenClaw, AstrBot, Gemini Antigravity, and similar MCP clients.
+**公开工具 16 个**（`packages/core/ae_mcp/handlers/__init__.py:16-35`）：
+`ae.checkpoint` `ae.diagnose` `ae.exec` `ae.nativeExec` `ae.ping` `ae.previewFrame` `ae.revert` `ae.skillList` `ae.skillUse` `ae.snapshot` `ae.status` `ae.toolIndex` `ae.toolInspect` `ae.toolSearch` `ae.toolUse` `ae.validateExpressions`
 
-OpenCode note: OpenCode is an external client in v0.7.0. Embedded OpenCode is intentionally not counted as delivered here; it is deferred to v0.7.1.
+---
 
-## Delivered Parity Items
+## 2. 逐项对标
 
-| Area | Status | Notes |
-|---|---:|---|
-| P1 Runtime helpers | Delivered | Shared ExtendScript prelude/runtime helpers exist and templates use the AEMCP helper path. |
-| P2 Compact read output | Delivered | `ae.layers` supports pagination and `format='text'`; compact render support exists in Python. |
-| P3 Static server guidance | Delivered | MCP server is constructed with `instructions=SERVER_INSTRUCTIONS`. |
-| P4 Non-blocking `ae.exec` checkpoint | Delivered | Auto-checkpoint is best-effort and guarded so checkpoint failures do not abort the edit. |
-| P5 `ae.layers` pagination + type/parent | Delivered | `ae.layers` supports offset/limit and richer layer fields. |
-| P6 Init/checkpoint hardening | Delivered | `ae.init` guidance/state improvements, checkpoint undo, and `emptyResult` handling are part of the v0.7.0 baseline. |
-| Multi-framework client path | Delivered | Panel-generated MCP config covers mainstream local clients and documents same-machine/port reachability for IM-bot/Docker deployments. |
-| Panel product layer | Delivered | Built-in chat, approvals, wizard, diagnostics, activity stream, and kill switch are v0.7.0 features. |
+### 2.1 我们已经做到或做得更好
 
-## Remaining Roadmap
+| 项 | 我们 | Atom | 说明 |
+|---|---|---|---|
+| 整份 `.aep` checkpoint | `ae.checkpoint` / `ae.revert`，`checkpoint_store.py` 按**解析后工程路径**做 key 存 `%TEMP%`，prune 50 | 存在用户工程目录旁的 `_atom_checkpoints/` | 我们的路径 key 修过同名工程碰撞（#10）；不落工程目录也不会进用户的 git 和交付包 |
+| revert 安全性 | 关闭不存盘 → Python 侧原子替换（临时文件 + `os.replace`）→ 重开；每步都有失败分支，替换失败会尝试重开原件并报 `recoveredOriginal` | 关闭不存盘 → `File.copy` 覆盖 → 重开；可选 branch 备份 | 我们的原子性更强 |
+| revert 前备份 | `_branch_snapshot()` | `branchBeforeRevert` 选项 | 等价 |
+| 渲染真帧而非截屏 | `ae.previewFrame` 已调 `comp.saveFrameToPng()` | 同 | **已达成**，不是待办 |
+| 单一写动词 | `ae.exec`（任意 JSX） | `run_extendscript` | 等价 |
+| 共享 ExtendScript prelude | `plugin/jsx/runtime.jsx`（371 行，CSXS ScriptPath 载入） | `Main.jsx` 运行时 `eval` 加载各模块 | 等价；Atom 的运行时加载在改 JSX 后无需重启 AE，值得借鉴 |
+| 外部 MCP 客户端 | 一等支持：Claude Desktop / Claude Code / Cursor / OpenCode / OpenClaw / AstrBot 等 | 有 Connector 模式，但 server 仍在面板内 | 我们的形态更开放 |
+| Tool Library | 可持久、可版本、扫密钥、带风险分级、可 ZIP 导入导出 | 无等价物（skill 系统更轻） | 我们独有 |
+| kill switch / 客户端阻断 / `/exec` 共享密钥 | 有 | 无 | Atom 没有外部客户端，不需要 |
+| 精确有理数时间 | native 平面 `{value, scale}` | 无，纯 JSX 浮点 | **差异化**，见 2.4 |
+| 世代绑定 locator / `STALE_LOCATOR` | native 平面 | 无 | **差异化**，见 2.4 |
+| 32bpc / EXR 正确性 | 位深 primitive + `grade-stack` / `render-order` skill | 取帧时临时降 8bpc 并给色彩警告 | **差异化** |
 
-| # | Title | Area | Priority | Notes |
+### 2.2 我们缺、且确实该补
+
+| # | 项 | Atom 的做法 | 我们的去向 | 优先级 |
 |---|---|---|---|---|
-| 1 | More compact renderers for scan/props/keyframes | read-format | M | `ae.layers` text mode exists; extend the same discipline to larger read verbs. |
-| 2 | Richer `ae.exec` envelope | exec envelope | M | Keep opt-in; report touched paths, failed mutation attribution, and expression errors without breaking existing return shapes. |
-| 3 | Stronger property discovery filters | discovery | M | Path root, query, paging, and better ranking remain useful for large comps. |
-| 4 | `getKeyframes` scan mode | discovery | M | Current workflows still benefit from easier keyframe discovery across selected layers/comps. |
-| 5 | Preview contact sheets / sampling | previewFrame | M | Useful for reviewing motion over a range rather than one frame at a time. |
-| 6 | Preview diff mode | previewFrame | M | Good follow-up once baseline preview paths are stable. |
-| 7 | More typed rig controls and presets | createRig | M | `ae.createRig` remains useful but not a full rigging platform. |
-| 8 | Embedded OpenCode backend | panel | M | Deferred from v0.7.0 to v0.7.1; keep docs clear that v0.7.0 OpenCode is external. |
-| 9 | More robust remote/Docker client guidance | workflow | S | OpenClaw/AstrBot-style deployments need explicit network examples beyond same-machine warning. |
+| 1 | **结构化读工具** | 9 个：`list_layers` `get_properties` `get_expressions` `get_keyframes` `scan_property_tree` `inspect_property_capabilities` `project_overview` `list_effects` `search_project`，全部带分页、排序、查询过滤 | 新增 `ae.read`，合并这些语义。**读路径绝不 checkpoint、绝不开 undo group** | **P0**，Phase 1 |
+| 2 | **写失败的恢复信封** | 落盘可编辑 `.jsx` + 元数据（attempt 历史、脚本哈希、前后 checkpoint id、`project.revision`），只回 5 字符 `recoveryId`；模型用自己的 Edit 工具改文件后凭 id 重跑，默认先还原到失败前状态 | `ae.exec` 加恢复信封，恢复脚本放 `checkpoint_store` 的同一个 keyed 目录（**不放工程目录**） | **P0**，Phase 4 |
+| 3 | **失败归因** | 执行前给 `Property.prototype.setValue` / `PropertyGroup.prototype.addProperty` 打临时补丁，记录碰过哪些 layer/property、哪些 mutation 失败；出错时回**被碰过图层的属性树快照** + 劫持到的 `$.writeln` | 同样的产出，**不同机制**——用 `wrapForEvalScriptTransport`（`plugin/host/server.js:365`）装显式 per-call recorder，`finally` 拆除。持久引擎共享全局，猴子补丁会跨调用污染 | P1，Phase 4 |
+| 4 | **previewFrame 对比表 / 区间采样 / 差分** | 缩放代理合成 + `saveFrameToPng` + canvas 拼图；支持归一化坐标网格、ROI 裁剪、diff 模式 | 同路子，合成与缩放放**面板的 Chromium canvas**（顺带消掉 Pillow 依赖） | P1，Phase 4 |
+| 5 | **紧凑读输出** | 所有读工具默认分页 + 排序 + 上限，效果搜索支持空格 AND、`\|` OR | 并入 `ae.read` 的输出格式 | P1，Phase 1 |
+| 6 | **JSX 领域规则进模型上下文** | 系统提示词十几段硬规则：禁用语法、禁用模式（空值守卫/空 catch/自己开 undo group/`layer.locked`）、图层顺序（add* 都是 prepend）、引用失效（`addProperty` 作废同组已有引用，必须三趟走）、matchName 寻址、表达式引擎限制、验证策略、任务分解 | 非协商项进 MCP `instructions`（`build_server_instructions()` 已在用）；配方进 skill。面板自家聊天额外前置完整规则集 | P1 |
+| 7 | **JSX 改动后免重启** | 面板在初始化时 `eval` 加载 JSX 模块 | 现在走 CSXS `ScriptPath`，改 `runtime.jsx` 要重开面板 | P2 |
 
-## Cautions That Still Apply
+### 2.3 Atom 有、但我们**不抄**
 
-- `runtime.jsx` / shared prelude changes have high blast radius. Keep additions ES3-compatible and covered by render-token tests plus live smoke where possible.
-- Existing tool return shapes are part of the MCP contract. Add fields and opt-in formats; do not remove current JSON defaults.
-- Checkpoint/revert must remain fail-safe. Any checkpoint failure should surface as a note or skipped state, not abort unrelated user edits.
-- Preview capture is for fast feedback. Do not document it as a final render pipeline unless the implementation actually switches to a render-backed path.
-- Remote clients must account for `127.0.0.1:11488` resolving on their own host. Dockerized or remote IM-bot frameworks need same-machine execution, port forwarding, or a wrapper running beside AE.
+| 项 | 不抄的理由 |
+|---|---|
+| checkpoint / 恢复脚本落在 `<projectDir>/` | 污染用户工作树，会进他们的 git、素材备份和客户交付包 |
+| 原型猴子补丁记录 touched props | 持久引擎共享全局作用域，跨调用污染。要产出不要机制 |
+| 烘焙静态效果参数库 | 用户装了 Trapcode / Element 3D / Deep Glow 或升级 AE 就过期。`inspect_property_capabilities.jsx` 反射实时属性树，慢一点但永远正确，且对第三方效果有效 |
+| 取帧时临时降 8bpc | 我们的核心场景就是 32bpc EXR |
+| `--dangerously-skip-permissions` 取消全部审批 | 与我们的用户画像和信任边界不符 |
+| 把三个 agent CLI 打进包里（280 MB） | 见 [ARCHITECTURE_DIRECTION.md §9](ARCHITECTURE_DIRECTION.md) |
+| 发布版带 `.debug`（DevTools 端口 9193 常开） | 我们的打包脚本会删掉它，保持 |
+| 25 个工具 | 其中 24 个不写的工具仍然占每次请求的描述预算。目标约 10 个 |
 
-## Verification Targets
+### 2.4 只有我们有的（要守住）
 
-Use these before claiming parity work is delivered:
+1. **精确有理数时间**与**世代绑定 locator**。JSX 浮点漂移导致的差一帧、图层重排后写错目标——**这两种失效在预览图上都看不出来**，模型的自我验证抓不到。这是 native 平面唯一的存在理由，也是它被**冻结而非退役**的原因。
+2. **32bpc / EXR / ACES 正确性**。
+3. **外部 MCP 客户端**。用户已在为 Claude Code / Cursor 付费。
+4. **Tool Library**。Atom 的 JSX 是一次性的，每次会话重新推导同一个"32bpc 辉光"脚本。
+
+---
+
+## 3. 仍然适用的注意事项
+
+- `runtime.jsx` / 共享 prelude 改动的爆炸半径很大。保持 ES3 兼容，配 render-token 测试和 live smoke。
+- 现有工具返回形状是 MCP 契约的一部分。加字段、加可选格式；**不要删现有 JSON 默认字段**。工具面裁剪（16→10）是有意的破坏性变更，必须同步 `test_tool_names.py` 与四份文档。
+- checkpoint / revert 必须 fail-safe。checkpoint 失败应表现为 note 或 skipped，不能中止用户的编辑。
+- preview 是快速反馈，不是最终渲染管线。不要在文档里把它写成 render pipeline。
+- 远端客户端要考虑 `127.0.0.1:11488` 在它们自己主机上解析。Docker 化或远程 IM bot 需要同机执行、端口转发，或在 AE 旁边跑一个 wrapper。
+
+---
+
+## 4. 验证入口
 
 ```powershell
 uv run pytest
 ```
 
-With After Effects open and the panel running:
+AE 打开且面板运行时：
 
 ```powershell
 $env:AE_MCP_LIVE_TESTS = "1"
@@ -80,10 +106,12 @@ $env:AE_MCP_PLUGIN_URL = "http://127.0.0.1:11488"
 uv run pytest packages/core/tests/live -o addopts='' -vv
 ```
 
-Panel/model smoke:
+面板 / 模型 smoke：
 
 ```powershell
 node scripts/live-model-matrix.mjs
 ```
 
-For release-facing work, also rebuild `plugin/client/dist/app.js` and run the ZXP smoke from [docs/RELEASE.md](RELEASE.md).
+发布相关改动还要重建 `plugin/client/dist/app.js` 并跑 [docs/RELEASE.md](RELEASE.md) 里的 ZXP smoke。
+
+> Phase 1 起，`packages/core/tests/live` 的用例要转写成打 `/mcp` 的版本，作为面板内 MCP server 的验收套件。**移植测试先于移植代码。**


### PR DESCRIPTION
把已批准的架构方向固化进仓库，让新会话不必重读拆解过程就能接上工作。**纯文档，无代码改动。**

## 背景

竞品 `atom-ae 3.5.4` 的 ZXP 拆解暴露了我们自己树里的三个事实：

1. **约 100 个 verb 实现函数里只有 16 个被注册。** `handlers/native.py`（2,697 行）定义约 70 个 `_run_*` 只注册 1 个；`handlers/typed.py` 注册 1/12。typed-native 投影层约 **21,743 行**，绝大部分不可达。
2. **我们没有任何结构化读动词。** 模型想看工程只能自己写 JSX 走 `ae.exec`。竞品有 9 个带分页/排序/过滤的读工具。**这是我们弱于竞品的地方。**
3. **platform-helper 的 3 个截屏方法在生产代码里零调用点。** 它唯一活着的消费者是用钥匙串存 provider API key——而 provider 三通道方向让这个用途消失。

## 记录的决策

- Python 服务端：本季度退役，MCP server 手写进 CEP Node 上下文
- native AEGP 平面：**冻结**（保留 `.aex` 与 23 个 primitive，不再新增，删掉 Python 投影层）
- platform-helper：删除

## 改了什么

| 文件 | 变化 |
|---|---|
| `docs/ARCHITECTURE_DIRECTION.md` | **新增**。自足的入口文档：目标形态、三个已定决策、Phase 0–4 与退出条件、移植 vs 删除清单、明确不做的事 |
| `AGENTS.md` | +17 行。**交付纪律完全不变**，只加方向锚点。新 §0.0 写明三条冻结；§3 的 AEGP 验收链路加范围注（现在只适用于冻结的 native 平面） |
| `docs/ATOM_PARITY_ROADMAP.md` | 重写。旧版停在 v0.7.0，还写着 31 个 `ae_` 工具和 Python stdio 链路 |
| `README.md` / `README.zh-CN.md` | +3 行。顶部提示：面板内对话正在重构，请用纯 MCP 注册到自己的 agent 客户端 |

`AGENTS.md` 的改动是**外科手术式**的——没有动任何证据要求、验收档位、停止条件或 `.aep` 生命周期规则。改它的原因是：它整篇围绕 native capability package 写流程法，新会话照着读会直接去做我们刚决定停掉的事。

## 关联

阶段跟踪：#260 #261 #262 #263 #264 #265
已关闭：#67（ScreenCaptureKit 后端，结构性作废）
已批注归属：#253 #255 #239 #234 #259 #237 #215 #240 #241 #230 #257 #256 #227 #233 #254 #81 #63 #69 #70

## 验证

纯文档改动，无测试影响。合并后 issue #260–#265 正文里指向 `docs/ARCHITECTURE_DIRECTION.md` 的链接才会解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
