### PR TITLE
docs(install): give the native plug-in a real destination on each platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ through ExtendScript and the frozen native AEGP plane.
    bundle on macOS. Keep the version pair from the same release. The ZXP
    carries no platform binaries and installs on both systems; only this
    native plug-in is built per platform, and `ae_nativeExec` is the one tool
-   that needs it.
+   that needs it. [Install](docs/INSTALL.md) has the exact per-platform
+   destination, and the macOS bundle additionally needs its download
+   quarantine cleared before After Effects will load it.
 3. Start After Effects and open **Window > Extensions > ae-mcp**. Keep the panel
    open while an external client uses MCP.
 4. Configure one of the two supported external connection forms below.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,8 @@ After Effects 状态通过 ExtendScript 和冻结的原生 AEGP 平面访问。
 2. 把同一版本的原生插件装到该 After Effects 宿主使用的插件目录——Windows 用
    `.aex`，macOS 用 `AeMcpNative.plugin` 包。ZXP 不含任何平台二进制，两个系统
    通用；只有原生插件按平台分别构建，`ae_nativeExec` 是唯一需要它的工具。
+   两个平台的确切安装位置见[安装文档](docs/INSTALL.md)；macOS 的包还需要先去掉
+   下载隔离属性，After Effects 才会加载它。
 3. 启动 After Effects，打开 **Window > Extensions > ae-mcp**。外部客户端
    使用 MCP 时保持面板打开。
 4. 按下面两种接入方式之一配置客户端。

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,6 +15,30 @@ supported client connections.
    directory used by the selected After Effects host. `ae_nativeExec` is the
    only tool that needs it, so a release that has not yet published the
    native plug-in for your platform is still usable through the other ten.
+
+   On Windows, copy the file into the selected host with administrator
+   rights:
+
+   ```text
+   <After Effects>\Support Files\Plug-ins\Extensions\AeMcpNative.aex
+   ```
+
+   On macOS, unzip the download and place the whole `AeMcpNative.plugin`
+   bundle in the per-user MediaCore directory, then clear the download
+   quarantine so After Effects can load it:
+
+   ```bash
+   mkdir -p ~/Library/Application\ Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp
+   ditto -x -k AeMcpNative-<version>-macos-arm64.plugin.zip /tmp/ae-mcp-plugin
+   mv /tmp/ae-mcp-plugin/AeMcpNative.plugin \
+     ~/Library/Application\ Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/
+   xattr -dr com.apple.quarantine \
+     ~/Library/Application\ Support/Adobe/Common/Plug-ins/7.0/MediaCore/ae-mcp/AeMcpNative.plugin
+   ```
+
+   The macOS bundle is ad-hoc signed and not notarized, so verify its
+   SHA-256 against the release checksum file before installing it. Keep the
+   bundle intact — copying only the executable out of it does not work.
 4. Start After Effects and open **Window > Extensions > ae-mcp**.
 
 The panel must remain open because it owns the local service at


### PR DESCRIPTION
Found while building the macOS assets for v0.10.0.

`docs/INSTALL.md` step 3 said to install the native plug-in "in the plug-in directory used by the selected After Effects host" and stopped there. On Windows that is guessable from precedent; on macOS it is not, and there is a second, invisible blocker: a downloaded `AeMcpNative.plugin` carries `com.apple.quarantine`, and the bundle we ship is ad-hoc signed and not notarized. AE 2026 itself is fine with ad-hoc plug-ins — it is signed with `com.apple.security.cs.disable-library-validation` (verified on hardware today, and the currently loaded AEGP plug-in on this Mac publishes a live endpoint) — so quarantine, not the signature, is what a macOS user actually has to clear.

- `docs/INSTALL.md`: the exact Windows `Support Files\Plug-ins\Extensions` path, and the macOS per-user MediaCore path with the `ditto` / `mv` / `xattr -dr` sequence; plus notes that the bundle is ad-hoc signed, should be checksum-verified first, and must stay intact.
- `README.md` / `README.zh-CN.md`: install step 2 now points at the install doc and names the macOS quarantine step instead of leaving it undiscoverable.

Docs only — no code, no packaging, no contract changes. `repository-governance`, `support-matrix`, and `product-trust-policy` contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)