### PR TITLE
release: bump the product version to 0.10.2 and cut its changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
-### Unreleased
+### [0.10.2] — 2026-08-23
 
-- **失败恢复从 `ae_exec` 中拆出**——恢复操作改由独立的 `ae_execRecover` 接收 `recoveryId` 与可选修正脚本，`ae_exec` 只接受正常脚本执行参数，避免模型把恢复编号误当脚本内容。本项会把公开工具从 11 个增加到 12 个，并改变旧恢复调用方式，合并前仍需完成兼容性决策。
+- **失败恢复从 `ae_exec` 中拆出**——恢复操作改由独立的 `ae_execRecover` 接收 `recoveryId` 与可选修正脚本，`ae_exec` 只接受正常脚本执行参数，避免模型把恢复编号误当脚本内容。本项把公开工具从 11 个增加到 12 个。旧的 `ae_exec({recoveryId})` 调用方式不再受理，会返回一条指明改用 `ae_execRecover` 的错误；不提供兼容垫片——在同一个 schema 里并列两个可选字段正是这次要消除的歧义来源。
 - **OpenCode 自定义模型可按模型设置上下文窗口**——Provider 管理器为每个模型提供 32K / 64K / 128K（推荐）/ 200K 与自定义数值；旧配置自动沿用 128K。面板拒绝小于 32K 或大于 2M 的值，并按窗口自动预留合理的回复空间，避免把 32K 模型同时声明成 32K 输出而导致每轮都压缩。填大不会增加模型真实能力，界面明确提示过大可能来不及压缩、过小会更频繁压缩。
 - **Luna 的属性读取不再被本地拒绝**——`ae_read` 现在接受按属性完整路径排序；Luna 在真实长会话里生成这种合法请求时，可以直接读取而不会在到达 AE 前失败。
 - **低档模型的脚本返回要求更明确**——主机现在明确区分普通脚本末尾的结果与函数包装内必须 `return` 的结果，减少“AE 已执行、面板却只能判失败”的可避免恢复流程。
+- **审批卡会真正显示，档位与当前会话一致**——手动档下每个写操作都会弹出审批卡，并可展开查看真实调用参数。审批身份改用被调工具自身的名字（恢复操作显示为 `ae_execRecover` 而不是 `ae_exec`）；授权绑定的内容指纹按完整调用计算，而不是卡片上那段 200 字预览，避免前缀相同的两个脚本被当成同一次已授权操作。用户取消、审批对话框不可用、审批超时、明确拒绝现在是四条不同的提示，不再一律显示为「用户拒绝」。
+- **长任务持续显示进度，运行中切换会话会先确认**——回合运行期间持续显示已用时长与预计 token。任务尚未结束时新建或切换会话会先弹出确认框：「取消」让当前任务继续跑完，「停止并继续」才停止当前任务并切换，不再静默中断。
+- **OpenCode 失败后会话仍然可用**——provider 或 socket 失败会保留真实失败原因，并允许在同一个会话里重试，而不是让会话卡在永久忙碌状态。（issue 里要求的「自动一次性重试 / 退避」尚未实现。）
+- **OpenCode 长会话的请求不再膨胀**——发送前会精简历史里已经执行过的旧脚本正文；工具结果与 AE 回读保持不变，主要缓解第 6、7 轮之后的请求体积增长。代价是模型无法引用旧脚本原文，除非重新提供。
+- **中文跨数据块不再乱码**——Claude、Codex、OpenCode 三条通道的分块输出统一按完整 UTF-8 边界解码。
 
 ### [0.10.1] — 2026-08-23
 
@@ -331,12 +336,17 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ## English
 
-### Unreleased
+### [0.10.2] — 2026-08-23
 
-- **Failure recovery is split out of `ae_exec`** — a dedicated `ae_execRecover` now accepts `recoveryId` and optional corrected code, while `ae_exec` accepts only normal script-execution arguments so models cannot mistake a recovery id for script text. This increases the public surface from 11 tools to 12 and changes the previous recovery call shape; the compatibility decision remains required before merge.
+- **Failure recovery is split out of `ae_exec`** — a dedicated `ae_execRecover` now accepts `recoveryId` and optional corrected code, while `ae_exec` accepts only normal script-execution arguments so models cannot mistake a recovery id for script text. This increases the public surface from 11 tools to 12. The previous `ae_exec({recoveryId})` shape is rejected with an error naming `ae_execRecover`; no compatibility shim is provided, because two optional fields sharing one schema is the ambiguity this change exists to remove.
 - **Per-model context windows for custom OpenCode models** — Provider Manager now offers 32K / 64K / 128K (recommended) / 200K presets plus a custom value for every model; existing configurations keep the 128K default. Values below 32K or above 2M are rejected, and the advertised output reserve scales with the chosen window so a 32K model is not also declared as having 32K of output capacity. The UI warns that a larger number cannot increase a provider's real capacity, while a smaller number compacts more often.
 - **Luna property reads no longer fail local validation** — `ae_read` now accepts sorting properties by their full match path, so this valid request shape from Luna reaches After Effects instead of failing before dispatch.
 - **Clearer script-result guidance for smaller models** — host instructions now distinguish a bare script's final value from the explicit `return` required inside an IIFE, reducing avoidable recoveries where AE changed but the panel received `undefined`.
