### PR TITLE
release: 发布 v0.10.0（把 rc.1 的 changelog 段升为正式版，补上 mac 轮次的三项改动）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### Unreleased
 
-### [0.10.0-rc.1] — 2026-08-22
+### [0.10.0] — 2026-08-22
 
 #### ✨ 新增
 
+- **Provider 管理器一键探测模型（#306）**——填好 Base URL 与 API Key 后，「探测模型」按钮对 `<baseURL>/v1/models` 发一次请求（Anthropic 方言用 `x-api-key` + `anthropic-version`，OpenAI 兼容方言用 `Authorization: Bearer`），把返回的模型 id 去重后追加到已填内容之后。请求由 CEP 的 Node 侧发出——面板是 `file://` 页面而 provider 主机不给 CORS 头，浏览器 `fetch` 走不通；`http://` 需显式确认，所有可见错误按 key 脱敏。Phase 3 拆除 legacy provider 机制时一并删掉的模型发现能力就此补回。
 - **`ae_previewFrame` 区间拼图与 A/B 像素差分**——新增 `range:{start,end,count}` 等距采样、`layout:'grid'` 带时间码对比表，以及可引用本次时刻或最近 50 次进程内捕获的 `compare`；差分返回热力图、并排图、变化比例 / 像素数 / 均值 / 最大差值与外接框，所有合成、重采样和缩放均由 CEP 宿主的零依赖 PNG 路径完成，不依赖 Chromium canvas。
 - **`ae_exec` 失败恢复信封与快照差分归因**——已派发的脚本失败时会把可编辑 `.jsx` 与元数据写入 `~/.ae-mcp/checkpoints/<project>/recovery/`，返回 `recoveryId`、绝对 `scriptPath`、`errorLine`、对应的 `errorSource`、`$.writeln` 输出、工程 revision 前后值，以及通过失败前后快照识别新增 / 删除 / 改动图层和工程项的有上限 `touched`；改文件或内联传入修正后的 `code` 后用 `ae_exec({recoveryId})` 重跑，默认先还原到本次失败前由 `checkpoint_label` 创建的 checkpoint，`retryMode:'continue'` 可明确保留当前失败状态。`$.writeln` 捕获每次调用安装并在 `finally` 拆除；旧 `/exec` HTTP 路由不开 diagnostics，形状不变。
 - **面板会话管理（#231）**——内嵌聊天现可新建会话、搜索和按最近活动查看历史、切换后恢复完整转录与真实后端上下文（Codex 持久 thread、Claude `--resume`、OpenCode session）、改名、归档 / 还原并经二次确认永久删除；本地索引与转录原子保存于 `~/.ae-mcp/sessions`。面板重载或 AE 重启后只恢复已落盘历史，审批 / 提问等中断状态会取消，绝不自动续跑进行中的回合。删除会话会同步清理本地文件并 best-effort 删除 Codex / OpenCode 后端会话；Claude CLI 没有对应删除 API，因此不会删除其自管会话文件。
@@ -44,7 +45,8 @@ Format based on Keep a Changelog; versioning follows SemVer.
 - **ExtendScript 超时不再提前放行串行锁（#260）**——调用方仍会按原期限收到超时，但 Bridge 会等迟到回调或排空哨兵返回后才继续，期间 `/health`、`/exec`、`ae.status` 与 `ae.diagnose` 报告 `degraded`；错误 disposition 收敛为三值：从未进入 AE、可安全重试的 `not_dispatched`，已派发但结果未知的 `uncertain`，以及已执行并明确报错的 `failed`。
 - **依赖清扫：`npm audit` 归零**——`plugin/sidecar` 锁文件把 `fast-uri` 升到 3.1.5（修 CVE-2026-13676 / GHSA-4c8g-83qw-93j6 以及其后的 GHSA-v2hh-gcrm-f6hx、GHSA-7p8r-x3mc-p8w7，仍在 ajv 声明的 `^3.0.1` 范围内，不引入 `overrides`），同批升级 `ip-address` 10.5.0、`hono` 4.13.3、`@hono/node-server` 1.19.17、`body-parser` 2.3.0；`plugin/host` 的 `express` 4.22.1→4.22.2（连带 `qs` 6.15.3、`body-parser` 1.20.6）。两个工作区 `npm audit` 均为 0；这些包只在本机回环路径上工作，属扫描器噪音清理而非已确认可达的漏洞。由 #271（@anupamme / OrbisAI 扫描报告）触发。
 - **`ae_exec` 非字符串结果不再被摧毁（#254）**——ExtendScript 侧新增 ES3 安全序列化器：数字 / 布尔 / `null` / 纯 Object / 纯 Array 结果在 AE 内序列化为规范 JSON 文本原样带回（`structuredContent.contentType: "json"`，`content` 恒为字符串），字符串结果保持原语义（`contentType: "text"`）。此前对象变成 `"[object Object]"` 解析错误、数组变成 `ok:true` 的 `"1,two,[object Object]"` 静默损毁。宿主对象（CompItem / Layer 等）不做深遍历、保持 `String(v)` 叶节点；循环引用 / 深度超 12 / 序列化超 1,000,000 字符按确定性错误返回并提示改用更小的投影；`ae_exec` 路径彻底移除「结果看着像 JSON 就尝试解析」的猜测逻辑，其余工具的结果解析不受影响。
