### PR TITLE
release: bump product version to 0.10.0 and cut the v0.10.0-rc.1 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### Unreleased
 
+### [0.10.0-rc.1] — 2026-08-22
+
 #### ✨ 新增
 
 - **`ae_previewFrame` 区间拼图与 A/B 像素差分**——新增 `range:{start,end,count}` 等距采样、`layout:'grid'` 带时间码对比表，以及可引用本次时刻或最近 50 次进程内捕获的 `compare`；差分返回热力图、并排图、变化比例 / 像素数 / 均值 / 最大差值与外接框，所有合成、重采样和缩放均由 CEP 宿主的零依赖 PNG 路径完成，不依赖 Chromium canvas。
@@ -322,6 +324,8 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ## English
 
 ### Unreleased
+
+### [0.10.0-rc.1] — 2026-08-22
 
 #### ✨ Added
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ English | [简体中文](README.zh-CN.md)
 **One-line setup prompt — paste this into Claude Code or another AI agent:**
 
 ```text
-Install the ae-mcp ZXP and AEX from the v0.9.6 release, open Window > Extensions
+Install the ae-mcp ZXP and AEX from the v0.10.0-rc.1 pre-release, open Window > Extensions
 > ae-mcp in After Effects, then connect Claude Code with `claude mcp add
 --transport http ae http://127.0.0.1:11488/mcp`; for Claude Desktop, configure
 the extension's `host/stdio-shim.js` with the system Node executable and ask me

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 **一行安装提示词——复制给 Claude Code 或其它 AI agent：**
 
 ```text
-请从 v0.9.6 发布页安装 ae-mcp 的 ZXP 和 AEX，在 After Effects 中打开
+请从 v0.10.0-rc.1 预发布页安装 ae-mcp 的 ZXP 和 AEX，在 After Effects 中打开
 Window > Extensions > ae-mcp，然后用 `claude mcp add --transport http ae
 http://127.0.0.1:11488/mcp` 接入 Claude Code；Claude Desktop 则使用系统 Node
 执行扩展目录里的 `host/stdio-shim.js`，并在测试 `ae_ping` 前提醒我重新启动

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.9.6"
+                   ExtensionBundleVersion="0.10.0"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.9.6" />
+        <Extension Id="com.aemcp.panel" Version="0.10.0" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20412,7 +20412,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.9.6",
+    version: "0.10.0",
     private: true,
     type: "module",
     scripts: {
@@ -27698,7 +27698,7 @@
   // src/cep/mcpClient.js
   init_cep_runtime_inject();
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.9.6";
+  var PANEL_VERSION = "0.10.0";
   function defaultFetch() {
     if (globalThis.window && globalThis.window.fetch) {
       return globalThis.window.fetch.bind(globalThis.window);

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1048,7 +1048,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-        version: input.version || '0.9.6',
+        version: input.version || '0.10.0',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.9.6",
+      "version": "0.10.0",
       "dependencies": {
         "express": "4.22.2"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.9.6",
+      "version": "0.10.0",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,5 +1,5 @@
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.9.6';
+export const PANEL_VERSION = '0.10.0';
 
 function defaultFetch() {
   if (globalThis.window && globalThis.window.fetch) {

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -11,7 +11,7 @@ param(
     [string]$CertPassword = '',
     [string]$CertPath = '',
     [string]$OutputPath = '',
-    [string]$Version = '0.9.6',
+    [string]$Version = '0.10.0',
     [string]$Tsa = 'http://timestamp.digicert.com',
     [switch]$SkipSigning
 )

--- a/scripts/package/test/freeze-signed-manifests.test.mjs
+++ b/scripts/package/test/freeze-signed-manifests.test.mjs
@@ -22,7 +22,7 @@ test('writes canonical freeze evidence bound to the direct extension stage', asy
   const evidence = await freezeSignedManifestsWithEvidence({
     root: signingRoot,
     platform: 'windows-x64',
-    version: '0.9.6',
+    version: '0.10.0',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
     evidencePath,
@@ -56,21 +56,21 @@ test('freezes a changed direct payload without adding retired payload roots', as
   await assert.rejects(verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.9.6',
+    version: '0.10.0',
     sourceCommitSha: h.input.sourceCommitSha,
   }), { code: 'BUNDLE_FILE_METADATA_MISMATCH' });
 
   const result = await freezeSignedManifests({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.9.6',
+    version: '0.10.0',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
   });
   await verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.9.6',
+    version: '0.10.0',
     sourceCommitSha: h.input.sourceCommitSha,
   });
   assert.equal(result.signedBundleManifestSha256, await sha256File(
@@ -91,7 +91,7 @@ test('refuses to freeze when the asserted source digest is malformed', async (t)
   await assert.rejects(freezeSignedManifests({
     root: h.outDir,
     platform: 'windows-x64',
-    version: '0.9.6',
+    version: '0.10.0',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256: 'bad',
   }), /source stage digest/i);

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { canonicalJson } from '../../lib/manifest.mjs';
 
 export const SOURCE_COMMIT_SHA = '0123456789abcdef0123456789abcdef01234567';
-export const PRODUCT_VERSION = '0.9.6';
+export const PRODUCT_VERSION = '0.10.0';
 
 export function sha256Bytes(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -69,8 +69,8 @@ async function writePlugin(repoRoot) {
   const plugin = path.join(repoRoot, 'plugin');
   await writeFixtureFile(plugin, 'CSXS/manifest.xml', [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.9.6">',
-    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.9.6" /></ExtensionList>',
+    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.0">',
+    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.0" /></ExtensionList>',
     '  <ExecutionEnvironment><HostList><Host Name="AEFT" Version="[23.0,26.9]" />',
     '  </HostList></ExecutionEnvironment>',
     '</ExtensionManifest>',

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { verifyWindowsZxpStage } from '../verify-windows-zxp-stage.mjs';
 
-const VERSION = '0.9.6';
+const VERSION = '0.10.0';
 
 async function write(root, relative, value) {
   const file = path.join(root, ...relative.split('/'));

--- a/scripts/release/run-signing-plan.mjs
+++ b/scripts/release/run-signing-plan.mjs
@@ -23,7 +23,7 @@ import { freezeSignedManifests as foundationFreezeSignedManifests } from '../pac
 import { sha256Directory as foundationSha256Directory } from '../package/lib/files.mjs';
 import { collectManifestEntries, copyTree } from '../package/lib/manifest.mjs';
 
-const RELEASE_VERSION = '0.9.6';
+const RELEASE_VERSION = '0.10.0';
 const CANDIDATE_SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const PLATFORMS = new Set(['macos-arm64', 'windows-x64']);

--- a/scripts/release/signing-report.mjs
+++ b/scripts/release/signing-report.mjs
@@ -176,7 +176,7 @@ function expectedOutputRoles(platform) {
 }
 
 function expectedOutputName(platform, role) {
-  return `ae-mcp-panel-v0.9.6-${platform}.${role}`;
+  return `ae-mcp-panel-v0.10.0-${platform}.${role}`;
 }
 
 function validateIdentityFields(input) {

--- a/scripts/release/test/artifact-manifest.test.mjs
+++ b/scripts/release/test/artifact-manifest.test.mjs
@@ -12,7 +12,7 @@ import { makeArtifactManifestFixture } from './helpers/artifact-manifest-fixture
 test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.9.6',
+    version: '0.10.0',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,
@@ -32,7 +32,7 @@ test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence'
 test('artifact manifest rejects an unsupported artifact role and malformed evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.9.6',
+    version: '0.10.0',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,

--- a/scripts/release/test/attestation.test.mjs
+++ b/scripts/release/test/attestation.test.mjs
@@ -20,7 +20,7 @@ const MAC_COMMANDS = [
 ];
 
 function report(platform = 'windows-x64', result = 'PASS') {
-  const name = `ae-mcp-panel-v0.9.6-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
+  const name = `ae-mcp-panel-v0.10.0-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
   return {
     schemaVersion: 1,
     platform,

--- a/scripts/release/test/helpers/artifact-manifest-fixture.mjs
+++ b/scripts/release/test/helpers/artifact-manifest-fixture.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { canonicalJson } from '../../../package/lib/manifest.mjs';
 import { canonicalStringify, sha256File } from '../../artifact-manifest.mjs';
 
-export const PRODUCT_VERSION = '0.9.6';
+export const PRODUCT_VERSION = '0.10.0';
 export const PRODUCT_SCENARIOS = [
   'clean-install-and-upgrade-rollback',
   'permission-denial-and-recovery',

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -21,7 +21,7 @@ async function signingInput(t, platform) {
   t.after(() => rm(root, { recursive: true, force: true }));
   const input = {
     platform,
-    version: '0.9.6',
+    version: '0.10.0',
     candidateSha: CANDIDATE_SHA,
     stageRoot: path.join(root, 'stage'),
     signingRoot: path.join(root, 'signing'),

--- a/scripts/release/test/validate-attestation-comment.test.mjs
+++ b/scripts/release/test/validate-attestation-comment.test.mjs
@@ -22,7 +22,7 @@ function report(result = 'PASS') {
     candidateSha: 'b'.repeat(40),
     workflowRunId: '42',
     artifactId: '101',
-    artifactName: 'ae-mcp-panel-v0.9.6-windows-x64.zxp',
+    artifactName: 'ae-mcp-panel-v0.10.0-windows-x64.zxp',
     artifactSha256: 'c'.repeat(64),
     osVersion: 'Windows 10.0.26100',
     codexVersion: '0.144.0-alpha.4',

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -26,7 +26,7 @@ const MAC_COMMANDS = [
 function artifact(platform, id) {
   return {
     artifactId: String(id),
-    name: `ae-mcp-panel-v0.9.6-${platform}.zxp`,
+    name: `ae-mcp-panel-v0.10.0-${platform}.zxp`,
     platform,
     role: 'zxp',
     sha256: String(id).repeat(64).slice(0, 64),
@@ -62,7 +62,7 @@ function fixture() {
   const windows = artifact('windows-x64', 102);
   const manifest = {
     schemaVersion: 1,
-    version: '0.9.6',
+    version: '0.10.0',
     candidateSha: CANDIDATE_SHA,
     workflowRunId: '42',
     artifacts: [mac, windows],

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import test from 'node:test';
 
-const VERSION = '0.9.6';
+const VERSION = '0.10.0';
 
 async function text(relative) {
   return fs.readFile(relative, 'utf8');

--- a/scripts/release/verify-release-inputs.mjs
+++ b/scripts/release/verify-release-inputs.mjs
@@ -6,7 +6,7 @@ const SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const DECIMAL_ID = /^\d+$/;
 const POSITIVE_DECIMAL_ID = /^[1-9]\d*$/;
-const VERSION = '0.9.6';
+const VERSION = '0.10.0';
 
 function recordIdentity(record, field) {
   return record?.[field] ?? record?.report?.[field];


### PR DESCRIPTION
Version bump for the **v0.10.0-rc.1 pre-release** (product version `0.10.0`; the rc suffix lives in the tag, the GitHub release, the changelog heading and the README link).

- host/panel `package.json` + locks, CSXS manifest, `PANEL_VERSION`, native client default, `package-zxp.ps1`, release verify/signing scripts and their tests: 0.9.6 → 0.10.0
- CHANGELOG: the Unreleased entries become `[0.10.0-rc.1] — 2026-08-22` (zh + en, entries untouched); README one-line setup now points at the rc.1 pre-release
- panel bundle rebuilt; remaining `0.9.6` strings are test sample data only

Verification: panel 482/481/1 skipped, host 223/207/16 skipped, release+package suites' failing set identical to the main baseline (Windows POSIX-only cases), `git diff --check` clean, `verify-bundle` clean.

After merge: build the AEX with `--evidence` from the merge commit, package and sign the ZXP, publish `v0.10.0-rc.1` as a pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)