### PR TITLE
test(package): resolve os.tmpdir() before building the Windows dev-install fixture

### DIFF
--- a/scripts/package/test/install-dev-windows.test.mjs
+++ b/scripts/package/test/install-dev-windows.test.mjs
@@ -18,8 +18,10 @@ const SOURCE_COMMIT = 'a'.repeat(40);
 const PRODUCT_VERSION = '0.9.2';
 
 async function makeFixture(t) {
+  // macOS places its temp directory below /var, a symlink rejected by the install guard.
+  const temporaryRoot = await fs.promises.realpath(os.tmpdir());
   const root = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'ae-mcp-install-windows-'),
+    path.join(temporaryRoot, 'ae-mcp-install-windows-'),
   );
   t.after(() => fs.promises.rm(root, { force: true, recursive: true }));
   const artifactDirectory = path.join(root, 'build');


### PR DESCRIPTION
## 问题

在 macOS 上 `node --test scripts/package/test/install-dev-windows.test.mjs` 27 条里 23 条失败，全部是 `build receipt cannot traverse a symbolic link`。夹具用 `os.tmpdir()`（`/var/folders/…`，`/var → /private/var` 是符号链接），被测代码的符号链接守卫按设计拒绝了它。详见 #302。

## 改动

只改夹具：`mkdtemp` 之前先 `fs.promises.realpath(os.tmpdir())`。守卫（`native/ae-plugin/install-dev-windows.mjs:112/:235`）不动。

## 验证（macOS 26.5.2 arm64，Node 20.20.2，默认 `TMPDIR=/var/folders/…`）

```
node --test scripts/package/test/install-dev-windows.test.mjs
# tests 27  # pass 27  # fail 0

node --test scripts/release/test/*.test.mjs scripts/package/test/*.test.mjs
# tests 254  # pass 253  # fail 0  # skipped 1   (Windows 命名管道用例，预期 skip)

node --test scripts/package/test/no-platform-leaks.test.mjs
# pass 2  # fail 0
```

Windows 上 `os.tmpdir()` 本来就不是符号链接，`realpath` 是恒等变换，CI 行为不变。

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