-
+- **一个 ZXP 通吃 Windows 与 macOS**——Python 运行时与 platform-helper 退役后，签名 ZXP 里已不含任何平台二进制（842 个条目、零 `.node` / `.dll` / `.dylib` / `.exe`，宿主依赖树也没有任何 `os` / `cpu` 限定包），因此本版起只发一个不带平台后缀的 ZXP，两个系统共用。按平台分别构建的只剩原生插件——Windows 的 `.aex` 与 macOS 的 `AeMcpNative.plugin`——而它只被 `ae_nativeExec` 一个工具使用，其余十个工具没有它照常工作。
+- **工程**——两处只在 macOS 上暴露的测试环境依赖已修：审批超时用例改用 mock timers 推进（计时器是有意 `unref()` 的，Node 20 的 runner 此前会先行退出，#303）；Windows dev-install 夹具先 `realpath` 系统临时目录再建树（macOS 的 `/var` 是符号链接，安装守卫按设计拒绝，#302）。两处都只动测试，不动被测代码。
 
 ### [0.9.6] — 2026-08-19
 
@@ -325,10 +327,11 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### Unreleased
 
-### [0.10.0-rc.1] — 2026-08-22
+### [0.10.0] — 2026-08-22
 
 #### ✨ Added
 
+- **One-click model discovery in the Provider Manager (#306)** — with a Base URL and API key in the form, "Probe models" issues a single request to `<baseURL>/v1/models` (`x-api-key` plus `anthropic-version` for the Anthropic dialect, `Authorization: Bearer` for the OpenAI-compatible one) and appends the returned ids, deduplicated, after whatever is already typed. The request leaves from the CEP Node side because the panel is a `file://` page and provider hosts send no CORS headers, so browser `fetch` cannot reach them; `http://` requires explicit confirmation, and every visible error is redacted against the key. This restores the model discovery that was removed together with the legacy provider machinery in Phase 3.
 - **`ae_previewFrame` interval grids and A/B pixel diffs** — adds evenly spaced `range:{start,end,count}` sampling, labeled `layout:'grid'` contact sheets, and `compare` selectors for current times or the 50 most recent in-process captures; comparisons return heatmap and side-by-side artifacts plus changed ratio/pixels, mean/max difference, and a bounding box, with all composition, resampling, and scaling handled by the CEP host's dependency-free PNG path rather than Chromium canvas.
 - **`ae_exec` failure-recovery envelopes and snapshot-diff attribution** — dispatched script failures now persist an editable `.jsx` plus metadata under `~/.ae-mcp/checkpoints/<project>/recovery/` and return a `recoveryId`, absolute `scriptPath`, `errorLine` with its `errorSource`, captured `$.writeln` output, before/after project revisions, and bounded `touched` evidence identifying added, removed, or changed layers and project items from before/after snapshots. Edit the file or provide corrected inline `code`, then retry with `ae_exec({recoveryId})`; the default restores the checkpoint created by `checkpoint_label` before the failed call, while `retryMode:'continue'` explicitly preserves the failed state. Per-call `$.writeln` capture is always removed in `finally`; the legacy HTTP `/exec` route does not enable diagnostics and keeps its existing shape.
 - **Panel session management (#231)** — embedded chat can now create sessions, search and sort history by recent activity, switch back into the full transcript and real backend context (persistent Codex threads, Claude `--resume`, and OpenCode sessions), rename, archive / restore, and permanently delete after inline confirmation. The local index and transcripts are written atomically under `~/.ae-mcp/sessions`. Panel reloads and AE restarts restore only persisted history: interrupted approvals and questions are cancelled, and an in-progress turn is never redispatched automatically. Deletion removes the local transcript and best-effort deletes Codex / OpenCode backend sessions; Claude CLI has no matching delete API, so its CLI-owned session files remain.
@@ -354,6 +357,9 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 - **`ae.skillUse(execute=true)` restores the v0.9.0 pass-through response shape** — The skill script's own JSON result is returned unchanged at the top level instead of being wrapped in `{ok,name,template_type,result}`, eliminating contradictory outer `ok:true` / inner `ok:false` responses. Callers that read `result.*` in v0.9.2–v0.9.6 must switch back to top-level fields. Execution still uses the approval engine, and `execute=false` is unchanged. (#269)
 - **ExtendScript timeouts no longer release the serialization lock early (#260)** — Callers still receive a timeout on schedule, while the bridge waits for a late callback or drain sentinel before proceeding and reports `degraded` through `/health`, `/exec`, `ae.status`, and `ae.diagnose`. Error dispositions are a closed three-value set: `not_dispatched` for scripts that never entered AE and are safe to retry, `uncertain` for dispatched scripts whose result is unknown, and `failed` for scripts that executed and returned a definite error.
 - **Dependency sweep: `npm audit` clean** — the `plugin/sidecar` lockfile moves `fast-uri` to 3.1.5 (fixes CVE-2026-13676 / GHSA-4c8g-83qw-93j6 plus the later GHSA-v2hh-gcrm-f6hx and GHSA-7p8r-x3mc-p8w7, staying inside ajv's declared `^3.0.1` range with no `overrides`), alongside `ip-address` 10.5.0, `hono` 4.13.3, `@hono/node-server` 1.19.17 and `body-parser` 2.3.0; `plugin/host` bumps `express` 4.22.1→4.22.2 (with `qs` 6.15.3 and `body-parser` 1.20.6). Both workspaces now audit at 0. These packages only ever see loopback traffic here, so this is scanner-noise cleanup rather than a confirmed reachable vulnerability. Prompted by #271 (@anupamme / OrbisAI scan report).
+
+- **One ZXP for Windows and macOS** — with the Python runtime and the platform helper retired, the signed ZXP holds no platform binaries at all (842 entries, zero `.node` / `.dll` / `.dylib` / `.exe`, and no `os`- or `cpu`-constrained package anywhere in the host dependency tree), so this release ships a single ZXP without a platform suffix for both systems. Only the native plug-in is still built per platform — the `.aex` on Windows and the `AeMcpNative.plugin` bundle on macOS — and `ae_nativeExec` is the one tool that uses it; the other ten work without it.
+- **Engineering** — two test-environment dependencies that only surfaced on macOS are fixed: the approval-timeout cases now drive the deliberately `unref()`'d timer with mock timers, so the Node 20 runner no longer exits first (#303), and the Windows dev-install fixture resolves the system temp directory with `realpath` before building its tree, because macOS `/var` is a symlink that the installer guard rejects by design (#302). Both changes touch tests only, never the code under test.
 
 ### [0.9.6] — 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ English | [简体中文](README.zh-CN.md)
 **One-line setup prompt — paste this into Claude Code or another AI agent:**
 
 ```text
-Install the ae-mcp ZXP and AEX from the v0.10.0-rc.1 pre-release, open Window > Extensions
+Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.0
+release, open Window > Extensions
 > ae-mcp in After Effects, then connect Claude Code with `claude mcp add
 --transport http ae http://127.0.0.1:11488/mcp`; for Claude Desktop, configure
 the extension's `host/stdio-shim.js` with the system Node executable and ask me
@@ -20,8 +21,12 @@ through ExtendScript and the frozen native AEGP plane.
 ## Install and first run
 
 1. Install the signed ZXP in After Effects.
-2. Install the matching `.aex` beside the After Effects plug-ins selected for
-   the host. Keep the version pair from the same release.
+2. Install the matching native plug-in beside the After Effects plug-ins
+   selected for the host — the `.aex` on Windows, the `AeMcpNative.plugin`
+   bundle on macOS. Keep the version pair from the same release. The ZXP
+   carries no platform binaries and installs on both systems; only this
+   native plug-in is built per platform, and `ae_nativeExec` is the one tool
+   that needs it.
 3. Start After Effects and open **Window > Extensions > ae-mcp**. Keep the panel
    open while an external client uses MCP.
 4. Configure one of the two supported external connection forms below.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,8 @@
 **一行安装提示词——复制给 Claude Code 或其它 AI agent：**
 
 ```text
-请从 v0.10.0-rc.1 预发布页安装 ae-mcp 的 ZXP 和 AEX，在 After Effects 中打开
+请从 v0.10.0 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
+中打开
 Window > Extensions > ae-mcp，然后用 `claude mcp add --transport http ae
 http://127.0.0.1:11488/mcp` 接入 Claude Code；Claude Desktop 则使用系统 Node
 执行扩展目录里的 `host/stdio-shim.js`，并在测试 `ae_ping` 前提醒我重新启动
@@ -19,7 +20,9 @@ After Effects 状态通过 ExtendScript 和冻结的原生 AEGP 平面访问。
 ## 安装和首次启动
 
 1. 在 After Effects 中安装签名 ZXP。
-2. 把同一版本的 `.aex` 安装到该 After Effects 宿主使用的插件目录。
+2. 把同一版本的原生插件装到该 After Effects 宿主使用的插件目录——Windows 用
+   `.aex`，macOS 用 `AeMcpNative.plugin` 包。ZXP 不含任何平台二进制，两个系统
+   通用；只有原生插件按平台分别构建，`ae_nativeExec` 是唯一需要它的工具。
 3. 启动 After Effects，打开 **Window > Extensions > ae-mcp**。外部客户端
    使用 MCP 时保持面板打开。
 4. 按下面两种接入方式之一配置客户端。

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,15 +6,20 @@ supported client connections.
 
 ## 1. Install the After Effects assets
 
-1. Download the ZXP and matching `.aex` from the same release.
-2. Install the ZXP with a supported ZXP installer.
-3. With After Effects closed, install the `.aex` in the native plug-in
-   directory used by the selected After Effects host.
+1. Download the ZXP and the native plug-in for your platform from the same
+   release — `AeMcpNative-<version>-windows-x64.aex` on Windows,
+   `AeMcpNative-<version>-macos-arm64.plugin.zip` on macOS.
+2. Install the ZXP with a supported ZXP installer. One ZXP serves both
+   Windows and macOS because it contains no platform binaries.
+3. With After Effects closed, install the native plug-in in the plug-in
+   directory used by the selected After Effects host. `ae_nativeExec` is the
+   only tool that needs it, so a release that has not yet published the
+   native plug-in for your platform is still usable through the other ten.
 4. Start After Effects and open **Window > Extensions > ae-mcp**.
 
 The panel must remain open because it owns the local service at
-`http://127.0.0.1:11488/mcp`. Verify release checksums before installing both
-files.
+`http://127.0.0.1:11488/mcp`. Verify release checksums before installing the
+files you downloaded.
 
 ## 2. Claude Code
 


### PR DESCRIPTION
## 前提：合并顺序

**这个 PR 必须最后合。** 先合 #304、#305、#307，再合本 PR，tag 才会落在包含全部四项改动的提交上。

## 改动

只动文档，不动代码：

- `CHANGELOG.md`：中英两侧的 `[0.10.0-rc.1] — 2026-08-22` 改为 `[0.10.0] — 2026-08-22`；新增三条——Provider 管理器一键探测模型（#306）、「一个 ZXP 通吃 Windows 与 macOS」的打包形态，以及一条「工程 / Engineering」记录两处只在 macOS 上暴露的测试环境依赖修复（#302、#303）。
- `README.md` / `README.zh-CN.md`：一行安装提示词改指 v0.10.0 发布页，并让读者取**自己平台**的原生插件。
- `README` 与 `docs/INSTALL.md`：安装步骤改成平台中立——ZXP 不含任何平台二进制、两个系统共用；按平台分别构建的只剩原生插件（Windows 的 `.aex`、macOS 的 `AeMcpNative.plugin`），而 `ae_nativeExec` 是唯一需要它的工具，所以某个平台的原生件还没挂上去时，那个平台照样能用其余十个工具。

这样 v0.10.0 的发布页天然给 macOS 留了位置：mac 上编译完把 `AeMcpNative-v0.10.0-macos-arm64.plugin.zip` 与对应的 `SHA256SUMS-v0.10.0-macos-arm64.txt` 挂到同一个 release 即可，文档不用再改一次。

## 验证（Windows 11，Node 24.14.0）

三个待合 PR 在本地按 `main` + 三路合并的集成分支跑过：

```
plugin/host   npm test   → tests 223  pass 207  fail 0  skipped 16
plugin/panel  npm test   → tests 492  pass 491  fail 0  skipped 1
scripts/package/test/*   → tests 182  pass 121  fail 61
scripts/release/test/*   → tests 72   pass 69   fail 1  skipped 2
```

打包 / 发布两套件的失败集与 `main` 上**逐条同名**（62 + 2 个唯一名，全部是本机非管理员的 symlink/hardlink EPERM 与缺 `compile.cmd`，CI 上绿）。`scripts/package/test/install-dev-windows.test.mjs` 单跑 27/27 通过，证明 #305 在 Windows 上是恒等变换。

本 PR 自身：`node --test scripts/release/test/version-consistency.test.mjs` → 6/6 通过。
面板产物 `npm run build` + `node verify-bundle.mjs` → 与源码一致，重建后 `plugin/client/dist` 无 diff。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
