### PR TITLE
release: 产品版本 bump 到 0.10.1 并切出 changelog 段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### Unreleased
 
+### [0.10.1] — 2026-08-23
+
+#### 🐛 修复 / 改进
+
+- **首跑向导的「连接外部客户端」改成一段可复制的提示词**——原来要先在 Claude Desktop / Claude Code / Cursor 三者里单选，再照抄对应的配置块，每支持一个新客户端就多一份配置要维护，用户拿到 JSON 后还得自己判断该放进哪个文件。现在只给一段话，粘给你正在用的 AI 客户端，由它自己完成 MCP 注册；提示词里的地址与 stdio shim 路径取自**本次安装的真实端口与扩展目录**，不是占位符。下方保留一行裸 URL 作为手工出口，可选的系统 Node 检测改为常驻（只有 Claude Desktop 这类只支持 stdio 的客户端需要）。设置页的逐客户端配置作为高级入口保持不变。
+
 ### [0.10.0] — 2026-08-22
 
 #### ✨ 新增
@@ -326,6 +332,12 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ## English
 
 ### Unreleased
+
+### [0.10.1] — 2026-08-23
+
+#### 🐛 Fixed / Improved
+
+- **The wizard's "connect an external client" page is now one copyable prompt** — it used to make the reader pick between Claude Desktop, Claude Code and Cursor and then copy the matching config blob, so every additional client meant another config to maintain and the reader still had to work out which file it belonged in. It now shows a single prompt to paste into whichever AI client the reader already uses, letting that client perform the MCP registration; the address and stdio shim path inside it come from **this install's real port and extension directory**, not placeholders. The bare URL stays below it as a manual exit, and the optional system-Node check is always visible now that no client is selected (only stdio-only clients such as Claude Desktop need it). The Settings page keeps its per-client configs as the advanced entry point.
 
 ### [0.10.0] — 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ English | [简体中文](README.zh-CN.md)
 **One-line setup prompt — paste this into Claude Code or another AI agent:**
 
 ```text
-Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.0
+Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.1
 release, open Window > Extensions
 > ae-mcp in After Effects, then connect Claude Code with `claude mcp add
 --transport http ae http://127.0.0.1:11488/mcp`; for Claude Desktop, configure

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 **一行安装提示词——复制给 Claude Code 或其它 AI agent：**
 
 ```text
-请从 v0.10.0 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
+请从 v0.10.1 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
 中打开
 Window > Extensions > ae-mcp，然后用 `claude mcp add --transport http ae
 http://127.0.0.1:11488/mcp` 接入 Claude Code；Claude Desktop 则使用系统 Node

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.10.0"
+                   ExtensionBundleVersion="0.10.1"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.10.0" />
+        <Extension Id="com.aemcp.panel" Version="0.10.1" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20412,7 +20412,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.10.0",
+    version: "0.10.1",
     private: true,
     type: "module",
     scripts: {
@@ -27727,7 +27727,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   // src/cep/mcpClient.js
   init_cep_runtime_inject();
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.10.0";
+  var PANEL_VERSION = "0.10.1";
   function defaultFetch() {
     if (globalThis.window && globalThis.window.fetch) {
       return globalThis.window.fetch.bind(globalThis.window);

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1048,7 +1048,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-        version: input.version || '0.10.0',
+                version: input.version || '0.10.1',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "express": "4.22.2"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,5 +1,5 @@
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.10.0';
+export const PANEL_VERSION = '0.10.1';
 
 function defaultFetch() {
   if (globalThis.window && globalThis.window.fetch) {

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -11,7 +11,7 @@ param(
     [string]$CertPassword = '',
     [string]$CertPath = '',
     [string]$OutputPath = '',
-    [string]$Version = '0.10.0',
+    [string]$Version = '0.10.1',
     [string]$Tsa = 'http://timestamp.digicert.com',
     [switch]$SkipSigning
 )

--- a/scripts/package/test/freeze-signed-manifests.test.mjs
+++ b/scripts/package/test/freeze-signed-manifests.test.mjs
@@ -22,7 +22,7 @@ test('writes canonical freeze evidence bound to the direct extension stage', asy
   const evidence = await freezeSignedManifestsWithEvidence({
     root: signingRoot,
     platform: 'windows-x64',
-    version: '0.10.0',
+    version: '0.10.1',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
     evidencePath,
@@ -56,21 +56,21 @@ test('freezes a changed direct payload without adding retired payload roots', as
   await assert.rejects(verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.0',
+    version: '0.10.1',
     sourceCommitSha: h.input.sourceCommitSha,
   }), { code: 'BUNDLE_FILE_METADATA_MISMATCH' });
 
   const result = await freezeSignedManifests({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.0',
+    version: '0.10.1',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
   });
   await verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.0',
+    version: '0.10.1',
     sourceCommitSha: h.input.sourceCommitSha,
   });
   assert.equal(result.signedBundleManifestSha256, await sha256File(
@@ -91,7 +91,7 @@ test('refuses to freeze when the asserted source digest is malformed', async (t)
   await assert.rejects(freezeSignedManifests({
     root: h.outDir,
     platform: 'windows-x64',
-    version: '0.10.0',
+    version: '0.10.1',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256: 'bad',
   }), /source stage digest/i);

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { canonicalJson } from '../../lib/manifest.mjs';
 
 export const SOURCE_COMMIT_SHA = '0123456789abcdef0123456789abcdef01234567';
-export const PRODUCT_VERSION = '0.10.0';
+export const PRODUCT_VERSION = '0.10.1';
 
 export function sha256Bytes(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -69,8 +69,8 @@ async function writePlugin(repoRoot) {
   const plugin = path.join(repoRoot, 'plugin');
   await writeFixtureFile(plugin, 'CSXS/manifest.xml', [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.0">',
-    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.0" /></ExtensionList>',
+    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.1">',
+    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.1" /></ExtensionList>',
     '  <ExecutionEnvironment><HostList><Host Name="AEFT" Version="[23.0,26.9]" />',
     '  </HostList></ExecutionEnvironment>',
     '</ExtensionManifest>',

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { verifyWindowsZxpStage } from '../verify-windows-zxp-stage.mjs';
 
-const VERSION = '0.10.0';
+const VERSION = '0.10.1';
 
 async function write(root, relative, value) {
   const file = path.join(root, ...relative.split('/'));

--- a/scripts/release/run-signing-plan.mjs
+++ b/scripts/release/run-signing-plan.mjs
@@ -23,7 +23,7 @@ import { freezeSignedManifests as foundationFreezeSignedManifests } from '../pac
 import { sha256Directory as foundationSha256Directory } from '../package/lib/files.mjs';
 import { collectManifestEntries, copyTree } from '../package/lib/manifest.mjs';
 
-const RELEASE_VERSION = '0.10.0';
+const RELEASE_VERSION = '0.10.1';
 const CANDIDATE_SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const PLATFORMS = new Set(['macos-arm64', 'windows-x64']);

--- a/scripts/release/signing-report.mjs
+++ b/scripts/release/signing-report.mjs
@@ -176,7 +176,7 @@ function expectedOutputRoles(platform) {
 }
 
 function expectedOutputName(platform, role) {
-  return `ae-mcp-panel-v0.10.0-${platform}.${role}`;
+  return `ae-mcp-panel-v0.10.1-${platform}.${role}`;
 }
 
 function validateIdentityFields(input) {

--- a/scripts/release/test/artifact-manifest.test.mjs
+++ b/scripts/release/test/artifact-manifest.test.mjs
@@ -12,7 +12,7 @@ import { makeArtifactManifestFixture } from './helpers/artifact-manifest-fixture
 test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.0',
+    version: '0.10.1',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,
@@ -32,7 +32,7 @@ test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence'
 test('artifact manifest rejects an unsupported artifact role and malformed evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.0',
+    version: '0.10.1',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,

--- a/scripts/release/test/attestation.test.mjs
+++ b/scripts/release/test/attestation.test.mjs
@@ -20,7 +20,7 @@ const MAC_COMMANDS = [
 ];
 
 function report(platform = 'windows-x64', result = 'PASS') {
-  const name = `ae-mcp-panel-v0.10.0-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
+  const name = `ae-mcp-panel-v0.10.1-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
   return {
     schemaVersion: 1,
     platform,

--- a/scripts/release/test/helpers/artifact-manifest-fixture.mjs
+++ b/scripts/release/test/helpers/artifact-manifest-fixture.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { canonicalJson } from '../../../package/lib/manifest.mjs';
 import { canonicalStringify, sha256File } from '../../artifact-manifest.mjs';
 
-export const PRODUCT_VERSION = '0.10.0';
+export const PRODUCT_VERSION = '0.10.1';
 export const PRODUCT_SCENARIOS = [
   'clean-install-and-upgrade-rollback',
   'permission-denial-and-recovery',

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -21,7 +21,7 @@ async function signingInput(t, platform) {
   t.after(() => rm(root, { recursive: true, force: true }));
   const input = {
     platform,
-    version: '0.10.0',
+    version: '0.10.1',
     candidateSha: CANDIDATE_SHA,
     stageRoot: path.join(root, 'stage'),
     signingRoot: path.join(root, 'signing'),

--- a/scripts/release/test/validate-attestation-comment.test.mjs
+++ b/scripts/release/test/validate-attestation-comment.test.mjs
@@ -22,7 +22,7 @@ function report(result = 'PASS') {
     candidateSha: 'b'.repeat(40),
     workflowRunId: '42',
     artifactId: '101',
-    artifactName: 'ae-mcp-panel-v0.10.0-windows-x64.zxp',
+    artifactName: 'ae-mcp-panel-v0.10.1-windows-x64.zxp',
     artifactSha256: 'c'.repeat(64),
     osVersion: 'Windows 10.0.26100',
     codexVersion: '0.144.0-alpha.4',

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -26,7 +26,7 @@ const MAC_COMMANDS = [
 function artifact(platform, id) {
   return {
     artifactId: String(id),
-    name: `ae-mcp-panel-v0.10.0-${platform}.zxp`,
+    name: `ae-mcp-panel-v0.10.1-${platform}.zxp`,
     platform,
     role: 'zxp',
     sha256: String(id).repeat(64).slice(0, 64),
@@ -62,7 +62,7 @@ function fixture() {
   const windows = artifact('windows-x64', 102);
   const manifest = {
     schemaVersion: 1,
-    version: '0.10.0',
+    version: '0.10.1',
     candidateSha: CANDIDATE_SHA,
     workflowRunId: '42',
     artifacts: [mac, windows],

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import test from 'node:test';
 
-const VERSION = '0.10.0';
+const VERSION = '0.10.1';
 
 async function text(relative) {
   return fs.readFile(relative, 'utf8');

--- a/scripts/release/verify-release-inputs.mjs
+++ b/scripts/release/verify-release-inputs.mjs
@@ -6,7 +6,7 @@ const SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const DECIMAL_ID = /^\d+$/;
 const POSITIVE_DECIMAL_ID = /^[1-9]\d*$/;
-const VERSION = '0.10.0';
+const VERSION = '0.10.1';
 
 function recordIdentity(record, field) {
   return record?.[field] ?? record?.report?.[field];


### PR DESCRIPTION
## 为什么发新版而不是替换 v0.10.0 的 ZXP

#311 改了首跑向导第 3 页的形态，面板载荷跟着变了。v0.10.0 已经发布、tag 已推，就地替换它的 ZXP 会让已发布的校验和在别人脚下变，而且 tag `v0.10.0` 指向的 `5a85be7` 里根本没有这次改动——等于发一个任何 tag 源码都构建不出来的二进制。所以走新版本号。

## 改动

**版本面**（`version-consistency.test.mjs` 钉死的全表面，0.10.0 → 0.10.1）：host / panel 的 `package.json` 与 lockfile、CSXS 清单、`PANEL_VERSION`、native 客户端握手时自报的默认版本，以及 `package-zxp.ps1` / `run-signing-plan.mjs` / `signing-report.mjs` / `verify-release-inputs.mjs` 与它们的测试夹具。

lockfile 里 `"node": ">= 0.10.0"` 那类**引擎约束刻意不动**——那不是产品版本，用行级替换避开了。

**文档**：CHANGELOG 中英各加一段 `[0.10.1] — 2026-08-23` 记向导页改动；两份 README 的一行安装提示词改指 v0.10.1 发布页。

**产物**：`plugin/client/dist` 已重建（`PANEL_VERSION` 变了）。

## 原生插件不重建

面板改动不碰 `native/`，两个原生件的源码与字节都没变。v0.10.1 会把 v0.10.0 的 `.aex` 与 `.plugin.zip` **原字节、原文件名**重新挂到新 release 上，而不是给它们改个名冒充 0.10.1——文件名里的版本号如实反映其构建版本。面板与原生插件之间靠 wire version 协商（本会话实测过 0.10.0 面板对 0.9.6 AEX 正常握手），产品版本不参与兼容判定。

## 验证（Windows 11，Node 24.14.0）

```
node --test scripts/release/test/version-consistency.test.mjs  → tests 6    pass 6    fail 0
cd plugin/panel && npm test                                    → tests 496  pass 495  fail 0  skipped 1
cd plugin/host  && npm test                                    → tests 223  pass 207  fail 0  skipped 16
cd plugin/panel && npm run build && node verify-bundle.mjs     → plugin/client/dist matches the panel sources.
```

打包 / 发布两套件的失败集与 `main` 基线**逐条同名**（62 + 2 个唯一名，全部是本机非管理员的 symlink/hardlink EPERM 与缺 `compile.cmd`，CI 上绿）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
