### PR TITLE
fix(nativeExec): advertise an API-safe inputSchema without a top-level allOf (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### [Unreleased]
+
+#### 🐛 修复 / 改进
+
+- **兼容 Anthropic / AWS Bedrock 的工具 schema 限制**——`ae_nativeExec` 广告给 MCP 客户端的 `inputSchema` 不再在顶层带 `allOf`（Anthropic 直连与 Bedrock 会以 `input_schema does not support oneOf, allOf, or anyOf at the top level` 拒绝整个请求，经中转站接 Bedrock 的 Claude Code 用户首当其冲）；23 个原语的嵌套判别 schema、服务端完整的读/写程序校验与结构化错误契约保持不变，并新增守卫测试禁止任何工具在 schema 顶层出现组合子。
+
 ### [0.9.5] — 2026-08-12
 
 #### ✨ 新增
@@ -273,6 +279,12 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### [Unreleased]
+
+#### 🐛 Fixed / Improved
+
+- **Anthropic / AWS Bedrock tool-schema compatibility** — the `inputSchema` that `ae_nativeExec` advertises to MCP clients no longer carries a top-level `allOf` (the Anthropic API and Bedrock reject the whole request with `input_schema does not support oneOf, allOf, or anyOf at the top level`; Claude Code users routed to Bedrock through a relay hit it first). The nested discriminated schemas for all 23 primitives, full server-side read/write program validation, and the structured error contract are unchanged, and a guard test now forbids top-level combinators on every advertised tool.
 
 ### [0.9.5] — 2026-08-12
 

--- a/packages/core/ae_mcp/schemas.py
+++ b/packages/core/ae_mcp/schemas.py
@@ -128,6 +128,14 @@ class AeExecArgs(_StrictModel):
 
 NativeProgramOperation = Dict[str, Any]
 _NATIVE_EXEC_VALIDATOR = Draft202012Validator(NATIVE_EXEC_INPUT_SCHEMA)
+_MCP_TOP_LEVEL_SCHEMA_COMBINATORS = frozenset(
+    {"allOf", "anyOf", "else", "if", "not", "oneOf", "then"}
+)
+NATIVE_EXEC_ADVERTISED_INPUT_SCHEMA: dict[str, Any] = deepcopy(
+    NATIVE_EXEC_INPUT_SCHEMA
+)
+for _key in _MCP_TOP_LEVEL_SCHEMA_COMBINATORS:
+    NATIVE_EXEC_ADVERTISED_INPUT_SCHEMA.pop(_key, None)
 _NATIVE_EXEC_PRIMITIVE_BY_ID = {
     row["id"]: row for row in NATIVE_EXEC_PRIMITIVES
 }
@@ -139,7 +147,8 @@ class AeNativeExecArgs(_StrictModel):
     Use ae.exec for operations supported by the maintained AE scripting object
     model. Native programs allow at most 64 ordered operations and may reference
     only earlier request-local values. Programs containing writes require one
-    stable operationKey and one real AE undoGroup.
+    stable operationKey and one real AE undoGroup; read-only programs must omit
+    both fields.
     """
 
     model_config = ConfigDict(
@@ -221,7 +230,7 @@ class AeNativeExecArgs(_StrictModel):
 
     @classmethod
     def __get_pydantic_json_schema__(cls, _core_schema, _handler):
-        schema = deepcopy(NATIVE_EXEC_INPUT_SCHEMA)
+        schema = deepcopy(NATIVE_EXEC_ADVERTISED_INPUT_SCHEMA)
         schema["title"] = cls.__name__
         schema["description"] = (cls.__doc__ or "").strip()
         return schema

--- a/packages/core/ae_mcp/server.py
+++ b/packages/core/ae_mcp/server.py
@@ -1151,10 +1151,9 @@ def build_server() -> Server:
 
     server: Server = Server("ae", instructions=build_server_instructions())
 
-    # Runtime JSON Schema validation must use the exact schema advertised by
-    # tools/list. The MCP SDK still populates its tool cache before invoking
-    # our call handler even when its own pre-validation is disabled; this map
-    # lets the handler apply the same schema without reaching into SDK internals.
+    # The MCP SDK still populates its tool cache before invoking our call handler
+    # even when its own pre-validation is disabled. Keep the advertised schemas
+    # here so the handler can apply them without reaching into SDK internals.
     advertised_input_schemas: dict[str, dict[str, Any]] = {}
 
     @server.list_tools()
@@ -1241,14 +1240,17 @@ def build_server() -> Server:
 
         # The SDK's default validation happens before this handler and reduces
         # every schema failure to unstructured text. Reapply the same
-        # jsonschema validation here using the exact tools/list schema: the
-        # native layer-property tool can then expose its structured recovery
-        # contract, while established tools keep the SDK's original text error.
-        input_schema = (
-            schema_cls.model_json_schema()
-            if panel_developer
-            else advertised_input_schemas.get(expose_tool_name(name))
-        )
+        # jsonschema validation here so native tools can expose their structured
+        # recovery contract, while established tools keep the SDK's original
+        # text error. nativeExec uses the complete generated contract because
+        # its MCP advertisement omits top-level combinators rejected by strict
+        # Anthropic-compatible tool-schema endpoints.
+        if name == "ae.nativeExec":
+            input_schema = schemas.NATIVE_EXEC_INPUT_SCHEMA
+        elif panel_developer:
+            input_schema = schema_cls.model_json_schema()
+        else:
+            input_schema = advertised_input_schemas.get(expose_tool_name(name))
         if input_schema is not None:
             try:
                 validate_json_schema(

--- a/packages/core/tests/test_native_exec.py
+++ b/packages/core/tests/test_native_exec.py
@@ -120,6 +120,9 @@ def _write_program() -> dict[str, Any]:
 
 def test_native_exec_schema_is_generated_closed_and_discriminated():
     schema = S.AeNativeExecArgs.model_json_schema()
+    forbidden = {"allOf", "anyOf", "else", "if", "not", "oneOf", "then"}
+    assert not forbidden.intersection(schema)
+    assert "allOf" in S.NATIVE_EXEC_INPUT_SCHEMA
     operation_union = schema["properties"]["operations"]["items"]["oneOf"]
     assert len(operation_union) == 23
     assert {

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -135,10 +135,19 @@ def test_preview_frame_rejects_invalid_ranges():
 
 def test_every_schema_can_generate_json_schema():
     """MCP tools/list will call .model_json_schema() on every verb."""
-    for name, cls in S.SCHEMAS.items():
+    from ae_mcp.server import _PANEL_DEVELOPER_SCHEMAS
+
+    schema_classes = [
+        *((f"public:{name}", cls) for name, cls in S.SCHEMAS.items()),
+        *((f"panel:{name}", cls) for name, cls in _PANEL_DEVELOPER_SCHEMAS.items()),
+    ]
+    forbidden = {"allOf", "anyOf", "else", "if", "not", "oneOf", "then"}
+    for name, cls in schema_classes:
         schema = cls.model_json_schema()
         assert schema["type"] == "object", name
         assert "properties" in schema, name
+        invalid = forbidden.intersection(schema)
+        assert not invalid, f"{name} has forbidden top-level key(s): {sorted(invalid)}"
 
 
 def test_ae_ping_default():

--- a/packages/core/tests/test_server_native_tools.py
+++ b/packages/core/tests/test_server_native_tools.py
@@ -94,3 +94,67 @@ async def test_native_exec_invalid_program_returns_structured_not_started_error(
     assert payload["error"]["code"] == "INVALID_ARGUMENT"
     assert payload["error"]["sideEffect"] == "not-started"
     assert payload["error"]["details"]["capabilityId"] == "ae.native.exec"
+
+
+@pytest.mark.asyncio
+async def test_native_exec_enforces_unadvertised_write_envelope_contract(
+    monkeypatch,
+):
+    from ae_mcp import server as server_module
+
+    monkeypatch.setattr(
+        server_module,
+        "_filtered_tool_names",
+        lambda: {"ae.nativeExec"},
+    )
+    server = build_server()
+    tools = await server._ae_list_tools()
+    advertised = tools[0].inputSchema
+    assert "allOf" not in advertised
+
+    invalid_programs = [
+        {
+            "operations": [
+                {
+                    "op": "composition.resolve",
+                    "args": {
+                        "locator": {
+                            "kind": "composition",
+                            "hostInstanceId": "22222222-2222-4222-8222-222222222222",
+                            "sessionId": "11111111-1111-4111-8111-111111111111",
+                            "projectId": "33333333-3333-4333-8333-333333333333",
+                            "generation": 1,
+                            "objectId": "44444444-4444-4444-8444-444444444444",
+                        }
+                    },
+                    "saveAs": "composition",
+                },
+                {
+                    "op": "composition.time.set",
+                    "args": {
+                        "composition": {"ref": "composition"},
+                        "targetTime": {"value": 5, "scale": 24},
+                    },
+                    "returnAs": "time",
+                },
+            ]
+        },
+        {
+            "operationKey": "read-program-must-not-have-write-metadata",
+            "operations": [
+                {
+                    "op": "project.items.list",
+                    "args": {"offset": 0, "limit": 1},
+                    "returnAs": "items",
+                }
+            ],
+        },
+    ]
+    for arguments in invalid_programs:
+        response = await server._ae_call_tool("ae_nativeExec", arguments)
+        payload = json.loads(response.content[0].text)
+        assert response.isError is True
+        assert payload["error"]["code"] == "INVALID_ARGUMENT"
+        assert payload["error"]["sideEffect"] == "not-started"
+        assert payload["error"]["details"]["capabilityId"] == "ae.native.exec"
+        assert payload["error"]["details"]["field"].startswith("arguments")

--- a/packages/core/tests/test_tool_names.py
+++ b/packages/core/tests/test_tool_names.py
@@ -34,6 +34,9 @@ from ae_mcp.server import (
 )
 
 _MCP_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+_TOP_LEVEL_SCHEMA_COMBINATORS = frozenset(
+    {"allOf", "anyOf", "else", "if", "not", "oneOf", "then"}
+)
 _ROOT = Path(__file__).resolve().parents[3]
 _MIGRATION = (
     _ROOT / "native/ae-plugin/protocol/native-exec-migration.json"
@@ -223,6 +226,18 @@ def _full_tool_listing(monkeypatch):
     return build_server()
 
 
+def _assert_safe_advertised_input_schema(tool):
+    schema = tool.inputSchema
+    assert schema.get("type") == "object", (
+        f"{tool.name} inputSchema top-level type must be object"
+    )
+    forbidden = _TOP_LEVEL_SCHEMA_COMBINATORS.intersection(schema)
+    assert not forbidden, (
+        f"{tool.name} inputSchema contains forbidden top-level key(s): "
+        f"{sorted(forbidden)}"
+    )
+
+
 async def test_list_tools_emits_only_mcp_compliant_names(_full_tool_listing):
     """Drive the registered list_tools handler and assert every emitted
     Tool.name is underscore-form (no dots). Fails if _list_tools reverts to
@@ -233,6 +248,15 @@ async def test_list_tools_emits_only_mcp_compliant_names(_full_tool_listing):
     for tool in tools:
         assert _MCP_TOOL_NAME.fullmatch(tool.name), f"{tool.name!r} is not MCP-compliant"
         assert "." not in tool.name
+
+
+async def test_list_tools_advertises_only_plain_top_level_object_schemas(
+    _full_tool_listing,
+):
+    tools = await _full_tool_listing._ae_list_tools()
+    assert len(tools) == 16
+    for tool in tools:
+        _assert_safe_advertised_input_schema(tool)
 
 
 async def test_list_tools_descriptions_lead_with_exposed_name(_full_tool_listing):


### PR DESCRIPTION
Closes #273.

## 改了什么

- **`packages/core/ae_mcp/schemas.py`**：新增 `NATIVE_EXEC_ADVERTISED_INPUT_SCHEMA`（完整生成 schema 去掉顶层 `allOf/anyOf/oneOf/if/then/else/not`），`AeNativeExecArgs.__get_pydantic_json_schema__` 改用它；嵌套的 23 原语 `oneOf`、`$defs` 原样保留；docstring 补一句"含写程序必须带 operationKey+undoGroup，只读程序必须省略"（这条规则不再由 schema 表达）。
- **`packages/core/ae_mcp/server.py`**：`ae.nativeExec` 的 jsonschema 预校验继续用**完整**的 `NATIVE_EXEC_INPUT_SCHEMA`，读/写程序规则与结构化 `INVALID_ARGUMENT` / `sideEffect: not-started` 错误契约逐字节不变（pydantic 的 `_generated_contract` 本来就用完整 schema）。
- **测试**：`test_tool_names.py` 守卫全部 16 个广告工具的 `inputSchema` 顶层（`type == object` 且无组合子，失败时点名工具与键）；`test_schemas.py` 同样覆盖所有公共 verb + panel developer schema 类；`test_server_native_tools.py` 回归——写程序缺 key/undo、只读程序多带 key 仍被拦成结构化错误；`test_native_exec.py` 断言广告 schema 无顶层组合子、完整 schema 仍有 `allOf`。
- **`CHANGELOG.md`**：`[Unreleased]` 中英文各一条（含用户会搜索的错误原文）。

不碰生成器 / `native_exec_generated.py` / `native/ae-plugin/protocol/*.mjs`（host 侧协议校验仍用完整 schema）。

## 为什么

v0.9.5 的 16 个工具里只有 `ae_nativeExec` 顶层带 `allOf`；Anthropic 直连与 AWS Bedrock 都拒绝 `input_schema` 顶层的 `oneOf/allOf/anyOf`，经中转站接 Bedrock 的 Claude Code 用户首个请求就 400。维护者本机看不到是因为 Claude Code 2.1.227 发请求前会把 MCP 工具 schema 顶层的 `allOf` 剥掉（抓包证实）——所以"本机没问题"不能当作 schema 兼容性证据，这次把守卫放进测试。

## 验证（orchestrator 本机）

- `uv run --frozen --python 3.13.13 pytest -q packages/core/tests` → **731 passed, 8 skipped**（基线 729 passed / 8 skipped，+2 新测试，无新增 skip）
- `packages/bridge/tests` 9 个失败与 stash 掉本改动后完全相同（issue157/190 symlink 类，本机恒败，非回归）；`packages/snapshot-mss/tests` 绿
- 工作树上真起 bridge backend 调 `tools/list`：16 工具顶层组合子 offenders = none；`ae_nativeExec` 顶层键 = `additionalProperties/description/properties/required/title/type`
- 实现：Sol（gpt-5.6-sol，Codex，effort high）；审查 + 复跑：Fable 5

## 发版提示

需要随 **v0.9.6** 补丁版发出（v0.9.5 安装命令的用户会持续踩到）。在那之前的用户侧绕法：`permissions.deny` 加 `"mcp__ae__ae_nativeExec"`（或 `--disallowedTools mcp__ae__ae_nativeExec`），已验证该工具就不再发给 API。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
