### PR TITLE
fix(core): loopback probe ignores proxy env, argsSchema accepts description, skillUse execute returns the script result unwrapped (#267, #268, #269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 #### 🐛 修复 / 改进
 
+- **`ae.diagnose` 本机探针忽略代理环境变量**——本机 `/health` 探针不再继承 `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`，代理返回的 502 不再被当成本机宿主不可达。（#267）
+- **Tool Library `argsSchema` 接受属性描述**——每个属性现在可带不超过 1024 字符的字符串 `description`，legacy skill 不再“能列出、不能执行”。（#268）
+- **`ae.skillUse(execute=true)` 恢复 v0.9.0 透传返回形状**——技能脚本自己的 JSON 结果原样放在顶层，不再包 `{ok,name,template_type,result}`，也不再出现外层 `ok:true` 包住内层 `ok:false` 的矛盾；v0.9.2–v0.9.6 期间按 `result.*` 读取的调用方需改回顶层字段。执行仍走审批引擎，`execute=false` 不变。（#269）
 - **ExtendScript 超时不再提前放行串行锁（#260）**——调用方仍会按原期限收到超时，但 Bridge 会等迟到回调或排空哨兵返回后才继续，期间 `/health`、`/exec`、`ae.status` 与 `ae.diagnose` 报告 `degraded`；错误 disposition 收敛为三值：从未进入 AE、可安全重试的 `not_dispatched`，已派发但结果未知的 `uncertain`，以及已执行并明确报错的 `failed`。
 
 
@@ -308,6 +311,9 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 #### 🐛 Fixes / Improvements
 
+- **`ae.diagnose` local probe ignores proxy environment variables** — The local `/health` probe no longer inherits `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`, so a proxy-generated 502 is no longer mistaken for an unreachable local host. (#267)
+- **Tool Library `argsSchema` accepts property descriptions** — Each property may now include a string `description` of at most 1024 characters, so legacy skills no longer “list successfully but fail to execute.” (#268)
+- **`ae.skillUse(execute=true)` restores the v0.9.0 pass-through response shape** — The skill script's own JSON result is returned unchanged at the top level instead of being wrapped in `{ok,name,template_type,result}`, eliminating contradictory outer `ok:true` / inner `ok:false` responses. Callers that read `result.*` in v0.9.2–v0.9.6 must switch back to top-level fields. Execution still uses the approval engine, and `execute=false` is unchanged. (#269)
 - **ExtendScript timeouts no longer release the serialization lock early (#260)** — Callers still receive a timeout on schedule, while the bridge waits for a late callback or drain sentinel before proceeding and reports `degraded` through `/health`, `/exec`, `ae.status`, and `ae.diagnose`. Error dispositions are a closed three-value set: `not_dispatched` for scripts that never entered AE and are safe to retry, `uncertain` for dispatched scripts whose result is unknown, and `failed` for scripts that executed and returned a definite error.
 
 ### [0.9.6] — 2026-08-19

--- a/packages/core/ae_mcp/handlers/status.py
+++ b/packages/core/ae_mcp/handlers/status.py
@@ -120,7 +120,7 @@ def _diagnose_template() -> Template:
 async def _probe_host(url: str, *, timeout_sec: float = 5.0) -> dict[str, Any]:
     """Raw GET /health to capture the echoed python handshake fields."""
     try:
-        async with httpx.AsyncClient(timeout=timeout_sec) as http:
+        async with httpx.AsyncClient(timeout=timeout_sec, trust_env=False) as http:
             r = await http.get(
                 f"{url}/health",
                 headers={_PY_VERSION_HEADER: _PY_VERSION},

--- a/packages/core/ae_mcp/tool_artifact.py
+++ b/packages/core/ae_mcp/tool_artifact.py
@@ -101,7 +101,16 @@ _ARGS_SCHEMA_ROOT_KEYS = frozenset(
     {"type", "properties", "required", "additionalProperties"}
 )
 _ARGS_SCHEMA_VALUE_KEYS = frozenset(
-    {"type", "enum", "default", "minimum", "maximum", "minLength", "maxLength"}
+    {
+        "type",
+        "enum",
+        "default",
+        "description",
+        "minimum",
+        "maximum",
+        "minLength",
+        "maxLength",
+    }
 )
 _ARGS_SCHEMA_TYPES = frozenset(
     {"string", "number", "integer", "boolean", "object", "array", "null"}
@@ -247,6 +256,12 @@ def validate_args_schema(
             raise ValueError(
                 f"argsSchema property {name} contains unsupported keywords: "
                 + ", ".join(unknown)
+            )
+        if "description" in raw_rule:
+            cast(dict[str, JsonValue], raw_rule)["description"] = _string(
+                raw_rule["description"],
+                label=f"argsSchema property {name} description",
+                max_length=1024,
             )
         rule_type = raw_rule.get("type")
         if rule_type is not None and rule_type not in _ARGS_SCHEMA_TYPES:

--- a/packages/core/ae_mcp/tool_execution.py
+++ b/packages/core/ae_mcp/tool_execution.py
@@ -2206,12 +2206,7 @@ class ToolExecutionEngine:
             started_at=started_at,
         )
         self._record_successful_use(plan)
-        return {
-            "ok": True,
-            "name": record.skill.name,
-            "template_type": record.skill.template_type,
-            "result": cast(JsonValue, dict(parsed)),
-        }
+        return parsed
 
 
 __all__ = [

--- a/packages/core/tests/test_skill_tool_compat.py
+++ b/packages/core/tests/test_skill_tool_compat.py
@@ -55,6 +55,100 @@ async def test_skill_use_execute_false_keeps_legacy_payload(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_skill_use_executes_legacy_args_schema_with_description(
+    monkeypatch, tmp_path, mock_backend
+):
+    monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path / "skills"))
+    monkeypatch.setenv("AE_MCP_TOOL_DIR", str(tmp_path / "tools"))
+    tier = tmp_path / "tier"
+    tier.write_text("none\n", encoding="utf-8")
+    monkeypatch.setenv("AE_MCP_TOOL_APPROVAL_TIER_FILE", str(tier))
+    SkillStore().create(
+        Skill(
+            name="described-amount",
+            description="",
+            template_type="jsx",
+            template="JSON.stringify({ ok: true, amount: ${amount} })",
+            args_schema={
+                "amount": {
+                    "type": "number",
+                    "description": "Amount to report",
+                    "default": 50,
+                }
+            },
+        )
+    )
+    mock_backend.set_response('{"ok":true,"amount":50}')
+
+    result = await _run_skill_use(
+        S.AeSkillUseArgs(name="described-amount", execute=True),
+        None,
+    )
+
+    assert result["ok"] is True
+    assert len(mock_backend.calls) == 1
+    assert "amount: 50" in mock_backend.calls[0]["code"]
+
+
+@pytest.mark.asyncio
+async def test_skill_use_execute_true_returns_failure_payload_at_top_level(
+    monkeypatch, tmp_path, mock_backend
+):
+    monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path / "skills"))
+    monkeypatch.setenv("AE_MCP_TOOL_DIR", str(tmp_path / "tools"))
+    tier = tmp_path / "tier"
+    tier.write_text("none\n", encoding="utf-8")
+    monkeypatch.setenv("AE_MCP_TOOL_APPROVAL_TIER_FILE", str(tier))
+    SkillStore().create(
+        Skill(
+            name="failure-payload",
+            description="",
+            template_type="jsx",
+            template='JSON.stringify({ ok: false, error: "example failure", changed: false })',
+            args_schema={},
+        )
+    )
+    mock_backend.set_response(
+        '{"ok":false,"error":"example failure","changed":false}'
+    )
+
+    result = await _run_skill_use(
+        S.AeSkillUseArgs(name="failure-payload", execute=True),
+        None,
+    )
+
+    assert result == {"ok": False, "error": "example failure", "changed": False}
+
+
+@pytest.mark.asyncio
+async def test_skill_use_execute_true_returns_success_payload_at_top_level(
+    monkeypatch, tmp_path, mock_backend
+):
+    monkeypatch.setenv("AE_MCP_SKILL_DIR", str(tmp_path / "skills"))
+    monkeypatch.setenv("AE_MCP_TOOL_DIR", str(tmp_path / "tools"))
+    tier = tmp_path / "tier"
+    tier.write_text("none\n", encoding="utf-8")
+    monkeypatch.setenv("AE_MCP_TOOL_APPROVAL_TIER_FILE", str(tier))
+    SkillStore().create(
+        Skill(
+            name="success-payload",
+            description="",
+            template_type="jsx",
+            template='JSON.stringify({ ok: true, changed: true, layers: ["a"] })',
+            args_schema={},
+        )
+    )
+    mock_backend.set_response('{"ok":true,"changed":true,"layers":["a"]}')
+
+    result = await _run_skill_use(
+        S.AeSkillUseArgs(name="success-payload", execute=True),
+        None,
+    )
+
+    assert result == {"ok": True, "changed": True, "layers": ["a"]}
+
+
+@pytest.mark.asyncio
 async def test_skill_use_execute_true_none_still_elicits_destructive_jsx(
     monkeypatch, tmp_path, mock_backend
 ):

--- a/packages/core/tests/test_status_tool.py
+++ b/packages/core/tests/test_status_tool.py
@@ -189,6 +189,32 @@ async def test_probe_host_sends_python_identity_header(respx_mock):
 
 
 @pytest.mark.asyncio
+async def test_probe_host_ignores_proxy_environment(monkeypatch, respx_mock):
+    import ae_mcp.handlers.status as status
+
+    real_client = status.httpx.AsyncClient
+    captured = {}
+
+    class RecordingAsyncClient(real_client):
+        def __init__(self, *args, **kwargs):
+            captured["trust_env"] = kwargs.get("trust_env")
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+    monkeypatch.setenv("ALL_PROXY", "http://127.0.0.1:9")
+    monkeypatch.setattr(status.httpx, "AsyncClient", RecordingAsyncClient)
+    respx_mock.get("http://127.0.0.1:11488/health").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+
+    result = await status._probe_host("http://127.0.0.1:11488")
+
+    assert captured["trust_env"] is False
+    assert result["reachable"] is True
+
+
+@pytest.mark.asyncio
 async def test_status_best_effort_reads_jsx_bridge_from_backend_health(monkeypatch, respx_mock):
     backend = MockBackend()
     backend.url = "http://127.0.0.1:11488"

--- a/packages/core/tests/test_tool_artifact.py
+++ b/packages/core/tests/test_tool_artifact.py
@@ -16,6 +16,7 @@ from ae_mcp.tool_artifact import (
     legacy_artifact_id,
     max_risk,
     new_user_artifact_id,
+    validate_args_schema,
 )
 
 
@@ -90,6 +91,32 @@ def test_content_hash_binds_kind_content_and_args_schema():
     assert base != compute_content_hash(
         "expression", "return 1;", {"x": {"type": "number"}}
     )
+
+
+def test_args_schema_property_accepts_bounded_description():
+    schema = {"amount": {"type": "number", "description": "Cafe\u0301", "default": 50}}
+
+    assert validate_args_schema(schema) == {
+        "amount": {"type": "number", "description": "Caf\u00e9", "default": 50}
+    }
+
+
+def test_args_schema_property_rejects_non_string_description():
+    with pytest.raises(
+        ValueError,
+        match="argsSchema property amount description must be a string",
+    ):
+        validate_args_schema({"amount": {"type": "number", "description": 1}})
+
+
+def test_args_schema_property_rejects_description_over_1024_characters():
+    with pytest.raises(
+        ValueError,
+        match="argsSchema property amount description exceeds 1024 characters",
+    ):
+        validate_args_schema(
+            {"amount": {"type": "number", "description": "x" * 1025}}
+        )
 
 
 def test_namespaced_ids_are_stable_and_non_overlapping(tmp_path: Path):


### PR DESCRIPTION
Closes #267
Closes #268
Closes #269

Three independent fixes from @86merako's reports, each with a regression test that is red before / green after.

| # | Change | Where |
|---|---|---|
| #267 | `ae.diagnose`'s loopback `/health` probe now passes `trust_env=False` (same as every other loopback call in the bridge client), so `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` can no longer turn a healthy host into a false `HTTP 502`. | `packages/core/ae_mcp/handlers/status.py` |
| #268 | Tool Library `argsSchema` accepts a per-property `description` — validated as an NFC-normalized string of at most 1024 characters. A legacy skill the SkillStore accepts no longer fails only when it reaches `ae.skillUse` through the legacy adapter. | `packages/core/ae_mcp/tool_artifact.py` |
| #269 | `ae.skillUse(execute=true)` returns the skill script's own parsed JSON at the top level again (v0.9.0 shape) instead of `{ok, name, template_type, result}`. The wrapper was never a documented contract — it came along with the v0.9.2 reroute through the approval engine, and that reroute **stays**. `execute=false` is unchanged. | `packages/core/ae_mcp/tool_execution.py` |

**Compatibility note (#269):** callers that read `result.*` during v0.9.2–v0.9.6 must switch back to top-level fields. Recorded in the bilingual CHANGELOG `Unreleased` entries.

## Verification (Windows, Python 3.13 via `uv run --frozen`)
- `pytest packages/core/tests/test_status_tool.py test_tool_artifact.py test_skill_tool_compat.py test_tool_execution.py test_handlers_tools.py` → **132 passed**
- full `pytest` → **933 passed, 9 failed** — the 9 are the pre-existing Windows-local symlink failures in `packages/bridge/tests/test_issue157_*` / `test_issue190_*` (identical set on `main`; green on CI)

Implemented by Codex worker Sol from `.codex/brief.md`; diff reviewed and tests re-run by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