+- **The approval card actually appears, and its tier matches the conversation** — in manual tier every write raises an approval card whose real call arguments can be expanded. Approval identity now uses the invoked tool's own name (a retry shows as `ae_execRecover`, not `ae_exec`), and the authorization content hash covers the complete call instead of the card's 200-character preview, so two scripts sharing a prefix are no longer treated as the same approved operation. User cancellation, an unavailable approval dialog, an approval timeout, and an explicit denial are now four distinct messages rather than one generic "user denied".
+- **Long turns keep reporting progress, and switching sessions mid-run asks first** — a running turn continuously reports elapsed time and estimated tokens. Creating or switching sessions while a turn is unfinished raises a confirmation: "cancel" leaves the running task alone, and only "stop and continue" stops it before switching. Turns are no longer dropped silently.
+- **An OpenCode failure leaves the session usable** — a provider or socket failure preserves the real cause and allows a retry in the same conversation instead of leaving the session permanently busy. (The automatic one-shot retry/backoff the issue asks for is still not implemented.)
+- **OpenCode long sessions stop inflating their requests** — already-executed script bodies are trimmed from the outbound history copy before sending. Tool results and AE readbacks are unchanged; this mainly relieves the request growth seen after the sixth or seventh turn. The tradeoff is that the model cannot quote an old script body unless it is supplied again.
+- **Chunked output no longer corrupts multi-byte text** — the Claude, Codex, and OpenCode channels all decode streamed chunks on complete UTF-8 boundaries.
 
 ### [0.10.1] — 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ English | [简体中文](README.zh-CN.md)
 **One-line setup prompt — paste this into Claude Code or another AI agent:**
 
 ```text
-Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.1
+Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.2
 release, open Window > Extensions
 > ae-mcp in After Effects, then connect Claude Code with `claude mcp add
 --transport http ae http://127.0.0.1:11488/mcp`; for Claude Desktop, configure

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 **一行安装提示词——复制给 Claude Code 或其它 AI agent：**
 
 ```text
-请从 v0.10.1 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
+请从 v0.10.2 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
 中打开
 Window > Extensions > ae-mcp，然后用 `claude mcp add --transport http ae
 http://127.0.0.1:11488/mcp` 接入 Claude Code；Claude Desktop 则使用系统 Node

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.10.1"
+                   ExtensionBundleVersion="0.10.2"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.10.1" />
+        <Extension Id="com.aemcp.panel" Version="0.10.2" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20412,7 +20412,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.10.1",
+    version: "0.10.2",
     private: true,
     type: "module",
     scripts: {
@@ -27774,7 +27774,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   // src/cep/mcpClient.js
   init_cep_runtime_inject();
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.10.1";
+  var PANEL_VERSION = "0.10.2";
   function defaultFetch() {
     if (globalThis.window && globalThis.window.fetch) {
       return globalThis.window.fetch.bind(globalThis.window);

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1048,7 +1048,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-                version: input.version || '0.10.1',
+                version: input.version || '0.10.2',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "express": "4.22.2"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,5 +1,5 @@
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.10.1';
+export const PANEL_VERSION = '0.10.2';
 
 function defaultFetch() {
   if (globalThis.window && globalThis.window.fetch) {

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -11,7 +11,7 @@ param(
     [string]$CertPassword = '',
     [string]$CertPath = '',
     [string]$OutputPath = '',
-    [string]$Version = '0.10.1',
+    [string]$Version = '0.10.2',
     [string]$Tsa = 'http://timestamp.digicert.com',
     [switch]$SkipSigning
 )

--- a/scripts/package/test/freeze-signed-manifests.test.mjs
+++ b/scripts/package/test/freeze-signed-manifests.test.mjs
@@ -22,7 +22,7 @@ test('writes canonical freeze evidence bound to the direct extension stage', asy
   const evidence = await freezeSignedManifestsWithEvidence({
     root: signingRoot,
     platform: 'windows-x64',
-    version: '0.10.1',
+    version: '0.10.2',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
     evidencePath,
@@ -56,21 +56,21 @@ test('freezes a changed direct payload without adding retired payload roots', as
   await assert.rejects(verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.1',
+    version: '0.10.2',
     sourceCommitSha: h.input.sourceCommitSha,
   }), { code: 'BUNDLE_FILE_METADATA_MISMATCH' });
 
   const result = await freezeSignedManifests({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.1',
+    version: '0.10.2',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
   });
   await verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.1',
+    version: '0.10.2',
     sourceCommitSha: h.input.sourceCommitSha,
   });
   assert.equal(result.signedBundleManifestSha256, await sha256File(
@@ -91,7 +91,7 @@ test('refuses to freeze when the asserted source digest is malformed', async (t)
   await assert.rejects(freezeSignedManifests({
     root: h.outDir,
     platform: 'windows-x64',
-    version: '0.10.1',
+    version: '0.10.2',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256: 'bad',
   }), /source stage digest/i);

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { canonicalJson } from '../../lib/manifest.mjs';
 
 export const SOURCE_COMMIT_SHA = '0123456789abcdef0123456789abcdef01234567';
-export const PRODUCT_VERSION = '0.10.1';
+export const PRODUCT_VERSION = '0.10.2';
 
 export function sha256Bytes(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -69,8 +69,8 @@ async function writePlugin(repoRoot) {
   const plugin = path.join(repoRoot, 'plugin');
   await writeFixtureFile(plugin, 'CSXS/manifest.xml', [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.1">',
-    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.1" /></ExtensionList>',
+    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.2">',
+    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.2" /></ExtensionList>',
     '  <ExecutionEnvironment><HostList><Host Name="AEFT" Version="[23.0,26.9]" />',
     '  </HostList></ExecutionEnvironment>',
     '</ExtensionManifest>',

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { verifyWindowsZxpStage } from '../verify-windows-zxp-stage.mjs';
 
-const VERSION = '0.10.1';
+const VERSION = '0.10.2';
 
 async function write(root, relative, value) {
   const file = path.join(root, ...relative.split('/'));

--- a/scripts/release/run-signing-plan.mjs
+++ b/scripts/release/run-signing-plan.mjs
@@ -23,7 +23,7 @@ import { freezeSignedManifests as foundationFreezeSignedManifests } from '../pac
 import { sha256Directory as foundationSha256Directory } from '../package/lib/files.mjs';
 import { collectManifestEntries, copyTree } from '../package/lib/manifest.mjs';
 
-const RELEASE_VERSION = '0.10.1';
+const RELEASE_VERSION = '0.10.2';
 const CANDIDATE_SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const PLATFORMS = new Set(['macos-arm64', 'windows-x64']);

--- a/scripts/release/signing-report.mjs
+++ b/scripts/release/signing-report.mjs
@@ -176,7 +176,7 @@ function expectedOutputRoles(platform) {
 }
 
 function expectedOutputName(platform, role) {
-  return `ae-mcp-panel-v0.10.1-${platform}.${role}`;
+  return `ae-mcp-panel-v0.10.2-${platform}.${role}`;
 }
 
 function validateIdentityFields(input) {

--- a/scripts/release/test/artifact-manifest.test.mjs
+++ b/scripts/release/test/artifact-manifest.test.mjs
@@ -12,7 +12,7 @@ import { makeArtifactManifestFixture } from './helpers/artifact-manifest-fixture
 test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.1',
+    version: '0.10.2',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,
@@ -32,7 +32,7 @@ test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence'
 test('artifact manifest rejects an unsupported artifact role and malformed evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.1',
+    version: '0.10.2',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,

--- a/scripts/release/test/attestation.test.mjs
+++ b/scripts/release/test/attestation.test.mjs
@@ -20,7 +20,7 @@ const MAC_COMMANDS = [
 ];
 
 function report(platform = 'windows-x64', result = 'PASS') {
-  const name = `ae-mcp-panel-v0.10.1-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
+  const name = `ae-mcp-panel-v0.10.2-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
   return {
     schemaVersion: 1,
     platform,

--- a/scripts/release/test/helpers/artifact-manifest-fixture.mjs
+++ b/scripts/release/test/helpers/artifact-manifest-fixture.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { canonicalJson } from '../../../package/lib/manifest.mjs';
 import { canonicalStringify, sha256File } from '../../artifact-manifest.mjs';
 
-export const PRODUCT_VERSION = '0.10.1';
+export const PRODUCT_VERSION = '0.10.2';
 export const PRODUCT_SCENARIOS = [
   'clean-install-and-upgrade-rollback',
   'permission-denial-and-recovery',

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -21,7 +21,7 @@ async function signingInput(t, platform) {
   t.after(() => rm(root, { recursive: true, force: true }));
   const input = {
     platform,
-    version: '0.10.1',
+    version: '0.10.2',
     candidateSha: CANDIDATE_SHA,
     stageRoot: path.join(root, 'stage'),
     signingRoot: path.join(root, 'signing'),

--- a/scripts/release/test/validate-attestation-comment.test.mjs
+++ b/scripts/release/test/validate-attestation-comment.test.mjs
@@ -22,7 +22,7 @@ function report(result = 'PASS') {
     candidateSha: 'b'.repeat(40),
     workflowRunId: '42',
     artifactId: '101',
-    artifactName: 'ae-mcp-panel-v0.10.1-windows-x64.zxp',
+    artifactName: 'ae-mcp-panel-v0.10.2-windows-x64.zxp',
     artifactSha256: 'c'.repeat(64),
     osVersion: 'Windows 10.0.26100',
     codexVersion: '0.144.0-alpha.4',

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -26,7 +26,7 @@ const MAC_COMMANDS = [
 function artifact(platform, id) {
   return {
     artifactId: String(id),
-    name: `ae-mcp-panel-v0.10.1-${platform}.zxp`,
+    name: `ae-mcp-panel-v0.10.2-${platform}.zxp`,
     platform,
     role: 'zxp',
     sha256: String(id).repeat(64).slice(0, 64),
@@ -62,7 +62,7 @@ function fixture() {
   const windows = artifact('windows-x64', 102);
   const manifest = {
     schemaVersion: 1,
-    version: '0.10.1',
+    version: '0.10.2',
     candidateSha: CANDIDATE_SHA,
     workflowRunId: '42',
     artifacts: [mac, windows],

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import test from 'node:test';
 
-const VERSION = '0.10.1';
+const VERSION = '0.10.2';
 
 async function text(relative) {
   return fs.readFile(relative, 'utf8');

--- a/scripts/release/verify-release-inputs.mjs
+++ b/scripts/release/verify-release-inputs.mjs
@@ -6,7 +6,7 @@ const SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const DECIMAL_ID = /^\d+$/;
 const POSITIVE_DECIMAL_ID = /^[1-9]\d*$/;
-const VERSION = '0.10.1';
+const VERSION = '0.10.2';
 
 function recordIdentity(record, field) {
   return record?.[field] ?? record?.report?.[field];


### PR DESCRIPTION
## Common

- Change type: release bump
- Issue or package Issue: follows #319
- User-visible outcome: the panel ZXP ships as `v0.10.2` instead of silently replacing the published `0.10.1`, and the changelog records what actually shipped.
- Scope and explicit non-goals:
  - Version strings across the host/panel packages and locks, CSXS manifest, `PANEL_VERSION`, the native client's handshake default, and the package/release scripts with their fixtures and version anchors — the same 25-file shape as #312.
  - The changelog `Unreleased` section becomes `[0.10.2]` in both languages, the `ae_execRecover` entry records that the split ships **without** a compatibility shim, and five shipped changes the section was missing are added.
  - Non-goal: the native plug-in. `native/` and `packaging/` are unchanged since `v0.10.0`, so this release carries the existing `AeMcpNative-v0.10.0-windows-x64.aex` and `AeMcpNative-v0.10.0-macos-arm64.plugin.zip` artifacts rather than rebuilding them — the same carry-forward `v0.10.1` used.

Commands and results (run on Windows, by the reviewer, not the implementing worker):

```text
node --test scripts/release/test/version-consistency.test.mjs  -> 6/6 passed
(cd plugin/panel && npm test)                                  -> 543 tests, 542 passed, 1 skipped, 0 failed
(cd plugin/host && npm test)                                   -> 231 tests, 215 passed, 16 skipped, 0 failed
(cd plugin/panel && npm run build)                             -> passed
(cd plugin/panel && npm run verify-bundle)                     -> passed
node scripts/check-repository-governance.mjs                   -> passed
node --test scripts/package/test/verify-windows-zxp-stage.test.mjs   -> 4/4 passed
node --test scripts/package/test/freeze-signed-manifests.test.mjs    -> 3/3 passed
git diff --check                                               -> passed
```

Only the two historical `### [0.10.1] — 2026-08-23` changelog headings still reference the old version; no active version string does.

## Native package evidence (conditional)

N/A — no native primitive or native package changed. The release reuses the unchanged `v0.10.0` native artifacts.