### PR TITLE
panel(provider): probe <baseURL>/v1/models from the Provider Manager to fill model ids (#306)

### DIFF
--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -32864,6 +32864,26 @@ ${command}`
               ]
             }
           ) }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("label", { style: {
+            display: "flex",
+            gap: 6,
+            alignItems: "center",
+            font: "400 11px/1.35 var(--font-ui)"
+          }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
+              "input",
+              {
+                type: "checkbox",
+                checked: draft.allowInsecureHttp,
+                onChange: (event) => setDraft({
+                  ...draft,
+                  allowInsecureHttp: event.target.checked
+                })
+              }
+            ),
+            t.insecure
+          ] }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Field, { label: t.apiKey, caption: t.openCodeKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) }),
           /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { style: { display: "flex", gap: 6, alignItems: "center" }, children: [
             /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
               Input,
@@ -32908,26 +32928,6 @@ ${command}`
               }
             )
           ] }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("label", { style: {
-            display: "flex",
-            gap: 6,
-            alignItems: "center",
-            font: "400 11px/1.35 var(--font-ui)"
-          }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
-              "input",
-              {
-                type: "checkbox",
-                checked: draft.allowInsecureHttp,
-                onChange: (event) => setDraft({
-                  ...draft,
-                  allowInsecureHttp: event.target.checked
-                })
-              }
-            ),
-            t.insecure
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Field, { label: t.apiKey, caption: t.openCodeKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) }),
           error ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("div", { style: {
             font: "400 10px/1.4 var(--font-ui)",
             color: "var(--warn)"

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -11889,17 +11889,17 @@
           return function() {
             var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
             var query = _ref.query, _ref$success = _ref.success, success = _ref$success === void 0 ? function() {
-            } : _ref$success, _ref$failure = _ref.failure, failure = _ref$failure === void 0 ? function() {
+            } : _ref$success, _ref$failure = _ref.failure, failure2 = _ref$failure === void 0 ? function() {
             } : _ref$failure, options = _objectWithoutProperties(_ref, ["query", "success", "failure"]);
             var item2 = getItemByQuery(state2.items, query);
             if (!item2) {
-              failure({
+              failure2({
                 error: createResponse("error", 0, "Item not found"),
                 file: null
               });
               return;
             }
-            itemHandler(item2, success, failure, options || {});
+            itemHandler(item2, success, failure2, options || {});
           };
         };
         var actions = function actions2(dispatch2, query, state2) {
@@ -12035,7 +12035,7 @@
             },
             ADD_ITEMS: function ADD_ITEMS(_ref6) {
               var items = _ref6.items, index = _ref6.index, interactionMethod = _ref6.interactionMethod, _ref6$success = _ref6.success, success = _ref6$success === void 0 ? function() {
-              } : _ref6$success, _ref6$failure = _ref6.failure, failure = _ref6$failure === void 0 ? function() {
+              } : _ref6$success, _ref6$failure = _ref6.failure, failure2 = _ref6$failure === void 0 ? function() {
               } : _ref6$failure;
               var currentIndex = index;
               if (index === -1 || typeof index === "undefined") {
@@ -12060,7 +12060,7 @@
                   });
                 });
               });
-              Promise.all(promises).then(success).catch(failure);
+              Promise.all(promises).then(success).catch(failure2);
             },
             /**
              * @param source
@@ -12069,10 +12069,10 @@
              */
             ADD_ITEM: function ADD_ITEM(_ref7) {
               var source = _ref7.source, _ref7$index = _ref7.index, index = _ref7$index === void 0 ? -1 : _ref7$index, interactionMethod = _ref7.interactionMethod, _ref7$success = _ref7.success, success = _ref7$success === void 0 ? function() {
-              } : _ref7$success, _ref7$failure = _ref7.failure, failure = _ref7$failure === void 0 ? function() {
+              } : _ref7$success, _ref7$failure = _ref7.failure, failure2 = _ref7$failure === void 0 ? function() {
               } : _ref7$failure, _ref7$options = _ref7.options, options = _ref7$options === void 0 ? {} : _ref7$options;
               if (isEmpty(source)) {
-                failure({
+                failure2({
                   error: createResponse("error", 0, "No source"),
                   file: null
                 });
@@ -12088,7 +12088,7 @@
                     source,
                     error: error2
                   });
-                  failure({ error: error2, file: null });
+                  failure2({ error: error2, file: null });
                   return;
                 }
                 var _item = getActiveItems(state2.items)[0];
@@ -12107,7 +12107,7 @@
                       index,
                       interactionMethod,
                       success,
-                      failure,
+                      failure: failure2,
                       options
                     });
                   }).catch(function() {
@@ -12161,7 +12161,7 @@
                       sub: error3.code + " (" + error3.body + ")"
                     }
                   });
-                  failure({ error: error3, file: createItemAPI(item2) });
+                  failure2({ error: error3, file: createItemAPI(item2) });
                   return;
                 }
                 dispatch2("DID_THROW_ITEM_LOAD_ERROR", {
@@ -12179,7 +12179,7 @@
                   error: error3.status,
                   status: error3.status
                 });
