### PR TITLE
fix: stream ordering, live CLI detection, and a self-healing exec feedback loop (#321 #322 #323 #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
+### Unreleased
+
+- **AI 回复不再被工具卡撕成两截（#322）**——三条通道统一在插入工具、审批、提问卡片之前先把已生成的文字完整落屏。此前配置了 API Key 时，最后几十个字符会被扣在防泄漏缓冲里，等你答完问题才出现在卡片下面，甚至把一个单词拆成两半。
+- **AE 开着也能装好 CLI（#321）**——Windows 上「重新检测」现在会重读注册表里的用户/系统 PATH，并认识 Claude 官方安装器（`~\.local\bin`）、scoop、OpenCode 官方安装器的默认位置。装完 CLI 直接点重新检测即可，不必重启 After Effects。
+- **智能体不再被自己的历史带进死循环（#323）**——修复一起真实事故：为省 token 而脱敏的历史脚本占位符被模型当成代码原样发回，先是执行一句注释永远失败，重试时还会把存档的恢复脚本覆写掉，单个任务连败四十余次。现在主机直接拦下占位符并明确告知重写完整脚本，恢复存档不再会被覆写；占位符文本也改为自带「不要把这句注释当代码发回」的指令。
+- **报错终于带上修复提示（#323）**——错误提示此前只在「脚本跑完但没返回值」的旁路上生效，真正抛 ExtendScript 异常时从未附带；现已修复,并新增滑块 ±100 万上限、颜色数组、失效对象、NO_VALUE 属性组四条实战提示。返回值约定（最后一条语句必须是裸表达式）与 `ae_previewFrame` 参数冲突的报错现在会直接给出正确写法示例。
+- **诊断包能还原真实故障了（#323）**——活动日志新增工具名、调用通道、客户端归因；失败时记录脚本摘要与命中的提示；宿主执行成功但被判失败的调用（如返回 undefined）不再伪装成成功；skill 调用留痕；导出包合并历史进程的错误。OpenCode 内建工具（read/apply_patch 等）在界面与导出中不再被误标为 `mcp__ae__` 前缀（#324）。
+
 ### [0.10.2] — 2026-08-23
 
 - **失败恢复从 `ae_exec` 中拆出**——恢复操作改由独立的 `ae_execRecover` 接收 `recoveryId` 与可选修正脚本，`ae_exec` 只接受正常脚本执行参数，避免模型把恢复编号误当脚本内容。本项把公开工具从 11 个增加到 12 个。旧的 `ae_exec({recoveryId})` 调用方式不再受理，会返回一条指明改用 `ae_execRecover` 的错误；不提供兼容垫片——在同一个 schema 里并列两个可选字段正是这次要消除的歧义来源。
@@ -335,6 +343,14 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ---
 
 ## English
+
+### Unreleased
+
+- **AI replies are no longer torn apart by tool cards (#322)** — all three channels flush pending assistant text before inserting a tool, approval, or question card. Previously, with an API key configured, the last few dozen characters were withheld in the leak-prevention buffer and only appeared below the card after you answered — sometimes splitting a word in half.
+- **CLIs installed while AE is open are now detected (#321)** — on Windows, Re-check re-reads the registry user/system PATH and knows the official install locations (Claude's `~\.local\bin`, scoop shims, OpenCode's `~\.opencode\bin`). No more restarting After Effects after installing a CLI.
+- **Agents can no longer be trapped by their own redacted history (#323)** — fixes a real incident: the placeholder that hides old scripts from history (to save tokens) was imitated by the model and sent back as code, executing a bare comment forever and even overwriting the stored recovery script on retry — one task failed 40+ times. The host now rejects placeholder code with clear guidance, recovery scripts can no longer be overwritten by it, and the placeholder text itself now says never to send it back.
+- **Errors finally carry fix hints (#323)** — hints previously fired only on the "ran but returned nothing" side path, never on actual ExtendScript exceptions; that is fixed, with four new field-driven hints (slider ±1,000,000 clamp, color arity, invalid object, NO_VALUE groups). The completion-value contract (the last statement must be a bare expression) and `ae_previewFrame` parameter conflicts now state the correct call shapes inline.
+- **Diagnostics bundles can reconstruct real failures (#323)** — activity entries now carry the tool name, transport, and client attribution; failures record a bounded script head and which hint fired; calls the bridge saw as success but the MCP layer failed (e.g. undefined results) are no longer disguised as successes; skill invocations leave a trace; exports merge errors from prior panel processes. OpenCode built-in tools (read/apply_patch/…) are no longer mislabeled with an `mcp__ae__` prefix (#324).
 
 ### [0.10.2] — 2026-08-23
 

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -21295,6 +21295,14 @@
       }
       const hasExplicitEnv = Object.prototype.hasOwnProperty.call(options, "env");
       const environment = hasExplicitEnv ? completeEnvironment(options.env || {}) : completeSpawnEnv();
+      if (windows && (executable.source === "registry-path" || executable.source === "standard")) {
+        const pathKey = environmentKey(environment, "PATH", true) || "Path";
+        const executableDirectory = paths.dirname(executable.path);
+        const pathDirectories = String(environment[pathKey] || "").split(separator).filter(Boolean);
+        if (!pathDirectories.some((directory) => windowsPathEqual(directory, executableDirectory))) {
+          environment[pathKey] = [executableDirectory, ...pathDirectories].join(separator);
+        }
+      }
       const commandArgs = [...executable.argsPrefix || [], ...args];
       return deps.spawnImpl(executable.path, commandArgs, {
         ...options,
@@ -21457,6 +21465,64 @@
       }
       return result;
     }
+    function windowsPathEqual(left, right) {
+      return String(left).replace(/[\\/]+$/, "").toLowerCase() === String(right).replace(/[\\/]+$/, "").toLowerCase();
+    }
+    function expandedRegistryPath(value, type, env) {
+      if (type.toUpperCase() !== "REG_EXPAND_SZ") return value;
+      return value.replace(/%([^%]+)%/g, (match, name) => {
+        const replacement = environmentValue(env, name, true);
+        return replacement === void 0 ? match : String(replacement);
+      });
+    }
+    function registryPathValue(output, env) {
+      const line = String(output || "").split(/\r?\n/).find((value) => {
+        return /^\s*Path\s+REG_(?:SZ|EXPAND_SZ)\s+/i.test(value);
+      });
+      if (!line) return null;
+      const match = line.match(/^\s*Path\s+(REG_(?:SZ|EXPAND_SZ))\s+(.*)$/i);
+      return match ? expandedRegistryPath(match[2], match[1], env) : null;
+    }
+    async function registryPathCandidates(id, env) {
+      if (!windows) return [];
+      const systemRoot = String(environmentValue(env, "SystemRoot", true) || environmentValue(env, "WINDIR", true) || "C:\\Windows");
+      const executable = {
+        ok: true,
+        id: "reg",
+        path: paths.join([systemRoot, "System32", "reg.exe"]),
+        argsPrefix: [],
+        source: "registry-path",
+        version: null,
+        arch: null
+      };
+      const queries = [
+        ["HKCU\\Environment", "/v", "Path"],
+        ["HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment", "/v", "Path"]
+      ];
+      const values = [];
+      for (const args of queries) {
+        const result = await run({
+          executable,
+          args: ["query", ...args],
+          env,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+          maxOutputBytes: DEFAULT_OUTPUT_LIMIT
+        });
+        if (result.exitCode !== 0 || result.timedOut || result.aborted) continue;
+        const value = registryPathValue(result.stdout, env);
+        if (value !== null) values.push(value);
+      }
+      const inherited = String(environmentValue(env, "PATH", true) || "").split(separator).filter(Boolean);
+      const directories = [];
+      for (const value of values) {
+        for (const directory of value.split(separator).filter(Boolean)) {
+          if (inherited.some((entry2) => windowsPathEqual(entry2, directory))) continue;
+          if (!directories.some((entry2) => windowsPathEqual(entry2, directory))) directories.push(directory);
+        }
+      }
+      const extensions = ["", ".exe", ".com", ".cmd", ".bat"];
+      return directories.flatMap((directory) => extensions.map((extension) => paths.join([directory, id + extension])));
+    }
     function standardCandidates(id, env) {
       if (!windows) {
         const values2 = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"].map((root) => paths.join([root, id]));
@@ -21471,6 +21537,10 @@
       if (id === "winget") values.unshift(paths.join([local, "Microsoft", "WindowsApps", "winget.exe"]));
       if (id === "powershell") values.unshift(paths.join([systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"]));
       values.push(paths.join([local, "Programs", id, id + ".exe"]));
+      values.push(paths.join([paths.home, ".local", "bin", id + ".exe"]));
+      values.push(paths.join([paths.home, "scoop", "shims", id + ".exe"]));
+      values.push(paths.join([paths.home, "scoop", "shims", id + ".cmd"]));
+      if (id === "opencode") values.push(paths.join([paths.home, ".opencode", "bin", "opencode.exe"]));
       return values;
     }
     function windowsPathInside(root, candidate) {
@@ -21756,6 +21826,22 @@
       for (const group of groups) {
         for (const path of group.values) {
           const rawCandidate = fileCandidate(path, group.source, env, id !== "node");
+          if (!rawCandidate) continue;
+          const materialized = await materializeScriptCandidate(rawCandidate, id, { ...options, env }, attempts);
+          const candidate = materialized.candidate;
+          if (!candidate) {
+            if (materialized.failure === "ARCH_MISMATCH") strongestFailure = "ARCH_MISMATCH";
+            else if (materialized.failure === "VERSION_TOO_OLD" && strongestFailure !== "ARCH_MISMATCH") strongestFailure = "VERSION_TOO_OLD";
+            continue;
+          }
+          const result = await probe(candidate, id, { ...options, env }, attempts);
+          if (result.success) return result.success;
+          strongestFailure = result.failure === "ARCH_MISMATCH" ? result.failure : strongestFailure === "NOT_FOUND" || strongestFailure === "PROBE_FAILED" && result.failure === "VERSION_TOO_OLD" ? result.failure : strongestFailure;
+        }
+      }
+      if (windows && !hasExplicitEnv) {
+        for (const path of await registryPathCandidates(id, env)) {
+          const rawCandidate = fileCandidate(path, "registry-path", env, id !== "node");
           if (!rawCandidate) continue;
           const materialized = await materializeScriptCandidate(rawCandidate, id, { ...options, env }, attempts);
           const candidate = materialized.candidate;
@@ -28754,6 +28840,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         ]));
       }
     }
+    function emitAfterText(evt) {
+      providerDeltaRedactor.flush();
+      emit(evt);
+    }
     function clearNoProgressWarning() {
       if (noProgressWarningTimer !== null) {
         clearTimeoutImpl(noProgressWarningTimer);
@@ -28891,7 +28981,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       for (const [toolUseId, pending] of pendingQuestions) {
         pendingQuestions.delete(toolUseId);
         if (writeResponses) denyControl(pending.requestId, message);
-        emit({ type: "question-resolved", toolUseId, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId, outcome: "cancelled" });
       }
     }
     function finishActive() {
@@ -28918,7 +29008,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       pendingQuestions.delete(id);
       if (!result || result.action !== "submit") {
         denyControl(pending.requestId, "User dismissed the question.");
-        emit({ type: "question-resolved", toolUseId: id, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId: id, outcome: "cancelled" });
         return true;
       }
       const answers = answersForAskUserQuestion(pending.questions, result.values);
@@ -28927,7 +29017,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         questions: pending.originalQuestions,
         answers
       });
-      emit({
+      emitAfterText({
         type: "question-resolved",
         toolUseId: id,
         outcome: "answered",
@@ -29005,7 +29095,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       if (activeRun) {
         providerDeltaRedactor.flush();
         const classified = classifyErrorCode(classificationInput);
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -29075,7 +29165,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           name,
           startedAt: now()
         });
-        emit({
+        emitAfterText({
           type: "tool-start",
           toolUseId,
           name,
@@ -29091,7 +29181,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         const toolUseId = String(block.tool_use_id || "");
         const tool = startedTools.get(toolUseId);
         if (!tool) continue;
-        emit({
+        emitAfterText({
           type: "tool-result",
           toolUseId,
           ok: block.is_error !== true,
@@ -29166,7 +29256,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         originalQuestions,
         questions
       });
-      emit({
+      emitAfterText({
         type: "question-required",
         toolUseId,
         source: "claude-ask-user-question",
@@ -29197,7 +29287,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       const toolUseId = String(request.tool_use_id || requestId);
       const annotation = activeTurn.toolMeta.annotations[name] || {};
       pendingApprovals.set(toolUseId, { requestId, name, input });
-      emit({
+      emitAfterText({
         type: "approval-required",
         toolUseId,
         name,
@@ -29252,7 +29342,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           upstreamText: safeMessage
         });
         const kindReference = classifyError(safeMessage);
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.code === "UPSTREAM_ERROR" && ["auth", "model"].includes(kindReference) ? kindReference : classified.kind,
           code: classified.code,
@@ -29413,7 +29503,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (!(resolved == null ? void 0 : resolved.ok)) {
           const classification = classifyErrorCode({ resolutionCode: resolved == null ? void 0 : resolved.code });
           const resolution = boundedResolution((resolved == null ? void 0 : resolved.resolution) || resolved);
-          emit({
+          emitAfterText({
             type: "error",
             kind: classification.kind,
             code: classification.code,
@@ -29500,7 +29590,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           let message = (error == null ? void 0 : error.message) || "Failed to start Claude CLI.";
           if (classification.code === "SPAWN_FAILED") message = "Claude CLI process could not be started.";
           else if (classification.code === "MCP_UNREACHABLE") message = "Claude could not prepare the panel MCP connection.";
-          emit({
+          emitAfterText({
             type: "error",
             kind: classification.kind,
             code: classification.code,
@@ -29564,7 +29654,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
             fallbackCode: "BACKEND_ERROR"
           });
           const message = classification.code === "MCP_UNREACHABLE" ? "Claude could not prepare the panel MCP connection." : (error == null ? void 0 : error.message) || "Failed to start Claude CLI.";
-          emit({
+          emitAfterText({
             type: "error",
             kind: classification.kind,
             code: classification.code,
@@ -29620,7 +29710,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         turn = canonicalTurn(input);
       } catch (error) {
         const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
-        emit({
+        emitAfterText({
           type: "error",
           kind: "attachment",
           code: "TURN_INPUT_INVALID",
@@ -29668,7 +29758,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       providerDeltaRedactor.flush();
       setThinking(false);
       drainControls("Turn was stopped.");
-      emit({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted." });
+      emitAfterText({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted." });
       finishActive();
       void discardRuntime();
     }
@@ -30081,6 +30171,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     function emit(evt) {
       if (onEvent) onEvent(redactValue(evt, activeAttachmentPaths));
     }
+    function emitAfterText(evt) {
+      providerDeltaRedactor.flush();
+      emit(evt);
+    }
     function emitTurnProgress(stage) {
       if (!activeRun || !activeTurn) return;
       emit({
@@ -30167,7 +30261,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       for (const [toolUseId, pending] of Array.from(pendingUserInputs.entries())) {
         pendingUserInputs.delete(toolUseId);
         if (rpc) rpc.respond(pending.rpcId, { answers: {} });
-        emit({ type: "question-resolved", toolUseId, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId, outcome: "cancelled" });
       }
     }
     function answerQuestion(toolUseId, result) {
@@ -30177,12 +30271,12 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       pendingUserInputs.delete(id);
       if (!result || result.action !== "submit") {
         if (rpc) rpc.respond(pending.rpcId, { answers: {} });
-        emit({ type: "question-resolved", toolUseId: id, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId: id, outcome: "cancelled" });
         return true;
       }
       const answers = answersForCodexUserInput(pending.questions, result.values);
       if (rpc) rpc.respond(pending.rpcId, { answers });
-      emit({
+      emitAfterText({
         type: "question-resolved",
         toolUseId: id,
         outcome: "answered",
@@ -30218,7 +30312,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           return;
         }
         if (item.type !== "mcpToolCall") return;
-        emit({
+        emitAfterText({
           type: "tool-start",
           toolUseId: String(item.id || ""),
           name: mcpToolName(item),
@@ -30233,7 +30327,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           return;
         }
         if (item.type !== "mcpToolCall") return;
-        emit({
+        emitAfterText({
           type: "tool-result",
           toolUseId: String(item.id || ""),
           name: mcpToolName(item),
@@ -30283,7 +30377,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       const toolUseId = "ask_" + String(message.id);
       pendingUserInputs.set(toolUseId, { rpcId: message.id, questions });
-      emit({
+      emitAfterText({
         type: "question-required",
         toolUseId,
         source: "codex-user-input",
@@ -30330,7 +30424,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           plan,
           allowSession: policy.allowSession
         });
-        emit({
+        emitAfterText({
           type: "approval-required",
           toolUseId,
           name: "mcp__ae__ae_toolUse",
@@ -30362,7 +30456,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         input
       };
       pendingApprovals.set(toolUseId, approval);
-      emit({
+      emitAfterText({
         type: "approval-required",
         toolUseId,
         name: approval.name,
@@ -30390,7 +30484,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       if (activeRun) {
         const classified = classifyErrorCode({ exitCode: code, signal, stderrTail: tail });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -30422,7 +30516,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       drainApprovals();
       if (activeRun) {
         const classified = classifyErrorCode({ error: err, spawnError: true });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -30704,7 +30798,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (message !== rawMessage && rawMessage) {
           detail.upstreamMessage = String(rawMessage).slice(0, 500);
         }
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -30724,7 +30818,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         turn = normalizeTurnInput(input);
       } catch (error) {
         const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
-        emit({
+        emitAfterText({
           type: "error",
           kind: "attachment",
           code: "TURN_INPUT_INVALID",
@@ -30780,7 +30874,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       drainApprovals();
       providerDeltaRedactor.discard();
       if (activeRun) {
-        emit({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted.", ...activeTurnFailureFields() });
+        emitAfterText({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted.", ...activeTurnFailureFields() });
         finishActive();
       }
     }
@@ -31334,7 +31428,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
   // src/cep/openCodeHistoryGuard.js
   init_cep_runtime_inject();
   var OPEN_CODE_HISTORY_GUARD_FILENAME = "ae-mcp-history-guard.js";
-  var OPEN_CODE_HISTORY_GUARD_MARKER = "/* executed AE script omitted from prior model history */";
+  var OPEN_CODE_HISTORY_GUARD_MARKER = "/* ae-mcp: script body hidden from history to save tokens. Never send this comment back as code \u2014 write the full script again, or rerun the stored script via ae_execRecover with its recoveryId. */";
   var AE_EXEC_TOOL_NAMES = Object.freeze([
     "ae_exec",
     "ae_execRecover",
@@ -31475,6 +31569,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     const text = String(raw || "");
     if (!text) return "";
     if (text.startsWith("mcp__")) return text;
+    if (!text.startsWith("ae_")) return text;
     return "mcp__ae__" + text.replace(/^ae_/, "");
   }
   function eventType(evt) {
@@ -31711,7 +31806,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     function settlePendingQuestions() {
       for (const [questionId] of pendingQuestions) {
         pendingQuestions.delete(questionId);
-        emit({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
       }
     }
     function settleFailedTurnInteractions() {
@@ -31725,6 +31820,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     }
     function emit(evt) {
       if (onEvent) onEvent(redactValue(evt, redactionValues(activeAttachmentPaths)));
+    }
+    function emitAfterText(evt) {
+      assistantDeltaRedactor.flush();
+      emit(evt);
     }
     function emitTurnProgress(stage) {
       if (!activeRun || !activeTurn) return;
@@ -32090,7 +32189,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       removeInstanceMarker(home);
       if (activeRun) {
         const classified = classifyErrorCode({ exitCode: code, signal, stderrTail: tail });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32123,7 +32222,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       if (activeRun) {
         const tail = trimStderrTail(stderrTail);
         const classified = classifyErrorCode({ error, spawnError: true, stderrTail: tail });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32319,7 +32418,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           baseUrl = "";
           configHome = "";
           if (wasActive) {
-            emit({
+            emitAfterText({
               type: "error",
               kind: "network",
               code: "EVENT_STREAM_FAILED",
@@ -32404,7 +32503,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           httpStatus,
           fallbackCode: "BACKEND_ERROR"
         });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32435,7 +32534,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         return;
       }
       pendingApprovals.set(permissionId, { name, input });
-      emit({
+      emitAfterText({
         type: "approval-required",
         toolUseId: permissionId,
         name,
@@ -32452,7 +32551,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       const status = state.status;
       if (status === "completed" || status === "error") {
         const ms = state.time && Number.isFinite(state.time.start) && Number.isFinite(state.time.end) ? state.time.end - state.time.start : void 0;
-        emit({
+        emitAfterText({
           type: "tool-result",
           toolUseId,
           name,
@@ -32464,7 +32563,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       if (startedTools.has(toolUseId)) return;
       startedTools.add(toolUseId);
-      emit({ type: "tool-start", toolUseId, name, input: state.input || {} });
+      emitAfterText({ type: "tool-start", toolUseId, name, input: state.input || {} });
     }
     function handleOpenCodeEvent(evt) {
       var _a;
@@ -32528,7 +32627,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           return;
         }
         pendingQuestions.set(questionId, { questions, settling: false });
-        emit({
+        emitAfterText({
           type: "question-required",
           toolUseId: questionId,
           source: "opencode-question",
@@ -32543,10 +32642,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (!pending) return;
         pendingQuestions.delete(questionId);
         if (type === "question.rejected") {
-          emit({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
+          emitAfterText({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
         } else {
           const values = valuesFromOpenCodeAnswers(pending.questions, p.answers);
-          emit({
+          emitAfterText({
             type: "question-resolved",
             toolUseId: questionId,
             outcome: "answered",
@@ -32574,7 +32673,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           upstreamText: combined
         });
         settleFailedTurnInteractions();
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32631,7 +32730,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         turn = normalizeTurnInput(input);
       } catch (error) {
         const turnId = typeof (input == null ? void 0 : input.turnId) === "string" ? input.turnId : "";
-        emit({
+        emitAfterText({
           type: "error",
           kind: "attachment",
           code: "TURN_INPUT_INVALID",
@@ -32708,7 +32807,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           ...(e == null ? void 0 : e.code) && (e == null ? void 0 : e.spawnError) ? { spawnCode: e.code } : {},
           ...sessionReset ? { sessionReset: true } : {}
         };
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32749,7 +32848,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (pendingQuestions.get(id) === pending) pending.settling = false;
         const httpStatus = extractHttpStatus(error == null ? void 0 : error.httpStatus);
         const classified = classifyErrorCode({ error, httpStatus, fallbackCode: "BACKEND_ERROR" });
-        emit({
+        emitAfterText({
           type: "error",
           kind: classified.kind,
           code: classified.code,
@@ -32763,7 +32862,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       if (pendingQuestions.get(id) !== pending) return true;
       pendingQuestions.delete(id);
-      emit({
+      emitAfterText({
         type: "question-resolved",
         toolUseId: id,
         outcome: submitted ? "answered" : "cancelled",
@@ -32778,7 +32877,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (!pending.settling && baseUrl) {
           rejects.push(postJson(questionReplyPath(questionId, "reject"), {}));
         }
-        emit({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
+        emitAfterText({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
       }
       await Promise.allSettled(rejects);
     }
@@ -32791,7 +32890,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       await drainApprovals();
       if (activeRun) {
-        emit({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted.", ...activeTurnFailureFields() });
+        emitAfterText({ type: "error", kind: "aborted", code: "TURN_ABORTED", message: "Turn aborted.", ...activeTurnFailureFields() });
         finishActive();
       }
     }
@@ -34382,9 +34481,12 @@ ${command}`
     const sessions = host && typeof host.getMcpSessions === "function" ? host.getMcpSessions() : [];
     const latest = sessions.reduce((value, session) => Math.max(value, Number(session.lastActivityAt) || 0), 0);
     const age = latest ? Date.now() - latest : Infinity;
+    if (!latest || age >= 10 * 60 * 1e3) {
+      return { ok: true, detail: "No recent MCP session" };
+    }
     return {
-      ok: age < 10 * 60 * 1e3,
-      detail: latest ? "Last MCP session activity " + Math.round(age / 1e3) + "s ago" : "No MCP session activity yet"
+      ok: true,
+      detail: "Last MCP session activity " + Math.round(age / 1e3) + "s ago"
     };
   }
   async function runDiagnostics({
@@ -34831,7 +34933,13 @@ ${command}`
       event.disposition !== void 0 ? "disposition=" + scalar2(event.disposition) : null,
       event.error !== void 0 ? "error=" + scalar2(event.error) : null,
       event.durationMs !== void 0 ? "durationMs=" + scalar2(event.durationMs) : null,
-      event.undoGroup !== void 0 ? "undoGroup=" + scalar2(event.undoGroup) : null
+      event.undoGroup !== void 0 ? "undoGroup=" + scalar2(event.undoGroup) : null,
+      event.tool !== void 0 ? "tool=" + scalar2(event.tool) : null,
+      event.transport !== void 0 ? "transport=" + scalar2(event.transport) : null,
+      event.scriptChars !== void 0 ? "scriptChars=" + scalar2(event.scriptChars) : null,
+      event.scriptHead !== void 0 ? "scriptHead=" + scalar2(event.scriptHead) : null,
+      event.hinted !== void 0 ? "hinted=" + scalar2(event.hinted) : null,
+      event.hintIndex !== void 0 ? "hintIndex=" + scalar2(event.hintIndex) : null
     ].filter(Boolean).join(" ");
   }
   function redactedField(value, exactSecrets) {
@@ -34881,12 +34989,39 @@ ${command}`
     if (!event || typeof event !== "object") return "-";
     return [
       iso(event.ts),
+      "pid=" + scalar2(redactedField(event.pid, exactSecrets)),
       "backend=" + scalar2(redactedField(event.backend, exactSecrets)),
       "code=" + scalar2(redactedField(event.code, exactSecrets)),
       "kind=" + scalar2(redactedField(event.kind, exactSecrets)),
       "message=" + scalar2(redactedBackendErrorField(event.message, exactSecrets)),
       event.detail ? "detail=" + scalar2(redactedBackendErrorField(event.detail, exactSecrets)) : null
     ].filter(Boolean).join(" ");
+  }
+  function backendErrorKey(event) {
+    return [event.ts, event.backend, event.code, event.kind, event.message].map((value) => String(value != null ? value : "")).join("\0");
+  }
+  function mergedBackendErrors(memoryErrors, diskEvents) {
+    const merged = [];
+    const positions = /* @__PURE__ */ new Map();
+    const add = (event) => {
+      if (!event || typeof event !== "object") return;
+      const key = backendErrorKey(event);
+      if (positions.has(key)) {
+        const index = positions.get(key);
+        if (event.pid !== void 0 && merged[index].pid === void 0) merged[index] = event;
+        return;
+      }
+      positions.set(key, merged.length);
+      merged.push(event);
+    };
+    if (Array.isArray(memoryErrors)) memoryErrors.forEach(add);
+    if (Array.isArray(diskEvents)) diskEvents.filter((event) => event && event.level === "error" && event.source === "chat").forEach(add);
+    return merged.sort((a, b) => {
+      const left = Date.parse(a.ts);
+      const right = Date.parse(b.ts);
+      if (Number.isFinite(left) && Number.isFinite(right)) return left - right;
+      return 0;
+    });
   }
   function section(lines, title, producer, exactSecrets, alreadyRedacted = false) {
     lines.push(title);
@@ -35002,9 +35137,9 @@ ${command}`
       return hostLogDisk.slice(-500).map((event) => formatHostLog(event, exactSecrets));
     }, exactSecrets, true);
     section(lines, "## panel log (" + panelLogs.length + ")", () => panelLogs.map(String), exactSecrets);
-    section(lines, "## backend errors (last 50)", () => {
-      if (!Array.isArray(backendErrors)) return unavailable("backend error history is unavailable");
-      return backendErrors.slice(-50).map((event) => formatBackendError(event, exactSecrets));
+    section(lines, "## backend errors (last 50, memory + disk)", () => {
+      if (!Array.isArray(backendErrors) && !Array.isArray(hostLogDisk)) return unavailable("backend error history is unavailable");
+      return mergedBackendErrors(backendErrors, hostLogDisk).slice(-50).map((event) => formatBackendError(event, exactSecrets));
     }, exactSecrets, true);
     section(lines, "## backend stderr tails", () => {
       const tails = backendStderrTails;

--- a/plugin/host/activity.js
+++ b/plugin/host/activity.js
@@ -6,7 +6,14 @@ let seq = 0;
 const subscribers = new Set();
 
 function record(evt) {
-    const e = Object.assign({ id: ++seq, ts: Date.now() }, evt);
+    const e = Object.assign({ id: ++seq, ts: Date.now() }, evt || {});
+    e.transport = e.transport || 'internal';
+    e.tool = e.tool || (e.transport === 'http' ? 'http' : 'internal');
+    if (!e.client || e.client === 'unknown') {
+        e.client = e.transport === 'http'
+            ? 'http-direct'
+            : (e.transport === 'mcp' ? 'mcp-session' : 'internal');
+    }
     buf.push(e);
     if (buf.length > MAX) buf = buf.slice(-MAX);
     subscribers.forEach((fn) => {
@@ -17,6 +24,20 @@ function record(evt) {
         }
     });
     return e;
+}
+
+function update(id, patch) {
+    const event = buf.find((item) => item.id === id);
+    if (!event || !patch || typeof patch !== 'object') return null;
+    Object.assign(event, patch);
+    subscribers.forEach((fn) => {
+        try {
+            fn(event);
+        } catch (err) {
+            // Subscriber errors must not break /exec.
+        }
+    });
+    return event;
 }
 
 function list(sinceId) {
@@ -34,4 +55,4 @@ function _reset() {
     subscribers.clear();
 }
 
-module.exports = { record, list, subscribe, _reset, MAX };
+module.exports = { record, update, list, subscribe, _reset, MAX };

--- a/plugin/host/activity.test.js
+++ b/plugin/host/activity.test.js
@@ -39,3 +39,14 @@ test('activity list filters by since id', () => {
     const c = activity.record({ ok: true, n: 3 });
     assert.deepStrictEqual(activity.list(a.id), [b, c]);
 });
+
+test('activity supplies attribution defaults and can enrich a recorded failure', () => {
+    activity._reset();
+    const event = activity.record({ ok: false, error: 'boom' });
+    assert.deepEqual(
+        { client: event.client, tool: event.tool, transport: event.transport },
+        { client: 'internal', tool: 'internal', transport: 'internal' },
+    );
+    assert.equal(activity.update(event.id, { hinted: true, hintIndex: 3 }).hintIndex, 3);
+    assert.equal(activity.list()[0].hinted, true);
+});

--- a/plugin/host/mcp/checkpoint-ops.js
+++ b/plugin/host/mcp/checkpoint-ops.js
@@ -1,4 +1,5 @@
 'use strict';
+const { appendHint } = require('./error-hints');
 
 // Shared checkpoint mechanics. ae_exec uses the best-effort wrapper while
 // ae_checkpoint and ae_revert use the explicit result-producing primitives.
@@ -28,6 +29,11 @@ function executionFailure(execution) {
         },
     );
     if (execution && execution.disposition) payload.disposition = execution.disposition;
+    // Hint on the copy only: the caller's execution object stays untouched, and
+    // appendHint is idempotent so re-entry cannot stack markers.
+    if (typeof payload.error === 'string' && payload.error.trim()) {
+        payload.error = appendHint(payload.error);
+    }
     return payload;
 }
 

--- a/plugin/host/mcp/conversation-exec-integration.test.js
+++ b/plugin/host/mcp/conversation-exec-integration.test.js
@@ -147,7 +147,7 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         }, toolCall(5, 'empty'));
         assert.equal(empty.body.result.isError, true);
         assert.equal(empty.body.result.structuredContent.ok, false);
-        assert.equal(empty.body.result.structuredContent.error, 'jsx returned no value (empty output)');
+        assert.match(empty.body.result.structuredContent.error, /^jsx returned no value \(empty output\)/);
         assert.equal(empty.body.result.structuredContent.raw, '');
         assert.match(empty.body.result.structuredContent.recoveryId, /^[a-z0-9]{6}$/);
         assert.equal(fs.existsSync(empty.body.result.structuredContent.scriptPath), true);

--- a/plugin/host/mcp/error-hints.js
+++ b/plugin/host/mcp/error-hints.js
@@ -37,6 +37,22 @@ const HINTS = [
         /0\.1\s*至\s*1296|out of range[^\n]{0,12}1296/i,
         'fontSize hard-caps at 1296; clamp the value before setValue.',
     ],
+    [
+        /值\s+\S+\s+在\s+-?1000000\s+至\s+1000000\s+的范围外|value\s+\S+\s+is outside the range\s+-?1000000\s+to\s+1000000/i,
+        'AE Slider Controls hard-clamp to ±1,000,000; for larger numbers drive a text layer sourceText expression or split digits into separate layers or sliders.',
+    ],
+    [
+        /颜色数组没有\s*3\s*个值|color array does not have 3 values/i,
+        'colors are [r,g,b] (0-1 floats), with alpha passed separately; a text fillColor takes exactly 3 values.',
+    ],
+    [
+        /对象无效|object is invalid/i,
+        'the referenced AE object was deleted or its collection index shifted; re-acquire comps, layers, and properties by name right before use instead of holding references across edits.',
+    ],
+    [
+        /PropertyValueType\.NO_VALUE/i,
+        'that match name is a GROUP, not a leaf property; set values on its child leaf properties by walking with AEMCP.propByMatchPath or numeric indices.',
+    ],
 ];
 
 const HINT_MARK = '[hint]';
@@ -44,10 +60,16 @@ const HINT_MARK = '[hint]';
 function appendHint(error) {
     const text = String(error || '');
     if (text.indexOf(HINT_MARK) !== -1) return text;
-    for (let i = 0; i < HINTS.length; i += 1) {
-        if (HINTS[i][0].test(text)) return text + '\n' + HINT_MARK + ' ' + HINTS[i][1];
-    }
-    return text;
+    const match = matchHint(text);
+    return match ? text + '\n' + HINT_MARK + ' ' + match.hint : text;
 }
 
-module.exports = { HINTS, HINT_MARK, appendHint };
+function matchHint(error) {
+    const text = String(error || '');
+    for (let i = 0; i < HINTS.length; i += 1) {
+        if (HINTS[i][0].test(text)) return { index: i, hint: HINTS[i][1] };
+    }
+    return null;
+}
+
+module.exports = { HINTS, HINT_MARK, appendHint, matchHint };

--- a/plugin/host/mcp/error-hints.test.js
+++ b/plugin/host/mcp/error-hints.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { appendHint } = require('./error-hints');
+const { appendHint, matchHint } = require('./error-hints');
 
 const CASES = [
     ['由于参数 2，无法调用"setTemporalEaseAtKey"。值数组没有 3 元素。', 'AEMCP.easeKeys(prop)'],
@@ -11,6 +11,13 @@ const CASES = [
     ['由于参数 1，无法设置值。该属性未与图层关联。', 'AEMCP.propByMatchPath'],
     ['After Effects 错误: font 包含无效字符', 'PostScript name'],
     ['value out of range 1296', 'fontSize hard-caps at 1296'],
+    ['值 987654336 在 -1000000 至 1000000 的范围外', 'AE Slider Controls hard-clamp'],
+    ['value 987654336 is outside the range -1000000 to 1000000', 'AE Slider Controls hard-clamp'],
+    ['颜色数组没有 3 个值', 'colors are [r,g,b]'],
+    ['color array does not have 3 values', 'colors are [r,g,b]'],
+    ['对象无效', 'referenced AE object was deleted'],
+    ['object is invalid', 'referenced AE object was deleted'],
+    ['PropertyValueType.NO_VALUE', 'GROUP, not a leaf property'],
 ];
 
 test('appendHint covers every migrated error pattern', () => {
@@ -30,4 +37,11 @@ test('appendHint leaves unknown and already hinted errors unchanged', () => {
 test('null lookup hint includes effect index fallback', () => {
     const result = appendHint('TypeError: undefined is not an object');
     assert.ok(result.indexOf('effect.property(1)') !== -1);
+});
+
+test('matchHint returns the stable index and hint text', () => {
+    const match = matchHint('对象无效');
+    assert.equal(typeof match.index, 'number');
+    assert.match(match.hint, /re-acquire comps/);
+    assert.equal(matchHint('unrelated'), null);
 });

--- a/plugin/host/mcp/index.js
+++ b/plugin/host/mcp/index.js
@@ -121,6 +121,8 @@ function mountMcp(app, deps) {
             return recoveryStore;
         },
         sessionCount: function () { return sessions.size; },
+        recordMcpActivity: deps.recordMcpActivity,
+        updateActivity: deps.updateActivity,
     });
 
     function routeConversation(req, res, next) {
@@ -156,10 +158,12 @@ function mountMcp(app, deps) {
             && deps.isClientBlocked(session.clientInfo && session.clientInfo.name);
     }
 
-    function recordDenied(session, reason) {
+    function recordDenied(session, reason, tool) {
         if (typeof deps.recordMcpActivity !== 'function') return;
         deps.recordMcpActivity({
             client: session.clientName,
+            tool: tool || 'mcp',
+            transport: 'mcp',
             sessionId: session.id,
             clientInfo: session.clientInfo,
             conversationId: session.conversationId,
@@ -190,7 +194,7 @@ function mountMcp(app, deps) {
             session.conversationToken = conversation ? conversation.token : null;
             if (typeof deps.isClientBlocked === 'function'
                 && deps.isClientBlocked(session.clientInfo.name)) {
-                recordDenied(session, 'blocked');
+                recordDenied(session, 'blocked', 'mcp-initialize');
                 sessions.delete(session.id);
                 return {
                     status: 200,
@@ -215,11 +219,11 @@ function mountMcp(app, deps) {
         if (!session) return missingSession(message, 404, 'Mcp-Session-Id is unknown');
         touchSession(session);
         if (message.method === 'tools/call' && isBlocked(session)) {
-            recordDenied(session, 'blocked');
+            recordDenied(session, 'blocked', params.name || 'mcp');
             return { status: 200, session, response: blockedError(message, session, 'blocked') };
         }
         if (message.method === 'tools/call' && typeof deps.isPaused === 'function' && deps.isPaused()) {
-            recordDenied(session, 'paused');
+            recordDenied(session, 'paused', params.name || 'mcp');
             return { status: 200, session, response: blockedError(message, session, 'paused') };
         }
         if (message.method === 'notifications/initialized') {

--- a/plugin/host/mcp/jsx-result.js
+++ b/plugin/host/mcp/jsx-result.js
@@ -4,6 +4,7 @@ const { appendHint } = require('./error-hints');
 
 const NO_VALUE_SENTINELS = ['undefined', 'null'];
 const EVALSCRIPT_ERR_SENTINEL = 'EvalScript error.';
+const MISSING_COMPLETION_VALUE = "jsx evaluated to undefined: the script's last statement must be a bare expression, e.g. end with JSON.stringify(result); — a trailing var/if/for statement yields undefined, and a top-level return is invalid";
 
 function fail(error, raw) {
     return { ok: false, error: appendHint(error), raw };
@@ -47,13 +48,17 @@ function parseExecResult(resultType, text) {
         return fail('ae_exec returned an invalid result type', text);
     }
     if (!text || String(text).trim() === '') {
-        return fail('jsx returned no value (empty output)', text);
+        return fail(
+            'jsx returned no value (empty output); an uncaught ExtendScript throw can '
+                + 'surface as empty evalScript output — wrap risky code in try/catch '
+                + 'and return the error as JSON',
+            text,
+        );
     }
     const stripped = String(text).trim();
     if (NO_VALUE_SENTINELS.indexOf(stripped) !== -1) {
         return fail(
-            'jsx evaluated to ' + stripped
-                + '; ensure your code returns JSON.stringify(...) or a value',
+            MISSING_COMPLETION_VALUE.replace('jsx evaluated to undefined', 'jsx evaluated to ' + stripped),
             text,
         );
     }

--- a/plugin/host/mcp/jsx-result.test.js
+++ b/plugin/host/mcp/jsx-result.test.js
@@ -70,14 +70,19 @@ test('parseExecResult maps explicit transport types without sniffing JSON-like t
 });
 
 test('parseExecResult preserves empty, undefined, and EvalScript sentinel errors', () => {
-    assert.deepEqual(parseExecResult('string', ''), {
-        ok: false,
-        error: 'jsx returned no value (empty output)',
-        raw: '',
-    });
+    const emptyResult = parseExecResult('string', '');
+    assert.equal(emptyResult.ok, false);
+    assert.match(emptyResult.error, /^jsx returned no value \(empty output\)/);
+    assert.match(emptyResult.error, /uncaught ExtendScript throw/);
+    assert.equal(emptyResult.raw, '');
     const undefinedResult = parseExecResult('string', 'undefined');
     assert.equal(undefinedResult.ok, false);
-    assert.match(undefinedResult.error, /evaluated to undefined/);
+    assert.match(undefinedResult.error, /^jsx evaluated to undefined/);
+    assert.match(undefinedResult.error, /last statement must be a bare expression/);
+    const nullResult = parseExecResult('string', 'null');
+    assert.equal(nullResult.ok, false);
+    assert.match(nullResult.error, /^jsx evaluated to null/);
+    assert.match(nullResult.error, /last statement must be a bare expression/);
     assert.deepEqual(parseExecResult('string', 'EvalScript error.'), {
         ok: false,
         error: 'EvalScript error.',

--- a/plugin/host/mcp/tools.js
+++ b/plugin/host/mcp/tools.js
@@ -8,6 +8,7 @@
 
 const jsonrpc = require('./jsonrpc');
 const { textResult, noTopLevelCombinator } = require('./tool-result');
+const { HINT_MARK, matchHint } = require('./error-hints');
 
 function assertPatternDescriptions(schema, toolName, path) {
     if (schema === null || typeof schema !== 'object') return;
@@ -67,7 +68,57 @@ function buildTools(deps) {
         if (!mod) {
             return { result: textResult({ ok: false, error: 'unknown tool: ' + params.name }, true) };
         }
-        return mod.call(args, context, deps);
+        const activityRef = {};
+        const callContext = Object.assign({}, context, { tool: params.name, transport: 'mcp' });
+        const callDeps = Object.assign({}, deps, {
+            executeJsx: typeof deps.executeJsx === 'function'
+                ? async function (request) {
+                    const input = Object.assign({}, request, {
+                        tool: params.name,
+                        transport: 'mcp',
+                        activityRef,
+                    });
+                    if (typeof input.code === 'string') activityRef.code = input.code;
+                    return deps.executeJsx(input);
+                }
+                : deps.executeJsx,
+        });
+        let output;
+        try {
+            output = await mod.call(args, callContext, callDeps);
+        } catch (error) {
+            output = { result: textResult({ ok: false, error: error && error.message ? error.message : String(error) }, true) };
+        }
+        const structured = output && output.result && output.result.structuredContent;
+        const errorText = structured && typeof structured.error === 'string' ? structured.error : '';
+        if (activityRef.id && errorText.indexOf(HINT_MARK) !== -1
+            && typeof deps.updateActivity === 'function') {
+            const match = matchHint(errorText);
+            if (match) {
+                deps.updateActivity(activityRef.id, {
+                    ok: false,
+                    error: errorText,
+                    hinted: true,
+                    hintIndex: match.index,
+                    ...(typeof activityRef.code === 'string'
+                        ? {
+                            scriptChars: activityRef.code.length,
+                            scriptHead: activityRef.code.replace(/\s+/g, ' ').trim().slice(0, 200),
+                        } : {}),
+                });
+            }
+        }
+        if (!activityRef.id && typeof deps.recordMcpActivity === 'function') {
+            deps.recordMcpActivity({
+                client: callContext.session && callContext.session.clientName,
+                tool: params.name,
+                transport: 'mcp',
+                engine: 'mcp',
+                ok: !(structured && structured.ok === false),
+                ...(structured && structured.error ? { error: structured.error } : {}),
+            });
+        }
+        return output;
     }
 
     return { list: function () { return definitions; }, call };

--- a/plugin/host/mcp/tools.test.js
+++ b/plugin/host/mcp/tools.test.js
@@ -117,3 +117,21 @@ test('ae_exec preserves bridge disposition in structured tool errors', async () 
         disposition: 'possibly-side-effecting',
     });
 });
+
+test('registry passes the MCP tool identity to the execution dependency', async () => {
+    let request;
+    const registry = buildTools({
+        getStatus: function () { return { ok: true }; },
+        executeJsx: async function (value) {
+            request = value;
+            return { payload: { ok: true, resultType: 'string', result: 'ok' } };
+        },
+        sessionCount: function () { return 1; },
+    });
+    await registry.call({ name: 'ae_exec', arguments: { code: '1 + 1' } }, {
+        session: { clientName: 'cursor' },
+        port: 1,
+    });
+    assert.equal(request.tool, 'ae_exec');
+    assert.equal(request.transport, 'mcp');
+});

--- a/plugin/host/mcp/tools/exec.js
+++ b/plugin/host/mcp/tools/exec.js
@@ -5,6 +5,23 @@ const { textResult } = require('../tool-result');
 const { VERB_ANNOTATIONS } = require('../annotations');
 const { enforce } = require('../approval-gate');
 const { parseExecResult } = require('../jsx-result');
+const { matchHint } = require('../error-hints');
+
+const HISTORY_REDACTION_MARKERS = [
+    'omitted from prior model history',
+    'hidden from history to save tokens'
+];
+
+function isHistoryRedactionPlaceholder(value) {
+    return typeof value === 'string' && HISTORY_REDACTION_MARKERS.some((marker) => value.includes(marker));
+}
+
+function placeholderError(recovery) {
+    const suffix = recovery
+        ? ' omit `code` entirely to rerun the stored recovery script, or pass a full replacement script.'
+        : '';
+    return `\`code\` is a redaction placeholder from the conversation history, not runnable code (earlier scripts are hidden to save tokens). Write the complete script again from scratch.${suffix}`;
+}
 const {
     autoCheckpoint,
     executionFailure,
@@ -159,6 +176,22 @@ function executionDisposition(execution, failure) {
     return null;
 }
 
+function recordMcpFailure(execution, failure, code, deps, tool) {
+    if (!execution || !execution.payload || execution.payload.ok !== true || !failure || failure.ok !== false || !deps || typeof deps.recordMcpActivity !== 'function') return;
+    const error = typeof failure.error === 'string' ? failure.error : String(failure.error || 'MCP execution failed');
+    const match = matchHint(error);
+    deps.recordMcpActivity({
+        tool: tool || 'ae_exec',
+        transport: 'mcp',
+        ok: false,
+        verdict: 'mcp_failed',
+        error,
+        scriptChars: typeof code === 'string' ? code.length : undefined,
+        scriptHead: typeof code === 'string' ? code.replace(/\s+/g, ' ').trim().slice(0, 200) : undefined,
+        ...(match ? { hinted: true, hintIndex: match.index } : {})
+    });
+}
+
 function resultFailure(execution) {
     if (!execution || !execution.payload || execution.payload.ok !== true) {
         return executionFailure(execution);
@@ -268,6 +301,7 @@ async function runInitial(args, context, deps) {
         recentProjectPath = execution.payload.projectPath || null;
     }
     const failure = withErrorSource(resultFailure(execution), args.code);
+    recordMcpFailure(execution, failure, args.code, deps, 'ae_exec');
     if (failure) {
         annotateCheckpoint(failure, checkpointRun);
         const disposition = executionDisposition(execution, failure);
@@ -388,6 +422,7 @@ async function runRecovery(args, context, deps) {
         recentProjectPath = execution.payload.projectPath || null;
     }
     const failure = withErrorSource(resultFailure(execution), code);
+    recordMcpFailure(execution, failure, code, deps, 'ae_execRecover');
     const attemptNumber = Array.isArray(meta.attempts) ? meta.attempts.length + 1 : 1;
     const checkpointId = checkpoint ? checkpoint.id : (meta.checkpointId || null);
     const attempt = attemptRecord({
@@ -420,6 +455,9 @@ async function runRecovery(args, context, deps) {
 }
 
 async function call(args, context, deps) {
+    if (isHistoryRedactionPlaceholder(args && args.code)) {
+        return { result: textResult({ ok: false, error: placeholderError(false) }, true) };
+    }
     const input = args || {};
     const invalid = initialValidationError(input);
     if (invalid) return { result: textResult({ ok: false, error: invalid }, true) };
@@ -434,6 +472,9 @@ async function call(args, context, deps) {
 }
 
 async function recover(args, context, deps) {
+    if (isHistoryRedactionPlaceholder(args && args.code)) {
+        return { result: textResult({ ok: false, error: placeholderError(true) }, true) };
+    }
     const input = args || {};
     const invalid = recoveryValidationError(input);
     if (invalid) return { result: textResult({ ok: false, error: invalid }, true) };

--- a/plugin/host/mcp/tools/exec.test.js
+++ b/plugin/host/mcp/tools/exec.test.js
@@ -385,3 +385,49 @@ test('retry uses one ae_execRecover approval with complete code and recovery sum
         f.close();
     }
 });
+
+test('history-guard placeholder code is rejected before execution and never overwrites a stored recovery script', async () => {
+    const f = fixture();
+    try {
+        const freshMarker = '/* ae-mcp: script body hidden from history to save tokens. Never send this comment back as code. */';
+        const rejected = value(await execTool.call({ code: freshMarker }, context(null), f.deps));
+        assert.equal(rejected.ok, false);
+        assert.match(rejected.error, /redaction placeholder/);
+        assert.equal(f.calls.length, 0);
+
+        f.deps.setUserHandler(async function () {
+            return failed('ExtendScript error: bad (line 2)', { errorLine: 2 });
+        });
+        const failure = value(await execTool.call({ code: 'var broken = 1;\nthrow new Error("bad");' }, context(null), f.deps));
+        assert.ok(failure.recoveryId);
+        const stored = fs.readFileSync(failure.scriptPath, 'utf8');
+
+        const callsBefore = f.calls.length;
+        const blocked = value(await execRecoverTool.call({
+            recoveryId: failure.recoveryId,
+            code: '/* executed AE script omitted from prior model history */',
+        }, context(null), f.deps));
+        assert.equal(blocked.ok, false);
+        assert.match(blocked.error, /redaction placeholder/);
+        assert.match(blocked.error, /omit `code`/);
+        assert.equal(f.calls.length, callsBefore);
+        assert.equal(fs.readFileSync(failure.scriptPath, 'utf8'), stored);
+    } finally {
+        f.close();
+    }
+});
+
+test('a thrown ExtendScript error reaches the tool result with an appended hint', async () => {
+    const f = fixture();
+    try {
+        f.deps.setUserHandler(async function () {
+            return failed('ExtendScript error: TypeError: null 不是对象 (line 3)', { errorLine: 3 });
+        });
+        const failure = value(await execTool.call({ code: 'var v = comp.layer(99);\nv.name;\nv.x;' }, context(null), f.deps));
+        assert.equal(failure.ok, false);
+        assert.match(failure.error, /\[hint\]/);
+        assert.match(failure.error, /lookup returned null/);
+    } finally {
+        f.close();
+    }
+});

--- a/plugin/host/mcp/tools/preview-frame.js
+++ b/plugin/host/mcp/tools/preview-frame.js
@@ -203,7 +203,7 @@ function validateArgs(args) {
     if (args.time !== undefined && (!Number.isFinite(args.time) || args.time < 0)) throw new Error('`time` must be a non-negative number');
     if (args.range !== undefined) {
         validateExactKeys(args.range, ['start', 'end', 'count'], 'range');
-        if (args.time !== undefined || args.times !== undefined) throw new Error('`range` cannot be combined with `time` or `times`');
+        if (args.time !== undefined || args.times !== undefined) throw new Error('`range` cannot be combined with `time` or `times` — pass exactly one of: {time: 1.5} | {times: [0, 1, 2]} | {range: {start: 0, end: 2, count: 5}}');
         if (!Number.isFinite(args.range.start) || args.range.start < 0 || !Number.isFinite(args.range.end) || args.range.end < 0) throw new Error('`range.start` and `range.end` must be non-negative numbers');
         if (!Number.isInteger(args.range.count) || args.range.count < 2 || args.range.count > 16) throw new Error('`range.count` must be an integer between 2 and 16');
         if (args.range.count > timesLimit) throw new Error('`range.count` must be at most ' + timesLimit + ' with layout `' + layout + '`');
@@ -211,7 +211,7 @@ function validateArgs(args) {
     if (args.grid_max_side !== undefined && (!Number.isInteger(args.grid_max_side) || args.grid_max_side < 256 || args.grid_max_side > 2048)) throw new Error('`grid_max_side` must be an integer between 256 and 2048');
     if (args.compare !== undefined) {
         validateExactKeys(args.compare, ['a', 'b', 'mode', 'threshold'], 'compare');
-        if (args.time !== undefined || args.times !== undefined || args.range !== undefined || args.layout !== undefined) throw new Error('`compare` cannot be combined with `time`, `times`, `range`, or `layout`');
+        if (args.time !== undefined || args.times !== undefined || args.range !== undefined || args.layout !== undefined) throw new Error('`compare` cannot be combined with `time`, `times`, `range`, or `layout` — compare takes exactly {compare: {a: <selector>, b: <selector>}} plus optional mode/threshold');
         validateSelector(args.compare.a, 'compare.a');
         validateSelector(args.compare.b, 'compare.b');
         const mode = args.compare.mode === undefined ? 'both' : args.compare.mode;

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -272,7 +272,7 @@ function nativeGateError(code, message, retryable, action, hint) {
     };
 }
 
-function nativeRequestGate(req, res) {
+function nativeRequestGate(req, res, tool) {
     const provided = req.get(authToken.HEADER);
     if (!authToken.tokenMatches(provided, execToken)) {
         res.status(401).json({
@@ -284,10 +284,10 @@ function nativeRequestGate(req, res) {
         });
         return null;
     }
-    const client = req.get('x-ae-mcp-client') || 'unknown';
+    const client = req.get('x-ae-mcp-client') || 'http-direct';
     if (client !== INTERNAL_CLIENT) touchClient(client);
     if (blocked.has(client)) {
-        activity.record({ client, engine: 'native-aegp', ok: false, denied: 'blocked' });
+        activity.record({ client, tool, transport: 'http', engine: 'native-aegp', ok: false, denied: 'blocked' });
         res.status(403).json({
             ok: false,
             error: nativeGateError(
@@ -298,7 +298,7 @@ function nativeRequestGate(req, res) {
         return null;
     }
     if (paused) {
-        activity.record({ client, engine: 'native-aegp', ok: false, denied: 'paused' });
+        activity.record({ client, tool, transport: 'http', engine: 'native-aegp', ok: false, denied: 'paused' });
         res.status(503).json({
             ok: false,
             error: nativeGateError(
@@ -648,22 +648,35 @@ async function executeJsx(request) {
     const undoGroup = input.undoGroup;
     const nativeProjectGraphEffect = input.nativeProjectGraphEffect === undefined
         ? 'invalidate' : input.nativeProjectGraphEffect;
-    const client = input.client || 'unknown';
+    const transport = input.transport || 'internal';
+    const tool = input.tool || (transport === 'http' ? 'exec-http' : 'internal');
+    const client = input.client || (transport === 'http'
+        ? 'http-direct'
+        : (transport === 'mcp' ? 'mcp-session' : 'internal'));
+    const activityRef = input.activityRef && typeof input.activityRef === 'object' ? input.activityRef : null;
+    const scriptEvidence = typeof code === 'string' && code.length > 0
+        ? { scriptChars: code.length, scriptHead: code.replace(/\s+/g, ' ').trim().slice(0, 200) }
+        : {};
+    const recordExecution = function (event) {
+        const result = activity.record(Object.assign({ client, tool, transport }, event));
+        if (activityRef) activityRef.id = result.id;
+        return result;
+    };
     if (client !== INTERNAL_CLIENT) touchClient(client);
     if (blocked.has(client)) {
-        activity.record({ client, undoGroup: undoGroup || null, ok: false, denied: 'blocked' });
+        recordExecution({ undoGroup: undoGroup || null, ok: false, denied: 'blocked', ...scriptEvidence });
         return { status: 403, payload: { ok: false, error: 'blocked: this client is blocked in the panel' } };
     }
     if (paused) {
-        activity.record({ client, undoGroup: undoGroup || null, ok: false, denied: 'paused' });
+        recordExecution({ undoGroup: undoGroup || null, ok: false, denied: 'paused', ...scriptEvidence });
         return { status: 503, payload: { ok: false, error: 'paused: AI actions are blocked by the panel kill switch' } };
     }
     if (typeof code !== 'string' || code.length === 0) {
-        activity.record({ client, undoGroup: undoGroup || null, ok: false, denied: 'invalid_request' });
+        recordExecution({ undoGroup: undoGroup || null, ok: false, denied: 'invalid_request' });
         return { status: 400, payload: { ok: false, error: 'missing or empty `code`' } };
     }
     if (!['invalidate', 'preserve'].includes(nativeProjectGraphEffect)) {
-        activity.record({ client, undoGroup: undoGroup || null, ok: false, denied: 'invalid_request' });
+        recordExecution({ undoGroup: undoGroup || null, ok: false, denied: 'invalid_request', ...scriptEvidence });
         return {
             status: 400,
             payload: { ok: false, error: '`nativeProjectGraphEffect` must be invalidate or preserve' },
@@ -687,8 +700,7 @@ async function executeJsx(request) {
         dispatched = true;
         const encoded = await jsxBridge.evalScript(transported, t);
         const decoded = decodeEvalScriptTransportResult(encoded);
-        activity.record({
-            client,
+        recordExecution({
             undoGroup: undoGroup || null,
             ok: true,
             durationMs: Date.now() - startedAt,
@@ -714,13 +726,13 @@ async function executeJsx(request) {
             ? e.disposition
             : (dispatched ? 'uncertain' : 'not_dispatched');
         const bridgeState = jsxBridge.getState();
-        activity.record({
-            client,
+        recordExecution({
             undoGroup: undoGroup || null,
             ok: false,
             error: e.message,
             disposition,
             durationMs: Date.now() - startedAt,
+            ...scriptEvidence,
         });
         const payload = {
             ok: false,
@@ -802,6 +814,7 @@ function buildApp() {
         isClientBlocked,
         isPaused,
         recordMcpActivity: function (event) { activity.record(event); },
+        updateActivity: function (id, patch) { return activity.update(id, patch); },
     });
 
     a.get('/health', (req, res) => {
@@ -825,7 +838,7 @@ function buildApp() {
     });
 
     a.get('/native/status', (req, res) => {
-        if (nativeRequestGate(req, res) === null) return;
+        if (nativeRequestGate(req, res, 'native-status') === null) return;
         try {
             const status = makeNativeAegpClient().status();
             res.json({ ok: true, status });
@@ -835,7 +848,7 @@ function buildApp() {
     });
 
     a.post('/native/negotiate', async (req, res) => {
-        const clientLabel = nativeRequestGate(req, res);
+        const clientLabel = nativeRequestGate(req, res, 'native-negotiate');
         if (clientLabel === null) return;
         const body = req.body || {};
         if (!exactBody(body, ['deadlineUnixMs']) || !validDeadline(body.deadlineUnixMs)) {
@@ -864,6 +877,8 @@ function buildApp() {
             };
             activity.record({
                 client: clientLabel,
+                tool: 'native-negotiate',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'negotiate',
                 ok: true,
@@ -875,6 +890,8 @@ function buildApp() {
         } catch (error) {
             activity.record({
                 client: clientLabel,
+                tool: 'native-negotiate',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'negotiate',
                 ok: false,
@@ -886,7 +903,7 @@ function buildApp() {
     });
 
     a.post('/native/capabilities', async (req, res) => {
-        const clientLabel = nativeRequestGate(req, res);
+        const clientLabel = nativeRequestGate(req, res, 'native-capabilities');
         if (clientLabel === null) return;
         const body = req.body || {};
         const validIds = !Object.hasOwn(body, 'ids')
@@ -919,6 +936,8 @@ function buildApp() {
             const result = { sessionId: client.status().sessionId, ...nativeResult };
             activity.record({
                 client: clientLabel,
+                tool: 'native-capabilities',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'capabilities',
                 ok: true,
@@ -929,6 +948,8 @@ function buildApp() {
         } catch (error) {
             activity.record({
                 client: clientLabel,
+                tool: 'native-capabilities',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'capabilities',
                 ok: false,
@@ -940,7 +961,7 @@ function buildApp() {
     });
 
     a.post('/native/invoke', async (req, res) => {
-        const clientLabel = nativeRequestGate(req, res);
+        const clientLabel = nativeRequestGate(req, res, 'native-invoke');
         if (clientLabel === null) return;
         const body = req.body || {};
         if (!validNativeInvokeBody(body)) {
@@ -958,6 +979,8 @@ function buildApp() {
             const result = await client.invoke(body);
             activity.record({
                 client: clientLabel,
+                tool: 'native-invoke',
+                transport: 'http',
                 engine: 'native-aegp',
                 capabilityId: body.capabilityId,
                 requestId: body.requestId,
@@ -968,6 +991,8 @@ function buildApp() {
         } catch (error) {
             activity.record({
                 client: clientLabel,
+                tool: 'native-invoke',
+                transport: 'http',
                 engine: 'native-aegp',
                 capabilityId: body.capabilityId,
                 requestId: body.requestId,
@@ -980,7 +1005,7 @@ function buildApp() {
     });
 
     a.post('/native/cancel', async (req, res) => {
-        const clientLabel = nativeRequestGate(req, res);
+        const clientLabel = nativeRequestGate(req, res, 'native-cancel');
         if (clientLabel === null) return;
         const body = req.body || {};
         if (!validNativeCancelBody(body)) {
@@ -998,6 +1023,8 @@ function buildApp() {
             const result = await client.cancel(body);
             activity.record({
                 client: clientLabel,
+                tool: 'native-cancel',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'cancel',
                 requestId: body.requestId,
@@ -1009,6 +1036,8 @@ function buildApp() {
         } catch (error) {
             activity.record({
                 client: clientLabel,
+                tool: 'native-cancel',
+                transport: 'http',
                 engine: 'native-aegp',
                 operation: 'cancel',
                 requestId: body.requestId,
@@ -1037,7 +1066,7 @@ function buildApp() {
             timeoutMs,
             nativeProjectGraphEffect = 'invalidate',
         } = req.body || {};
-        const client = req.get('x-ae-mcp-client') || 'unknown';
+        const client = req.get('x-ae-mcp-client') || 'http-direct';
         // checkpointLabel remains accepted but deliberately unused until the
         // Phase 1 checkpoint store arrives.
         const output = await executeJsx({
@@ -1047,6 +1076,8 @@ function buildApp() {
             timeoutMs,
             nativeProjectGraphEffect,
             client,
+            tool: 'exec-http',
+            transport: 'http',
         });
         res.status(output.status).json(output.payload);
     });

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -1292,6 +1292,27 @@ test('/exec reports a completed ExtendScript error as failed, not uncertain', as
     }
 });
 
+test('/exec activity attributes direct HTTP failures and preserves bounded script evidence', async () => {
+    const fixture = await startApp({
+        evalScript: function (_jsx, callback) {
+            callback('{"ok":false,"error":"Error: boom (line 1)"}');
+        },
+    });
+    try {
+        const code = 'var value = 1;\nthrow new Error("boom");';
+        const response = await post(fixture.port, '/exec', { 'X-AE-MCP-Token': TOKEN }, { code });
+        assert.equal(response.body.ok, false);
+        const event = fixture.server.activity.list().find(function (item) { return item.ok === false; });
+        assert.equal(event.client, 'http-direct');
+        assert.equal(event.tool, 'exec-http');
+        assert.equal(event.transport, 'http');
+        assert.equal(event.scriptChars, code.length);
+        assert.equal(event.scriptHead, 'var value = 1; throw new Error("boom");');
+    } finally {
+        await closeFixture(fixture);
+    }
+});
+
 test('/exec distinguishes uncertain timeout from a queued not_dispatched call', async () => {
     const evalCalls = [];
     let sentinelCallback = null;

--- a/plugin/panel/src/cep/claudeAgentBackend.js
+++ b/plugin/panel/src/cep/claudeAgentBackend.js
@@ -418,6 +418,11 @@ export function createClaudeAgentBackend({
     }
   }
 
+  function emitAfterText(evt) {
+    providerDeltaRedactor.flush();
+    emit(evt);
+  }
+
   function clearNoProgressWarning() {
     if (noProgressWarningTimer !== null) {
       clearTimeoutImpl(noProgressWarningTimer);
@@ -573,7 +578,7 @@ export function createClaudeAgentBackend({
     for (const [toolUseId, pending] of pendingQuestions) {
       pendingQuestions.delete(toolUseId);
       if (writeResponses) denyControl(pending.requestId, message);
-      emit({ type: 'question-resolved', toolUseId, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId, outcome: 'cancelled' });
     }
   }
 
@@ -602,7 +607,7 @@ export function createClaudeAgentBackend({
     pendingQuestions.delete(id);
     if (!result || result.action !== 'submit') {
       denyControl(pending.requestId, 'User dismissed the question.');
-      emit({ type: 'question-resolved', toolUseId: id, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId: id, outcome: 'cancelled' });
       return true;
     }
     const answers = answersForAskUserQuestion(pending.questions, result.values);
@@ -611,7 +616,7 @@ export function createClaudeAgentBackend({
       questions: pending.originalQuestions,
       answers,
     });
-    emit({
+    emitAfterText({
       type: 'question-resolved',
       toolUseId: id,
       outcome: 'answered',
@@ -687,7 +692,7 @@ export function createClaudeAgentBackend({
     if (activeRun) {
       providerDeltaRedactor.flush();
       const classified = classifyErrorCode(classificationInput);
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -762,7 +767,7 @@ export function createClaudeAgentBackend({
         name,
         startedAt: now(),
       });
-      emit({
+      emitAfterText({
         type: 'tool-start',
         toolUseId,
         name,
@@ -780,7 +785,7 @@ export function createClaudeAgentBackend({
       const toolUseId = String(block.tool_use_id || '');
       const tool = startedTools.get(toolUseId);
       if (!tool) continue;
-      emit({
+      emitAfterText({
         type: 'tool-result',
         toolUseId,
         ok: block.is_error !== true,
@@ -860,7 +865,7 @@ export function createClaudeAgentBackend({
       originalQuestions,
       questions,
     });
-    emit({
+    emitAfterText({
       type: 'question-required',
       toolUseId,
       source: 'claude-ask-user-question',
@@ -892,7 +897,7 @@ export function createClaudeAgentBackend({
     const toolUseId = String(request.tool_use_id || requestId);
     const annotation = activeTurn.toolMeta.annotations[name] || {};
     pendingApprovals.set(toolUseId, { requestId, name, input });
-    emit({
+    emitAfterText({
       type: 'approval-required',
       toolUseId,
       name,
@@ -948,7 +953,7 @@ export function createClaudeAgentBackend({
         upstreamText: safeMessage,
       });
       const kindReference = classifyError(safeMessage);
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.code === 'UPSTREAM_ERROR' && ['auth', 'model'].includes(kindReference)
           ? kindReference
@@ -1113,7 +1118,7 @@ export function createClaudeAgentBackend({
       if (!resolved?.ok) {
         const classification = classifyErrorCode({ resolutionCode: resolved?.code });
         const resolution = boundedResolution(resolved?.resolution || resolved);
-        emit({
+        emitAfterText({
           type: 'error',
           kind: classification.kind,
           code: classification.code,
@@ -1202,7 +1207,7 @@ export function createClaudeAgentBackend({
         let message = error?.message || 'Failed to start Claude CLI.';
         if (classification.code === 'SPAWN_FAILED') message = 'Claude CLI process could not be started.';
         else if (classification.code === 'MCP_UNREACHABLE') message = 'Claude could not prepare the panel MCP connection.';
-        emit({
+        emitAfterText({
           type: 'error',
           kind: classification.kind,
           code: classification.code,
@@ -1276,7 +1281,7 @@ export function createClaudeAgentBackend({
         const message = classification.code === 'MCP_UNREACHABLE'
           ? 'Claude could not prepare the panel MCP connection.'
           : (error?.message || 'Failed to start Claude CLI.');
-        emit({
+        emitAfterText({
           type: 'error',
           kind: classification.kind,
           code: classification.code,
@@ -1331,7 +1336,7 @@ export function createClaudeAgentBackend({
       turn = canonicalTurn(input);
     } catch (error) {
       const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
-      emit({
+      emitAfterText({
         type: 'error',
         kind: 'attachment',
         code: 'TURN_INPUT_INVALID',
@@ -1378,7 +1383,7 @@ export function createClaudeAgentBackend({
     providerDeltaRedactor.flush();
     setThinking(false);
     drainControls('Turn was stopped.');
-    emit({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.' });
+    emitAfterText({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.' });
     finishActive();
     void discardRuntime();
   }

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -323,6 +323,11 @@ export function createCodexBackend({
     if (onEvent) onEvent(redactValue(evt, activeAttachmentPaths));
   }
 
+  function emitAfterText(evt) {
+    providerDeltaRedactor.flush();
+    emit(evt);
+  }
+
   function emitTurnProgress(stage) {
     if (!activeRun || !activeTurn) return;
     emit({
@@ -422,7 +427,7 @@ export function createCodexBackend({
     for (const [toolUseId, pending] of Array.from(pendingUserInputs.entries())) {
       pendingUserInputs.delete(toolUseId);
       if (rpc) rpc.respond(pending.rpcId, { answers: {} });
-      emit({ type: 'question-resolved', toolUseId, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId, outcome: 'cancelled' });
     }
   }
 
@@ -436,7 +441,7 @@ export function createCodexBackend({
     pendingUserInputs.delete(id);
     if (!result || result.action !== 'submit') {
       if (rpc) rpc.respond(pending.rpcId, { answers: {} });
-      emit({ type: 'question-resolved', toolUseId: id, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId: id, outcome: 'cancelled' });
       return true;
     }
     const answers = answersForCodexUserInput(pending.questions, result.values);
@@ -444,7 +449,7 @@ export function createCodexBackend({
     // The event carries the display shape (plain strings), not the wire shape —
     // QuestionCard joins the values, and `{answers:[...]}` objects would render
     // as "[object Object]".
-    emit({
+    emitAfterText({
       type: 'question-resolved',
       toolUseId: id,
       outcome: 'answered',
@@ -481,7 +486,7 @@ export function createCodexBackend({
         return;
       }
       if (item.type !== 'mcpToolCall') return;
-      emit({
+      emitAfterText({
         type: 'tool-start',
         toolUseId: String(item.id || ''),
         name: mcpToolName(item),
@@ -496,7 +501,7 @@ export function createCodexBackend({
         return;
       }
       if (item.type !== 'mcpToolCall') return;
-      emit({
+      emitAfterText({
         type: 'tool-result',
         toolUseId: String(item.id || ''),
         name: mcpToolName(item),
@@ -555,7 +560,7 @@ export function createCodexBackend({
     }
     const toolUseId = 'ask_' + String(message.id);
     pendingUserInputs.set(toolUseId, { rpcId: message.id, questions });
-    emit({
+    emitAfterText({
       type: 'question-required',
       toolUseId,
       source: 'codex-user-input',
@@ -609,7 +614,7 @@ export function createCodexBackend({
         plan,
         allowSession: policy.allowSession,
       });
-      emit({
+      emitAfterText({
         type: 'approval-required',
         toolUseId,
         name: 'mcp__ae__ae_toolUse',
@@ -646,7 +651,7 @@ export function createCodexBackend({
       input,
     };
     pendingApprovals.set(toolUseId, approval);
-    emit({
+    emitAfterText({
       type: 'approval-required',
       toolUseId,
       name: approval.name,
@@ -678,7 +683,7 @@ export function createCodexBackend({
     }
     if (activeRun) {
       const classified = classifyErrorCode({ exitCode: code, signal, stderrTail: tail });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -711,7 +716,7 @@ export function createCodexBackend({
     drainApprovals();
     if (activeRun) {
       const classified = classifyErrorCode({ error: err, spawnError: true });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -996,7 +1001,7 @@ export function createCodexBackend({
       if (message !== rawMessage && rawMessage) {
         detail.upstreamMessage = String(rawMessage).slice(0, 500);
       }
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1017,7 +1022,7 @@ export function createCodexBackend({
       turn = normalizeTurnInput(input);
     } catch (error) {
       const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
-      emit({
+      emitAfterText({
         type: 'error',
         kind: 'attachment',
         code: 'TURN_INPUT_INVALID',
@@ -1080,7 +1085,7 @@ export function createCodexBackend({
     drainApprovals();
     providerDeltaRedactor.discard();
     if (activeRun) {
-      emit({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.', ...activeTurnFailureFields() });
+      emitAfterText({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.', ...activeTurnFailureFields() });
       finishActive();
     }
   }

--- a/plugin/panel/src/cep/diagnostics.js
+++ b/plugin/panel/src/cep/diagnostics.js
@@ -70,11 +70,12 @@ function recentMcpSession(getHost) {
     Math.max(value, Number(session.lastActivityAt) || 0)
   ), 0);
   const age = latest ? Date.now() - latest : Infinity;
+  if (!latest || age >= 10 * 60 * 1000) {
+    return { ok: true, detail: 'No recent MCP session' };
+  }
   return {
-    ok: age < 10 * 60 * 1000,
-    detail: latest
-      ? 'Last MCP session activity ' + Math.round(age / 1000) + 's ago'
-      : 'No MCP session activity yet',
+    ok: true,
+    detail: 'Last MCP session activity ' + Math.round(age / 1000) + 's ago',
   };
 }
 

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -140,6 +140,7 @@ function prefixedToolName(raw) {
   const text = String(raw || '');
   if (!text) return '';
   if (text.startsWith('mcp__')) return text;
+  if (!text.startsWith('ae_')) return text;
   // opencode names an MCP tool "<server>_<tool>" — ae's ae_ping becomes
   // "ae_ae_ping". Strip the single "ae_" server prefix once -> "ae_ping".
   return 'mcp__ae__' + text.replace(/^ae_/, '');
@@ -425,7 +426,7 @@ export function createOpenCodeBackend({
   function settlePendingQuestions() {
     for (const [questionId] of pendingQuestions) {
       pendingQuestions.delete(questionId);
-      emit({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
     }
   }
 
@@ -441,6 +442,11 @@ export function createOpenCodeBackend({
 
   function emit(evt) {
     if (onEvent) onEvent(redactValue(evt, redactionValues(activeAttachmentPaths)));
+  }
+
+  function emitAfterText(evt) {
+    assistantDeltaRedactor.flush();
+    emit(evt);
   }
 
   function emitTurnProgress(stage) {
@@ -840,7 +846,7 @@ export function createOpenCodeBackend({
     removeInstanceMarker(home);
     if (activeRun) {
       const classified = classifyErrorCode({ exitCode: code, signal, stderrTail: tail });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -874,7 +880,7 @@ export function createOpenCodeBackend({
     if (activeRun) {
       const tail = trimStderrTail(stderrTail);
       const classified = classifyErrorCode({ error, spawnError: true, stderrTail: tail });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1065,7 +1071,7 @@ export function createOpenCodeBackend({
         baseUrl = '';
         configHome = '';
         if (wasActive) {
-          emit({
+          emitAfterText({
             type: 'error',
             kind: 'network',
             code: 'EVENT_STREAM_FAILED',
@@ -1155,7 +1161,7 @@ export function createOpenCodeBackend({
         httpStatus,
         fallbackCode: 'BACKEND_ERROR',
       });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1189,7 +1195,7 @@ export function createOpenCodeBackend({
     }
 
     pendingApprovals.set(permissionId, { name, input });
-    emit({
+    emitAfterText({
       type: 'approval-required',
       toolUseId: permissionId,
       name,
@@ -1212,7 +1218,7 @@ export function createOpenCodeBackend({
       const ms = state.time && Number.isFinite(state.time.start) && Number.isFinite(state.time.end)
         ? state.time.end - state.time.start
         : undefined;
-      emit({
+      emitAfterText({
         type: 'tool-result',
         toolUseId,
         name,
@@ -1225,7 +1231,7 @@ export function createOpenCodeBackend({
     // pending / running -> tool-start (once)
     if (startedTools.has(toolUseId)) return;
     startedTools.add(toolUseId);
-    emit({ type: 'tool-start', toolUseId, name, input: state.input || {} });
+    emitAfterText({ type: 'tool-start', toolUseId, name, input: state.input || {} });
   }
 
   // OpenCode SSE events arrive as { type, properties } with dotted lowercase
@@ -1289,7 +1295,7 @@ export function createOpenCodeBackend({
         return;
       }
       pendingQuestions.set(questionId, { questions, settling: false });
-      emit({
+      emitAfterText({
         type: 'question-required',
         toolUseId: questionId,
         source: 'opencode-question',
@@ -1304,10 +1310,10 @@ export function createOpenCodeBackend({
       if (!pending) return;
       pendingQuestions.delete(questionId);
       if (type === 'question.rejected') {
-        emit({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
+        emitAfterText({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
       } else {
         const values = valuesFromOpenCodeAnswers(pending.questions, p.answers);
-        emit({
+        emitAfterText({
           type: 'question-resolved',
           toolUseId: questionId,
           outcome: 'answered',
@@ -1344,7 +1350,7 @@ export function createOpenCodeBackend({
       // interactions that belonged to the failed turn. Local 404/process/SSE
       // failures still invalidate the session through their dedicated paths.
       settleFailedTurnInteractions();
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1410,7 +1416,7 @@ export function createOpenCodeBackend({
       turn = normalizeTurnInput(input);
     } catch (error) {
       const turnId = typeof input?.turnId === 'string' ? input.turnId : '';
-      emit({
+      emitAfterText({
         type: 'error',
         kind: 'attachment',
         code: 'TURN_INPUT_INVALID',
@@ -1494,7 +1500,7 @@ export function createOpenCodeBackend({
         ...(e?.code && e?.spawnError ? { spawnCode: e.code } : {}),
         ...(sessionReset ? { sessionReset: true } : {}),
       };
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1537,7 +1543,7 @@ export function createOpenCodeBackend({
       if (pendingQuestions.get(id) === pending) pending.settling = false;
       const httpStatus = extractHttpStatus(error?.httpStatus);
       const classified = classifyErrorCode({ error, httpStatus, fallbackCode: 'BACKEND_ERROR' });
-      emit({
+      emitAfterText({
         type: 'error',
         kind: classified.kind,
         code: classified.code,
@@ -1555,7 +1561,7 @@ export function createOpenCodeBackend({
     // case it already settled the card, so do not emit a duplicate event.
     if (pendingQuestions.get(id) !== pending) return true;
     pendingQuestions.delete(id);
-    emit({
+    emitAfterText({
       type: 'question-resolved',
       toolUseId: id,
       outcome: submitted ? 'answered' : 'cancelled',
@@ -1571,7 +1577,7 @@ export function createOpenCodeBackend({
       if (!pending.settling && baseUrl) {
         rejects.push(postJson(questionReplyPath(questionId, 'reject'), {}));
       }
-      emit({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
+      emitAfterText({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
     }
     await Promise.allSettled(rejects);
   }
@@ -1584,7 +1590,7 @@ export function createOpenCodeBackend({
     }
     await drainApprovals();
     if (activeRun) {
-      emit({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.', ...activeTurnFailureFields() });
+      emitAfterText({ type: 'error', kind: 'aborted', code: 'TURN_ABORTED', message: 'Turn aborted.', ...activeTurnFailureFields() });
       finishActive();
     }
   }

--- a/plugin/panel/src/cep/openCodeHistoryGuard.js
+++ b/plugin/panel/src/cep/openCodeHistoryGuard.js
@@ -1,5 +1,5 @@
 export const OPEN_CODE_HISTORY_GUARD_FILENAME = 'ae-mcp-history-guard.js';
-export const OPEN_CODE_HISTORY_GUARD_MARKER = '/* executed AE script omitted from prior model history */';
+export const OPEN_CODE_HISTORY_GUARD_MARKER = '/* ae-mcp: script body hidden from history to save tokens. Never send this comment back as code — write the full script again, or rerun the stored script via ae_execRecover with its recoveryId. */';
 
 const AE_EXEC_TOOL_NAMES = Object.freeze([
   'ae_exec',

--- a/plugin/panel/src/cep/platform/process.js
+++ b/plugin/panel/src/cep/platform/process.js
@@ -153,6 +153,14 @@ export function createProcessBoundary({ deps, paths, platform }) {
     }
     const hasExplicitEnv = Object.prototype.hasOwnProperty.call(options, 'env');
     const environment = hasExplicitEnv ? completeEnvironment(options.env || {}) : completeSpawnEnv();
+    if (windows && (executable.source === 'registry-path' || executable.source === 'standard')) {
+      const pathKey = environmentKey(environment, 'PATH', true) || 'Path';
+      const executableDirectory = paths.dirname(executable.path);
+      const pathDirectories = String(environment[pathKey] || '').split(separator).filter(Boolean);
+      if (!pathDirectories.some((directory) => windowsPathEqual(directory, executableDirectory))) {
+        environment[pathKey] = [executableDirectory, ...pathDirectories].join(separator);
+      }
+    }
     const commandArgs = [...(executable.argsPrefix || []), ...args];
     return deps.spawnImpl(executable.path, commandArgs, {
       ...options,
@@ -327,6 +335,69 @@ export function createProcessBoundary({ deps, paths, platform }) {
     return result;
   }
 
+  function windowsPathEqual(left, right) {
+    return String(left).replace(/[\\/]+$/, '').toLowerCase()
+      === String(right).replace(/[\\/]+$/, '').toLowerCase();
+  }
+
+  function expandedRegistryPath(value, type, env) {
+    if (type.toUpperCase() !== 'REG_EXPAND_SZ') return value;
+    return value.replace(/%([^%]+)%/g, (match, name) => {
+      const replacement = environmentValue(env, name, true);
+      return replacement === undefined ? match : String(replacement);
+    });
+  }
+
+  function registryPathValue(output, env) {
+    const line = String(output || '').split(/\r?\n/).find((value) => {
+      return /^\s*Path\s+REG_(?:SZ|EXPAND_SZ)\s+/i.test(value);
+    });
+    if (!line) return null;
+    const match = line.match(/^\s*Path\s+(REG_(?:SZ|EXPAND_SZ))\s+(.*)$/i);
+    return match ? expandedRegistryPath(match[2], match[1], env) : null;
+  }
+
+  async function registryPathCandidates(id, env) {
+    if (!windows) return [];
+    const systemRoot = String(environmentValue(env, 'SystemRoot', true) || environmentValue(env, 'WINDIR', true) || 'C:\\Windows');
+    const executable = {
+      ok: true,
+      id: 'reg',
+      path: paths.join([systemRoot, 'System32', 'reg.exe']),
+      argsPrefix: [],
+      source: 'registry-path',
+      version: null,
+      arch: null,
+    };
+    const queries = [
+      ['HKCU\\Environment', '/v', 'Path'],
+      ['HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', '/v', 'Path'],
+    ];
+    const values = [];
+    for (const args of queries) {
+      const result = await run({
+        executable,
+        args: ['query', ...args],
+        env,
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+        maxOutputBytes: DEFAULT_OUTPUT_LIMIT,
+      });
+      if (result.exitCode !== 0 || result.timedOut || result.aborted) continue;
+      const value = registryPathValue(result.stdout, env);
+      if (value !== null) values.push(value);
+    }
+    const inherited = String(environmentValue(env, 'PATH', true) || '').split(separator).filter(Boolean);
+    const directories = [];
+    for (const value of values) {
+      for (const directory of value.split(separator).filter(Boolean)) {
+        if (inherited.some((entry) => windowsPathEqual(entry, directory))) continue;
+        if (!directories.some((entry) => windowsPathEqual(entry, directory))) directories.push(directory);
+      }
+    }
+    const extensions = ['', '.exe', '.com', '.cmd', '.bat'];
+    return directories.flatMap((directory) => extensions.map((extension) => paths.join([directory, id + extension])));
+  }
+
   function standardCandidates(id, env) {
     if (!windows) {
       const values = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin'].map((root) => paths.join([root, id]));
@@ -341,6 +412,10 @@ export function createProcessBoundary({ deps, paths, platform }) {
     if (id === 'winget') values.unshift(paths.join([local, 'Microsoft', 'WindowsApps', 'winget.exe']));
     if (id === 'powershell') values.unshift(paths.join([systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe']));
     values.push(paths.join([local, 'Programs', id, id + '.exe']));
+    values.push(paths.join([paths.home, '.local', 'bin', id + '.exe']));
+    values.push(paths.join([paths.home, 'scoop', 'shims', id + '.exe']));
+    values.push(paths.join([paths.home, 'scoop', 'shims', id + '.cmd']));
+    if (id === 'opencode') values.push(paths.join([paths.home, '.opencode', 'bin', 'opencode.exe']));
     return values;
   }
 
@@ -659,6 +734,23 @@ export function createProcessBoundary({ deps, paths, platform }) {
     for (const group of groups) {
       for (const path of group.values) {
         const rawCandidate = fileCandidate(path, group.source, env, id !== 'node');
+        if (!rawCandidate) continue;
+        const materialized = await materializeScriptCandidate(rawCandidate, id, { ...options, env }, attempts);
+        const candidate = materialized.candidate;
+        if (!candidate) {
+          if (materialized.failure === 'ARCH_MISMATCH') strongestFailure = 'ARCH_MISMATCH';
+          else if (materialized.failure === 'VERSION_TOO_OLD' && strongestFailure !== 'ARCH_MISMATCH') strongestFailure = 'VERSION_TOO_OLD';
+          continue;
+        }
+        const result = await probe(candidate, id, { ...options, env }, attempts);
+        if (result.success) return result.success;
+        strongestFailure = result.failure === 'ARCH_MISMATCH' ? result.failure
+          : (strongestFailure === 'NOT_FOUND' || (strongestFailure === 'PROBE_FAILED' && result.failure === 'VERSION_TOO_OLD') ? result.failure : strongestFailure);
+      }
+    }
+    if (windows && !hasExplicitEnv) {
+      for (const path of await registryPathCandidates(id, env)) {
+        const rawCandidate = fileCandidate(path, 'registry-path', env, id !== 'node');
         if (!rawCandidate) continue;
         const materialized = await materializeScriptCandidate(rawCandidate, id, { ...options, env }, attempts);
         const candidate = materialized.candidate;

--- a/plugin/panel/src/lib/logExport.js
+++ b/plugin/panel/src/lib/logExport.js
@@ -61,6 +61,12 @@ function formatActivity(event) {
     event.error !== undefined ? 'error=' + scalar(event.error) : null,
     event.durationMs !== undefined ? 'durationMs=' + scalar(event.durationMs) : null,
     event.undoGroup !== undefined ? 'undoGroup=' + scalar(event.undoGroup) : null,
+    event.tool !== undefined ? 'tool=' + scalar(event.tool) : null,
+    event.transport !== undefined ? 'transport=' + scalar(event.transport) : null,
+    event.scriptChars !== undefined ? 'scriptChars=' + scalar(event.scriptChars) : null,
+    event.scriptHead !== undefined ? 'scriptHead=' + scalar(event.scriptHead) : null,
+    event.hinted !== undefined ? 'hinted=' + scalar(event.hinted) : null,
+    event.hintIndex !== undefined ? 'hintIndex=' + scalar(event.hintIndex) : null,
   ].filter(Boolean).join(' ');
 }
 
@@ -111,12 +117,43 @@ function formatBackendError(event, exactSecrets) {
   if (!event || typeof event !== 'object') return '-';
   return [
     iso(event.ts),
+    'pid=' + scalar(redactedField(event.pid, exactSecrets)),
     'backend=' + scalar(redactedField(event.backend, exactSecrets)),
     'code=' + scalar(redactedField(event.code, exactSecrets)),
     'kind=' + scalar(redactedField(event.kind, exactSecrets)),
     'message=' + scalar(redactedBackendErrorField(event.message, exactSecrets)),
     event.detail ? 'detail=' + scalar(redactedBackendErrorField(event.detail, exactSecrets)) : null,
   ].filter(Boolean).join(' ');
+}
+
+function backendErrorKey(event) {
+  return [event.ts, event.backend, event.code, event.kind, event.message].map((value) => String(value ?? '')).join('\u0000');
+}
+
+function mergedBackendErrors(memoryErrors, diskEvents) {
+  const merged = [];
+  const positions = new Map();
+  const add = (event) => {
+    if (!event || typeof event !== 'object') return;
+    const key = backendErrorKey(event);
+    if (positions.has(key)) {
+      const index = positions.get(key);
+      if (event.pid !== undefined && merged[index].pid === undefined) merged[index] = event;
+      return;
+    }
+    positions.set(key, merged.length);
+    merged.push(event);
+  };
+  if (Array.isArray(memoryErrors)) memoryErrors.forEach(add);
+  if (Array.isArray(diskEvents)) diskEvents
+    .filter((event) => event && event.level === 'error' && event.source === 'chat')
+    .forEach(add);
+  return merged.sort((a, b) => {
+    const left = Date.parse(a.ts);
+    const right = Date.parse(b.ts);
+    if (Number.isFinite(left) && Number.isFinite(right)) return left - right;
+    return 0;
+  });
 }
 
 function section(lines, title, producer, exactSecrets, alreadyRedacted = false) {
@@ -255,9 +292,10 @@ export function buildLogExport({
     return hostLogDisk.slice(-500).map((event) => formatHostLog(event, exactSecrets));
   }, exactSecrets, true);
   section(lines, '## panel log (' + panelLogs.length + ')', () => panelLogs.map(String), exactSecrets);
-  section(lines, '## backend errors (last 50)', () => {
-    if (!Array.isArray(backendErrors)) return unavailable('backend error history is unavailable');
-    return backendErrors.slice(-50).map((event) => formatBackendError(event, exactSecrets));
+  section(lines, '## backend errors (last 50, memory + disk)', () => {
+    if (!Array.isArray(backendErrors) && !Array.isArray(hostLogDisk)) return unavailable('backend error history is unavailable');
+    return mergedBackendErrors(backendErrors, hostLogDisk).slice(-50)
+      .map((event) => formatBackendError(event, exactSecrets));
   }, exactSecrets, true);
   section(lines, '## backend stderr tails', () => {
     const tails = backendStderrTails;

--- a/plugin/panel/src/lib/logExport.test.js
+++ b/plugin/panel/src/lib/logExport.test.js
@@ -15,7 +15,7 @@ test('buildLogExport includes all diagnostic sections and sources', () => {
       logsDir: '/home/user/.ae-mcp/logs', logLevel: 'info',
     },
     diagnostics: [{ id: 'host-listening', ok: true, detail: 'Host is ready' }],
-    hostActivity: [{ id: 4, ts: Date.parse('2026-08-19T10:00:00Z'), client: 'claude', engine: 'jsx', ok: true }, { id: 5, ts: Date.parse('2026-08-19T10:00:01Z'), client: 'claude', ok: false, error: 'JSX timeout after 3000ms', disposition: 'uncertain' }],
+    hostActivity: [{ id: 4, ts: Date.parse('2026-08-19T10:00:00Z'), client: 'claude', engine: 'jsx', ok: true }, { id: 5, ts: Date.parse('2026-08-19T10:00:01Z'), client: 'claude', ok: false, error: 'JSX timeout after 3000ms', disposition: 'uncertain', tool: 'ae_exec', transport: 'mcp', scriptChars: 42, scriptHead: 'throw new Error("boom")', hinted: true, hintIndex: 6 }],
     hostLogMemory: [{
       ts: '2026-08-19T10:01:00Z',
       pid: 10,
@@ -36,6 +36,8 @@ test('buildLogExport includes all diagnostic sections and sources', () => {
   ]) assert.match(text, new RegExp(heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(text, /summary: comp\/saveFrameToPng=1\s+failed=0/);
   assert.match(text, /#5 2026-08-19T10:00:01\.000Z client=claude engine=- ok=false disposition=uncertain error="JSX timeout after 3000ms"/);
+  assert.ok(text.includes('tool=ae_exec transport=mcp scriptChars=42 scriptHead="throw new Error(\\"boom\\")" hinted=true hintIndex=6'));
+  assert.match(text, /## backend errors \(last 50, memory \+ disk\)/);
 });
 
 test('a missing source only makes its own section unavailable', () => {

--- a/plugin/panel/test/claudeAgentBackend.test.js
+++ b/plugin/panel/test/claudeAgentBackend.test.js
@@ -514,6 +514,68 @@ test('real assistant and user wire map AE tool start and result events', async (
   });
 });
 
+test('Claude flushes redacted assistant text before tool_use events', async () => {
+  const selected = 'C:\\' + 's'.repeat(61);
+  assert.equal(selected.length, 64);
+  const h = makeHarness();
+  h.fs.files.add(selected);
+  const run = h.backend.sendUser({
+    turnId: 'turn-text-order',
+    text: 'use a tool',
+    attachments: [{
+      id: 'att-sensitive',
+      name: 'sensitive.txt',
+      mediaType: 'text/plain',
+      size: 1,
+      temporary: false,
+      localPath: selected,
+    }],
+  });
+  await flush();
+
+  const beforeToolChunks = [
+    'The composition is ready, and the expression setup is complete up to globalA',
+    'lpha 0.7 before the tool runs.',
+  ];
+  for (const text of beforeToolChunks) {
+    emitWire(h.processes[0], {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text },
+      },
+    });
+  }
+  emitWire(h.processes[0], {
+    type: 'assistant',
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: 'tool_text_order',
+        name: 'mcp__ae__ae_exec',
+        input: { value: 1 },
+      }],
+    },
+  });
+
+  const toolIndex = h.events.findIndex((event) => event.type === 'tool-start');
+  assert.ok(toolIndex >= 0);
+  assert.equal(
+    h.events.slice(0, toolIndex)
+      .filter((event) => event.type === 'text-delta')
+      .map((event) => event.text)
+      .join(''),
+    beforeToolChunks.join(''),
+  );
+
+  finishTurn(h.processes[0]);
+  await run;
+  assert.equal(
+    h.events.filter((event) => event.type === 'text-delta').map((event) => event.text).join(''),
+    beforeToolChunks.join(''),
+  );
+});
+
 test('manual can_use_tool allow and deny use the real control wire shape', async () => {
   for (const decision of ['allow', 'deny']) {
     const h = makeHarness();

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -110,8 +110,12 @@ function makeBackend(overrides = {}) {
   return { backend, platform, spawned, mkdirs, events };
 }
 
-async function startTurn(backend, spawned) {
-  const pending = backend.sendUser({ turnId: 'turn_1', text: 'hello', attachments: [] });
+async function startTurn(
+  backend,
+  spawned,
+  input = { turnId: 'turn_1', text: 'hello', attachments: [] },
+) {
+  const pending = backend.sendUser(input);
   await flush();
   const proc = spawned[0].proc;
   const initialize = parseWrites(proc)[0];
@@ -238,6 +242,64 @@ test('Codex reports cold-start stages before output and omits spawn on a warm tu
     assert.equal(spawned.length, 1);
   } finally {
     backend.reset();
+  }
+});
+
+test('Codex flushes redacted assistant text before MCP tool start events', async () => {
+  const sensitivePath = 'C:\\' + 's'.repeat(61);
+  assert.equal(sensitivePath.length, 64);
+  const h = makeBackend();
+  try {
+    const { pending, proc } = await startTurn(h.backend, h.spawned, {
+      turnId: 'turn_text_order',
+      text: 'use a tool',
+      attachments: [{
+        id: 'att-sensitive',
+        name: 'sensitive.txt',
+        mediaType: 'text/plain',
+        size: 1,
+        temporary: false,
+        localPath: sensitivePath,
+      }],
+    });
+    proc.emit({ method: 'turn/started', params: { turn: { id: 'remote_text_order' } } });
+    const beforeToolChunks = [
+      'The composition is ready, and the expression setup is complete up to globalA',
+      'lpha 0.7 before the tool runs.',
+    ];
+    for (const delta of beforeToolChunks) {
+      proc.emit({ method: 'item/agentMessage/delta', params: { delta } });
+    }
+    proc.emit({
+      method: 'item/started',
+      params: {
+        item: {
+          type: 'mcpToolCall',
+          id: 'tool_text_order',
+          tool: 'ae_exec',
+          arguments: { value: 1 },
+        },
+      },
+    });
+
+    const toolIndex = h.events.findIndex((event) => event.type === 'tool-start');
+    assert.ok(toolIndex >= 0);
+    assert.equal(
+      h.events.slice(0, toolIndex)
+        .filter((event) => event.type === 'text-delta')
+        .map((event) => event.text)
+        .join(''),
+      beforeToolChunks.join(''),
+    );
+
+    proc.emit({ method: 'turn/completed', params: { turn: { status: 'completed' } } });
+    await pending;
+    assert.equal(
+      h.events.filter((event) => event.type === 'text-delta').map((event) => event.text).join(''),
+      beforeToolChunks.join(''),
+    );
+  } finally {
+    h.backend.reset();
   }
 });
 

--- a/plugin/panel/test/diagnostics.test.js
+++ b/plugin/panel/test/diagnostics.test.js
@@ -96,7 +96,7 @@ test('runDiagnostics checks host, MCP session, AE, and the three optional CLIs',
   assert.doesNotMatch(JSON.stringify(items), /offline service|repair-service/i);
 });
 
-test('runDiagnostics reports missing token and stale MCP activity independently', async () => {
+test('runDiagnostics reports missing token while stale MCP activity stays neutral', async () => {
   const stale = Date.now() - (11 * 60 * 1000);
   const items = await runDiagnostics({
     ...makeDeps({ token: null, sessionAt: stale }),
@@ -104,9 +104,15 @@ test('runDiagnostics reports missing token and stale MCP activity independently'
   });
   assert.equal(items.find((item) => item.id === 'token-file').ok, false);
   const session = items.find((item) => item.id === 'mcp-session');
-  assert.equal(session.ok, false);
-  assert.match(session.fixHint.zh, /MCP/);
-  assert.match(session.fixHint.en, /MCP/);
+  assert.equal(session.ok, true);
+  assert.equal(session.detail, 'No recent MCP session');
+});
+
+test('runDiagnostics treats a never-used MCP session as neutral', async () => {
+  const items = await runDiagnostics({ ...makeDeps({ sessionAt: 0 }), port: 11488 });
+  const session = items.find((item) => item.id === 'mcp-session');
+  assert.equal(session.ok, true);
+  assert.equal(session.detail, 'No recent MCP session');
 });
 
 test('runDiagnostics exec probes identify as the panel-internal client', async () => {

--- a/plugin/panel/test/logExport.test.js
+++ b/plugin/panel/test/logExport.test.js
@@ -248,7 +248,7 @@ test('backend stderr is redacted line by line without losing later diagnostics',
     }],
   });
 
-  assert.match(text, /## backend errors \(last 50\)/);
+  assert.match(text, /## backend errors \(last 50, memory \+ disk\)/);
   assert.match(text, /code=AUTH_REQUIRED/);
   assert.match(text, /## backend stderr tails/);
   assert.equal(text.includes('relay.example'), false);
@@ -258,6 +258,24 @@ test('backend stderr is redacted line by line without losing later diagnostics',
   assert.equal(text.includes('http'), false);
   assert.match(text, /ECONNREFUSED 127\.0\.0\.1:443/);
   assert.match(text, /at connect \(node:net:123:4\)/);
+});
+
+test('backend errors merge disk chat failures from earlier host processes and dedupe memory copies', () => {
+  const text = buildLogExport({
+    backendErrors: [{
+      ts: '2026-08-22T10:00:00Z', backend: 'claude', code: 'AUTH_REQUIRED', kind: 'auth', message: 'login required',
+    }],
+    hostLogDisk: [
+      { ts: '2026-08-21T09:00:00Z', pid: 41, level: 'error', source: 'chat', backend: 'codex', code: 'TIMEOUT', kind: 'backend', message: 'old timeout', detail: 'disk detail' },
+      { ts: '2026-08-22T10:00:00Z', pid: 42, level: 'error', source: 'chat', backend: 'claude', code: 'AUTH_REQUIRED', kind: 'auth', message: 'login required', detail: 'disk copy' },
+      { ts: '2026-08-22T11:00:00Z', pid: 43, level: 'info', source: 'chat', backend: 'opencode', code: 'NOPE', kind: 'backend', message: 'not an error' },
+    ],
+  });
+  assert.match(text, /pid=41 backend=codex code=TIMEOUT/);
+  assert.match(text, /pid=42 backend=claude code=AUTH_REQUIRED/);
+  const backendSection = text.split('## backend errors (last 50, memory + disk)\n')[1].split('\n\n## backend stderr tails')[0];
+  assert.equal((backendSection.match(/login required/g) || []).length, 1);
+  assert.doesNotMatch(backendSection, /not an error/);
 });
 
 test('a sensitive host extra does not truncate sibling message and error fields', () => {

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -1102,6 +1102,177 @@ test('createOpenCodeBackend maps text, reasoning, tool, and idle SSE events to p
   ]);
 });
 
+test('OpenCode prefixes only ae server tool names', async () => {
+  const { backend, events, fetched } = makeBackend();
+  const pending = backend.sendUser('map tool names');
+  await flush();
+
+  const mappings = [
+    ['tool_ae', 'ae_ae_ping', 'mcp__ae__ae_ping'],
+    ['tool_prefixed', 'mcp__ae__x', 'mcp__ae__x'],
+    ['tool_patch', 'apply_patch', 'apply_patch'],
+    ['tool_read', 'read', 'read'],
+  ];
+  for (const [callID, tool] of mappings) {
+    fetched.sse.push({
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'session_1',
+        part: {
+          type: 'tool',
+          tool,
+          callID,
+          state: { status: 'running', input: {} },
+        },
+      },
+    });
+  }
+  completeTurn(fetched);
+  await pending;
+
+  assert.deepEqual(
+    events.filter((event) => event.type === 'tool-start').map((event) => [
+      event.toolUseId,
+      event.name,
+    ]),
+    mappings.map(([callID, , expected]) => [callID, expected]),
+  );
+});
+
+test('OpenCode flushes redacted assistant text before built-in question events', async () => {
+  const providerSecret = 'p'.repeat(64);
+  assert.equal(providerSecret.length, 64);
+  const { backend, events, fetched } = makeBackend({
+    getSensitiveValues: () => [providerSecret],
+  });
+  const pending = backend.sendUser('ask before continuing');
+  await flush();
+
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'busy' } },
+  });
+  const beforeQuestionChunks = [
+    'The composition is ready, and the expression setup is complete up to globalA',
+    'lpha 0.7 before I need one detail.',
+  ];
+  for (const delta of beforeQuestionChunks) {
+    fetched.sse.push({
+      type: 'message.part.delta',
+      properties: { sessionID: 'session_1', field: 'text', delta },
+    });
+  }
+  fetched.sse.push({
+    type: 'question.asked',
+    properties: {
+      id: 'que_order',
+      sessionID: 'session_1',
+      questions: [{ question: 'Continue?', header: 'Continue', options: [] }],
+    },
+  });
+  await flush();
+
+  const questionIndex = events.findIndex((event) => event.type === 'question-required');
+  assert.ok(questionIndex >= 0);
+  assert.equal(
+    events.slice(0, questionIndex)
+      .filter((event) => event.type === 'text-delta')
+      .map((event) => event.text)
+      .join(''),
+    beforeQuestionChunks.join(''),
+  );
+
+  fetched.sse.push({
+    type: 'question.replied',
+    properties: {
+      requestID: 'que_order',
+      sessionID: 'session_1',
+      answers: [['Proceed']],
+    },
+  });
+  await flush();
+  const resolvedIndex = events.findIndex((event) => event.type === 'question-resolved');
+  assert.ok(resolvedIndex > questionIndex);
+
+  const afterQuestion = ' Continuing after the answer.';
+  fetched.sse.push({
+    type: 'message.part.delta',
+    properties: { sessionID: 'session_1', field: 'text', delta: afterQuestion },
+  });
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'idle' } },
+  });
+  await pending;
+
+  const postAnswerText = events.findIndex((event, index) => (
+    index > resolvedIndex && event.type === 'text-delta'
+  ));
+  assert.ok(postAnswerText > resolvedIndex);
+  assert.equal(
+    events.filter((event) => event.type === 'text-delta').map((event) => event.text).join(''),
+    beforeQuestionChunks.join('') + afterQuestion,
+  );
+});
+
+test('OpenCode flushes redacted assistant text before tool start events', async () => {
+  const providerSecret = 'p'.repeat(64);
+  assert.equal(providerSecret.length, 64);
+  const { backend, events, fetched } = makeBackend({
+    getSensitiveValues: () => [providerSecret],
+  });
+  const pending = backend.sendUser('use a tool');
+  await flush();
+
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'busy' } },
+  });
+  const beforeToolChunks = [
+    'The composition is ready, and the expression setup is complete up to globalA',
+    'lpha 0.7 before the tool runs.',
+  ];
+  for (const delta of beforeToolChunks) {
+    fetched.sse.push({
+      type: 'message.part.delta',
+      properties: { sessionID: 'session_1', field: 'text', delta },
+    });
+  }
+  fetched.sse.push({
+    type: 'message.part.updated',
+    properties: {
+      sessionID: 'session_1',
+      part: {
+        type: 'tool',
+        tool: 'ae_ae_ping',
+        callID: 'tool_order',
+        state: { status: 'running', input: { value: 1 } },
+      },
+    },
+  });
+  await flush();
+
+  const toolIndex = events.findIndex((event) => event.type === 'tool-start');
+  assert.ok(toolIndex >= 0);
+  assert.equal(
+    events.slice(0, toolIndex)
+      .filter((event) => event.type === 'text-delta')
+      .map((event) => event.text)
+      .join(''),
+    beforeToolChunks.join(''),
+  );
+
+  fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'idle' } },
+  });
+  await pending;
+  assert.equal(
+    events.filter((event) => event.type === 'text-delta').map((event) => event.text).join(''),
+    beforeToolChunks.join(''),
+  );
+});
+
 test('OpenCode SSE preserves Chinese text split inside a UTF-8 character', async () => {
   const { backend, events, fetched } = makeBackend();
   const pending = backend.sendUser('utf8');

--- a/plugin/panel/test/openCodeHistoryGuard.test.js
+++ b/plugin/panel/test/openCodeHistoryGuard.test.js
@@ -28,7 +28,7 @@ function toolPart(tool, status, input, extras = {}) {
 test('history guard matches only exact AE exec and recovery tool names', () => {
   assert.equal(
     OPEN_CODE_HISTORY_GUARD_MARKER,
-    '/* executed AE script omitted from prior model history */',
+    '/* ae-mcp: script body hidden from history to save tokens. Never send this comment back as code — write the full script again, or rerun the stored script via ae_execRecover with its recoveryId. */',
   );
   assert.doesNotThrow(() => new Function(OPEN_CODE_HISTORY_GUARD_MARKER));
   for (const name of [
@@ -52,6 +52,10 @@ test('history guard matches only exact AE exec and recovery tool names', () => {
   ]) {
     assert.equal(isOpenCodeAeExecToolName(name), false, String(name));
   }
+});
+
+test('history guard marker retains the host rejection tripwire phrase', () => {
+  assert.ok(OPEN_CODE_HISTORY_GUARD_MARKER.includes('hidden from history to save tokens'));
 });
 
 test('history guard changes only outbound completed or errored AE scripts', () => {
@@ -95,6 +99,7 @@ test('history guard changes only outbound completed or errored AE scripts', () =
 
 test('generated OpenCode plugin is dependency-free, executable, and mutates hook output in place', async () => {
   const source = openCodeHistoryGuardPluginSource();
+  assert.ok(source.includes(OPEN_CODE_HISTORY_GUARD_MARKER));
   assert.doesNotMatch(source, /(?:from\s+['"]|require\s*\()/);
   const url = 'data:text/javascript;base64,' + Buffer.from(source, 'utf8').toString('base64');
   const plugin = await import(url);

--- a/plugin/panel/test/platform-process.test.js
+++ b/plugin/panel/test/platform-process.test.js
@@ -74,6 +74,11 @@ function processFactory(steps, calls) {
   };
 }
 
+function assertOnlyRegistryQueries(calls, message) {
+  assert.equal(calls.length, 2, message);
+  assert.equal(calls.every((call) => /reg\.exe$/i.test(call.file)), true, message);
+}
+
 function macHarness({ files = [], realpaths = {}, steps = [] } = {}) {
   const calls = [];
   const adapter = createMacosAdapter({
@@ -137,6 +142,129 @@ test('macOS login-shell probe accepts exactly one clean sentinel result', async 
   });
   const stderrRejected = await stderrPolluted.adapter.resolveExecutable('codex', { env: { PATH: '' } });
   assert.equal(stderrRejected.ok, false);
+});
+
+test('Windows standard candidates find common fresh CLI installer directories', async () => {
+  const cases = [
+    { id: 'claude', executable: 'C:\\Users\\a\\.local\\bin\\claude.exe' },
+    { id: 'opencode', executable: 'C:\\Users\\a\\scoop\\shims\\opencode.exe' },
+    { id: 'opencode', executable: 'C:\\Users\\a\\.opencode\\bin\\opencode.exe' },
+  ];
+
+  for (const fixture of cases) {
+    const calls = [];
+    const adapter = createWindowsAdapter({
+      platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { PATH: '' },
+      fs: fakeFs(new Set([fixture.executable])),
+      spawnImpl: processFactory([{ code: 1 }, { code: 1 }, { stdout: fixture.id + ' 1.0.0' }], calls), now: () => 0,
+    });
+
+    const result = await adapter.resolveExecutable(fixture.id);
+
+    assert.equal(result.ok, true, fixture.executable);
+    assert.equal(result.path, fixture.executable);
+    assert.equal(result.source, 'standard');
+    assert.equal(calls.filter((call) => /reg\.exe$/i.test(call.file)).length, 2);
+  }
+});
+
+test('Windows resolution reads expanded registry PATH entries for default environments', async () => {
+  const calls = [];
+  const executable = 'C:\\Users\\a\\.local\\bin\\claude.exe';
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp',
+    env: { PATH: 'C:\\Inherited', USERPROFILE: 'C:\\Users\\a' },
+    fs: fakeFs(new Set([executable])),
+    spawnImpl: processFactory([
+      { stdout: '\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_EXPAND_SZ    %USERPROFILE%\\.local\\bin;C:\\Custom Tools\r\n' },
+      { stdout: '\r\nHKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\r\n    Path    REG_SZ    C:\\System Tools\r\n' },
+      { stdout: 'claude 1.0.0' },
+    ], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('claude');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.path, executable);
+  assert.equal(result.source, 'registry-path');
+  assert.deepEqual(calls.slice(0, 2).map((call) => call.args), [
+    ['query', 'HKCU\\Environment', '/v', 'Path'],
+    ['query', 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', '/v', 'Path'],
+  ]);
+});
+
+test('Windows explicit resolver environments do not read the registry PATH', async () => {
+  const calls = [];
+  const executable = 'C:\\Users\\a\\.local\\bin\\claude.exe';
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { PATH: 'C:\\Inherited' },
+    fs: fakeFs(new Set([executable])), spawnImpl: processFactory([{ stdout: 'claude 1.0.0' }], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('claude', { env: { PATH: '' } });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.source, 'standard');
+  assert.equal(calls.some((call) => /reg\.exe$/i.test(call.file)), false);
+});
+
+test('Windows spawn prepends registry and standard executable directories without changing PATH resolutions', async () => {
+  const registryCalls = [];
+  const registryExecutable = 'C:\\Registry Bin\\claude.exe';
+  const registry = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { PATH: 'C:\\Inherited', KEEP: 'yes' },
+    fs: fakeFs(new Set([registryExecutable])),
+    spawnImpl: processFactory([
+      { stdout: '\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_SZ    C:\\Registry Bin\r\n' },
+      { code: 1 },
+      { stdout: 'claude 1.0.0' },
+      {},
+    ], registryCalls), now: () => 0,
+  });
+  const registryResult = await registry.resolveExecutable('claude');
+  registry.spawn(registryResult);
+  assert.equal(registryCalls.at(-1).options.env.PATH, 'C:\\Registry Bin;C:\\Inherited');
+  assert.equal(registryCalls.at(-1).options.env.KEEP, 'yes');
+
+  const standardCalls = [];
+  const standardExecutable = 'C:\\Users\\a\\.local\\bin\\claude.exe';
+  const standard = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { Path: 'C:\\Inherited', KEEP: 'yes' },
+    fs: fakeFs(new Set([standardExecutable])),
+    spawnImpl: processFactory([{ code: 1 }, { code: 1 }, { stdout: 'claude 1.0.0' }, {}], standardCalls), now: () => 0,
+  });
+  const standardResult = await standard.resolveExecutable('claude');
+  standard.spawn(standardResult);
+  assert.equal(standardCalls.at(-1).options.env.Path, 'C:\\Users\\a\\.local\\bin;C:\\Inherited');
+  assert.equal(standardCalls.at(-1).options.env.PATH, undefined);
+
+  const pathCalls = [];
+  const pathExecutable = 'C:\\Path Bin\\claude.exe';
+  const path = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { PATH: 'C:\\Path Bin;C:\\Inherited' },
+    fs: fakeFs(new Set([pathExecutable])), spawnImpl: processFactory([{ stdout: 'claude 1.0.0' }, {}], pathCalls), now: () => 0,
+  });
+  const pathResult = await path.resolveExecutable('claude');
+  path.spawn(pathResult);
+  assert.equal(pathCalls.at(-1).options.env.PATH, 'C:\\Path Bin;C:\\Inherited');
+});
+
+test('Windows registry PATH candidates skip directories already in the inherited PATH', async () => {
+  const calls = [];
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { PATH: 'C:\\Existing Bin\\' },
+    fs: fakeFs(new Set()),
+    spawnImpl: processFactory([
+      { stdout: '\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_SZ    c:\\existing bin\r\n' },
+      { stdout: '\r\nHKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\r\n    Path    REG_SZ    C:\\Existing Bin\\\r\n' },
+    ], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('claude');
+
+  assert.equal(result.ok, false);
+  assert.equal(calls.length, 2);
+  assert.equal(calls.every((call) => /reg\.exe$/i.test(call.file)), true);
 });
 
 test('run is shell-free, preserves nonzero exits and caps combined output', async () => {
@@ -337,7 +465,7 @@ test('a node.cmd candidate fails closed without recursively resolving Node', asy
 
   assert.equal(result.ok, false);
   assert.equal(result.code, 'NOT_FOUND');
-  assert.deepEqual(calls, []);
+  assertOnlyRegistryQueries(calls);
 });
 
 test('requiredArch rejects an arbitrary Windows command wrapper before probing Node', async () => {
@@ -357,7 +485,7 @@ test('requiredArch rejects an arbitrary Windows command wrapper before probing N
   const result = await adapter.resolveExecutable('codex', { requiredArch: 'x64' });
 
   assert.equal(result.ok, false);
-  assert.deepEqual(calls, []);
+  assertOnlyRegistryQueries(calls);
 });
 
 test('Windows command wrappers are rejected even when the caller omits requiredArch', async () => {
@@ -377,7 +505,7 @@ test('Windows command wrappers are rejected even when the caller omits requiredA
   const result = await adapter.resolveExecutable('codex');
 
   assert.equal(result.ok, false);
-  assert.deepEqual(calls, []);
+  assertOnlyRegistryQueries(calls);
 });
 
 test('strict npm cmd-shims use native Node even when the caller omits requiredArch', async () => {
@@ -471,7 +599,7 @@ test('direct-exe npm cmd-shims reject escape, non-exe, and mangled-prefix varian
     const result = await adapter.resolveExecutable('opencode', { requiredArch: 'x64' });
 
     assert.equal(result.ok, false, golden.name);
-    assert.deepEqual(calls, [], golden.name);
+    assertOnlyRegistryQueries(calls, golden.name);
   }
 });
 
@@ -496,7 +624,7 @@ test('requiredArch rejects an npm shim when its verified Node has the wrong nati
 
   assert.equal(result.ok, false);
   assert.equal(result.code, 'ARCH_MISMATCH');
-  assert.deepEqual(calls, []);
+  assertOnlyRegistryQueries(calls);
 });
 
 test('requiredArch rejects ambiguous or escaping cmd-shim entries', async () => {
@@ -519,7 +647,7 @@ test('requiredArch rejects ambiguous or escaping cmd-shim entries', async () => 
     });
     const result = await adapter.resolveExecutable('codex', { requiredArch: 'x64' });
     assert.equal(result.ok, false);
-    assert.deepEqual(calls, []);
+    assertOnlyRegistryQueries(calls);
   }
 });
 
@@ -712,7 +840,7 @@ test('Windows resolution rejects incomplete cmd wrappers instead of invoking cmd
   });
   const result = await adapter.resolveExecutable('codex');
   assert.equal(result.ok, false);
-  assert.deepEqual(calls, []);
+  assertOnlyRegistryQueries(calls);
 });
 
 test('Windows spawn rejects a forged command-script resolution', () => {


### PR DESCRIPTION
## 一句话

修复测试机 0825 实测暴露的四类体验杀手:流式文本被卡片撕裂、AE 开着装 CLI 检测不到、历史脱敏占位符把智能体带进 40+ 连败死循环、诊断包对最重故障全盲。

## 修了什么

- **#322 流式乱序**(Sol):三后端在发 tool/approval/question/中途 error 卡前统一 flush 文本缓冲;新增 64 字节密钥 + 拆词场景回归测试 ×4。
- **#321 检测失效**(Terra):Windows 解析新增注册表 PATH 候选组(仅枚举,绝不并入子进程 env)+ 白名单补 `~\.local\bin` / scoop shims / `~\.opencode\bin`;registry/standard 来源的可执行 spawn 时前插自身目录。「重新检测」不再需要重启 AE。
- **#323 exec 反馈回路**(Luna + 验收修复):
  - 占位符绊线:`code` 含历史脱敏占位符即拒绝执行并给定向指导,execRecover 不再会被它覆写存档脚本(真机事故根因,见 issue 评论的 recovery 元数据实锤);
  - error-hints 补上 ExtendScript 异常主路径(此前从未生效)+ 4 条实战 hint(滑块 ±1e6、颜色数组、对象无效、NO_VALUE);
  - undefined/空输出文案改为真实契约(最后一条语句须为裸表达式)并区分「空输出=可能未捕获异常」;
  - previewFrame 参数冲突报错内联正确写法;
  - activity 记录工具名/transport/客户端归因/失败脚本摘要/hint 命中,桥层成功但 MCP 判失败的调用记为 `mcp_failed` 关联事件,skillUse 留痕,诊断包合并磁盘历史错误,空闲 MCP 会话不再显示为故障。
- **#324 工具名误标**(Sol):只有 `ae_` 前缀的名字才冠 `mcp__ae__`,OpenCode 内建工具原样透传;历史卫士占位符改为自述文本并钉死绊线特征串。

## 验证(全部由 orchestrator 本机实跑)

- 集成分支:host **221 过 / 0 挂 / 16 跳**(跳过项与 main 基线一致),panel **555 过 / 0 挂 / 1 跳**。
- `npm run build` + `verify-bundle` 绿(dist 已随分支重建提交)。
- #321/#322 均有仓库真模块的机制级复现脚本佐证;#323 根因由测试机 recovery 目录 attempts 元数据实锤(占位符 sha 出现 ~40 次)。

## 备注

- Luna 最后一轮沙箱持续 `CreateProcessAsUserW` error 5 且补丁工具损坏文件,剩余机械修复(语法错误、重复调用、返回形状、preview 文案、补测试)由 orchestrator 直接完成,已在提交里如实归档。
- 真机验收建议:OpenCode 通道跑一次带提问的长回复(验 #322);AE 开着用官方安装器装 claude 后点重新检测(验 #321);故意发占位符注释当 code(验 #323 绊线文案)。

Closes #321, closes #322, closes #323, closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)