### PR TITLE
refactor(mcp): one module per /mcp tool so Phase 1 tool work lands in separate files

### DIFF
--- a/plugin/host/cep-runtime-contract.test.js
+++ b/plugin/host/cep-runtime-contract.test.js
@@ -35,6 +35,11 @@ const CEP_EXECUTED_FILES = [
     'mcp/session.js',
     'mcp/sse.js',
     'mcp/tools.js',
+    'mcp/tool-result.js',
+    // One file per /mcp tool (see mcp/tools.js). Every new tool module must be
+    // listed here so the node:-specifier and require-graph guards cover it.
+    'mcp/tools/status.js',
+    'mcp/tools/exec.js',
 ];
 
 // require('node:x'), require( `node:x` ), import('node:x'), from 'node:x',
@@ -68,7 +73,7 @@ test('every CEP-executed host file avoids node:-prefixed specifiers', () => {
 test('the CEP manifest stays in sync with what the host actually requires', () => {
     // Fail closed when a new local require appears in a CEP-executed file
     // without being added to the manifest above.
-    const local = /require\s*\(\s*['"`](\.\/[\w/-]+)(?:\.js)?['"`]\s*\)/g;
+    const local = /require\s*\(\s*['"`](\.\.?\/[\w/.-]+?)(?:\.js)?['"`]\s*\)/g;
     const known = new Set(CEP_EXECUTED_FILES);
     for (const name of CEP_EXECUTED_FILES) {
         const source = readCode(name);

--- a/plugin/host/mcp/tool-result.js
+++ b/plugin/host/mcp/tool-result.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// Shared result helpers for /mcp tools. Kept in its own module so tool files
+// under ./tools/ can require it without a cycle through the registry.
+
+function textResult(value, isError) {
+    const result = {
+        content: [{ type: 'text', text: JSON.stringify(value) }],
+        structuredContent: value,
+    };
+    if (isError) result.isError = true;
+    return result;
+}
+
+function noTopLevelCombinator(schema) {
+    return !['oneOf', 'allOf', 'anyOf'].some(function (key) {
+        return Object.prototype.hasOwnProperty.call(schema, key);
+    });
+}
+
+module.exports = { textResult, noTopLevelCombinator };

--- a/plugin/host/mcp/tools.js
+++ b/plugin/host/mcp/tools.js
@@ -1,48 +1,33 @@
 'use strict';
 
+// /mcp tool registry. Every tool lives in its own module under ./tools/ and
+// exports { definition, call(args, context, deps) }; this file only
+// aggregates, validates the advertised schemas, and dispatches by name.
+// Add a tool = add a file + one entry in TOOL_MODULES (keep list order: it is
+// the tools/list order clients see).
+
 const jsonrpc = require('./jsonrpc');
+const { textResult, noTopLevelCombinator } = require('./tool-result');
 
-function textResult(value, isError) {
-    const result = {
-        content: [{ type: 'text', text: JSON.stringify(value) }],
-        structuredContent: value,
-    };
-    if (isError) result.isError = true;
-    return result;
-}
-
-function noTopLevelCombinator(schema) {
-    return !['oneOf', 'allOf', 'anyOf'].some(function (key) {
-        return Object.prototype.hasOwnProperty.call(schema, key);
-    });
-}
+const TOOL_MODULES = [
+    require('./tools/status'),
+    require('./tools/exec'),
+];
 
 function buildTools(deps) {
-    const tools = [{
-        name: 'ae_status',
-        description: 'Read same-process ae-mcp host status without a network round trip.',
-        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
-        annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
-    }, {
-        name: 'ae_exec',
-        description: 'Run ExtendScript in After Effects through the host JSX bridge.',
-        inputSchema: {
-            type: 'object',
-            properties: {
-                code: { type: 'string', minLength: 1 },
-                undo_group_name: { type: 'string' },
-                checkpoint_label: { type: 'string' },
-                timeout_sec: { type: 'number', minimum: 1, maximum: 600 },
-            },
-            required: ['code'],
-            additionalProperties: false,
-        },
-        annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
-    }];
-    tools.forEach(function (tool) {
-        if (!noTopLevelCombinator(tool.inputSchema)) {
-            throw new Error('tool schema has a top-level combinator: ' + tool.name);
+    const byName = new Map();
+    const definitions = TOOL_MODULES.map(function (mod) {
+        if (!mod || !mod.definition || typeof mod.definition.name !== 'string' || typeof mod.call !== 'function') {
+            throw new Error('tool module must export { definition, call }');
         }
+        if (!noTopLevelCombinator(mod.definition.inputSchema)) {
+            throw new Error('tool schema has a top-level combinator: ' + mod.definition.name);
+        }
+        if (byName.has(mod.definition.name)) {
+            throw new Error('duplicate tool name: ' + mod.definition.name);
+        }
+        byName.set(mod.definition.name, mod);
+        return mod.definition;
     });
 
     async function call(params, context) {
@@ -51,47 +36,14 @@ function buildTools(deps) {
         }
         const args = params.arguments === undefined ? {} : params.arguments;
         if (!jsonrpc.isObject(args)) return { invalid: 'tools/call arguments must be an object' };
-        if (params.name === 'ae_status') {
-            if (Object.keys(args).length !== 0) {
-                return { result: textResult({ ok: false, error: 'ae_status accepts no arguments' }, true) };
-            }
-            const status = deps.getStatus(context.port);
-            status.mcp = { sessions: deps.sessionCount(), protocolVersion: context.session.protocolVersion };
-            return { result: textResult(status, false) };
-        }
-        if (params.name !== 'ae_exec') {
+        const mod = byName.get(params.name);
+        if (!mod) {
             return { result: textResult({ ok: false, error: 'unknown tool: ' + params.name }, true) };
         }
-        if (typeof args.code !== 'string' || args.code.length === 0) {
-            return { result: textResult({ ok: false, error: 'missing or empty `code`' }, true) };
-        }
-        if (args.undo_group_name !== undefined && typeof args.undo_group_name !== 'string') {
-            return { result: textResult({ ok: false, error: '`undo_group_name` must be a string' }, true) };
-        }
-        if (args.timeout_sec !== undefined
-            && (!Number.isFinite(args.timeout_sec) || args.timeout_sec < 1 || args.timeout_sec > 600)) {
-            return { result: textResult({ ok: false, error: '`timeout_sec` must be between 1 and 600' }, true) };
-        }
-        try {
-            const execution = await deps.executeJsx({
-                code: args.code,
-                undoGroup: args.undo_group_name,
-                checkpointLabel: args.checkpoint_label,
-                timeoutMs: (args.timeout_sec === undefined ? 30 : args.timeout_sec) * 1000,
-                client: context.session.clientName,
-                nativeProjectGraphEffect: 'invalidate',
-            });
-            const payload = execution.payload;
-            if (execution.disposition) payload.disposition = execution.disposition;
-            return { result: textResult(payload, !payload.ok) };
-        } catch (error) {
-            const payload = { ok: false, error: error && error.message ? error.message : String(error) };
-            if (error && typeof error.disposition === 'string') payload.disposition = error.disposition;
-            return { result: textResult(payload, true) };
-        }
+        return mod.call(args, context, deps);
     }
 
-    return { list: function () { return tools; }, call };
+    return { list: function () { return definitions; }, call };
 }
 
-module.exports = { buildTools, noTopLevelCombinator, textResult };
+module.exports = { buildTools, noTopLevelCombinator, textResult, TOOL_MODULES };

--- a/plugin/host/mcp/tools/exec.js
+++ b/plugin/host/mcp/tools/exec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// ae_exec — run ExtendScript through the host JSX bridge (shares the /exec
+// execution chain: pause / client block, undo group, transport envelope,
+// native graph invalidation, activity log).
+
+const { textResult } = require('../tool-result');
+
+const definition = {
+    name: 'ae_exec',
+    description: 'Run ExtendScript in After Effects through the host JSX bridge.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            code: { type: 'string', minLength: 1 },
+            undo_group_name: { type: 'string' },
+            checkpoint_label: { type: 'string' },
+            timeout_sec: { type: 'number', minimum: 1, maximum: 600 },
+        },
+        required: ['code'],
+        additionalProperties: false,
+    },
+    annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
+};
+
+async function call(args, context, deps) {
+    if (typeof args.code !== 'string' || args.code.length === 0) {
+        return { result: textResult({ ok: false, error: 'missing or empty `code`' }, true) };
+    }
+    if (args.undo_group_name !== undefined && typeof args.undo_group_name !== 'string') {
+        return { result: textResult({ ok: false, error: '`undo_group_name` must be a string' }, true) };
+    }
+    if (args.timeout_sec !== undefined
+        && (!Number.isFinite(args.timeout_sec) || args.timeout_sec < 1 || args.timeout_sec > 600)) {
+        return { result: textResult({ ok: false, error: '`timeout_sec` must be between 1 and 600' }, true) };
+    }
+    try {
+        const execution = await deps.executeJsx({
+            code: args.code,
+            undoGroup: args.undo_group_name,
+            checkpointLabel: args.checkpoint_label,
+            timeoutMs: (args.timeout_sec === undefined ? 30 : args.timeout_sec) * 1000,
+            client: context.session.clientName,
+            nativeProjectGraphEffect: 'invalidate',
+        });
+        const payload = execution.payload;
+        if (execution.disposition) payload.disposition = execution.disposition;
+        return { result: textResult(payload, !payload.ok) };
+    } catch (error) {
+        const payload = { ok: false, error: error && error.message ? error.message : String(error) };
+        if (error && typeof error.disposition === 'string') payload.disposition = error.disposition;
+        return { result: textResult(payload, true) };
+    }
+}
+
+module.exports = { definition, call };

--- a/plugin/host/mcp/tools/status.js
+++ b/plugin/host/mcp/tools/status.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// ae_status — read same-process host status. One tool per module: each file
+// exports { definition, call(args, context, deps) } and tools.js aggregates
+// them, so parallel tool work lands in separate files instead of one registry.
+
+const { textResult } = require('../tool-result');
+
+const definition = {
+    name: 'ae_status',
+    description: 'Read same-process ae-mcp host status without a network round trip.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+};
+
+async function call(args, context, deps) {
+    if (Object.keys(args).length !== 0) {
+        return { result: textResult({ ok: false, error: 'ae_status accepts no arguments' }, true) };
+    }
+    const status = deps.getStatus(context.port);
+    status.mcp = { sessions: deps.sessionCount(), protocolVersion: context.session.protocolVersion };
+    return { result: textResult(status, false) };
+}
+
+module.exports = { definition, call };


### PR DESCRIPTION
Mechanical scaffold ahead of the Phase 1 fan-out (#261). Three workers will add tools to `/mcp` in parallel; with one 97-line registry file they would all collide, so each tool now lives in its own module:

- `plugin/host/mcp/tools/status.js`, `plugin/host/mcp/tools/exec.js` — each exports `{ definition, call(args, context, deps) }`
- `plugin/host/mcp/tool-result.js` — `textResult` / `noTopLevelCombinator` shared without a registry cycle
- `plugin/host/mcp/tools.js` — aggregates `TOOL_MODULES`, rejects top-level combinators and duplicate names, dispatches by name. `tools/list` order and the `buildTools` / `list` / `call` API are unchanged
- `plugin/host/cep-runtime-contract.test.js` — new files join `CEP_EXECUTED_FILES`; the local-require scanner now also follows `../` paths so subdirectory tool modules cannot slip past the `node:`-specifier / require-graph guards

No behavior change. Verified: `plugin/host` 126 tests → 109 pass / 1 fail (pre-existing local-only symlink `EPERM`) / 16 skipped; `mcp/*.test.js` all green.

Phase 1 batch-1 worker branches will be based on this branch; merge order: this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)