### PR TITLE
test(host): drive the unref'd approval timeout with mock timers

### DIFF
--- a/plugin/host/mcp/approval-gate.test.js
+++ b/plugin/host/mcp/approval-gate.test.js
@@ -62,7 +62,9 @@ test('enforce allows null and none policies and denies readonly writes', async (
     });
 });
 
-test('enforce reports missing prompt API, accepted approval, and exact decline text', async () => {
+test('enforce reports missing prompt API, accepted approval, and exact decline text', async (t) => {
+    // The approval timer is unref'd, so the test drives it with mock time.
+    t.mock.timers.enable({ apis: ['setTimeout'] });
     assert.deepEqual(await enforce('ae_exec', context('manual'), {}), {
         ok: false, error: NO_PROMPT_API,
     });
@@ -81,7 +83,9 @@ test('enforce reports missing prompt API, accepted approval, and exact decline t
     });
 
     const timedOut = new ApprovalQueue({ timeoutMs: 5 });
-    assert.deepEqual(await enforce('ae_exec', context('manual'), { approvals: timedOut }), {
+    const timeoutResult = enforce('ae_exec', context('manual'), { approvals: timedOut });
+    t.mock.timers.tick(5);
+    assert.deepEqual(await timeoutResult, {
         ok: false, error: 'User denied this action.',
     });
 });

--- a/plugin/host/mcp/approvals.test.js
+++ b/plugin/host/mcp/approvals.test.js
@@ -37,9 +37,13 @@ test('approval request resolves decline and rejects invalid resolutions', async 
     assert.equal(await pending, 'decline');
 });
 
-test('approval timeout is a decline', async () => {
+test('approval timeout is a decline', async (t) => {
+    // The approval timer is unref'd, so the test drives it with mock time.
+    t.mock.timers.enable({ apis: ['setTimeout'] });
     const approvals = new ApprovalQueue({ timeoutMs: 5 });
-    const result = await approvals.request(details());
+    const pending = approvals.request(details());
+    t.mock.timers.tick(5);
+    const result = await pending;
     assert.equal(result, 'decline');
     assert.deepEqual(approvals.list(), []);
 });


### PR DESCRIPTION
## 问题

Node 20 上 `cd plugin/host && npm test` 固定出现 2 条 `cancelledByParent`（`approval-gate.test.js:65`、`approvals.test.js:40`）：`ApprovalQueue` 的超时计时器是有意 `unref()` 的，这两个用例 `await` 时没有任何东西撑着事件循环，Node 20 的 test runner 先退出了；Node 24（CI 用的版本）碰巧能等到。详见 #303。

## 改动

只改测试：启用 `node:test` 的 mock timers，`tick(5)` 推过超时再 `await`。`unref()` 保留，`approvals.js` / `approval-gate.js` 不动。用例不再依赖真实等待或 runner 的保活行为。

## 验证（macOS 26.5.2 arm64）

```
# Node 20.20.2
node --test mcp/approval-gate.test.js mcp/approvals.test.js   → # pass 7  # cancelled 0   (连续 4 次一致)
npm test                                                       → # tests 223  # pass 223  # fail 0  # cancelled 0

# Node 24.17.0（CI 版本）
node --test mcp/approval-gate.test.js mcp/approvals.test.js   → pass 7  fail 0  cancelled 0
```

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
