### PR TITLE
fix(host): ae_exec non-string results survive the transport — typed envelope + ES3 serializer (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 - **`ae.skillUse(execute=true)` 恢复 v0.9.0 透传返回形状**——技能脚本自己的 JSON 结果原样放在顶层，不再包 `{ok,name,template_type,result}`，也不再出现外层 `ok:true` 包住内层 `ok:false` 的矛盾；v0.9.2–v0.9.6 期间按 `result.*` 读取的调用方需改回顶层字段。执行仍走审批引擎，`execute=false` 不变。（#269）
 - **ExtendScript 超时不再提前放行串行锁（#260）**——调用方仍会按原期限收到超时，但 Bridge 会等迟到回调或排空哨兵返回后才继续，期间 `/health`、`/exec`、`ae.status` 与 `ae.diagnose` 报告 `degraded`；错误 disposition 收敛为三值：从未进入 AE、可安全重试的 `not_dispatched`，已派发但结果未知的 `uncertain`，以及已执行并明确报错的 `failed`。
 - **依赖清扫：`npm audit` 归零**——`plugin/sidecar` 锁文件把 `fast-uri` 升到 3.1.5（修 CVE-2026-13676 / GHSA-4c8g-83qw-93j6 以及其后的 GHSA-v2hh-gcrm-f6hx、GHSA-7p8r-x3mc-p8w7，仍在 ajv 声明的 `^3.0.1` 范围内，不引入 `overrides`），同批升级 `ip-address` 10.5.0、`hono` 4.13.3、`@hono/node-server` 1.19.17、`body-parser` 2.3.0；`plugin/host` 的 `express` 4.22.1→4.22.2（连带 `qs` 6.15.3、`body-parser` 1.20.6）。两个工作区 `npm audit` 均为 0；这些包只在本机回环路径上工作，属扫描器噪音清理而非已确认可达的漏洞。由 #271（@anupamme / OrbisAI 扫描报告）触发。
+- **`ae_exec` 非字符串结果不再被摧毁（#254）**——ExtendScript 侧新增 ES3 安全序列化器：数字 / 布尔 / `null` / 纯 Object / 纯 Array 结果在 AE 内序列化为规范 JSON 文本原样带回（`structuredContent.contentType: "json"`，`content` 恒为字符串），字符串结果保持原语义（`contentType: "text"`）。此前对象变成 `"[object Object]"` 解析错误、数组变成 `ok:true` 的 `"1,two,[object Object]"` 静默损毁。宿主对象（CompItem / Layer 等）不做深遍历、保持 `String(v)` 叶节点；循环引用 / 深度超 12 / 序列化超 1,000,000 字符按确定性错误返回并提示改用更小的投影；`ae_exec` 路径彻底移除「结果看着像 JSON 就尝试解析」的猜测逻辑，其余工具的结果解析不受影响。
 
 
 ### [0.9.6] — 2026-08-19

--- a/plugin/host/mcp/conversation-exec-integration.test.js
+++ b/plugin/host/mcp/conversation-exec-integration.test.js
@@ -83,12 +83,18 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         executeJsx: async function (requestValue) {
             calls.push(requestValue);
             if (requestValue.code === 'plain') {
-                return { payload: { ok: true, result: 'hi' } };
+                return { payload: { ok: true, resultType: 'string', result: 'hi' } };
             }
             if (requestValue.code === 'empty') {
-                return { payload: { ok: true, result: '' } };
+                return { payload: { ok: true, resultType: 'string', result: '' } };
             }
-            return { payload: { ok: true, result: JSON.stringify({ ok: true, n: 1 }) } };
+            return {
+                payload: {
+                    ok: true,
+                    resultType: 'json',
+                    result: JSON.stringify({ ok: true, n: 1 }),
+                },
+            };
         },
     });
     try {
@@ -103,7 +109,11 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         const allowed = await request(fixture.port, 'POST', none.path, {
             'Mcp-Session-Id': noneSession.session,
         }, toolCall(2, 'json'));
-        assert.deepEqual(allowed.body.result.structuredContent, { ok: true, n: 1 });
+        assert.deepEqual(allowed.body.result.structuredContent, {
+            ok: true,
+            content: '{"ok":true,"n":1}',
+            contentType: 'json',
+        });
         assert.equal(calls[0].client, 'claude@chat-none');
 
         const blocked = await request(fixture.port, 'POST', readonly.path, {
@@ -117,7 +127,11 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         const externalResult = await request(fixture.port, 'POST', '/mcp', {
             'Mcp-Session-Id': external.session,
         }, toolCall(4, 'plain'));
-        assert.deepEqual(externalResult.body.result.structuredContent, { ok: true, content: 'hi' });
+        assert.deepEqual(externalResult.body.result.structuredContent, {
+            ok: true,
+            content: 'hi',
+            contentType: 'text',
+        });
         assert.equal(calls[1].client, 'cursor');
 
         const empty = await request(fixture.port, 'POST', '/mcp', {
@@ -154,7 +168,13 @@ test('manual conversation approval accepts with progress and declines without ex
     const fixture = await start({
         executeJsx: async function (requestValue) {
             calls.push(requestValue);
-            return { payload: { ok: true, result: '{"ok":true,"approved":true}' } };
+            return {
+                payload: {
+                    ok: true,
+                    resultType: 'json',
+                    result: '{"ok":true,"approved":true}',
+                },
+            };
         },
         progressIntervalMs: 5,
     });
@@ -184,7 +204,11 @@ test('manual conversation approval accepts with progress and declines without ex
                 && frame.params.progressToken === 'approval-progress';
         }));
         const terminal = frames.find(function (frame) { return frame.id === 2; });
-        assert.deepEqual(terminal.result.structuredContent, { ok: true, approved: true });
+        assert.deepEqual(terminal.result.structuredContent, {
+            ok: true,
+            content: '{"ok":true,"approved":true}',
+            contentType: 'json',
+        });
         assert.equal(calls.length, 1);
 
         fixture.mounted.approvals.once('request', function (item) {
@@ -215,7 +239,13 @@ test('checkpoint success probes, snapshots, persists metadata, then executes use
         executeJsx: async function (requestValue) {
             calls.push(requestValue);
             if (calls.length === 1) {
-                return { payload: { ok: true, result: JSON.stringify({ ok: true, path: source }) } };
+                return {
+                    payload: {
+                        ok: true,
+                        resultType: 'string',
+                        result: JSON.stringify({ ok: true, path: source }),
+                    },
+                };
             }
             if (calls.length === 2) {
                 const match = requestValue.code.match(/var dstPath = (".*");/);
@@ -226,13 +256,20 @@ test('checkpoint success probes, snapshots, persists metadata, then executes use
                 return {
                     payload: {
                         ok: true,
+                        resultType: 'string',
                         result: JSON.stringify({
                             ok: true, sizeBytes: 10, activeCompId: '7', currentTime: 1.25,
                         }),
                     },
                 };
             }
-            return { payload: { ok: true, result: '{"ok":true,"edited":true}' } };
+            return {
+                payload: {
+                    ok: true,
+                    resultType: 'json',
+                    result: '{"ok":true,"edited":true}',
+                },
+            };
         },
     });
     try {
@@ -242,7 +279,11 @@ test('checkpoint success probes, snapshots, persists metadata, then executes use
         }, toolCall(2, 'user-edit-code', {
             checkpoint_label: 'Before edit', undo_group_name: 'Edit', timeout_sec: 45,
         }));
-        assert.deepEqual(response.body.result.structuredContent, { ok: true, edited: true });
+        assert.deepEqual(response.body.result.structuredContent, {
+            ok: true,
+            content: '{"ok":true,"edited":true}',
+            contentType: 'json',
+        });
         assert.equal(calls.length, 3);
         assert.match(calls[0].code, /app\.project\.file/);
         assert.ok(calls[1].code.indexOf('${dst_path}') === -1);
@@ -266,10 +307,22 @@ test('untitled and failed checkpoints annotate the result but never block user J
             executeJsx: async function (requestValue) {
                 calls.push(requestValue);
                 if (calls.length === 1) {
-                    return { payload: { ok: true, result: JSON.stringify({ ok: true, path: pathResult }) } };
+                    return {
+                        payload: {
+                            ok: true,
+                            resultType: 'string',
+                            result: JSON.stringify({ ok: true, path: pathResult }),
+                        },
+                    };
                 }
                 if (checkpointFailure && calls.length === 2) throw new Error('snapshot boom');
-                return { payload: { ok: true, result: '{"ok":true,"edited":true}' } };
+                return {
+                    payload: {
+                        ok: true,
+                        resultType: 'json',
+                        result: '{"ok":true,"edited":true}',
+                    },
+                };
             },
         });
         try {
@@ -286,7 +339,10 @@ test('untitled and failed checkpoints annotate the result but never block user J
 
     const untitled = await runCase(null, false);
     assert.deepEqual(untitled.result, {
-        ok: true, edited: true, checkpointSkipped: 'untitled-project',
+        ok: true,
+        content: '{"ok":true,"edited":true}',
+        contentType: 'json',
+        checkpointSkipped: 'untitled-project',
     });
     assert.equal(untitled.calls.length, 2);
     assert.equal(untitled.calls[1].code, 'user-edit');

--- a/plugin/host/mcp/index.test.js
+++ b/plugin/host/mcp/index.test.js
@@ -13,7 +13,10 @@ function start(options) {
         version: '0.9.6-test',
         getStatus: function (port) { return { ok: true, pluginVersion: '0.9.6-test', port }; },
         executeJsx: options && options.executeJsx || async function () {
-            return { status: 200, payload: { ok: true, result: 'ok' } };
+            return {
+                status: 200,
+                payload: { ok: true, resultType: 'string', result: 'ok' },
+            };
         },
         progressIntervalMs: options && options.progressIntervalMs,
         sseOptions: options && options.sseOptions,

--- a/plugin/host/mcp/jsx-result.js
+++ b/plugin/host/mcp/jsx-result.js
@@ -36,4 +36,29 @@ function parseJsxResult(text) {
     return { ok: true, content: text };
 }
 
-module.exports = { EVALSCRIPT_ERR_SENTINEL, parseJsxResult };
+// ae_exec receives an explicit transport type. Unlike maintained JSX tools,
+// arbitrary user code must never be interpreted by looking at its first byte.
+function parseExecResult(resultType, text) {
+    if (resultType === 'json') {
+        if (typeof text !== 'string') return fail('ae_exec returned an invalid json result', text);
+        return { ok: true, content: text, contentType: 'json' };
+    }
+    if (resultType !== 'string') {
+        return fail('ae_exec returned an invalid result type', text);
+    }
+    if (!text || String(text).trim() === '') {
+        return fail('jsx returned no value (empty output)', text);
+    }
+    const stripped = String(text).trim();
+    if (NO_VALUE_SENTINELS.indexOf(stripped) !== -1) {
+        return fail(
+            'jsx evaluated to ' + stripped
+                + '; ensure your code returns JSON.stringify(...) or a value',
+            text,
+        );
+    }
+    if (stripped === EVALSCRIPT_ERR_SENTINEL) return fail(stripped, text);
+    return { ok: true, content: text, contentType: 'text' };
+}
+
+module.exports = { EVALSCRIPT_ERR_SENTINEL, parseJsxResult, parseExecResult };

--- a/plugin/host/mcp/jsx-result.test.js
+++ b/plugin/host/mcp/jsx-result.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { parseJsxResult } = require('./jsx-result');
+const { parseJsxResult, parseExecResult } = require('./jsx-result');
 
 test('parseJsxResult returns parsed JSON objects and arrays', () => {
     assert.deepEqual(parseJsxResult('{"ok":true,"value":42}'), { ok: true, value: 42 });
@@ -43,5 +43,44 @@ test('parseJsxResult wraps non-JSON strings and preserves parsed ok:false', () =
     assert.deepEqual(parseJsxResult('hi'), { ok: true, content: 'hi' });
     assert.deepEqual(parseJsxResult('{"ok":false,"error":"no layer"}'), {
         ok: false, error: 'no layer',
+    });
+});
+
+test('parseExecResult maps explicit transport types without sniffing JSON-like text', () => {
+    assert.deepEqual(parseExecResult('text', '{"ok":true}'), {
+        ok: false,
+        error: 'ae_exec returned an invalid result type',
+        raw: '{"ok":true}',
+    });
+    assert.deepEqual(parseExecResult('string', '{"ok":false,"error":"not an exec error"}'), {
+        ok: true,
+        content: '{"ok":false,"error":"not an exec error"}',
+        contentType: 'text',
+    });
+    assert.deepEqual(parseExecResult('string', '[object Object]'), {
+        ok: true,
+        content: '[object Object]',
+        contentType: 'text',
+    });
+    assert.deepEqual(parseExecResult('json', '{"ok":true,"n":42}'), {
+        ok: true,
+        content: '{"ok":true,"n":42}',
+        contentType: 'json',
+    });
+});
+
+test('parseExecResult preserves empty, undefined, and EvalScript sentinel errors', () => {
+    assert.deepEqual(parseExecResult('string', ''), {
+        ok: false,
+        error: 'jsx returned no value (empty output)',
+        raw: '',
+    });
+    const undefinedResult = parseExecResult('string', 'undefined');
+    assert.equal(undefinedResult.ok, false);
+    assert.match(undefinedResult.error, /evaluated to undefined/);
+    assert.deepEqual(parseExecResult('string', 'EvalScript error.'), {
+        ok: false,
+        error: 'EvalScript error.',
+        raw: 'EvalScript error.',
     });
 });

--- a/plugin/host/mcp/read-integration.test.js
+++ b/plugin/host/mcp/read-integration.test.js
@@ -47,7 +47,11 @@ async function fixture() {
                     isThreeD: false, locked: false, parentLocator: null, sourceItemLocator: null,
                 }],
             };
-            callback(JSON.stringify({ ok: true, result: JSON.stringify(result) }));
+            callback(JSON.stringify({
+                ok: true,
+                resultType: 'string',
+                result: JSON.stringify(result),
+            }));
         },
     });
     const app = server.buildApp();

--- a/plugin/host/mcp/server-integration.test.js
+++ b/plugin/host/mcp/server-integration.test.js
@@ -35,7 +35,7 @@ async function fixture() {
     server.activity._reset();
     server.setPaused(false);
     server.setCSInterface({
-        evalScript: function (_jsx, callback) { callback('{"ok":true,"result":"bridge-ok"}'); },
+        evalScript: function (_jsx, callback) { callback('{"ok":true,"resultType":"string","result":"bridge-ok"}'); },
     });
     const app = server.buildApp();
     assert.equal(typeof server.mcp.conversations.create, 'function');
@@ -63,7 +63,11 @@ test('MCP ae_exec shares paused/blocked gates and activity records with /exec', 
             jsonrpc: '2.0', id: 2, method: 'tools/call',
             params: { name: 'ae_exec', arguments: { code: '1 + 1', undo_group_name: 'MCP test' } },
         });
-        assert.deepEqual(success.body.result.structuredContent, { ok: true, content: 'bridge-ok' });
+        assert.deepEqual(success.body.result.structuredContent, {
+            ok: true,
+            content: 'bridge-ok',
+            contentType: 'text',
+        });
         const invalidParams = await request(host.port, headers, {
             jsonrpc: '2.0', id: 21, method: 'tools/call', params: {},
         });

--- a/plugin/host/mcp/session-identity.test.js
+++ b/plugin/host/mcp/session-identity.test.js
@@ -67,7 +67,7 @@ async function fixture() {
     server.setRuntimeDependencies({ express });
     server.setPaused(false);
     server.setCSInterface({
-        evalScript: function (_jsx, callback) { callback('{"ok":true,"result":"identity-ok"}'); },
+        evalScript: function (_jsx, callback) { callback('{"ok":true,"resultType":"string","result":"identity-ok"}'); },
     });
     const app = server.buildApp();
     const listener = await new Promise(function (resolve) {
@@ -117,7 +117,11 @@ test('MCP identity blocks existing and new sessions, then restores after unblock
             jsonrpc: '2.0', id: 3, method: 'tools/call',
             params: { name: 'ae_exec', arguments: { code: '1 + 1' } },
         });
-        assert.deepEqual(restored.body.result.structuredContent, { ok: true, content: 'identity-ok' });
+        assert.deepEqual(restored.body.result.structuredContent, {
+            ok: true,
+            content: 'identity-ok',
+            contentType: 'text',
+        });
 
         host.server.setClientBlocked('cursor', true);
         const rejected = await request(host.port, 'POST', '/mcp', {}, initializeMessage(4, 'cursor', '2.0'));

--- a/plugin/host/mcp/tools.test.js
+++ b/plugin/host/mcp/tools.test.js
@@ -7,7 +7,9 @@ const { buildTools, noTopLevelCombinator } = require('./tools');
 test('tools/list uses top-level JSON-schema object forms only', () => {
     const registry = buildTools({
         getStatus: function () { return { ok: true }; },
-        executeJsx: async function () { return { payload: { ok: true, result: '' } }; },
+        executeJsx: async function () {
+            return { payload: { ok: true, resultType: 'string', result: '' } };
+        },
         sessionCount: function () { return 1; },
     });
     const tools = registry.list();
@@ -19,6 +21,55 @@ test('tools/list uses top-level JSON-schema object forms only', () => {
     tools.forEach(function (tool) {
         assert.equal(tool.inputSchema.type, 'object');
         assert.equal(noTopLevelCombinator(tool.inputSchema), true);
+    });
+    const exec = tools.find(function (tool) { return tool.name === 'ae_exec'; });
+    assert.deepEqual(exec.outputSchema.properties.contentType.enum, ['text', 'json']);
+    assert.match(exec.description, /contentType/);
+});
+
+test('ae_exec surfaces explicit contentType and never sniffs JSON-like text', async () => {
+    const registry = buildTools({
+        getStatus: function () { return { ok: true }; },
+        executeJsx: async function (request) {
+            if (request.code === 'object') {
+                return {
+                    payload: {
+                        ok: true,
+                        resultType: 'json',
+                        result: '{"ok":true,"n":42}',
+                    },
+                };
+            }
+            return {
+                payload: {
+                    ok: true,
+                    resultType: 'string',
+                    result: '{"broken":',
+                },
+            };
+        },
+        sessionCount: function () { return 1; },
+    });
+    const context = {
+        session: { clientName: 'test', protocolVersion: '2025-06-18' },
+        port: 1,
+    };
+    const structured = await registry.call({
+        name: 'ae_exec', arguments: { code: 'object' },
+    }, context);
+    assert.deepEqual(structured.result.structuredContent, {
+        ok: true,
+        content: '{"ok":true,"n":42}',
+        contentType: 'json',
+    });
+    const text = await registry.call({
+        name: 'ae_exec', arguments: { code: 'json-like text' },
+    }, context);
+    assert.equal(text.result.isError, undefined);
+    assert.deepEqual(text.result.structuredContent, {
+        ok: true,
+        content: '{"broken":',
+        contentType: 'text',
     });
 });
 

--- a/plugin/host/mcp/tools/exec.js
+++ b/plugin/host/mcp/tools/exec.js
@@ -7,12 +7,12 @@
 const { textResult } = require('../tool-result');
 const { VERB_ANNOTATIONS } = require('../annotations');
 const { enforce } = require('../approval-gate');
-const { parseJsxResult } = require('../jsx-result');
+const { parseExecResult } = require('../jsx-result');
 const { autoCheckpoint, executionFailure, record } = require('../checkpoint-ops');
 
 const definition = {
     name: 'ae_exec',
-    description: 'Run ExtendScript in After Effects through the host JSX bridge.',
+    description: 'Run ExtendScript in After Effects through the host JSX bridge. Successful structuredContent is {ok:true,content,contentType}; contentType is "json" for numbers, booleans, null, plain Objects, and Arrays serialized in ExtendScript, or "text" for string results. The content field always remains a string.',
     inputSchema: {
         type: 'object',
         properties: {
@@ -23,6 +23,18 @@ const definition = {
         },
         required: ['code'],
         additionalProperties: false,
+    },
+    outputSchema: {
+        type: 'object',
+        properties: {
+            ok: { type: 'boolean' },
+            content: { type: 'string' },
+            contentType: { type: 'string', enum: ['text', 'json'] },
+            error: { type: 'string' },
+            disposition: { type: 'string' },
+        },
+        required: ['ok'],
+        additionalProperties: true,
     },
     annotations: Object.assign({}, VERB_ANNOTATIONS.ae_exec, { openWorldHint: false }),
 };
@@ -64,7 +76,7 @@ async function call(args, context, deps) {
             const failure = executionFailure(execution);
             return { result: textResult(failure, true) };
         }
-        const parsed = parseJsxResult(execution.payload.result);
+        const parsed = parseExecResult(execution.payload.resultType, execution.payload.result);
         if (record(parsed) && checkpointSkipped
             && !Object.prototype.hasOwnProperty.call(parsed, 'checkpointSkipped')) {
             parsed.checkpointSkipped = checkpointSkipped;

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -377,6 +377,7 @@ function quoteAsciiJsString(value) {
 function wrapForEvalScriptTransport(code) {
     return (
         '(function(){' +
+        'var __aemcp_max_depth=12,__aemcp_max_length=1000000;' +
         'function __aemcp_quote(v){' +
         'var s=String(v),out="\\"";' +
         'for(var i=0;i<s.length;i++){' +
@@ -393,9 +394,81 @@ function wrapForEvalScriptTransport(code) {
         '}' +
         'return out+"\\"";' +
         '}' +
+        'function __aemcp_projection_error(reason){' +
+        'throw new Error("ae_exec result "+reason+"; return a smaller projection (for example, map to the fields you need)");' +
+        '}' +
+        'function __aemcp_piece(state,piece){' +
+        'state.length+=piece.length;' +
+        'if(state.length>__aemcp_max_length){__aemcp_projection_error("exceeds the 1000000 character serialization limit");}' +
+        'return piece;' +
+        '}' +
+        'function __aemcp_seen(stack,value){' +
+        'for(var i=0;i<stack.length;i++){if(stack[i]===value){return true;}}' +
+        'return false;' +
+        '}' +
+        'function __aemcp_kind(value){' +
+        'var tag;' +
+        'try{tag=Object.prototype.toString.call(value);}catch(ignore){return "leaf";}' +
+        'if(tag==="[object Array]"){return "array";}' +
+        'if(tag!=="[object Object]"){return "leaf";}' +
+        'var constructorValue;' +
+        'try{constructorValue=value.constructor;}catch(ignoreConstructor){return "leaf";}' +
+        'return constructorValue===Object?"object":"leaf";' +
+        '}' +
+        'function __aemcp_json(value,depth,seen,state){' +
+        'if(value===null){return __aemcp_piece(state,"null");}' +
+        'var valueType=typeof value;' +
+        'if(valueType==="string"){return __aemcp_piece(state,__aemcp_quote(value));}' +
+        'if(valueType==="number"){return __aemcp_piece(state,isFinite(value)?String(value):"null");}' +
+        'if(valueType==="boolean"){return __aemcp_piece(state,value?"true":"false");}' +
+        'if(valueType==="undefined"||valueType==="function"){return null;}' +
+        'if(valueType!=="object"){return __aemcp_piece(state,__aemcp_quote(String(value)));}' +
+        'var kind=__aemcp_kind(value);' +
+        'if(kind==="leaf"){return __aemcp_piece(state,__aemcp_quote(String(value)));}' +
+        'if(depth>=__aemcp_max_depth){__aemcp_projection_error("exceeds the maximum serialization depth of 12");}' +
+        'if(__aemcp_seen(seen,value)){__aemcp_projection_error("contains a cyclic plain Object or Array");}' +
+        'seen.push(value);' +
+        'try{' +
+        'var out,child,childValue,readable,i,key,own,first=true;' +
+        'if(kind==="array"){' +
+        'out=__aemcp_piece(state,"[");' +
+        'var arrayLength=0;' +
+        'try{arrayLength=value.length;}catch(ignoreLength){arrayLength=0;}' +
+        'for(i=0;i<arrayLength;i++){' +
+        'if(i>0){out+=__aemcp_piece(state,",");}' +
+        'readable=true;' +
+        'try{childValue=value[i];}catch(ignoreArrayProperty){readable=false;}' +
+        'child=readable?__aemcp_json(childValue,depth+1,seen,state):null;' +
+        'if(child===null){child=__aemcp_piece(state,"null");}' +
+        'out+=child;' +
+        '}' +
+        'return out+__aemcp_piece(state,"]");' +
+        '}' +
+        'out=__aemcp_piece(state,"{");' +
+        'for(key in value){' +
+        'own=false;' +
+        'try{own=Object.prototype.hasOwnProperty.call(value,key);}catch(ignoreOwn){own=false;}' +
+        'if(!own){continue;}' +
+        'readable=true;' +
+        'try{childValue=value[key];}catch(ignoreObjectProperty){readable=false;}' +
+        'if(!readable){continue;}' +
+        'child=__aemcp_json(childValue,depth+1,seen,state);' +
+        'if(child===null){continue;}' +
+        'if(!first){out+=__aemcp_piece(state,",");}' +
+        'first=false;' +
+        'out+=__aemcp_piece(state,__aemcp_quote(key))+__aemcp_piece(state,":")+child;' +
+        '}' +
+        'return out+__aemcp_piece(state,"}");' +
+        '}finally{seen.pop();}' +
+        '}' +
         'try{' +
         'var __aemcp_value=eval(' + quoteAsciiJsString(code) + ');' +
-        'return "{\\"ok\\":true,\\"result\\":"+__aemcp_quote(__aemcp_value)+"}";' +
+        'var __aemcp_type=typeof __aemcp_value;' +
+        'if(__aemcp_type==="string"||__aemcp_type==="undefined"||__aemcp_type==="function"){' +
+        'return "{\\"ok\\":true,\\"resultType\\":\\"string\\",\\"result\\":"+__aemcp_quote(__aemcp_value)+"}";' +
+        '}' +
+        'var __aemcp_result=__aemcp_json(__aemcp_value,0,[],{length:0});' +
+        'return "{\\"ok\\":true,\\"resultType\\":\\"json\\",\\"result\\":"+__aemcp_quote(__aemcp_result)+"}";' +
         '}catch(e){' +
         'var __aemcp_detail=String(e);' +
         'if(e&&e.line){__aemcp_detail+=" (line "+e.line+")";}' +
@@ -427,11 +500,14 @@ function decodeEvalScriptTransportResult(text) {
     if (!payload || payload.ok !== true || typeof payload.result !== 'string') {
         throw new Error('invalid evalScript transport envelope shape');
     }
-    return payload.result;
+    if (payload.resultType !== 'string' && payload.resultType !== 'json') {
+        throw new Error('invalid evalScript transport envelope resultType');
+    }
+    return { resultType: payload.resultType, result: payload.result };
 }
 
-// Shared /exec and MCP ae_exec execution path. The HTTP route keeps its
-// existing response shape; MCP maps this internal result into a tool result.
+// Shared /exec and MCP ae_exec execution path. Both surfaces receive the
+// explicit transport resultType; MCP maps it into contentType.
 async function executeJsx(request) {
     const input = request || {};
     const code = input.code;
@@ -474,15 +550,22 @@ async function executeJsx(request) {
         }
         dispatched = true;
         const encoded = await jsxBridge.evalScript(transported, t);
-        const result = decodeEvalScriptTransportResult(encoded);
+        const decoded = decodeEvalScriptTransportResult(encoded);
         activity.record({
             client,
             undoGroup: undoGroup || null,
             ok: true,
             durationMs: Date.now() - startedAt,
-            ...(result === '' ? { emptyResult: true } : {}),
+            ...(decoded.result === '' ? { emptyResult: true } : {}),
         });
-        return { status: 200, payload: { ok: true, result: result || '' } };
+        return {
+            status: 200,
+            payload: {
+                ok: true,
+                resultType: decoded.resultType,
+                result: decoded.result || '',
+            },
+        };
     } catch (e) {
         // Closed three-value disposition (#260): the bridge tags its own
         // rejections; anything untagged is classified by whether the script

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -56,6 +56,12 @@ function loadServer() {
     return server;
 }
 
+function evaluateTransportEnvelope(server, code) {
+    const wrapped = server.wrapForEvalScriptTransport(code);
+    const encoded = Function('return ' + wrapped)();
+    return { wrapped, encoded, payload: JSON.parse(encoded) };
+}
+
 function fakeNativeClient(overrides) {
     let state = 'disconnected';
     let closed = 0;
@@ -157,7 +163,7 @@ async function startApp(options) {
     server._setNativeAegpClientForTest(nativeClient);
     server.setCSInterface({
         evalScript: input.evalScript || function (_jsx, callback) {
-            callback('{"ok":true,"result":"stub-result"}');
+            callback('{"ok":true,"resultType":"string","result":"stub-result"}');
         },
     });
     const app = server.buildApp();
@@ -473,7 +479,7 @@ test('/exec requires auth and invalidates a connected native graph before JSX', 
         nativeClient,
         evalScript: function (_jsx, callback) {
             order.push(['eval']);
-            callback('{"ok":true,"result":"jsx-result"}');
+            callback('{"ok":true,"resultType":"string","result":"jsx-result"}');
         },
     });
     try {
@@ -491,7 +497,11 @@ test('/exec requires auth and invalidates a connected native graph before JSX', 
             { code: '1 + 1' },
         );
         assert.equal(response.status, 200);
-        assert.deepEqual(response.body, { ok: true, result: 'jsx-result' });
+        assert.deepEqual(response.body, {
+            ok: true,
+            resultType: 'string',
+            result: 'jsx-result',
+        });
         assert.equal(order[0][0], 'invalidate');
         assert.equal(order[1][0], 'eval');
     } finally {
@@ -550,22 +560,138 @@ test('/exec fails closed when connected graph invalidation fails', async () => {
     }
 });
 
-test('ExtendScript transport wrappers preserve localized success and errors', () => {
+test('ExtendScript transport serializes typed primitive and structured results as ASCII', () => {
     const server = loadServer();
-    const wrapped = server.wrapForEvalScriptTransport('"你好"');
-    assert.doesNotMatch(wrapped, /你好/);
-    assert.equal(
-        server.decodeEvalScriptTransportResult('{"ok":true,"result":"你好"}'),
-        '你好',
+    const cases = [
+        ['string', '"hello"', 'string', 'hello'],
+        ['plain object', '({ok:true,n:42})', 'json', '{"ok":true,"n":42}'],
+        ['nested object', '({a:{b:[1,{c:true}]}})', 'json', '{"a":{"b":[1,{"c":true}]}}'],
+        ['array', '[1,2,3]', 'json', '[1,2,3]'],
+        ['mixed array', '[1,"two",{three:3}]', 'json', '[1,"two",{"three":3}]'],
+        ['number', '6*7', 'json', '42'],
+        ['boolean', 'true', 'json', 'true'],
+        ['null', 'null', 'json', 'null'],
+        ['undefined', 'var x=1;', 'string', 'undefined'],
+    ];
+    cases.forEach(function (entry) {
+        const evaluated = evaluateTransportEnvelope(server, entry[1]);
+        assert.doesNotMatch(evaluated.wrapped, /[^\x00-\x7f]/, entry[0] + ' wrapper');
+        assert.doesNotMatch(evaluated.encoded, /[^\x00-\x7f]/, entry[0] + ' envelope');
+        assert.deepEqual(
+            server.decodeEvalScriptTransportResult(evaluated.encoded),
+            { resultType: entry[2], result: entry[3] },
+            entry[0],
+        );
+    });
+});
+
+test('ExtendScript transport applies JSON semantics and guards property access', () => {
+    const server = loadServer();
+    const objectResult = evaluateTransportEnvelope(
+        server,
+        '(function(){var o={safe:1,skip:undefined,fn:function(){},nan:NaN,infinity:Infinity};'
+            + 'Object.defineProperty(o,"throwing",{enumerable:true,get:function(){throw new Error("getter");}});'
+            + 'return o;})()',
+    );
+    assert.equal(objectResult.payload.resultType, 'json');
+    assert.deepEqual(JSON.parse(objectResult.payload.result), {
+        safe: 1,
+        nan: null,
+        infinity: null,
+    });
+
+    const arrayResult = evaluateTransportEnvelope(
+        server,
+        '(function(){var a=[1,undefined,function(){},NaN];'
+            + 'Object.defineProperty(a,"4",{enumerable:true,get:function(){throw new Error("getter");}});'
+            + 'return a;})()',
+    );
+    assert.deepEqual(JSON.parse(arrayResult.payload.result), [1, null, null, null, null]);
+});
+
+test('ExtendScript transport escapes non-ASCII JSON values and treats host-like objects as leaves', () => {
+    const server = loadServer();
+    const localized = evaluateTransportEnvelope(server, '({message:"你好",nested:["é"]})');
+    assert.doesNotMatch(localized.wrapped, /[^\x00-\x7f]/);
+    assert.doesNotMatch(localized.encoded, /[^\x00-\x7f]/);
+    assert.deepEqual(JSON.parse(localized.payload.result), { message: '你好', nested: ['é'] });
+
+    const hostLike = evaluateTransportEnvelope(
+        server,
+        '(function(){function CompItem(){}'
+            + 'CompItem.prototype.toString=function(){return "[object CompItem]";};'
+            + 'var item=new CompItem();'
+            + 'Object.defineProperty(item,"throwing",{enumerable:true,get:function(){throw new Error("must not walk");}});'
+            + 'return item;})()',
+    );
+    assert.equal(hostLike.payload.resultType, 'json');
+    assert.equal(JSON.parse(hostLike.payload.result), '[object CompItem]');
+});
+
+test('ExtendScript transport fails deterministically for cycles and serialization caps', () => {
+    const server = loadServer();
+    const cases = [
+        [
+            '(function(){var value={};value.self=value;return value;})()',
+            /cyclic plain Object or Array/,
+        ],
+        [
+            '(function(){var root={},cursor=root;for(var i=0;i<13;i++){cursor.next={};cursor=cursor.next;}return root;})()',
+            /maximum serialization depth of 12/,
+        ],
+        [
+            '({value:Array(1000002).join("x")})',
+            /1000000 character serialization limit/,
+        ],
+    ];
+    cases.forEach(function (entry) {
+        const evaluated = evaluateTransportEnvelope(server, entry[0]);
+        assert.equal(evaluated.payload.ok, false);
+        assert.match(evaluated.payload.error, entry[1]);
+        assert.match(evaluated.payload.error, /return a smaller projection/);
+        assert.throws(
+            function () { server.decodeEvalScriptTransportResult(evaluated.encoded); },
+            entry[1],
+        );
+    });
+});
+
+test('evalScript transport decoder requires typed successes and preserves error envelopes', () => {
+    const server = loadServer();
+    assert.deepEqual(
+        server.decodeEvalScriptTransportResult(
+            '{"ok":true,"resultType":"string","result":"你好"}',
+        ),
+        { resultType: 'string', result: '你好' },
+    );
+    assert.deepEqual(
+        server.decodeEvalScriptTransportResult(
+            '{"ok":true,"resultType":"json","result":"{\\"n\\":42}"}',
+        ),
+        { resultType: 'json', result: '{"n":42}' },
+    );
+    assert.throws(
+        function () {
+            server.decodeEvalScriptTransportResult('{"ok":true,"result":"legacy"}');
+        },
+        /resultType/,
     );
     assert.throws(
         function () {
             server.decodeEvalScriptTransportResult(
-                '{"ok":false,"error":"boom"}',
+                '{"ok":true,"resultType":"binary","result":"legacy"}',
             );
         },
-        /boom/,
+        /resultType/,
     );
+    let legacyError;
+    try {
+        server.decodeEvalScriptTransportResult('{"ok":false,"error":"boom"}');
+    } catch (error) {
+        legacyError = error;
+    }
+    assert.match(legacyError.message, /boom/);
+    assert.equal(legacyError.disposition, 'failed');
 });
 
 test('health and activity expose only authenticated operational state', async () => {

--- a/plugin/host/tests/live-mcp/run.mjs
+++ b/plugin/host/tests/live-mcp/run.mjs
@@ -3,6 +3,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { isDeepStrictEqual } from 'util';
 
 const sections = [
     'status',
@@ -42,6 +43,11 @@ let compId;
 let savedPath;
 function value(reply) {
     return reply && reply.structuredContent;
+}
+function parsedExecContent(reply) {
+    const envelope = value(reply);
+    if (!envelope || envelope.ok !== true || typeof envelope.content !== 'string') return null;
+    return JSON.parse(envelope.content);
 }
 function check(name, passed, detail) {
     results.push({ name, passed });
@@ -151,10 +157,10 @@ async function call(name, args) {
     return client.callTool({ name, arguments: args || {} });
 }
 async function prepareComp() {
-    const made = value(
+    const made = parsedExecContent(
         await call('ae_exec', {
             undo_group_name: 'live-build',
-            code: 'app.newProject(); var c=app.project.items.addComp("live-mcp",640,360,1,4,24); var l=c.layers.addSolid([1,0,0],"Red",100,100,1); var p=l.property("ADBE Transform Group").property("ADBE Position"); p.setValueAtTime(0,[50,50]); p.setValueAtTime(2,[400,200]); var t=c.layers.addText("live"); c.openInViewer(); JSON.stringify({ok:true,compId:String(c.id),layers:c.numLayers,keys:p.numKeys})',
+            code: 'app.newProject(); var c=app.project.items.addComp("live-mcp",640,360,1,4,24); var l=c.layers.addSolid([1,0,0],"Red",100,100,1); var p=l.property("ADBE Transform Group").property("ADBE Position"); p.setValueAtTime(0,[50,50]); p.setValueAtTime(2,[400,200]); var t=c.layers.addText("live"); c.openInViewer(); ({ok:true,compId:String(c.id),layers:c.numLayers,keys:p.numKeys})',
         }),
     );
     compId = made && made.compId;
@@ -172,7 +178,37 @@ async function main() {
     });
     await section('exec', async function () {
         const bare = value(await call('ae_exec', { code: '"hi-"+app.version' }));
-        check('exec bare result', bare && bare.ok && /^hi-/.test(bare.content), bare);
+        check(
+            'exec bare result',
+            bare && bare.ok && bare.contentType === 'text' && /^hi-/.test(bare.content),
+            bare,
+        );
+        const objectResult = value(
+            await call('ae_exec', { code: '({ok:true,n:42})' }),
+        );
+        const parsedObject = objectResult && objectResult.contentType === 'json'
+            ? JSON.parse(objectResult.content) : null;
+        check(
+            'exec preserves object result',
+            objectResult
+                && objectResult.ok
+                && objectResult.contentType === 'json'
+                && isDeepStrictEqual(parsedObject, { ok: true, n: 42 }),
+            objectResult,
+        );
+        const arrayResult = value(
+            await call('ae_exec', { code: '[1, "two", {three: 3}]' }),
+        );
+        const parsedArray = arrayResult && arrayResult.contentType === 'json'
+            ? JSON.parse(arrayResult.content) : null;
+        check(
+            'exec preserves mixed array result',
+            arrayResult
+                && arrayResult.ok
+                && arrayResult.contentType === 'json'
+                && isDeepStrictEqual(parsedArray, [1, 'two', { three: 3 }]),
+            arrayResult,
+        );
         const empty = await call('ae_exec', { code: 'var x=1;' });
         check('exec undefined is tool error', empty.isError && value(empty).ok === false, value(empty));
         const thrown = await call('ae_exec', { code: 'throw new Error("live-boom")' });
@@ -282,12 +318,12 @@ async function main() {
         );
         savedPath = path.join(os.tmpdir(), 'ae-mcp-live', 'live-' + Date.now() + '.aep');
         fs.mkdirSync(path.dirname(savedPath), { recursive: true });
-        const saved = value(
+        const saved = parsedExecContent(
             await call('ae_exec', {
                 code:
                     'app.project.save(new File(' +
                     JSON.stringify(savedPath) +
-                    ')); JSON.stringify({ok:true,file:app.project.file.fsName})',
+                    ')); ({ok:true,file:app.project.file.fsName})',
             }),
         );
         check('save disposable project', saved && saved.ok && saved.file, saved);
@@ -316,9 +352,9 @@ async function main() {
         );
     });
     await section('validateExpressions', async function () {
-        const setup = value(
+        const setup = parsedExecContent(
             await call('ae_exec', {
-                code: 'var c=AEMCP.compById(' + JSON.stringify(Number(compId)) + '); var bad=c.layers.addSolid([1,1,1],"bad",10,10,1); bad.property("ADBE Transform Group").property("ADBE Opacity").expression="thisIsNotDefined"; var good=c.layers.addSolid([1,1,1],"good",10,10,1); good.property("ADBE Transform Group").property("ADBE Opacity").expression="time*0+100"; JSON.stringify({ok:true})',
+                code: 'var c=AEMCP.compById(' + JSON.stringify(Number(compId)) + '); var bad=c.layers.addSolid([1,1,1],"bad",10,10,1); bad.property("ADBE Transform Group").property("ADBE Opacity").expression="thisIsNotDefined"; var good=c.layers.addSolid([1,1,1],"good",10,10,1); good.property("ADBE Transform Group").property("ADBE Opacity").expression="time*0+100"; ({ok:true})',
             }),
         );
         const checked = value(
@@ -513,7 +549,7 @@ async function main() {
         }
     await section('perf', async function () {
         const script = fs.readFileSync(new URL('../../mcp/tools/read.perf.jsx', import.meta.url), 'utf8');
-        const perf = value(await call('ae_exec', { code: script, timeout_sec: 300 }));
+        const perf = parsedExecContent(await call('ae_exec', { code: script, timeout_sec: 300 }));
         check('perf fixture', perf && perf.ok, perf);
         const perfComps = value(await call('ae_read', { target: 'comps', filter: { nameContains: 'ae_read_perf' } }));
         const perfComp = perfComps && perfComps.items && perfComps.items[0] ? perfComps.items[0].itemId : null;

--- a/plugin/host/tests/node15-spike.js
+++ b/plugin/host/tests/node15-spike.js
@@ -70,10 +70,12 @@ async function main() {
     server.setCSInterface({
         evalScript: function (jsx, callback) {
             if (jsx.indexOf('NODE15_LONG_CALL') !== -1) {
-                setTimeout(function () { callback('{"ok":true,"result":"long-result"}'); }, 31000);
+                setTimeout(function () {
+                    callback('{"ok":true,"resultType":"string","result":"long-result"}');
+                }, 31000);
                 return;
             }
-            callback('{"ok":true,"result":"bridge-result"}');
+            callback('{"ok":true,"resultType":"string","result":"bridge-result"}');
         },
     });
     const app = server.buildApp();


### PR DESCRIPTION
Closes #254.

## 问题(真机复现,2026-08-20)

`ae_exec` 的 ASCII 传输信封在 JSX 侧对最终值做 `String(v)`,结构在离开 AE 前就被摧毁:

- `({ok:true, n:42})` → `"[object Object]"` → 下游"像 JSON 就试 parse"猜测层报解析错误
- `[1,"two",{three:3}]` → **`ok:true` 携带 `"1,two,[object Object]"` 静默损毁**(最恶劣:成功状态+错误数据)

## 修复

- 信封带显式判别:`{ok, resultType: "string"|"json", result}`;缺失/未知 resultType 按无效信封硬失败
- JSX 侧自包含 **ES3 序列化器**(无 `JSON` 全局、无 `Array.isArray`、无 `indexOf`;逐属性 try/catch;`NaN/Infinity→null`;undefined/函数按 JSON.stringify 语义):数字/布尔/null/纯 Object/纯 Array 在 AE 内序列化为规范 JSON 文本
- **宿主对象(CompItem/Layer/Date 等)不深遍历**,保持 `String(v)` 叶节点;循环引用/深度>12/序列化>1,000,000 字符按确定性错误返回并提示改用更小投影;信封维持 ASCII-only
- `structuredContent` 增加 `contentType: "text"|"json"`,`content` 恒为字符串;`ae_exec` 路径彻底移除 JSON 嗅探;**其余工具的结果解析字节不变**(它们的 JSX 程序按契约返回 JSON 文本,`parseJsxResult` 原样保留);`ae_exec` 补 outputSchema(顶层无组合子)
- `undefined` / 抛错 / 空串语义与三值 disposition 全部保持

## 验证(验收方亲跑)

- 宿主套件 **169 过 / 0 败 / 16 平台跳过**(worker 沙箱与我本机双跑一致)
- **AE 2026 真机(26.3x87)live 套件 44/44**,exec 段 6/6:对象 → `content:"{\"ok\":true,\"n\":42}", contentType:"json"`;混合数组 → `"[1,\"two\",{\"three\":3}]"`;字符串/undefined/throw 旧语义逐字保持
- stdio shim 外部客户端路径同轮验证(typed envelope 已在 `/exec` HTTP 载荷与 MCP 面同时生效,增量兼容)

实现:Codex worker **Sol**(gpt-5.6-sol);评审/测试/提交:orchestrator。

> owner 合并命令(规则集 owner-only):
> ```
> gh pr merge <本PR号> --squash --delete-branch --admin
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)