-                failure({ error: error3.status, file: createItemAPI(item2) });
+                failure2({ error: error3.status, file: createItemAPI(item2) });
               });
               item2.on("load-abort", function() {
                 dispatch2("REMOVE_ITEM", { query: id2 });
@@ -12326,20 +12326,20 @@
               );
             },
             REQUEST_PREPARE_OUTPUT: function REQUEST_PREPARE_OUTPUT(_ref9) {
-              var item2 = _ref9.item, success = _ref9.success, _ref9$failure = _ref9.failure, failure = _ref9$failure === void 0 ? function() {
+              var item2 = _ref9.item, success = _ref9.success, _ref9$failure = _ref9.failure, failure2 = _ref9$failure === void 0 ? function() {
               } : _ref9$failure;
               var err = {
                 error: createResponse("error", 0, "Item not found"),
                 file: null
               };
-              if (item2.archived) return failure(err);
+              if (item2.archived) return failure2(err);
               applyFilterChain("PREPARE_OUTPUT", item2.file, { query, item: item2 }).then(
                 function(result) {
                   applyFilterChain("COMPLETE_PREPARE_OUTPUT", result, {
                     query,
                     item: item2
                   }).then(function(result2) {
-                    if (item2.archived) return failure(err);
+                    if (item2.archived) return failure2(err);
                     success(result2);
                   });
                 }
@@ -12381,7 +12381,7 @@
             RETRY_ITEM_LOAD: getItemByQueryFromState(state2, function(item2) {
               item2.retryLoad();
             }),
-            REQUEST_ITEM_PREPARE: getItemByQueryFromState(state2, function(item2, _success, failure) {
+            REQUEST_ITEM_PREPARE: getItemByQueryFromState(state2, function(item2, _success, failure2) {
               dispatch2(
                 "REQUEST_PREPARE_OUTPUT",
                 {
@@ -12394,12 +12394,12 @@
                       output: file2
                     });
                   },
-                  failure
+                  failure: failure2
                 },
                 true
               );
             }),
-            REQUEST_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2, success, failure) {
+            REQUEST_ITEM_PROCESSING: getItemByQueryFromState(state2, function(item2, success, failure2) {
               var itemCanBeQueuedForProcessing = (
                 // waiting for something
                 item2.status === ItemStatus.IDLE || // processing went wrong earlier
@@ -12410,7 +12410,7 @@
                   return dispatch2("REQUEST_ITEM_PROCESSING", {
                     query: item2,
                     success,
-                    failure
+                    failure: failure2
                   });
                 };
                 var process2 = function process3() {
@@ -12433,16 +12433,16 @@
               if (item2.status === ItemStatus.PROCESSING_QUEUED) return;
               item2.requestProcessing();
               dispatch2("DID_REQUEST_ITEM_PROCESSING", { id: item2.id });
-              dispatch2("PROCESS_ITEM", { query: item2, success, failure }, true);
+              dispatch2("PROCESS_ITEM", { query: item2, success, failure: failure2 }, true);
             }),
-            PROCESS_ITEM: getItemByQueryFromState(state2, function(item2, success, failure) {
+            PROCESS_ITEM: getItemByQueryFromState(state2, function(item2, success, failure2) {
               var maxParallelUploads = query("GET_MAX_PARALLEL_UPLOADS");
               var totalCurrentUploads = query("GET_ITEMS_BY_STATUS", ItemStatus.PROCESSING).length;
               if (totalCurrentUploads === maxParallelUploads) {
                 state2.processingQueue.push({
                   id: item2.id,
                   success,
-                  failure
+                  failure: failure2
                 });
                 return;
               }
@@ -12450,7 +12450,7 @@
               var processNext = function processNext2() {
                 var queueEntry = state2.processingQueue.shift();
                 if (!queueEntry) return;
-                var id2 = queueEntry.id, success2 = queueEntry.success, failure2 = queueEntry.failure;
+                var id2 = queueEntry.id, success2 = queueEntry.success, failure3 = queueEntry.failure;
                 var itemReference = getItemByQuery(state2.items, id2);
                 if (!itemReference || itemReference.archived) {
                   processNext2();
@@ -12458,7 +12458,7 @@
                 }
                 dispatch2(
                   "PROCESS_ITEM",
-                  { query: id2, success: success2, failure: failure2 },
+                  { query: id2, success: success2, failure: failure3 },
                   true
                 );
               };
@@ -12479,7 +12479,7 @@
                 }
               });
               item2.onOnce("process-error", function(error2) {
-                failure({ error: error2, file: createItemAPI(item2) });
+                failure2({ error: error2, file: createItemAPI(item2) });
                 processNext();
               });
               item2.onOnce("process-abort", function() {
@@ -12528,7 +12528,7 @@
             RELEASE_ITEM: getItemByQueryFromState(state2, function(item2) {
               item2.release();
             }),
-            REMOVE_ITEM: getItemByQueryFromState(state2, function(item2, success, failure, options) {
+            REMOVE_ITEM: getItemByQueryFromState(state2, function(item2, success, failure2, options) {
               var removeFromView = function removeFromView2() {
                 var id2 = item2.id;
                 getItemById(state2.items, id2).archive();
@@ -15719,7 +15719,7 @@
                 success: function success(item2) {
                   resolve(item2);
                 },
-                failure: function failure(error2) {
+                failure: function failure2(error2) {
                   reject(error2);
                 }
               });
@@ -15780,7 +15780,7 @@
                 success: function success(item2) {
                   resolve(item2);
                 },
-                failure: function failure(error2) {
+                failure: function failure2(error2) {
                   reject(error2);
                 }
               });
@@ -21794,6 +21794,53 @@
     return { completeSpawnEnv, resolveExecutable, run, spawn };
   }
 
+  // src/cep/platform/http-json.js
+  init_cep_runtime_inject();
+  function createHttpJsonRequester({ httpImpl, httpsImpl }) {
+    return function requestJson({ url, headers = {}, timeoutMs = 8e3 }) {
+      return new Promise((resolve, reject) => {
+        const target = url instanceof URL ? url : new URL(String(url));
+        const transport = target.protocol === "https:" ? httpsImpl : target.protocol === "http:" ? httpImpl : null;
+        if (!(transport == null ? void 0 : transport.request)) {
+          reject(new Error("HTTP transport is unavailable"));
+          return;
+        }
+        let settled = false;
+        const finish = (callback, value) => {
+          if (settled) return;
+          settled = true;
+          callback(value);
+        };
+        const req = transport.request(target, { method: "GET", headers }, (res) => {
+          var _a;
+          let text = "";
+          (_a = res.setEncoding) == null ? void 0 : _a.call(res, "utf8");
+          res.on("data", (chunk) => {
+            text += String(chunk);
+          });
+          res.on("error", (error) => finish(reject, error));
+          res.on("end", () => {
+            let json = null;
+            try {
+              json = JSON.parse(text);
+            } catch {
+            }
+            const status = Number(res.statusCode || 0);
+            finish(resolve, { ok: status >= 200 && status < 300, status, json, text });
+          });
+        });
+        req.on("error", (error) => finish(reject, error));
+        req.setTimeout(timeoutMs, () => {
+          const error = new Error("Request timed out");
+          error.code = "ETIMEDOUT";
+          req.destroy(error);
+          finish(reject, error);
+        });
+        req.end();
+      });
+    };
+  }
+
   // src/cep/platform/macos.js
   function normalizedExecutableName(value) {
     return String(value || "").trim().split("/").at(-1).replace(/\.exe$/i, "").toLowerCase();
@@ -21808,6 +21855,7 @@
       pid: deps.pid,
       paths,
       fs: deps.fs,
+      requestJson: createHttpJsonRequester(deps),
       ...boundary,
       async processAlive({ pid } = {}) {
         const processId = Number(pid);
@@ -21903,6 +21951,7 @@
       pid: deps.pid,
       paths,
       fs: deps.fs,
+      requestJson: createHttpJsonRequester(deps),
       ...boundary,
       async processAlive({ pid } = {}) {
         const processId = Number(pid);
@@ -22013,6 +22062,8 @@
       temp: os.tmpdir(),
       env,
       fs: require2("fs"),
+      httpImpl: require2("http"),
+      httpsImpl: require2("https"),
       spawnImpl: require2("child_process").spawn,
       now: () => Date.now()
     };
@@ -29304,9 +29355,9 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
               env: spawnEnv
             });
           } catch (error) {
-            const failure = error instanceof Error ? error : new Error((error == null ? void 0 : error.message) || String(error || "Claude CLI spawn failed"));
-            failure.spawnError = true;
-            throw failure;
+            const failure2 = error instanceof Error ? error : new Error((error == null ? void 0 : error.message) || String(error || "Claude CLI spawn failed"));
+            failure2.spawnError = true;
+            throw failure2;
           }
         } finally {
           if (spawnEnv) delete spawnEnv.ANTHROPIC_AUTH_TOKEN;
@@ -30682,9 +30733,9 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         platformId: adapter.id || ""
       };
       const probeSecrets = () => [];
-      const failure = (detail) => ({ loggedIn: false, runtimeOk: false, detail, ...diag });
+      const failure2 = (detail) => ({ loggedIn: false, runtimeOk: false, detail, ...diag });
       if (!cliInfo.ok) {
-        return failure(redactText(cliInfo.detail || "codex CLI is unavailable", probeSecrets()));
+        return failure2(redactText(cliInfo.detail || "codex CLI is unavailable", probeSecrets()));
       }
       const executable = cliInfo.executable || {
         ok: true,
@@ -30703,7 +30754,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           env: spawnEnv
         });
       } catch (error) {
-        return failure(redactText(error && error.message ? error.message : String(error), probeSecrets()));
+        return failure2(redactText(error && error.message ? error.message : String(error), probeSecrets()));
       }
       const probeRpc = createRpc({ writeLine: (line) => probeProc.stdin.write(line) });
       const reader = createNdjsonReader((message) => probeRpc.handleMessage(message));
@@ -30743,15 +30794,15 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           ...diag
         };
         if (containsExactSecret(result, probeSecrets())) {
-          return failure("Provider probe metadata was rejected");
+          return failure2("Provider probe metadata was rejected");
         }
         return result;
       } catch (e) {
         const detail = redactText(e && e.message ? e.message : String(e), probeSecrets());
         if (e && e.probeTimeout) {
-          return failure("probe timeout: " + e.probeTimeout + (detail ? " | " + detail : ""));
+          return failure2("probe timeout: " + e.probeTimeout + (detail ? " | " + detail : ""));
         }
-        return failure(detail);
+        return failure2(detail);
       } finally {
         try {
           probeProc.kill();
@@ -31005,19 +31056,22 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     }
     return value;
   }
+  function canonicalOpenCodeBaseUrl(value) {
+    const root = String(value || "").replace(/\/+$/, "");
+    return root.endsWith("/v1") ? root : root + "/v1";
+  }
   function openCodeProviderDefinitions(providers) {
     const definitions = {};
     for (const raw of providers || []) {
       const provider = normalizeProvider(raw);
       if (provider.needsApiKey) continue;
-      const root = provider.baseUrl.replace(/\/+$/, "");
       definitions[provider.id] = {
         npm: provider.protocol === "openai" ? "@ai-sdk/openai-compatible" : "@ai-sdk/anthropic",
         name: provider.name,
         // Both loaders append their endpoint path ("/messages" or
         // "/chat/completions") directly to baseURL, so the injected URL must
         // carry the "/v1" segment relay endpoints expect.
-        options: { baseURL: root.endsWith("/v1") ? root : root + "/v1" },
+        options: { baseURL: canonicalOpenCodeBaseUrl(provider.baseUrl) },
         models: Object.fromEntries(provider.modelIds.map((id) => [id, { name: id }]))
       };
     }
@@ -31046,6 +31100,11 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     function hasApiKey(providerId) {
       const entry2 = auth()[normalizeOpenCodeProviderId(providerId)];
       return (entry2 == null ? void 0 : entry2.type) === "api" && typeof entry2.key === "string" && entry2.key.length > 0;
+    }
+    function readApiKey(providerId) {
+      if (!String(providerId || "").trim()) return "";
+      const entry2 = auth()[normalizeOpenCodeProviderId(providerId)];
+      return (entry2 == null ? void 0 : entry2.type) === "api" && typeof entry2.key === "string" ? entry2.key : "";
     }
     function writeAuthKey(providerId, key) {
       const value = String(key || "");
@@ -31085,6 +31144,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       filePath: () => file,
       hasApiKey,
       list,
+      readApiKey,
       remove,
       save
     });
@@ -32455,6 +32515,68 @@ ${command}`
     return { pref, channelChoices };
   }
 
+  // src/cep/openCodeModelProbe.js
+  init_cep_runtime_inject();
+  function failure(detail, apiKey) {
+    return { ok: false, detail: redactCredentialText(detail, [apiKey]) };
+  }
+  function modelIds(value) {
+    const rows = Array.isArray(value) ? value : Array.isArray(value == null ? void 0 : value.data) ? value.data : null;
+    if (!rows) return null;
+    const seen = /* @__PURE__ */ new Set();
+    const models = [];
+    for (const row of rows) {
+      const id = String(typeof row === "string" ? row : (row == null ? void 0 : row.id) || "").trim();
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        models.push(id);
+      }
+    }
+    return models;
+  }
+  async function probeOpenCodeProviderModels({
+    draft,
+    apiKey = "",
+    adapter,
+    timeoutMs = 8e3
+  }) {
+    const key = String(apiKey || "");
+    let url;
+    try {
+      url = new URL(canonicalOpenCodeBaseUrl(String((draft == null ? void 0 : draft.baseUrl) || "").trim()) + "/models");
+    } catch {
+      return failure("Provider models URL is invalid", key);
+    }
+    if (url.protocol === "http:" && (draft == null ? void 0 : draft.allowInsecureHttp) !== true) {
+      return failure("Insecure HTTP requires confirmation", key);
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return failure("Provider models URL must use HTTP or HTTPS", key);
+    }
+    const headers = { accept: "application/json" };
+    if ((draft == null ? void 0 : draft.protocol) === "openai") {
+      if (key) headers.Authorization = `Bearer ${key}`;
+    } else {
+      if (key) headers["x-api-key"] = key;
+      headers["anthropic-version"] = "2023-06-01";
+      url.searchParams.set("limit", "1000");
+    }
+    let response;
+    try {
+      response = await adapter.requestJson({ url: url.toString(), headers, timeoutMs });
+    } catch (error) {
+      return failure((error == null ? void 0 : error.message) || "Provider models request failed", key);
+    }
+    if (!(response == null ? void 0 : response.ok)) {
+      const snippet = String((response == null ? void 0 : response.text) || "").slice(0, 120).trim();
+      return failure(`HTTP ${(response == null ? void 0 : response.status) || 0}${snippet ? `: ${snippet}` : ""}`, key);
+    }
+    if (response.json === null) return failure("Provider returned a non-JSON response", key);
+    const models = modelIds(response.json);
+    if (!models) return failure("Provider models response has an unsupported shape", key);
+    return { ok: true, models, total: models.length };
+  }
+
   // src/components/settings/ProviderManagerSection.jsx
   init_cep_runtime_inject();
   var import_react44 = __toESM(require_react(), 1);
@@ -32503,6 +32625,11 @@ ${command}`
       name
     };
   }
