### PR TITLE
docs(readme): add one-line agent install prompt and ZXP/panel prerequisite callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 English | [简体中文](README.zh-CN.md)
 
+**One-line install — paste this into your AI agent (Claude Code, Codex, Cursor, or any MCP client) and it sets up the ae-mcp runtime and MCP server entry for you:**
+
+```text
+Install ae-mcp for me: install uv if it is missing, then run uv tool install --force --from "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/core" ae-mcp --with "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/bridge" --with "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/snapshot-mss" and register an MCP server named "ae" in this client's MCP config whose command is the ae-mcp launcher inside `uv tool dir --bin`, with env AE_MCP_BACKEND=ae-mcp and AE_MCP_PLUGIN_URL=http://127.0.0.1:11488 (full guide: https://github.com/JUNKDOGE-JOE/after-effects-mcp/blob/main/docs/INSTALL.md). Then tell me to install the v0.9.5 ZXP and AEX from https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.9.5 and open Window > Extensions > ae-mcp inside After Effects; only after I confirm, call ae_ping to verify.
+```
+
+> [!IMPORTANT]
+> The prompt installs only the runtime and the MCP client entry. **ae-mcp cannot do anything until the panel is installed and open**: install `ae-mcp-panel-v0.9.5-windows-x64.zxp` into After Effects with a ZXP installer (plus `AeMcpNative-v0.9.5-windows-x64.aex` for `ae_nativeExec`), then keep `Window -> Extensions -> ae-mcp` open while you work — the panel is what listens on `127.0.0.1:11488`, and every tool call fails while it is closed. Steps: [Install and First Run](#install-and-first-run).
+
 > [!IMPORTANT]
 > **The panel's built-in chat is being rebuilt.** Until that work lands, use ae-mcp as a plain MCP server registered with your own agent client (Claude Code, Claude Desktop, Cursor, Codex, OpenCode, and similar).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,15 @@
 
 [English](README.md) | 简体中文
 
+**一行安装——把下面这条提示词粘贴给你的 AI agent（Claude Code、Codex、Cursor 或任何 MCP 客户端），它会替你装好 ae-mcp runtime 并写好 MCP server 配置：**
+
+```text
+帮我安装 ae-mcp：如果没有 uv 就先安装它，然后运行 uv tool install --force --from "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/core" ae-mcp --with "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/bridge" --with "git+https://github.com/JUNKDOGE-JOE/after-effects-mcp@v0.9.5#subdirectory=packages/snapshot-mss"，再在你所在客户端的 MCP 配置里注册一个名为 "ae" 的 MCP server：command 用 `uv tool dir --bin` 目录里的 ae-mcp 启动器，env 设 AE_MCP_BACKEND=ae-mcp 和 AE_MCP_PLUGIN_URL=http://127.0.0.1:11488（完整指南：https://github.com/JUNKDOGE-JOE/after-effects-mcp/blob/main/docs/INSTALL.md）。之后提醒我去 https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.9.5 安装 v0.9.5 的 ZXP 和 AEX，并在 After Effects 里打开 Window > Extensions > ae-mcp 面板；等我确认后再调用 ae_ping 验证。
+```
+
+> [!IMPORTANT]
+> 这条提示词只负责 runtime 和 MCP 客户端配置。**ZXP 没装、面板没开，ae-mcp 什么也做不了**：先用 ZXP installer 把 `ae-mcp-panel-v0.9.5-windows-x64.zxp` 装进 After Effects（`ae_nativeExec` 还需要 `AeMcpNative-v0.9.5-windows-x64.aex`），使用时保持 `Window -> Extensions -> ae-mcp` 面板打开——监听 `127.0.0.1:11488` 的就是这个面板，面板关着时所有工具调用都会失败。步骤见[安装和首次启动](#安装和首次启动)。
+
 > [!IMPORTANT]
 > **面板内对话功能正在整体重构。** 在重构落地前，请把 ae-mcp 作为纯粹的 MCP server 注册到你自己的 agent 客户端使用（Claude Code / Claude Desktop / Cursor / Codex / OpenCode 等）。
 


### PR DESCRIPTION
## Common

- Change type: docs
- Issue or package Issue: none (owner request)
- User-visible outcome: both READMEs now open with a paste-into-your-agent one-line install prompt (runs the wizard's v0.9.5 tag-pinned `uv tool install` and registers the `ae` MCP server with `AE_MCP_BACKEND=ae-mcp` / `AE_MCP_PLUGIN_URL=http://127.0.0.1:11488`), followed by an IMPORTANT callout that nothing works until the ZXP is installed into After Effects and the ae-mcp panel is open (the panel is what listens on `127.0.0.1:11488`). The existing #266 "panel chat is being rebuilt" notice is kept verbatim right after it.
- Scope and explicit non-goals: README.md / README.zh-CN.md top matter only. No CHANGELOG entry, no INSTALL.md change, no product behavior change.

Commands and results:

```text
node --test scripts/release/test/version-consistency.test.mjs scripts/package/test/native-aegp-build-contract.test.mjs scripts/package/test/product-trust-policy.test.mjs scripts/package/test/ae-sdk-input.test.mjs
  -> 49 tests, 48 pass, 1 skipped (SDK-dependent), 0 fail
uv run pytest packages/core/tests/test_tool_names.py -q
  -> 33 passed
uv tool dir --bin -> C:\Users\<USER>\.local\bin (launcher location the prompt tells the agent to use)
gh release view v0.9.5 -> tag/URL/asset names referenced by the prompt confirmed
```

Review findings and disposition (blocker / follow-up / out of scope): none.

## Native package evidence (conditional)

N/A — docs-only change; acceptance check is the README-scanning tests above passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)