+  function mergeProbedModelIds(current, discovered) {
+    const existing = String(current || "").split(/[\s,]+/).map((id) => id.trim()).filter(Boolean);
+    const merged = Array.from(/* @__PURE__ */ new Set([...existing, ...(discovered || []).map((id) => String(id).trim())]));
+    return { modelId: merged.filter(Boolean).join(", "), added: merged.length - new Set(existing).size };
+  }
 
   // src/components/settings/ProviderManagerSection.jsx
   var import_jsx_runtime42 = __toESM(require_jsx_runtime(), 1);
@@ -32525,6 +32652,9 @@ ${command}`
       openCodeKeyCap: "\u5BC6\u94A5\u5199\u5165 OpenCode auth.json\uFF1B\u4ECE\u65E7\u7248\u672C\u5347\u7EA7\u7684 Provider \u5FC5\u987B\u91CD\u65B0\u586B\u5199\u3002",
       needsApiKey: "\u9700\u91CD\u586B key",
       insecure: "\u5141\u8BB8\u975E\u56DE\u73AF HTTP\uFF08\u4FDD\u5B58\u65F6\u518D\u6B21\u786E\u8BA4\uFF09",
+      probe: "\u63A2\u6D4B\u6A21\u578B",
+      probing: "\u63A2\u6D4B\u4E2D\u2026",
+      probeFilled: (added, total) => `\u5DF2\u586B\u5165 ${added} \u4E2A\u6A21\u578B\uFF08\u5171 ${total}\uFF09`,
       models: (count) => `${count} \u4E2A\u6A21\u578B`,
       selected: "\u5DF2\u9009"
     },
@@ -32546,6 +32676,9 @@ ${command}`
       openCodeKeyCap: "The key is written to OpenCode auth.json. Older providers must be entered again.",
       needsApiKey: "API key required",
       insecure: "Allow non-loopback HTTP (confirmed again on save)",
+      probe: "Probe models",
+      probing: "Probing\u2026",
+      probeFilled: (added, total) => `Filled ${added} models (${total} found)`,
       models: (count) => `${count} models`,
       selected: "selected"
     }
@@ -32580,11 +32713,14 @@ ${command}`
     activeProviderId = "",
     onUpsert,
     onRemove,
+    onProbe,
     disabled = false
   }) {
     const t = L4[lang] || L4.zh;
     const [draft, setDraft] = import_react44.default.useState(null);
     const [error, setError] = import_react44.default.useState("");
+    const [note, setNote] = import_react44.default.useState("");
+    const [probing, setProbing] = import_react44.default.useState(false);
     const save = async (event) => {
       var _a, _b;
       event.preventDefault();
@@ -32630,6 +32766,7 @@ ${command}`
             onClick: (event) => {
               event.preventDefault();
               setDraft(emptyDraft());
+              setNote("");
             },
             children: t.add
           }
@@ -32679,6 +32816,7 @@ ${command}`
                   onClick: () => {
                     setDraft(draftFromEntry(provider));
                     setError("");
+                    setNote("");
                   },
                   children: t.edit
                 }
@@ -32726,15 +32864,50 @@ ${command}`
               ]
             }
           ) }),
-          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
-            Input,
-            {
-              mono: true,
-              value: draft.modelId,
-              onChange: (value) => setDraft({ ...draft, modelId: value }),
-              placeholder: "claude-sonnet-4"
-            }
-          ) }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { style: { display: "flex", gap: 6, alignItems: "center" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
+              Input,
+              {
+                mono: true,
+                value: draft.modelId,
+                onChange: (value) => setDraft({ ...draft, modelId: value }),
+                placeholder: "claude-sonnet-4"
+              }
+            ),
+            /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
+              Button,
+              {
+                type: "button",
+                variant: "secondary",
+                size: "sm",
+                disabled: disabled || probing || !String(draft.baseUrl || "").trim(),
+                onClick: async (event) => {
+                  const form = event.currentTarget.closest("form");
+                  const apiKey = String(new FormData(form).get("modelAuthSecret") || "");
+                  setProbing(true);
+                  setError("");
+                  setNote("");
+                  try {
+                    const result = await onProbe(draft, { apiKey });
+                    if (!result.ok) setError(result.detail);
+                    else {
+                      const merged = mergeProbedModelIds(draft.modelId, result.models);
+                      setDraft({ ...draft, modelId: merged.modelId });
+                      setNote(t.probeFilled(merged.added, result.total));
+                    }
+                  } catch (probeError) {
+                    setError(redactCredentialText(
+                      (probeError == null ? void 0 : probeError.message) || "Provider model probe failed",
+                      [apiKey]
+                    ));
+                  } finally {
+                    setProbing(false);
+                  }
+                },
+                children: probing ? t.probing : t.probe
+              }
+            )
+          ] }) }),
           /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("label", { style: {
             display: "flex",
             gap: 6,
@@ -32759,6 +32932,10 @@ ${command}`
             font: "400 10px/1.4 var(--font-ui)",
             color: "var(--warn)"
           }, children: error }) : null,
+          note ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("div", { style: {
+            font: "400 10px/1.4 var(--font-ui)",
+            color: "var(--text-tertiary)"
+          }, children: note }) : null,
           /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { style: { display: "flex", gap: 6, justifyContent: "flex-end" }, children: [
             /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
               Button,
@@ -32768,6 +32945,7 @@ ${command}`
                 onClick: () => {
                   setDraft(null);
                   setError("");
+                  setNote("");
                 },
                 children: t.cancel
               }
@@ -35521,6 +35699,11 @@ ${command}`
         lang,
         providers,
         disabled: providerInit.state !== "ready",
+        onProbe: async (draft, { apiKey }) => probeOpenCodeProviderModels({
+          draft,
+          apiKey: apiKey || openCodeProviderStore.readApiKey(draft.id || ""),
+          adapter: platform
+        }),
         onUpsert: async (event, draft) => {
           var _a;
           const formElement = event.currentTarget;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -21811,7 +21811,7 @@
           settled = true;
           callback(value);
         };
-        const req = transport.request(target, { method: "GET", headers }, (res) => {
+        const req = transport.request(target.toString(), { method: "GET", headers }, (res) => {
           var _a;
           let text = "";
           (_a = res.setEncoding) == null ? void 0 : _a.call(res, "utf8");

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -34,6 +34,7 @@ import {
   migrateBackendPref,
 } from '../lib/channels.js';
 import { createOpenCodeProviderStore } from '../cep/openCodeProviderStore.js';
+import { probeOpenCodeProviderModels } from '../cep/openCodeModelProbe.js';
 import { ProviderManagerSection } from '../components/settings/ProviderManagerSection';
 import { reduceEvent, userTurnEntry } from '../lib/chatEntries';
 import {
@@ -348,6 +349,11 @@ function Shell({ cs }) {
       lang={lang}
       providers={providers}
       disabled={providerInit.state !== 'ready'}
+      onProbe={async (draft, { apiKey }) => probeOpenCodeProviderModels({
+        draft,
+        apiKey: apiKey || openCodeProviderStore.readApiKey(draft.id || ''),
+        adapter: platform,
+      })}
       onUpsert={async (event, draft) => {
         const formElement = event.currentTarget;
         const form = new FormData(event.currentTarget);

--- a/plugin/panel/src/cep/openCodeModelProbe.js
+++ b/plugin/panel/src/cep/openCodeModelProbe.js
@@ -1,0 +1,63 @@
+import { redactCredentialText } from '../lib/credentialTextRedaction.js';
+import { canonicalOpenCodeBaseUrl } from './openCodeProviderStore.js';
+
+function failure(detail, apiKey) {
+  return { ok: false, detail: redactCredentialText(detail, [apiKey]) };
+}
+
+function modelIds(value) {
+  const rows = Array.isArray(value) ? value : Array.isArray(value?.data) ? value.data : null;
+  if (!rows) return null;
+  const seen = new Set();
+  const models = [];
+  for (const row of rows) {
+    const id = String(typeof row === 'string' ? row : row?.id || '').trim();
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      models.push(id);
+    }
+  }
+  return models;
+}
+
+export async function probeOpenCodeProviderModels({
+  draft, apiKey = '', adapter, timeoutMs = 8000,
+}) {
+  const key = String(apiKey || '');
+  let url;
+  try {
+    url = new URL(canonicalOpenCodeBaseUrl(String(draft?.baseUrl || '').trim()) + '/models');
+  } catch {
+    return failure('Provider models URL is invalid', key);
+  }
+  if (url.protocol === 'http:' && draft?.allowInsecureHttp !== true) {
+    return failure('Insecure HTTP requires confirmation', key);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return failure('Provider models URL must use HTTP or HTTPS', key);
+  }
+
+  const headers = { accept: 'application/json' };
+  if (draft?.protocol === 'openai') {
+    if (key) headers.Authorization = `Bearer ${key}`;
+  } else {
+    if (key) headers['x-api-key'] = key;
+    headers['anthropic-version'] = '2023-06-01';
+    url.searchParams.set('limit', '1000');
+  }
+
+  let response;
+  try {
+    response = await adapter.requestJson({ url: url.toString(), headers, timeoutMs });
+  } catch (error) {
+    return failure(error?.message || 'Provider models request failed', key);
+  }
+  if (!response?.ok) {
+    const snippet = String(response?.text || '').slice(0, 120).trim();
+    return failure(`HTTP ${response?.status || 0}${snippet ? `: ${snippet}` : ''}`, key);
+  }
+  if (response.json === null) return failure('Provider returned a non-JSON response', key);
+  const models = modelIds(response.json);
+  if (!models) return failure('Provider models response has an unsupported shape', key);
+  return { ok: true, models, total: models.length };
+}

--- a/plugin/panel/src/cep/openCodeProviderStore.js
+++ b/plugin/panel/src/cep/openCodeProviderStore.js
@@ -135,19 +135,23 @@ function normalizeAuth(value) {
   return value;
 }
 
+export function canonicalOpenCodeBaseUrl(value) {
+  const root = String(value || '').replace(/\/+$/, '');
+  return root.endsWith('/v1') ? root : root + '/v1';
+}
+
 export function openCodeProviderDefinitions(providers) {
   const definitions = {};
   for (const raw of providers || []) {
     const provider = normalizeProvider(raw);
     if (provider.needsApiKey) continue;
-    const root = provider.baseUrl.replace(/\/+$/, '');
     definitions[provider.id] = {
       npm: provider.protocol === 'openai' ? '@ai-sdk/openai-compatible' : '@ai-sdk/anthropic',
       name: provider.name,
       // Both loaders append their endpoint path ("/messages" or
       // "/chat/completions") directly to baseURL, so the injected URL must
       // carry the "/v1" segment relay endpoints expect.
-      options: { baseURL: root.endsWith('/v1') ? root : root + '/v1' },
+      options: { baseURL: canonicalOpenCodeBaseUrl(provider.baseUrl) },
       models: Object.fromEntries(provider.modelIds.map((id) => [id, { name: id }])),
     };
   }
@@ -180,6 +184,12 @@ export function createOpenCodeProviderStore({ platform, fsImpl, tempSuffix } = {
   function hasApiKey(providerId) {
     const entry = auth()[normalizeOpenCodeProviderId(providerId)];
     return entry?.type === 'api' && typeof entry.key === 'string' && entry.key.length > 0;
+  }
+
+  function readApiKey(providerId) {
+    if (!String(providerId || '').trim()) return '';
+    const entry = auth()[normalizeOpenCodeProviderId(providerId)];
+    return entry?.type === 'api' && typeof entry.key === 'string' ? entry.key : '';
   }
 
   function writeAuthKey(providerId, key) {
@@ -223,6 +233,7 @@ export function createOpenCodeProviderStore({ platform, fsImpl, tempSuffix } = {
     filePath: () => file,
     hasApiKey,
     list,
+    readApiKey,
     remove,
     save,
   });

--- a/plugin/panel/src/cep/platform/http-json.js
+++ b/plugin/panel/src/cep/platform/http-json.js
@@ -14,7 +14,8 @@ export function createHttpJsonRequester({ httpImpl, httpsImpl }) {
         settled = true;
         callback(value);
       };
-      const req = transport.request(target, { method: 'GET', headers }, (res) => {
+      // CEP mixed context: Node http.request only recognizes its own URL class.
+      const req = transport.request(target.toString(), { method: 'GET', headers }, (res) => {
         let text = '';
         res.setEncoding?.('utf8');
         res.on('data', (chunk) => { text += String(chunk); });

--- a/plugin/panel/src/cep/platform/http-json.js
+++ b/plugin/panel/src/cep/platform/http-json.js
@@ -1,0 +1,40 @@
+export function createHttpJsonRequester({ httpImpl, httpsImpl }) {
+  return function requestJson({ url, headers = {}, timeoutMs = 8000 }) {
+    return new Promise((resolve, reject) => {
+      const target = url instanceof URL ? url : new URL(String(url));
+      const transport = target.protocol === 'https:' ? httpsImpl
+        : target.protocol === 'http:' ? httpImpl : null;
+      if (!transport?.request) {
+        reject(new Error('HTTP transport is unavailable'));
+        return;
+      }
+      let settled = false;
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        callback(value);
+      };
+      const req = transport.request(target, { method: 'GET', headers }, (res) => {
+        let text = '';
+        res.setEncoding?.('utf8');
+        res.on('data', (chunk) => { text += String(chunk); });
+        // A destroyed response must reject here, never escape as an uncaught error.
+        res.on('error', (error) => finish(reject, error));
+        res.on('end', () => {
+          let json = null;
+          try { json = JSON.parse(text); } catch { /* response stays non-JSON */ }
+          const status = Number(res.statusCode || 0);
+          finish(resolve, { ok: status >= 200 && status < 300, status, json, text });
+        });
+      });
+      req.on('error', (error) => finish(reject, error));
+      req.setTimeout(timeoutMs, () => {
+        const error = new Error('Request timed out');
+        error.code = 'ETIMEDOUT';
+        req.destroy(error);
+        finish(reject, error);
+      });
+      req.end();
+    });
+  };
+}

--- a/plugin/panel/src/cep/platform/index.js
+++ b/plugin/panel/src/cep/platform/index.js
@@ -37,6 +37,8 @@ export function defaultPlatformDependencies() {
     temp: os.tmpdir(),
     env,
     fs: require('fs'),
+    httpImpl: require('http'),
+    httpsImpl: require('https'),
     spawnImpl: require('child_process').spawn,
     now: () => Date.now(),
   };

--- a/plugin/panel/src/cep/platform/macos.js
+++ b/plugin/panel/src/cep/platform/macos.js
@@ -1,5 +1,6 @@
 import { createPathCatalog } from './paths.js';
 import { createProcessBoundary } from './process.js';
+import { createHttpJsonRequester } from './http-json.js';
 
 function normalizedExecutableName(value) {
   return String(value || '').trim().split('/').at(-1).replace(/\.exe$/i, '').toLowerCase();
@@ -15,6 +16,7 @@ export function createMacosAdapter(deps) {
     pid: deps.pid,
     paths,
     fs: deps.fs,
+    requestJson: createHttpJsonRequester(deps),
     ...boundary,
     async processAlive({ pid } = {}) {
       const processId = Number(pid);

--- a/plugin/panel/src/cep/platform/types.js
+++ b/plugin/panel/src/cep/platform/types.js
@@ -5,6 +5,8 @@
  * @typedef {{ok:true,id:ExecutableId,path:string,argsPrefix:string[],source:ExecutableSource,version:string|null,arch:'arm64'|'x64'|null}} SuccessfulExecutableResolution
  * @typedef {{ok:false,id:ExecutableId,code:'NOT_FOUND'|'VERSION_TOO_OLD'|'ARCH_MISMATCH'|'PROBE_FAILED',attempts:Array<{path:string,source:ExecutableSource,detail:string}>}} FailedExecutableResolution
  * @typedef {SuccessfulExecutableResolution|FailedExecutableResolution} ExecutableResolution
+ * @typedef {{ok:boolean,status:number,json:unknown|null,text:string}} HttpJsonResponse
+ * @typedef {(request:{url:string|URL,headers?:Record<string,string>,timeoutMs?:number}) => Promise<HttpJsonResponse>} RequestJson
  *
  * This module intentionally contains declarations only.  Keeping the public
  * contract in one dependency-free file lets CEP business modules consume the

--- a/plugin/panel/src/cep/platform/windows.js
+++ b/plugin/panel/src/cep/platform/windows.js
@@ -1,5 +1,6 @@
 import { createPathCatalog } from './paths.js';
 import { createProcessBoundary } from './process.js';
+import { createHttpJsonRequester } from './http-json.js';
 
 function envValue(environment, name) {
   const key = Object.keys(environment || {}).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
@@ -27,6 +28,7 @@ export function createWindowsAdapter(deps) {
     pid: deps.pid,
     paths,
     fs: deps.fs,
+    requestJson: createHttpJsonRequester(deps),
     ...boundary,
     async processAlive({ pid } = {}) {
       const processId = Number(pid);

--- a/plugin/panel/src/components/settings/ProviderManagerSection.jsx
+++ b/plugin/panel/src/components/settings/ProviderManagerSection.jsx
@@ -200,6 +200,22 @@ export function ProviderManagerSection({
                 ]}
               />
             </Field>
+            <label style={{
+              display: 'flex', gap: 6, alignItems: 'center', font: '400 11px/1.35 var(--font-ui)',
+            }}>
+              <input
+                type="checkbox"
+                checked={draft.allowInsecureHttp}
+                onChange={(event) => setDraft({
+                  ...draft,
+                  allowInsecureHttp: event.target.checked,
+                })}
+              />
+              {t.insecure}
+            </label>
+            <Field label={t.apiKey} caption={t.openCodeKeyCap}>
+              <SecretInput name="modelAuthSecret" disabled={disabled} />
+            </Field>
             <Field label={t.model}>
               <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
                 <Input
@@ -239,22 +255,6 @@ export function ProviderManagerSection({
                   {probing ? t.probing : t.probe}
                 </Button>
               </div>
-            </Field>
-            <label style={{
-              display: 'flex', gap: 6, alignItems: 'center', font: '400 11px/1.35 var(--font-ui)',
-            }}>
-              <input
-                type="checkbox"
-                checked={draft.allowInsecureHttp}
-                onChange={(event) => setDraft({
-                  ...draft,
-                  allowInsecureHttp: event.target.checked,
-                })}
-              />
-              {t.insecure}
-            </label>
-            <Field label={t.apiKey} caption={t.openCodeKeyCap}>
-              <SecretInput name="modelAuthSecret" disabled={disabled} />
             </Field>
             {error ? <div style={{
               font: '400 10px/1.4 var(--font-ui)', color: 'var(--warn)',

--- a/plugin/panel/src/components/settings/ProviderManagerSection.jsx
+++ b/plugin/panel/src/components/settings/ProviderManagerSection.jsx
@@ -8,8 +8,10 @@ import {
   draftFromEntry,
   draftToEntry,
   emptyDraft,
+  mergeProbedModelIds,
   validateDraft,
 } from '../../lib/providerManagerState';
+import { redactCredentialText } from '../../lib/credentialTextRedaction.js';
 
 const L = {
   zh: {
@@ -20,6 +22,8 @@ const L = {
     dialectCap: '中转端点常按模型家族区分方言；混合模型列表选 OpenAI 兼容通常全部可用。',
     openCodeKeyCap: '密钥写入 OpenCode auth.json；从旧版本升级的 Provider 必须重新填写。',
     needsApiKey: '需重填 key', insecure: '允许非回环 HTTP（保存时再次确认）',
+    probe: '探测模型', probing: '探测中…',
+    probeFilled: (added, total) => `已填入 ${added} 个模型（共 ${total}）`,
     models: (count) => `${count} 个模型`, selected: '已选',
   },
   en: {
@@ -35,6 +39,8 @@ const L = {
     dialectCap: 'Relays often vary the dialect per model family; OpenAI-compatible usually covers mixed model lists.',
     openCodeKeyCap: 'The key is written to OpenCode auth.json. Older providers must be entered again.',
     needsApiKey: 'API key required', insecure: 'Allow non-loopback HTTP (confirmed again on save)',
+    probe: 'Probe models', probing: 'Probing…',
+    probeFilled: (added, total) => `Filled ${added} models (${total} found)`,
     models: (count) => `${count} models`, selected: 'selected',
   },
 };
@@ -64,11 +70,14 @@ export function ProviderManagerSection({
   activeProviderId = '',
   onUpsert,
   onRemove,
+  onProbe,
   disabled = false,
 }) {
   const t = L[lang] || L.zh;
   const [draft, setDraft] = React.useState(null);
   const [error, setError] = React.useState('');
+  const [note, setNote] = React.useState('');
+  const [probing, setProbing] = React.useState(false);
   const save = async (event) => {
     event.preventDefault();
     const message = validateDraft(draft);
@@ -105,6 +114,7 @@ export function ProviderManagerSection({
           onClick={(event) => {
             event.preventDefault();
             setDraft(emptyDraft());
+            setNote('');
           }}
         >
           {t.add}
@@ -146,6 +156,7 @@ export function ProviderManagerSection({
                   onClick={() => {
                     setDraft(draftFromEntry(provider));
                     setError('');
+                    setNote('');
                   }}
                 >
                   {t.edit}
@@ -190,12 +201,44 @@ export function ProviderManagerSection({
               />
             </Field>
             <Field label={t.model}>
-              <Input
-                mono
-                value={draft.modelId}
-                onChange={(value) => setDraft({ ...draft, modelId: value })}
-                placeholder="claude-sonnet-4"
-              />
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <Input
+                  mono
+                  value={draft.modelId}
+                  onChange={(value) => setDraft({ ...draft, modelId: value })}
+                  placeholder="claude-sonnet-4"
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={disabled || probing || !String(draft.baseUrl || '').trim()}
+                  onClick={async (event) => {
+                    const form = event.currentTarget.closest('form');
+                    const apiKey = String(new FormData(form).get('modelAuthSecret') || '');
+                    setProbing(true);
+                    setError('');
+                    setNote('');
+                    try {
+                      const result = await onProbe(draft, { apiKey });
+                      if (!result.ok) setError(result.detail);
+                      else {
+                        const merged = mergeProbedModelIds(draft.modelId, result.models);
+                        setDraft({ ...draft, modelId: merged.modelId });
+                        setNote(t.probeFilled(merged.added, result.total));
+                      }
+                    } catch (probeError) {
+                      setError(redactCredentialText(
+                        probeError?.message || 'Provider model probe failed', [apiKey],
+                      ));
+                    } finally {
+                      setProbing(false);
+                    }
+                  }}
+                >
+                  {probing ? t.probing : t.probe}
+                </Button>
+              </div>
             </Field>
             <label style={{
               display: 'flex', gap: 6, alignItems: 'center', font: '400 11px/1.35 var(--font-ui)',
@@ -216,6 +259,9 @@ export function ProviderManagerSection({
             {error ? <div style={{
               font: '400 10px/1.4 var(--font-ui)', color: 'var(--warn)',
             }}>{error}</div> : null}
+            {note ? <div style={{
+              font: '400 10px/1.4 var(--font-ui)', color: 'var(--text-tertiary)',
+            }}>{note}</div> : null}
             <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
               <Button
                 variant="ghost"
@@ -223,6 +269,7 @@ export function ProviderManagerSection({
                 onClick={() => {
                   setDraft(null);
                   setError('');
+                  setNote('');
                 }}
               >
                 {t.cancel}

--- a/plugin/panel/src/lib/providerManagerState.js
+++ b/plugin/panel/src/lib/providerManagerState.js
@@ -45,3 +45,9 @@ export function draftToEntry(draft) {
     name,
   };
 }
+
+export function mergeProbedModelIds(current, discovered) {
+  const existing = String(current || '').split(/[\s,]+/).map((id) => id.trim()).filter(Boolean);
+  const merged = Array.from(new Set([...existing, ...(discovered || []).map((id) => String(id).trim())]));
+  return { modelId: merged.filter(Boolean).join(', '), added: merged.length - new Set(existing).size };
+}

--- a/plugin/panel/test/openCodeModelProbe.test.js
+++ b/plugin/panel/test/openCodeModelProbe.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { probeOpenCodeProviderModels } from '../src/cep/openCodeModelProbe.js';
+
+function harness(response) {
+  const calls = [];
+  return {
+    calls,
+    adapter: { async requestJson(request) {
+      calls.push(request);
+      if (response instanceof Error) throw response;
+      return response;
+    } },
+  };
+}
+
+const draft = (baseUrl, extra = {}) => ({ baseUrl, protocol: 'openai', ...extra });
+const ok = (json) => ({ ok: true, status: 200, json, text: JSON.stringify(json) });
+
+test('builds one canonical /v1/models URL across base URL variants', async () => {
+  for (const [baseUrl, expected] of [
+    ['https://relay.test', 'https://relay.test/v1/models'],
+    ['https://relay.test/', 'https://relay.test/v1/models'],
+    ['https://relay.test/v1', 'https://relay.test/v1/models'],
+    ['https://relay.test/v1/', 'https://relay.test/v1/models'],
+  ]) {
+    const h = harness(ok({ data: [] }));
+    assert.equal((await probeOpenCodeProviderModels({ draft: draft(baseUrl), adapter: h.adapter })).ok, true);
+    assert.equal(h.calls[0].url, expected);
+  }
+});
+
+test('refuses insecure HTTP unless explicitly allowed and rejects invalid URLs', async () => {
+  const blocked = harness(ok([]));
+  assert.equal((await probeOpenCodeProviderModels({ draft: draft('http://relay.test'), adapter: blocked.adapter })).ok, false);
+  assert.equal(blocked.calls.length, 0);
+  const allowed = harness(ok([]));
+  assert.equal((await probeOpenCodeProviderModels({
+    draft: draft('http://relay.test', { allowInsecureHttp: true }), adapter: allowed.adapter,
+  })).ok, true);
+  assert.equal((await probeOpenCodeProviderModels({ draft: draft('bad-url'), adapter: allowed.adapter })).ok, false);
+});
+
+test('sends dialect-specific authentication and Anthropic pagination headers', async () => {
+  const openai = harness(ok([]));
+  await probeOpenCodeProviderModels({ draft: draft('https://relay.test'), apiKey: 'key-a', adapter: openai.adapter });
+  assert.deepEqual(openai.calls[0].headers, { accept: 'application/json', Authorization: 'Bearer key-a' });
+
+  const anthropic = harness(ok([]));
+  await probeOpenCodeProviderModels({
+    draft: draft('https://relay.test', { protocol: 'anthropic' }), apiKey: 'key-b', adapter: anthropic.adapter,
+  });
+  assert.deepEqual(anthropic.calls[0].headers, {
+    accept: 'application/json', 'x-api-key': 'key-b', 'anthropic-version': '2023-06-01',
+  });
+  assert.equal(anthropic.calls[0].url, 'https://relay.test/v1/models?limit=1000');
+
+  const openRelay = harness(ok([]));
+  await probeOpenCodeProviderModels({ draft: draft('https://relay.test'), apiKey: '', adapter: openRelay.adapter });
+  assert.deepEqual(openRelay.calls[0].headers, { accept: 'application/json' });
+});
+
+test('parses data and bare-array shapes with stable deduplication', async () => {
+  const data = await probeOpenCodeProviderModels({
+    draft: draft('https://relay.test'), adapter: harness(ok({ data: [{ id: ' a ' }, { id: 'b' }, { id: 'a' }, {}] })).adapter,
+  });
+  assert.deepEqual(data, { ok: true, models: ['a', 'b'], total: 2 });
+  const bare = await probeOpenCodeProviderModels({
+    draft: draft('https://relay.test'), adapter: harness(ok(['x', { id: ' y ' }, 'x'])).adapter,
+  });
+  assert.deepEqual(bare, { ok: true, models: ['x', 'y'], total: 2 });
+});
+
+test('reports HTTP, non-JSON, timeout and socket failures without leaking keys', async () => {
+  const key = 'sk-test-SECRET-123';
+  const cases = [
+    harness({ ok: false, status: 401, json: null, text: `denied ${key} ${'x'.repeat(150)}` }).adapter,
+    harness({ ok: true, status: 200, json: null, text: '<html>' }).adapter,
+    harness(new Error(`timeout for ${key}`)).adapter,
+    harness(new Error(`socket closed ${key}`)).adapter,
+  ];
+  const results = [];
+  for (const adapter of cases) {
+    const result = await probeOpenCodeProviderModels({ draft: draft('https://relay.test'), apiKey: key, adapter });
+    assert.equal(result.ok, false);
+    assert.equal(result.detail.includes(key), false);
+    results.push(result.detail);
+  }
+  assert.match(results[0], /^HTTP 401/);
+  assert.match(results[1], /non-JSON/);
+  assert.match(results[2], /timeout/);
+  assert.match(results[3], /socket/);
+});

--- a/plugin/panel/test/openCodeProviderStore.test.js
+++ b/plugin/panel/test/openCodeProviderStore.test.js
@@ -47,6 +47,9 @@ test('OpenCode provider store merge-writes auth.json and preserves existing prov
       opencode: { type: 'api', key: 'keep-me' },
       'aemcp-acme-relay': { type: 'api', key: 'new-key' },
     });
+    assert.equal(store.readApiKey(provider.id), 'new-key');
+    assert.equal(store.readApiKey('missing-provider'), '');
+    assert.equal(store.readApiKey(''), '');
     if (process.platform !== 'win32') assert.equal(fs.statSync(authFile).mode & 0o077, 0);
     assert.deepEqual(openCodeProviderDefinitions(store.list()), {
       'aemcp-acme-relay': {

--- a/plugin/panel/test/platform-http-json.test.js
+++ b/plugin/panel/test/platform-http-json.test.js
@@ -5,7 +5,7 @@ import { createHttpJsonRequester } from '../src/cep/platform/http-json.js';
 
 function transport(step, calls) {
   return { request(url, options, onResponse) {
-    calls.push({ url: url.toString(), options });
+    calls.push({ target: url, url: url.toString(), options });
     const requestListeners = {};
     const req = {
       on(event, handler) { requestListeners[event] = handler; return req; },
@@ -40,7 +40,26 @@ test('requestJson selects HTTPS and parses JSON without hiding HTTP status', asy
     ok: true, status: 200, json: { data: [] }, text: '{"data":[]}',
   });
   assert.equal(httpCalls.length, 0);
+  assert.equal(typeof httpsCalls[0].target, 'string');
+  assert.equal(httpsCalls[0].target, 'https://relay.test/v1/models');
   assert.equal(httpsCalls[0].options.method, 'GET');
+});
+
+test('requestJson satisfies a Node-like transport that rejects foreign URL objects', async () => {
+  const calls = [];
+  const fake = transport({ status: 200, body: '{}' }, calls);
+  const request = fake.request;
+  fake.request = (target, ...args) => {
+    if (typeof target !== 'string') {
+      const error = new TypeError('The listener argument must be of type function');
+      error.code = 'ERR_INVALID_ARG_TYPE';
+      throw error;
+    }
+    return request(target, ...args);
+  };
+  const requestJson = createHttpJsonRequester({ httpsImpl: fake });
+  await assert.doesNotReject(requestJson({ url: 'https://relay.test/models' }));
+  assert.equal(calls[0].target, 'https://relay.test/models');
 });
 
 test('requestJson returns non-2xx bodies and rejects timeout/socket errors', async () => {

--- a/plugin/panel/test/platform-http-json.test.js
+++ b/plugin/panel/test/platform-http-json.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createHttpJsonRequester } from '../src/cep/platform/http-json.js';
+
+function transport(step, calls) {
+  return { request(url, options, onResponse) {
+    calls.push({ url: url.toString(), options });
+    const requestListeners = {};
+    const req = {
+      on(event, handler) { requestListeners[event] = handler; return req; },
+      setTimeout(_ms, handler) { req.timeout = handler; return req; },
+      destroy(error) { requestListeners.error?.(error); },
+      end() {
+        queueMicrotask(() => {
+          if (step === 'timeout') return req.timeout();
+          if (step instanceof Error) return requestListeners.error?.(step);
+          const res = new EventEmitter();
+          res.statusCode = step.status;
+          res.setEncoding = () => {};
+          onResponse(res);
+          res.emit('data', step.body);
+          if (step.responseError) res.emit('error', step.responseError);
+          else res.emit('end');
+        });
+      },
+    };
+    return req;
+  } };
+}
+
+test('requestJson selects HTTPS and parses JSON without hiding HTTP status', async () => {
+  const httpCalls = [];
+  const httpsCalls = [];
+  const requestJson = createHttpJsonRequester({
+    httpImpl: transport({ status: 500, body: 'no' }, httpCalls),
+    httpsImpl: transport({ status: 200, body: '{"data":[]}' }, httpsCalls),
+  });
+  assert.deepEqual(await requestJson({ url: 'https://relay.test/v1/models', headers: { accept: 'application/json' }, timeoutMs: 25 }), {
+    ok: true, status: 200, json: { data: [] }, text: '{"data":[]}',
+  });
+  assert.equal(httpCalls.length, 0);
+  assert.equal(httpsCalls[0].options.method, 'GET');
+});
+
+test('requestJson returns non-2xx bodies and rejects timeout/socket errors', async () => {
+  const calls = [];
+  const non2xx = createHttpJsonRequester({ httpImpl: transport({ status: 503, body: 'busy' }, calls) });
+  assert.deepEqual(await non2xx({ url: 'http://relay.test/models' }), {
+    ok: false, status: 503, json: null, text: 'busy',
+  });
+  const timeout = createHttpJsonRequester({ httpsImpl: transport('timeout', []) });
+  await assert.rejects(timeout({ url: 'https://relay.test/models' }), /timed out/);
+  const socket = createHttpJsonRequester({ httpsImpl: transport(new Error('socket closed'), []) });
+  await assert.rejects(socket({ url: 'https://relay.test/models' }), /socket closed/);
+});
+
+test('requestJson rejects a response-stream error after a partial body', async () => {
+  const responseError = new Error('response aborted');
+  const requestJson = createHttpJsonRequester({
+    httpsImpl: transport({ status: 200, body: '{"partial":', responseError }, []),
+  });
+  await assert.rejects(requestJson({ url: 'https://relay.test/models' }), responseError);
+});

--- a/plugin/panel/test/platform-paths.test.js
+++ b/plugin/panel/test/platform-paths.test.js
@@ -159,6 +159,7 @@ test('default Windows dependencies find USERPROFILE case-insensitively', (t) => 
       require(name) {
         if (name === 'os') return { homedir: () => 'C:\\Fallback', tmpdir: () => 'D:\\Temp' };
         if (name === 'fs') return fs;
+        if (name === 'http' || name === 'https') return { request() {} };
         if (name === 'child_process') return { spawn };
         throw new Error('unexpected require: ' + name);
       },

--- a/plugin/panel/test/providerManagerState.test.js
+++ b/plugin/panel/test/providerManagerState.test.js
@@ -4,6 +4,7 @@ import {
   draftFromEntry,
   draftToEntry,
   emptyDraft,
+  mergeProbedModelIds,
   validateDraft,
 } from '../src/lib/providerManagerState.js';
 
@@ -51,4 +52,10 @@ test('draft protocol round-trips and defaults to anthropic', () => {
   assert.equal(draftFromEntry({ protocol: 'openai' }).protocol, 'openai');
   assert.equal(draftFromEntry({ protocol: 'weird' }).protocol, 'anthropic');
   assert.equal(draftToEntry({ name: 'x', protocol: 'openai' }).protocol, 'openai');
+});
+
+test('probed model ids append after existing ids without duplicates', () => {
+  assert.deepEqual(mergeProbedModelIds('old, shared', ['shared', 'new']), {
+    modelId: 'old, shared, new', added: 1,
+  });
 });


### PR DESCRIPTION
## 背景

Phase 3（#285）删掉 legacy 自定义 provider 机制时把模型探测一起删了，Provider 管理器只能手填模型 id；OpenCode 自身不会为自定义 provider 发现模型。详见 #306。

## 改动

- Provider 管理器表单的「模型」旁新增「探测模型 / Probe models」按钮：对 `<baseURL>/v1/models` 发一次 GET（OpenAI 方言 `Authorization: Bearer`；Anthropic 方言 `x-api-key` + `anthropic-version` + `limit=1000`），返回的 id 去重后**追加**在用户已填的 id 之后，并提示「已填入 N 个模型（共 M）」。
- 请求在 CEP 的 Node 侧发：新增平台传输 `adapter.requestJson`（`platform/http-json.js`，`http`/`https` 在 `platform/index.js` 注入，macOS / Windows 适配器都暴露，`types.js` 有声明）。面板是 `file://` 的 CEF 页面，provider 主机不给 CORS 头，所以不能走 `fetch`。
- `/v1` 规则抽成 `canonicalOpenCodeBaseUrl()`，探测与 `opencode.json` 注入共用同一条。
- 用表单里刚输入的 key；没输入时用 OpenCode `auth.json` 里已存的（新增 `store.readApiKey`）。所有可见错误经 `redactCredentialText` 脱敏。
- 响应流被销毁时 reject，不会在 CEP 进程里变成 uncaughtException。
- `plugin/client/dist` 已重建。

不做：方言自动识别、端点候选枚举、capability probe、自动探测、代理支持、新依赖、全局错误码。

## 验证（macOS 26.5.2 arm64，Node 20.20.2）

```
cd plugin/panel && npm test                        → # tests 491  # pass 491  # fail 0
node --test scripts/package/test/no-platform-leaks.test.mjs → # pass 2  # fail 0
cd plugin/panel && npm run build && node verify-bundle.mjs  → matches the panel sources
```

真实端点（用假 key `sk-test-SECRET-123`）：中转站两种方言 → `HTTP 401: {"error":…Invalid token…}`；api.openai.com 直连 → `HTTP 401`（915 ms）；`http://` 未勾选确认 → `Insecure HTTP requires confirmation`。detail 里没有出现 key。

已知限制：Node 的 `http` 不认 `HTTP(S)_PROXY`，直连被墙的主机时探测会超时（本机实测直连 api.openai.com 可达）；如需代理另开 issue。

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
