### PR TITLE
feat: zero-terminal setup — bundled OpenCode, one-click sign-in and installs (#321 P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 .local-workspace-archive/
 .superpowers/sdd/
 .cache/capability-package-index/
+scripts/package/runtime-staging/
 plugin/panel/ae_viewer_*.png
 /.install-panel.ps1
 /.restart-ae.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### Unreleased
 
+- **ZXP 内置 OpenCode，全新安装开箱即有可用通道（#321）**——Windows 发布包随附经 SHA-256 校验的官方 OpenCode 可执行文件，面板自动优先使用内置版本（显式环境变量覆盖仍然最高优先），不再要求用户自行安装任何 CLI。构建期由钉版拉取脚本获取产物，正式构建缺产物会直接失败而不是悄悄发出不完整的包。
+- **登录不再需要终端**——Claude 通道新增「打开登录窗口」按钮（登录后本页自动刷新）；Codex 通道新增「一键登录」：面板在隔离环境里代跑登录、自动帮你打开浏览器验证页，失败时才回退为可复制命令。所有修复提示不再出现"请在终端运行 X"式的裸指令。
+- **向导一键安装 Claude Code**——首启向导可直接代跑 Anthropic 官方安装器（明确标注来源），装完点重新检测即可识别；另提供可选的「加入系统 PATH」按钮（免管理员、保留原有 PATH 变量类型、不用会截断 PATH 的 setx），方便你在自己的终端里也能使用。
+- **全新安装默认使用 OpenCode Provider 通道**——三个通道中唯一无需 CLI 登录的一个；已有用户的选择保持不变。
 - **AI 回复不再被工具卡撕成两截（#322）**——三条通道统一在插入工具、审批、提问卡片之前先把已生成的文字完整落屏。此前配置了 API Key 时，最后几十个字符会被扣在防泄漏缓冲里，等你答完问题才出现在卡片下面，甚至把一个单词拆成两半。
 - **AE 开着也能装好 CLI（#321）**——Windows 上「重新检测」现在会重读注册表里的用户/系统 PATH，并认识 Claude 官方安装器（`~\.local\bin`）、scoop、OpenCode 官方安装器的默认位置。装完 CLI 直接点重新检测即可，不必重启 After Effects。
 - **智能体不再被自己的历史带进死循环（#323）**——修复一起真实事故：为省 token 而脱敏的历史脚本占位符被模型当成代码原样发回，先是执行一句注释永远失败，重试时还会把存档的恢复脚本覆写掉，单个任务连败四十余次。现在主机直接拦下占位符并明确告知重写完整脚本，恢复存档不再会被覆写；占位符文本也改为自带「不要把这句注释当代码发回」的指令。
@@ -346,6 +350,10 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### Unreleased
 
+- **OpenCode ships inside the ZXP — a fresh install has a working channel out of the box (#321)** — the Windows package bundles the official OpenCode executable (SHA-256-verified, pinned version fetched at build time; release builds fail rather than silently ship without it). The panel prefers the bundled copy automatically, with the explicit env-var override still winning.
+- **Signing in no longer needs a terminal** — the Claude channel gains an Open-sign-in-window button (the page refreshes automatically once you're in); the Codex channel gains one-click sign-in that runs the login inside the panel's isolated environment and opens the browser verification page for you, falling back to a copyable command only when that fails. No fix hint tells you to "run X in a terminal" anymore.
+- **The wizard installs Claude Code for you** — one click runs Anthropic's official installer (provenance clearly labeled); Re-check finds it immediately. An optional add-to-PATH button registers CLI directories on the user PATH without admin rights, preserving the value type and never using the PATH-truncating setx.
+- **Fresh installs default to the OpenCode Provider channel** — the only channel needing no CLI sign-in; existing users keep their stored choice.
 - **AI replies are no longer torn apart by tool cards (#322)** — all three channels flush pending assistant text before inserting a tool, approval, or question card. Previously, with an API key configured, the last few dozen characters were withheld in the leak-prevention buffer and only appeared below the card after you answered — sometimes splitting a word in half.
 - **CLIs installed while AE is open are now detected (#321)** — on Windows, Re-check re-reads the registry user/system PATH and knows the official install locations (Claude's `~\.local\bin`, scoop shims, OpenCode's `~\.opencode\bin`). No more restarting After Effects after installing a CLI.
 - **Agents can no longer be trapped by their own redacted history (#323)** — fixes a real incident: the placeholder that hides old scripts from history (to save tokens) was imitated by the model and sent back as code, executing a bare comment forever and even overwriting the stored recovery script on retry — one task failed 40+ times. The host now rejects placeholder code with clear guidance, recovery scripts can no longer be overwritten by it, and the placeholder text itself now says never to send it back.

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20660,6 +20660,8 @@
     selectedChannel = "",
     onSelectChannel,
     onRecheck,
+    onLogin,
+    loginState = null,
     recheckLabel,
     recheckDisabled = false,
     readOnly = false,
@@ -20689,9 +20691,14 @@
     };
     return /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
       channels.map((probe) => {
+        var _a, _b;
         const texts = channelTexts(probe, lang);
         const isActive = probe.channel === activeChannel;
         const choice = channelChoiceState(probe.channel, selectedChannel, lang);
+        const loginAction = !probe.ok && !probe.checking ? probe.loginAction : null;
+        const activeLogin = (loginState == null ? void 0 : loginState.channel) === probe.channel ? loginState : null;
+        const loginWaiting = ["launching", "waiting", "verifying"].includes(activeLogin == null ? void 0 : activeLogin.status);
+        const loginLabel = loginWaiting ? lang === "en" ? "Waiting for sign-in\u2026" : "\u7B49\u5F85\u767B\u5F55\u2026" : ((_a = loginAction == null ? void 0 : loginAction.label) == null ? void 0 : _a[lang]) || ((_b = loginAction == null ? void 0 : loginAction.label) == null ? void 0 : _b.zh) || "";
         return /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px 10px", border: `1px solid ${isActive ? "var(--border-strong)" : "var(--border-subtle)"}`, borderRadius: "var(--radius-md)", background: "var(--bg-well)" }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
             /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(ChannelDot, { token: channelDot(probe) }),
@@ -20700,6 +20707,8 @@
             !readOnly && onSelectChannel ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: choice.active ? "secondary" : "ghost", size: "sm", disabled: choice.active, onClick: () => onSelectChannel(probe.channel), children: choice.label }) : null
           ] }),
           texts.fixHint ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-tertiary)", whiteSpace: "pre-wrap" }, children: texts.fixHint }) : null,
+          (activeLogin == null ? void 0 : activeLogin.detail) ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { role: "status", style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-secondary)" }, children: activeLogin.detail }) : null,
+          !readOnly && loginAction && onLogin ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: "primary", size: "sm", disabled: loginWaiting, onClick: () => onLogin(probe, loginAction), children: loginLabel }) }) : null,
           !readOnly && texts.copyText ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyLoginCommand(probe.channel, texts.copyText), children: copied === probe.channel ? channelCopiedLabel(lang) : texts.copyLabel }) }) : null,
           !readOnly && renderChannelBody ? renderChannelBody(probe.channel) : null
         ] }, probe.channel);
@@ -21265,7 +21274,7 @@
     const firstLine = bytes.toString("utf8", 0, Math.min(bytes.length, 512)).split(/\r?\n/, 1)[0];
     return /^#!.*\bnode(?:\.exe)?(?:\s|$)/i.test(firstLine);
   }
-  function createProcessBoundary({ deps, paths, platform }) {
+  function createProcessBoundary({ deps, paths, platform, extensionRoot = deps.extensionRoot }) {
     const windows = platform === "win32";
     const separator = windows ? ";" : ":";
     function completeEnvironment(...sources) {
@@ -21454,7 +21463,8 @@
       }
     }
     function runtimeCandidates(id) {
-      return [];
+      if (!windows || id !== "opencode" || !extensionRoot) return [];
+      return [paths.join([extensionRoot, "runtime", "opencode", "opencode.exe"])];
     }
     function pathCandidates(id, env) {
       const raw = windows ? environmentValue(env, "PATH", true) || "" : env.PATH || "";
@@ -21934,7 +21944,12 @@
   function createMacosAdapter(deps) {
     if (!deps || deps.platform !== "darwin" || deps.arch !== "arm64") throw new Error("macOS arm64 dependencies are required");
     const paths = createPathCatalog({ home: deps.home, temp: deps.temp, platform: deps.platform });
-    const boundary = createProcessBoundary({ deps, paths, platform: deps.platform });
+    const boundary = createProcessBoundary({
+      deps,
+      paths,
+      platform: deps.platform,
+      extensionRoot: deps.extensionRoot
+    });
     const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: "standard", version: null, arch: "arm64" });
     return Object.freeze({
       id: "macos-arm64",
@@ -22029,7 +22044,12 @@
   function createWindowsAdapter(deps) {
     if (!deps || deps.platform !== "win32" || deps.arch !== "x64") throw new Error("Windows x64 dependencies are required");
     const paths = createPathCatalog({ home: deps.home, temp: deps.temp, platform: deps.platform });
-    const boundary = createProcessBoundary({ deps, paths, platform: deps.platform });
+    const boundary = createProcessBoundary({
+      deps,
+      paths,
+      platform: deps.platform,
+      extensionRoot: deps.extensionRoot
+    });
     const systemRoot = String(envValue(deps.env, "SystemRoot") || envValue(deps.env, "WINDIR") || "C:\\Windows");
     const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: "standard", version: null, arch: "x64" });
     return Object.freeze({
@@ -22131,6 +22151,25 @@
     const key = Object.keys(environment || {}).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
     return key === void 0 ? void 0 : environment[key];
   }
+  function extensionRootFromPage() {
+    var _a, _b, _c;
+    try {
+      const root = (_c = (_b = (_a = globalThis.window) == null ? void 0 : _a.__adobe_cep__) == null ? void 0 : _b.getSystemPath) == null ? void 0 : _c.call(_b, "extension");
+      if (typeof root === "string" && root.trim()) return root;
+    } catch {
+    }
+    try {
+      const location2 = globalThis.location;
+      if (typeof (location2 == null ? void 0 : location2.href) !== "string" || !location2.href.startsWith("file:")) return null;
+      let pagePath = decodeURIComponent(new URL(location2.href).pathname);
+      pagePath = pagePath.replace(/^\/([A-Za-z]:\/)/, "$1");
+      const clientDirectory = pagePath.slice(0, pagePath.lastIndexOf("/"));
+      const root = clientDirectory.slice(0, clientDirectory.lastIndexOf("/"));
+      return root || null;
+    } catch {
+      return null;
+    }
+  }
   function defaultPlatformDependencies() {
     var _a, _b;
     const require2 = cepRequire();
@@ -22146,6 +22185,7 @@
       pid: processImpl.pid,
       home,
       temp: os.tmpdir(),
+      extensionRoot: extensionRootFromPage(),
       env,
       fs: require2("fs"),
       httpImpl: require2("http"),
@@ -22459,6 +22499,8 @@
     selectedChannel = "",
     onSelectChannel,
     onRecheckBackend,
+    onLoginChannel,
+    loginState = null,
     recheckDisabled = false,
     providerManager = null,
     providerInit = { state: "checking", error: "" },
@@ -22514,6 +22556,8 @@
             selectedChannel,
             onSelectChannel,
             onRecheck: onRecheckBackend,
+            onLogin: onLoginChannel,
+            loginState,
             recheckLabel: t.recheck,
             recheckDisabled
           }
@@ -22983,7 +23027,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   var LOG_TAIL = 4096;
   var ALL_STEPS = [...HOST_STEPS, ...CLI_STEPS, ...OPTIONAL_CLIENT_STEPS];
   function emptyState() {
-    return { status: "idle", version: "", logTail: "" };
+    return { status: "idle", version: "", path: "", source: "", logTail: "" };
   }
   function initialStepStates() {
     return ALL_STEPS.reduce((acc, id) => {
@@ -23013,7 +23057,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
         return patchStep(state, action.id, {
           status: action.ok ? "ok" : "missing",
           version: action.ok ? action.version || "" : "",
-          logTail: action.detail || current.logTail
+          logTail: action.detail || current.logTail,
+          path: action.ok ? action.path || "" : "",
+          source: action.ok ? action.source || "" : ""
         });
       case "run-start":
         return patchStep(state, action.id, { status: "running", logTail: "" });
@@ -23053,6 +23099,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       copyLog: "\u590D\u5236\u65E5\u5FD7",
       optionalNode: "\u7CFB\u7EDF Node\uFF08stdio \u5BA2\u6237\u7AEF\u53EF\u9009\uFF09",
       optionalNodeHint: "\u53EA\u6709 Claude Desktop \u8FD9\u7C7B\u53EA\u652F\u6301 stdio \u7684\u5BA2\u6237\u7AEF\u624D\u9700\u8981\u3002",
+      claudeInstallHint: "\u8FD9\u4F1A\u4ECE claude.ai \u4E0B\u8F7D\u5E76\u8FD0\u884C Anthropic \u5B98\u65B9\u5B89\u88C5\u7A0B\u5E8F\uFF1B\u9762\u677F\u4F7F\u7528\u5DF2\u68C0\u6D4B\u5230\u7684\u7EDD\u5BF9\u8DEF\u5F84\uFF0C\u4E0D\u4F9D\u8D56\u7CFB\u7EDF PATH\u3002",
+      pathHint: "\u52A0\u5165\u540E\u53EF\u5728\u4F60\u81EA\u5DF1\u7684\u7EC8\u7AEF\u4F7F\u7528\uFF1B\u9762\u677F\u4F7F\u7528\u5DF2\u68C0\u6D4B\u5230\u7684\u7EDD\u5BF9\u8DEF\u5F84\uFF0C\u4E0D\u4F9D\u8D56\u7CFB\u7EDF PATH\u3002",
+      addToPath: "\u52A0\u5165\u7CFB\u7EDF PATH\uFF08\u53EF\u9009\uFF0C\u65B9\u4FBF\u4F60\u5728\u81EA\u5DF1\u7684\u7EC8\u7AEF\u91CC\u4F7F\u7528\uFF09",
       panelOpenNote: "\u9762\u677F\u5F00\u7740\u624D\u80FD\u8FDE\u63A5\uFF1B\u5173\u95ED\u6216\u91CD\u8F7D\u9762\u677F\u540E\u5BA2\u6237\u7AEF\u9700\u8981\u91CD\u8FDE\u3002",
       directUrl: "\u6216\u76F4\u63A5\u4F7F\u7528\u8FD9\u4E2A\u5730\u5740"
     },
@@ -23075,6 +23124,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       copyLog: "Copy log",
       optionalNode: "System Node (optional for stdio clients)",
       optionalNodeHint: "Only stdio-only clients such as Claude Desktop need this step.",
+      claudeInstallHint: "This downloads and runs Anthropic's official installer from claude.ai; the panel uses the detected absolute path and does not require PATH.",
+      pathHint: "Add it to use this CLI in your own terminal; the panel uses the detected absolute path and does not require PATH.",
+      addToPath: "Add to user PATH (optional, for your terminal)",
       panelOpenNote: "The panel must stay open. Clients reconnect after it closes or reloads.",
       directUrl: "Or use this address directly"
     }
@@ -23133,7 +23185,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       }
     );
   }
-  function CheckRow({ label, state, t, onDetect, onInstall, commandPreview: commandPreview2, hint }) {
+  function CheckRow({ label, state, t, onDetect, onInstall, commandPreview: commandPreview2, hint, pathEntry, onAddToPath }) {
     const status = state && state.status ? state.status : "idle";
     const busy = status === "checking" || status === "running";
     const problem = status === "missing" || status === "fail";
@@ -23198,7 +23250,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 }
               ),
               /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "secondary", size: "sm", onClick: onInstall, children: t.install })
-            ] }) : null
+            ] }) : null,
+            pathEntry && onAddToPath ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { variant: "secondary", size: "sm", onClick: onAddToPath, children: t.addToPath }) }) : null
           ] })
         ]
       }
@@ -23219,7 +23272,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     stepStates = EMPTY_STEPS,
     onDetect,
     onInstall,
-    commandPreviews = {}
+    commandPreviews = {},
+    pathOffers = {},
+    onAddToPath
   }) {
     const t = W[lang] || W.zh;
     const promptText = mcpReady ? externalClientSetupPrompt({
@@ -23278,7 +23333,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
                       label: STEP_LABELS[id],
                       state: stepStates[id] || EMPTY_STEPS[id],
                       t,
-                      onDetect: () => onDetect && onDetect(id)
+                      onDetect: () => onDetect && onDetect(id),
+                      hint: id === "claude" ? t.claudeInstallHint : pathOffers[id] ? t.pathHint : "",
+                      commandPreview: commandPreviews[id] || "",
+                      onInstall: () => onInstall && onInstall(id),
+                      pathEntry: pathOffers[id],
+                      onAddToPath: () => onAddToPath && onAddToPath(id)
                     },
                     id
                   )),
@@ -23352,10 +23412,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
                       label: t.optionalNode,
                       state: stepStates[id] || EMPTY_STEPS[id],
                       t,
-                      hint: t.optionalNodeHint,
+                      hint: pathOffers[id] ? `${t.optionalNodeHint} ${t.pathHint}` : t.optionalNodeHint,
                       commandPreview: commandPreviews[id] || "",
                       onDetect: () => onDetect && onDetect(id),
-                      onInstall: () => onInstall && onInstall(id)
+                      onInstall: () => onInstall && onInstall(id),
+                      pathEntry: pathOffers[id],
+                      onAddToPath: () => onAddToPath && onAddToPath(id)
                     },
                     id
                   ))
@@ -25929,7 +25991,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     CLI_MISSING: entry("CLI_MISSING", "backend", "\u8BF7\u5B89\u88C5\u5BF9\u5E94 CLI\uFF0C\u5E76\u786E\u8BA4\u9762\u677F\u8FDB\u7A0B\u80FD\u4ECE PATH \u627E\u5230\u5B83\u3002", "Install the CLI and make sure it is visible on the panel PATH."),
     CLI_TOO_OLD: entry("CLI_TOO_OLD", "backend", "\u8BF7\u5347\u7EA7\u5BF9\u5E94 CLI \u540E\u91CD\u65B0\u68C0\u6D4B\u3002", "Upgrade the CLI and re-check."),
     CLI_ARCH_MISMATCH: entry("CLI_ARCH_MISMATCH", "backend", "\u8BF7\u5B89\u88C5\u4E0E\u5F53\u524D After Effects \u4E3B\u673A\u67B6\u6784\u4E00\u81F4\u7684 CLI\u3002", "Install a CLI build matching the After Effects host architecture."),
-    CLI_PROBE_FAILED: entry("CLI_PROBE_FAILED", "backend", "CLI \u5DF2\u627E\u5230\u4F46\u63A2\u9488\u5931\u8D25\uFF1B\u8BF7\u5728\u7EC8\u7AEF\u786E\u8BA4\u5B83\u80FD\u6B63\u5E38\u542F\u52A8\u3002", "The CLI was found but its probe failed; confirm it starts normally in a terminal."),
+    CLI_PROBE_FAILED: entry("CLI_PROBE_FAILED", "backend", "CLI \u5DF2\u627E\u5230\u4F46\u63A2\u9488\u5931\u8D25\uFF1B\u8BF7\u56DE\u5230\u201C\u8BBE\u7F6E \u2192 AI\u201D\u4F7F\u7528\u901A\u9053\u5361\u4E0A\u7684\u64CD\u4F5C\u91CD\u8BD5\u3002", "The CLI was found but its probe failed. Return to Settings \u2192 AI and retry from the channel card."),
     SPAWN_FAILED: entry("SPAWN_FAILED", "backend", "\u8BF7\u68C0\u67E5 CLI \u8DEF\u5F84\u3001\u6267\u884C\u6743\u9650\u548C\u5B89\u5168\u8F6F\u4EF6\u62E6\u622A\u3002", "Check the CLI path, execute permission, and security-software blocks."),
     PROCESS_EXITED: entry("PROCESS_EXITED", "backend", "\u8BF7\u67E5\u770B\u6298\u53E0\u8BE6\u60C5\u4E2D\u7684\u9000\u51FA\u4FE1\u606F\u4E0E stderr \u5C3E\u90E8\u3002", "Inspect the exit information and stderr tail in the collapsed details."),
     AUTH_REQUIRED: entry("AUTH_REQUIRED", "auth", "\u8BF7\u6309\u300C\u8BBE\u7F6E \u2192 AI\u300D\u901A\u9053\u5361\u4E0A\u7684\u767B\u5F55\u6307\u5F15\u5B8C\u6210\u5BF9\u5E94 CLI \u767B\u5F55\u540E\u91CD\u65B0\u68C0\u6D4B\u3002", "Follow the sign-in guidance on the channel card under Settings \u2192 AI for this CLI, then re-check."),
@@ -29931,6 +29993,157 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     });
   }
 
+  // src/cep/codexHeadlessLogin.js
+  init_cep_runtime_inject();
+  var DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60 * 1e3;
+  var DEFAULT_URL_TIMEOUT_MS = 20 * 1e3;
+  var URL_PATTERN = /https:\/\/[^\s<>"'`]+/;
+  function loginError(code, message) {
+    const error = new Error(message);
+    error.code = code;
+    return error;
+  }
+  function startCodexLogin({
+    adapter,
+    codexHome,
+    onUrl = () => {
+    },
+    onDone = () => {
+    },
+    timeoutMs = DEFAULT_LOGIN_TIMEOUT_MS,
+    urlTimeoutMs = DEFAULT_URL_TIMEOUT_MS
+  } = {}) {
+    if (!adapter || typeof adapter.resolveExecutable !== "function" || typeof adapter.spawn !== "function") {
+      throw new TypeError("A platform adapter is required");
+    }
+    if (!codexHome) throw new TypeError("codexHome is required");
+    let child = null;
+    let settled = false;
+    let cancelled = false;
+    let sawUrl = false;
+    let resolvePromise;
+    let rejectPromise;
+    let overallTimer = null;
+    let urlTimer = null;
+    const lineBuffers = { stdout: "", stderr: "" };
+    const promise = new Promise((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    function killChild() {
+      if (!child || typeof child.kill !== "function") return;
+      try {
+        child.kill();
+      } catch {
+      }
+    }
+    function clearTimers() {
+      if (overallTimer) clearTimeout(overallTimer);
+      if (urlTimer) clearTimeout(urlTimer);
+      overallTimer = null;
+      urlTimer = null;
+    }
+    function finishError(error, { kill = true } = {}) {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      if (kill) killChild();
+      rejectPromise(error);
+    }
+    function finishSuccess(result) {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      try {
+        onDone(result);
+      } catch (error) {
+        rejectPromise(error);
+        return;
+      }
+      resolvePromise(result);
+    }
+    function inspectLine(line) {
+      if (sawUrl) return;
+      const match = String(line || "").match(URL_PATTERN);
+      if (!match) return;
+      sawUrl = true;
+      if (urlTimer) clearTimeout(urlTimer);
+      urlTimer = null;
+      try {
+        onUrl(match[0]);
+      } catch (error) {
+        finishError(error);
+      }
+    }
+    function readLines(streamName, chunk, flush = false) {
+      lineBuffers[streamName] += String(chunk || "");
+      const lines = lineBuffers[streamName].split(/\r?\n/);
+      if (!flush) lineBuffers[streamName] = lines.pop() || "";
+      else lineBuffers[streamName] = "";
+      for (const line of lines) inspectLine(line);
+    }
+    function handleExit(code, signal) {
+      if (settled) return;
+      readLines("stdout", "", true);
+      readLines("stderr", "", true);
+      if (code !== 0) {
+        finishError(loginError(
+          "CODEX_LOGIN_EXITED",
+          `codex login exited with ${code === null || code === void 0 ? signal || "an unknown status" : `code ${code}`}`
+        ), { kill: false });
+        return;
+      }
+      if (!sawUrl) {
+        finishError(loginError("CODEX_LOGIN_URL_MISSING", "codex login exited without a sign-in URL"), { kill: false });
+        return;
+      }
+      finishSuccess({ exitCode: 0, urlSeen: true });
+    }
+    overallTimer = setTimeout(() => {
+      finishError(loginError("CODEX_LOGIN_TIMEOUT", "codex login timed out"));
+    }, Math.max(0, Number(timeoutMs)));
+    (async () => {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+      try {
+        const env = adapter.completeSpawnEnv({}, { CODEX_HOME: codexHome });
+        const executable = await adapter.resolveExecutable("codex", { env });
+        if (cancelled || settled) return;
+        if (!executable || executable.ok !== true) {
+          finishError(loginError(
+            (executable == null ? void 0 : executable.code) || "CODEX_LOGIN_RESOLUTION_FAILED",
+            (executable == null ? void 0 : executable.detail) || "Codex CLI could not be resolved"
+          ), { kill: false });
+          return;
+        }
+        child = adapter.spawn(executable, ["login"], {
+          stdio: "pipe",
+          windowsHide: true,
+          env
+        });
+        (_b = (_a = child.stdout) == null ? void 0 : _a.setEncoding) == null ? void 0 : _b.call(_a, "utf8");
+        (_d = (_c = child.stderr) == null ? void 0 : _c.setEncoding) == null ? void 0 : _d.call(_c, "utf8");
+        (_f = (_e = child.stdout) == null ? void 0 : _e.on) == null ? void 0 : _f.call(_e, "data", (chunk) => readLines("stdout", chunk));
+        (_h = (_g = child.stderr) == null ? void 0 : _g.on) == null ? void 0 : _h.call(_g, "data", (chunk) => readLines("stderr", chunk));
+        (_i = child.on) == null ? void 0 : _i.call(child, "error", (error) => finishError(error));
+        (_j = child.on) == null ? void 0 : _j.call(child, "exit", handleExit);
+        (_k = child.on) == null ? void 0 : _k.call(child, "close", handleExit);
+        urlTimer = setTimeout(() => {
+          finishError(loginError("CODEX_LOGIN_URL_TIMEOUT", "codex login did not provide a sign-in URL"));
+        }, Math.max(0, Number(urlTimeoutMs)));
+      } catch (error) {
+        finishError(error);
+      }
+    })();
+    return {
+      promise,
+      cancel() {
+        if (settled) return;
+        cancelled = true;
+        finishError(loginError("CODEX_LOGIN_CANCELLED", "codex login was cancelled"));
+      }
+    };
+  }
+
   // src/cep/codexBackend.js
   init_cep_runtime_inject();
   var RPC_TIMEOUT_MS = 3e4;
@@ -33039,8 +33252,11 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
   }
 
   // src/lib/channels.js
-  function claudeChannels({ probe } = {}) {
+  function claudeChannels({ probe, canOpenLoginTerminal = true } = {}) {
     const probeFailed = ["probe-timeout", "probe-failed"].includes(probe == null ? void 0 : probe.reason);
+    const needsLogin = Boolean(
+      probe && probe.cliOk === true && !probe.loggedIn && !probeFailed && probe.reason !== "cli-too-old"
+    );
     return [{
       channel: "subscription",
       source: { zh: "\u8BA2\u9605\u767B\u5F55", en: "Subscription login" },
@@ -33057,15 +33273,21 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         zh: "\u672A\u627E\u5230 Claude CLI\uFF1A\u8BF7\u5B89\u88C5 Claude Code 2.x\uFF1B\u82E5\u9762\u677F PATH \u4E0D\u542B claude\uFF0C\u53EF\u8BBE\u7F6E AE_MCP_CLAUDE_CLI \u540E\u91CD\u542F AE\u3002",
         en: "Claude CLI was not found. Install Claude Code 2.x; if claude is not on the panel PATH, set AE_MCP_CLAUDE_CLI and restart AE."
       } : {
-        zh: "\u8BA2\u9605\u672A\u767B\u5F55\uFF1A\u5728\u7EC8\u7AEF\u8FD0\u884C claude /login \u5B8C\u6210\u767B\u5F55\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u6216\u6539\u7528 OpenCode Provider \u901A\u9053\u3002",
-        en: "Not logged in: run claude /login in a terminal and re-check, or use the OpenCode Provider channel."
-      }
+        zh: canOpenLoginTerminal ? "\u5728\u6253\u5F00\u7684\u7A97\u53E3\u4E2D\u8F93\u5165 /login \u5B8C\u6210\u767B\u5F55\uFF0C\u672C\u9875\u4F1A\u81EA\u52A8\u5237\u65B0\u3002" : "\u5F53\u524D\u5E73\u53F0\u65E0\u6CD5\u4ECE\u9762\u677F\u6253\u5F00 Claude \u767B\u5F55\u7A97\u53E3\uFF0C\u53EF\u6539\u7528 OpenCode Provider \u901A\u9053\u3002",
+        en: canOpenLoginTerminal ? "Enter /login in the window that opens. This page refreshes automatically after sign-in." : "This platform cannot open the Claude sign-in window from the panel. Use the OpenCode Provider channel instead."
+      },
+      ...needsLogin && canOpenLoginTerminal ? {
+        loginAction: {
+          label: { zh: "\u6253\u5F00\u767B\u5F55\u7A97\u53E3", en: "Open sign-in window" },
+          kind: "terminal"
+        }
+      } : {}
     }];
   }
-  function codexChannels({ codexProbe } = {}) {
+  function codexChannels({ codexProbe, loginFallback = false } = {}) {
     const cliFixHint = {
-      zh: "\u5728\u7EC8\u7AEF\u5B8C\u6210 codex \u767B\u5F55\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u82E5 codex \u4E0D\u5728\u9762\u677F PATH \u4E0A\uFF0C\u8BBE\u7F6E\u73AF\u5883\u53D8\u91CF AE_MCP_CODEX_CLI \u6307\u5411 codex \u53EF\u6267\u884C\u6587\u4EF6\u540E\u91CD\u542F AE\u3002",
-      en: "Sign in with codex in a terminal and re-check; if codex is not on the panel PATH, set AE_MCP_CODEX_CLI to the codex executable and restart AE."
+      zh: "\u8BF7\u5148\u5B89\u88C5 Codex CLI\uFF1B\u82E5 codex \u4E0D\u5728\u9762\u677F PATH \u4E0A\uFF0C\u8BBE\u7F6E\u73AF\u5883\u53D8\u91CF AE_MCP_CODEX_CLI \u6307\u5411 codex \u53EF\u6267\u884C\u6587\u4EF6\u540E\u91CD\u542F AE\u3002",
+      en: "Install Codex CLI first. If codex is not on the panel PATH, set AE_MCP_CODEX_CLI to the codex executable and restart AE."
     };
     const needsIsolatedLogin = Boolean(
       codexProbe && !codexProbe.loggedIn && codexProbe.runtimeOk !== false && codexProbe.codexHome
@@ -33085,16 +33307,25 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         codexProbe.cliPath,
         codexProbe.cliVersion
       ].filter(Boolean).join(" \xB7 ") : codexProbe.detail || "" : "",
-      fixHint: needsIsolatedLogin ? {
-        zh: `\u9762\u677F\u7684 Codex \u8FD0\u884C\u5728\u9694\u79BB\u76EE\u5F55 ${codexProbe.codexHome}\uFF08\u4E0D\u8BFB\u53D6 ~/.codex\uFF09\uFF0C\u7CFB\u7EDF\u91CC\u5DF2\u767B\u5F55\u7684 codex \u5BF9\u9762\u677F\u65E0\u6548\u3002\u5728\u7EC8\u7AEF\u8FD0\u884C\u4E0B\u9762\u547D\u4EE4\u5B8C\u6210\u767B\u5F55\u540E\u70B9\u300C\u91CD\u65B0\u68C0\u6D4B\u300D\uFF1A
+      fixHint: needsIsolatedLogin ? loginFallback ? {
+        zh: `\u81EA\u52A8\u767B\u5F55\u672A\u80FD\u6253\u5F00\u9A8C\u8BC1\u9875\u9762\u3002\u53EF\u91CD\u8BD5\u300C\u4E00\u952E\u767B\u5F55\u300D\uFF1B\u5982\u4ECD\u5931\u8D25\uFF0C\u8BF7\u590D\u5236\u767B\u5F55\u547D\u4EE4\u5B8C\u6210\u9762\u677F\u9694\u79BB\u767B\u5F55\uFF1A
 ${command}`,
-        en: `The panel runs Codex with its own CODEX_HOME at ${codexProbe.codexHome} (it never reads ~/.codex), so a system-wide codex login does not apply here. Run this in a terminal, then re-check:
+        en: `Automatic sign-in could not open the verification page. Retry One-click sign-in; if it still fails, copy the command to sign in to the panel's isolated Codex home:
 ${command}`
+      } : {
+        zh: `\u9762\u677F\u7684 Codex \u8FD0\u884C\u5728\u9694\u79BB\u76EE\u5F55 ${codexProbe.codexHome}\uFF08\u4E0D\u8BFB\u53D6 ~/.codex\uFF09\uFF0C\u7CFB\u7EDF\u767B\u5F55\u6001\u5BF9\u9762\u677F\u65E0\u6548\u3002\u70B9\u51FB\u300C\u4E00\u952E\u767B\u5F55\u300D\u540E\u5728\u6D4F\u89C8\u5668\u4E2D\u5B8C\u6210\u9A8C\u8BC1\uFF0C\u672C\u9875\u4F1A\u81EA\u52A8\u5237\u65B0\u3002`,
+        en: `The panel runs Codex with its own CODEX_HOME at ${codexProbe.codexHome} (it never reads ~/.codex), so the system login does not apply. Choose One-click sign-in and finish verification in the browser; this page refreshes automatically.`
       } : cliFixHint,
-      ...needsIsolatedLogin ? {
+      ...needsIsolatedLogin && loginFallback ? {
         copyAction: {
           label: { zh: "\u590D\u5236\u767B\u5F55\u547D\u4EE4", en: "Copy login command" },
           text: command
+        }
+      } : {},
+      ...needsIsolatedLogin ? {
+        loginAction: {
+          label: { zh: "\u4E00\u952E\u767B\u5F55", en: "One-click sign-in" },
+          kind: "headless"
         }
       } : {}
     };
@@ -33120,15 +33351,17 @@ ${command}`
   var CLAUDE_CHANNEL_IDS = ["subscription"];
   var CODEX_CHANNEL_IDS = ["cli"];
   function migrateBackendPref(storage) {
-    let pref = "subscription";
+    let pref = "opencode";
     const channelChoices = { claude: "subscription", codex: "cli", opencode: "provider" };
     try {
-      const raw = storage.getItem("ae_mcp_backend") || "subscription";
+      const storedBackend = storage.getItem("ae_mcp_backend");
+      const raw = storedBackend || "";
       const storedClaude = storage.getItem("ae_mcp_channel_claude") || "";
       const storedCodex = storage.getItem("ae_mcp_channel_codex") || "";
       if (raw === "opencode" || raw === "codex" || raw === "subscription") {
         pref = raw;
-      } else {
+      } else if (raw) {
+        pref = "subscription";
         storage.setItem("ae_mcp_backend", pref);
       }
       if (CLAUDE_CHANNEL_IDS.includes(storedClaude)) channelChoices.claude = storedClaude;
@@ -34283,13 +34516,26 @@ ${command}`
   }
   function buildInstallCommands({ platform } = {}) {
     const adapter = platform || createPlatformAdapter();
-    if (typeof adapter.legacyWizardInstallCommands !== "function") return {};
-    const commands = adapter.legacyWizardInstallCommands({
+    const commands = typeof adapter.legacyWizardInstallCommands === "function" ? adapter.legacyWizardInstallCommands({
       panelVersion: "",
       repoRoot: "",
       repo: ""
-    });
-    return commands && commands.node ? { node: commands.node } : {};
+    }) : {};
+    const result = commands && commands.node ? { node: commands.node } : {};
+    if (adapter.id === "windows-x64" || adapter.platform === "win32") {
+      result.claude = {
+        file: "powershell",
+        executableId: "powershell",
+        args: [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          "irm https://claude.ai/install.ps1 | iex"
+        ]
+      };
+    }
+    return result;
   }
   async function runAction({
     file,
@@ -34356,6 +34602,146 @@ ${command}`
     return [file, ...(args || []).map((value) => /\s/.test(value) ? `"${value}"` : value)].join(" ");
   }
 
+  // src/cep/registryPath.js
+  init_cep_runtime_inject();
+  var REG_EXECUTABLE = {
+    ok: true,
+    id: "reg",
+    path: "reg.exe",
+    argsPrefix: [],
+    source: "override",
+    version: null,
+    arch: "x64"
+  };
+  var USER_PATH_QUERY = ["query", "HKCU\\Environment", "/v", "Path"];
+  var USER_PATH_DEFAULT = { value: "", type: "REG_EXPAND_SZ" };
+  function isWindowsPlatform(adapter) {
+    return (adapter == null ? void 0 : adapter.id) === "windows-x64" || (adapter == null ? void 0 : adapter.platform) === "win32";
+  }
+  function requireWindows(adapter) {
+    if (!isWindowsPlatform(adapter)) {
+      throw new Error("User PATH updates are only supported on Windows");
+    }
+  }
+  function normalizedPathEntry(value) {
+    let result = String(value || "").trim().replace(/\//g, "\\");
+    while (result.length > 3 && result.endsWith("\\")) result = result.slice(0, -1);
+    return result.toLowerCase();
+  }
+  function expandEnvironmentEntry(value, environment) {
+    return String(value || "").replace(/%([^%]+)%/g, (match, name) => {
+      const key = Object.keys(environment || {}).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+      return key === void 0 ? match : String(environment[key]);
+    });
+  }
+  function pathIncludesEntry(rawValue, directory, environment = {}) {
+    const expected = normalizedPathEntry(directory);
+    if (!expected) return false;
+    return String(rawValue || "").split(";").some((entry2) => normalizedPathEntry(entry2) === expected || normalizedPathEntry(expandEnvironmentEntry(entry2, environment)) === expected);
+  }
+  async function resolvePowerShell(adapter) {
+    const executable = await adapter.resolveExecutable("powershell");
+    if (!executable || !executable.ok) {
+      throw new Error("powershell resolution failed: " + ((executable == null ? void 0 : executable.code) || "NOT_FOUND"));
+    }
+    return executable;
+  }
+  function spawnAndCollect(adapter, executable, args) {
+    return new Promise((resolve, reject) => {
+      var _a, _b, _c, _d, _e, _f;
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      const finish = (result, error) => {
+        if (settled) return;
+        settled = true;
+        if (error) reject(error);
+        else resolve({ ...result, stdout, stderr });
+      };
+      try {
+        const child = adapter.spawn(executable, args, { windowsHide: true });
+        (_b = (_a = child.stdout) == null ? void 0 : _a.on) == null ? void 0 : _b.call(_a, "data", (chunk) => {
+          stdout += String(chunk || "");
+        });
+        (_d = (_c = child.stderr) == null ? void 0 : _c.on) == null ? void 0 : _d.call(_c, "data", (chunk) => {
+          stderr += String(chunk || "");
+        });
+        (_e = child.on) == null ? void 0 : _e.call(child, "error", (error) => finish({}, error));
+        (_f = child.on) == null ? void 0 : _f.call(child, "close", (code) => finish({ code }, null));
+      } catch (error) {
+        finish({}, error);
+      }
+    });
+  }
+  function parseUserPath(output) {
+    const line = String(output || "").split(/\r?\n/).find((entry2) => /^\s*Path\s+REG_(?:SZ|EXPAND_SZ)\s+/i.test(entry2));
+    if (!line) return null;
+    const match = line.match(/^\s*Path\s+(REG_(?:SZ|EXPAND_SZ))\s+(.*)$/i);
+    return match ? { value: match[2].trim(), type: match[1].toUpperCase() } : null;
+  }
+  async function readUserPath(adapter) {
+    requireWindows(adapter);
+    const result = await spawnAndCollect(adapter, REG_EXECUTABLE, USER_PATH_QUERY);
+    if (result.code !== 0) return { ...USER_PATH_DEFAULT };
+    return parseUserPath(result.stdout) || { ...USER_PATH_DEFAULT };
+  }
+  async function addRegistryPath(adapter, value, type) {
+    const result = await spawnAndCollect(adapter, REG_EXECUTABLE, [
+      "add",
+      "HKCU\\Environment",
+      "/v",
+      "Path",
+      "/t",
+      type,
+      "/d",
+      value,
+      "/f"
+    ]);
+    if (result.code !== 0) {
+      throw new Error((result.stderr || result.stdout || "reg add failed").trim());
+    }
+  }
+  var BROADCAST_SCRIPT = [
+    "Add-Type @'",
+    "using System;",
+    "using System.Runtime.InteropServices;",
+    "public static class EnvironmentChange {",
+    "  public static readonly IntPtr HWND_BROADCAST = new IntPtr(0xffff);",
+    "  public const uint WM_SETTINGCHANGE = 0x001A;",
+    "  public const uint SMTO_ABORTIFHUNG = 0x0002;",
+    '  [DllImport("user32.dll", CharSet = CharSet.Unicode)]',
+    "  public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);",
+    "}",
+    "'@",
+    "$result = [UIntPtr]::Zero",
+    '[EnvironmentChange]::SendMessageTimeout([EnvironmentChange]::HWND_BROADCAST, [EnvironmentChange]::WM_SETTINGCHANGE, [UIntPtr]::Zero, "Environment", [EnvironmentChange]::SMTO_ABORTIFHUNG, 2000, [ref]$result) | Out-Null'
+  ].join("\n");
+  async function broadcastEnvironmentChange(adapter) {
+    const executable = await resolvePowerShell(adapter);
+    const result = await spawnAndCollect(adapter, executable, [
+      "-NoProfile",
+      "-Command",
+      BROADCAST_SCRIPT
+    ]);
+    if (result.code !== 0) throw new Error((result.stderr || result.stdout || "broadcast failed").trim());
+  }
+  async function addUserPathEntry(adapter, directory) {
+    var _a, _b;
+    requireWindows(adapter);
+    const entry2 = String(directory || "").trim();
+    if (!entry2) throw new Error("A non-empty PATH directory is required");
+    const current = await readUserPath(adapter);
+    if (pathIncludesEntry(current.value, entry2)) return { changed: false };
+    const newValue = current.value ? current.value + ";" + entry2 : entry2;
+    await addRegistryPath(adapter, newValue, current.type);
+    try {
+      await broadcastEnvironmentChange(adapter);
+    } catch (error) {
+      (_b = (_a = globalThis.console) == null ? void 0 : _a.warn) == null ? void 0 : _b.call(_a, "User PATH broadcast failed:", error);
+    }
+    return { changed: true };
+  }
+
   // src/app/wizardWiring.js
   function useWizardWiring({
     port = 11488,
@@ -34363,13 +34749,45 @@ ${command}`
     platform
   } = {}) {
     const [stepStates, dispatch] = import_react46.default.useReducer(stepReducer, null, initialStepStates);
+    const [pathOffers, setPathOffers] = import_react46.default.useState({});
     const commands = import_react46.default.useMemo(
       () => buildInstallCommands({ platform }),
       [platform]
     );
     const commandPreviews = import_react46.default.useMemo(() => ({
-      node: commandPreview(commands.node)
+      node: commandPreview(commands.node),
+      claude: commandPreview(commands.claude)
     }), [commands]);
+    const updatePathOffer = import_react46.default.useCallback(async (id, result) => {
+      var _a, _b;
+      if (!isWindowsPlatform(platform) || !result.ok || !result.path) {
+        setPathOffers((current) => {
+          if (!current[id]) return current;
+          const next = { ...current };
+          delete next[id];
+          return next;
+        });
+        return;
+      }
+      const directory = ((_a = platform.paths) == null ? void 0 : _a.dirname) ? platform.paths.dirname(result.path) : String(result.path).replace(/[\\/][^\\/]*$/, "");
+      try {
+        const userPath = await readUserPath(platform);
+        const environment = ((_b = platform.paths) == null ? void 0 : _b.home) ? { USERPROFILE: platform.paths.home, HOME: platform.paths.home } : {};
+        setPathOffers((current) => {
+          const next = { ...current };
+          if (pathIncludesEntry(userPath.value, directory, environment)) delete next[id];
+          else next[id] = { directory };
+          return next;
+        });
+      } catch {
+        setPathOffers((current) => {
+          if (!current[id]) return current;
+          const next = { ...current };
+          delete next[id];
+          return next;
+        });
+      }
+    }, [platform]);
     const detect = import_react46.default.useCallback(async (id) => {
       dispatch({ type: "detect-start", id });
       const result = await detectTool(id, {
@@ -34382,10 +34800,13 @@ ${command}`
         id,
         ok: result.ok,
         version: result.version || "",
-        detail: result.detail || ""
+        detail: result.detail || "",
+        path: result.path || "",
+        source: result.source || ""
       });
+      await updatePathOffer(id, result);
       return result;
-    }, [fetchImpl, platform, port]);
+    }, [fetchImpl, platform, port, updatePathOffer]);
     const install = import_react46.default.useCallback(async (id) => {
       const command = commands[id];
       if (!command) return { ok: false, output: "No install command configured for " + id };
@@ -34399,6 +34820,20 @@ ${command}`
       await detect(id);
       return result;
     }, [commands, detect, platform]);
+    const addToPath = import_react46.default.useCallback(async (id) => {
+      const offer = pathOffers[id];
+      if (!offer) return { changed: false };
+      const result = await addUserPathEntry(platform, offer.directory);
+      if (result.changed) {
+        setPathOffers((current) => {
+          const next = { ...current };
+          delete next[id];
+          return next;
+        });
+        await detect(id);
+      }
+      return result;
+    }, [detect, pathOffers, platform]);
     const bootDetectRef = import_react46.default.useRef(false);
     import_react46.default.useEffect(() => {
       if (bootDetectRef.current) return;
@@ -34413,7 +34848,9 @@ ${command}`
         stepStates,
         commandPreviews,
         onDetect: detect,
-        onInstall: install
+        onInstall: install,
+        pathOffers,
+        onAddToPath: addToPath
       }
     };
   }
@@ -36375,6 +36812,8 @@ ${command}`
   };
   var pkgVersion = package_default.version;
   var PROBE_PENDING_GRACE_MS = 8e3;
+  var LOGIN_POLL_INTERVAL_MS = 5e3;
+  var LOGIN_POLL_LIMIT_MS = 5 * 60 * 1e3;
   function readPref(key, fallback) {
     try {
       const v = window.localStorage.getItem(key);
@@ -36388,6 +36827,13 @@ ${command}`
       window.localStorage.setItem(key, value);
     } catch (e) {
     }
+  }
+  function openLoginUrl(url) {
+    var _a, _b;
+    if (typeof ((_b = (_a = window == null ? void 0 : window.cep) == null ? void 0 : _a.util) == null ? void 0 : _b.openURLInDefaultBrowser) !== "function") {
+      throw new Error("CEP browser opener is unavailable");
+    }
+    window.cep.util.openURLInDefaultBrowser(url);
   }
   var DEFAULT_MODEL = claudeSubDescriptor().defaultModelId;
   function cepRequire2(mod) {
@@ -36570,6 +37016,8 @@ ${command}`
     const [probe, setProbe] = import_react47.default.useState(null);
     const [codexProbe, setCodexProbe] = import_react47.default.useState(null);
     const [codexModels, setCodexModels] = import_react47.default.useState(null);
+    const [loginState, setLoginState] = import_react47.default.useState({ channel: "", status: "idle", detail: "" });
+    const codexLoginRef = import_react47.default.useRef(null);
     const [openCodeProbe, setOpenCodeProbe] = import_react47.default.useState(null);
     const [openCodeProbeStale, setOpenCodeProbeStale] = import_react47.default.useState(false);
     const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = import_react47.default.useState(0);
@@ -36647,8 +37095,14 @@ ${draft.baseUrl}`)) return;
       }
     );
     const channels = import_react47.default.useMemo(() => ({
-      claude: claudeChannels({ probe }),
-      codex: codexChannels({ codexProbe }),
+      claude: claudeChannels({
+        probe,
+        canOpenLoginTerminal: typeof platform.openLoginTerminal === "function"
+      }),
+      codex: codexChannels({
+        codexProbe,
+        loginFallback: loginState.channel === "cli" && loginState.status === "fallback"
+      }),
       opencode: openCodeChannels({
         probe: openCodeProbe,
         providers: openCodeAvailableProviders
@@ -36656,8 +37110,11 @@ ${draft.baseUrl}`)) return;
     }), [
       probe,
       codexProbe,
+      loginState.channel,
+      loginState.status,
       openCodeProbe,
-      openCodeAvailableProviders
+      openCodeAvailableProviders,
+      platform
     ]);
     const effective = pickBackend({ pref: backendPref, channels, channelChoices });
     const effectiveBackendRef = import_react47.default.useRef(effective.backend);
@@ -37087,6 +37544,120 @@ ${draft.baseUrl}`)) return;
       if (backendPref !== "codex") return void 0;
       return runCodexProbe();
     }, [backendPref, runCodexProbe]);
+    const onLoginChannel = import_react47.default.useCallback((_channel, action) => {
+      if ((action == null ? void 0 : action.kind) === "terminal") {
+        setLoginState({
+          channel: "subscription",
+          status: "launching",
+          detail: langRef.current === "en" ? "Opening the sign-in window\u2026" : "\u6B63\u5728\u6253\u5F00\u767B\u5F55\u7A97\u53E3\u2026"
+        });
+        Promise.resolve().then(() => platform.openLoginTerminal("claude")).then((result) => {
+          if (result && result.exitCode !== void 0 && result.exitCode !== 0) {
+            throw new Error(result.stderr || "The sign-in window could not be opened");
+          }
+          setLoginState({
+            channel: "subscription",
+            status: "waiting",
+            detail: langRef.current === "en" ? "Waiting for Claude sign-in; status refreshes automatically." : "\u6B63\u5728\u7B49\u5F85 Claude \u767B\u5F55\uFF0C\u72B6\u6001\u4F1A\u81EA\u52A8\u5237\u65B0\u3002"
+          });
+        }).catch((error) => {
+          setLoginState({
+            channel: "subscription",
+            status: "fallback",
+            detail: (error == null ? void 0 : error.message) || String(error)
+          });
+        });
+        return;
+      }
+      if ((action == null ? void 0 : action.kind) !== "headless" || !(codexProbe == null ? void 0 : codexProbe.codexHome)) return;
+      if (codexLoginRef.current) codexLoginRef.current.cancel();
+      setLoginState({
+        channel: "cli",
+        status: "waiting",
+        detail: langRef.current === "en" ? "Starting Codex sign-in and waiting for browser verification\u2026" : "\u6B63\u5728\u542F\u52A8 Codex \u767B\u5F55\u5E76\u7B49\u5F85\u6D4F\u89C8\u5668\u9A8C\u8BC1\u2026"
+      });
+      const login = startCodexLogin({
+        adapter: platform,
+        codexHome: codexProbe.codexHome,
+        onUrl: openLoginUrl
+      });
+      codexLoginRef.current = login;
+      login.promise.then(() => {
+        if (codexLoginRef.current !== login) return;
+        codexLoginRef.current = null;
+        setLoginState({
+          channel: "cli",
+          status: "verifying",
+          detail: langRef.current === "en" ? "Verifying Codex sign-in\u2026" : "\u6B63\u5728\u9A8C\u8BC1 Codex \u767B\u5F55\u72B6\u6001\u2026"
+        });
+        codexBackend.reset();
+        runCodexProbe();
+      }).catch((error) => {
+        var _a;
+        if (codexLoginRef.current !== login) return;
+        codexLoginRef.current = null;
+        setLoginState({
+          channel: "cli",
+          status: "fallback",
+          detail: langRef.current === "en" ? "Automatic sign-in stopped safely. Retry or use the copy-command fallback below." : "\u81EA\u52A8\u767B\u5F55\u5DF2\u5B89\u5168\u505C\u6B62\u3002\u8BF7\u91CD\u8BD5\uFF0C\u6216\u4F7F\u7528\u4E0B\u65B9\u7684\u590D\u5236\u547D\u4EE4\u5907\u7528\u64CD\u4F5C\u3002"
+        });
+        (_a = panelLogRef.current) == null ? void 0 : _a.call(panelLogRef, `Codex login failed: ${(error == null ? void 0 : error.message) || String(error)}`);
+      });
+    }, [codexBackend, codexProbe == null ? void 0 : codexProbe.codexHome, platform, runCodexProbe]);
+    import_react47.default.useEffect(() => {
+      if (loginState.channel !== "subscription" || loginState.status !== "waiting") return void 0;
+      if (tab !== "settings" || backendPref !== "subscription") return void 0;
+      let alive = true;
+      let timer = null;
+      const deadline = Date.now() + LOGIN_POLL_LIMIT_MS;
+      const poll = () => {
+        probeClaudeLogin({ platform }).then((result) => {
+          if (!alive) return;
+          setProbe(result);
+          if (result == null ? void 0 : result.loggedIn) {
+            setLoginState({ channel: "", status: "idle", detail: "" });
+            return;
+          }
+          if (Date.now() >= deadline) {
+            setLoginState({
+              channel: "subscription",
+              status: "fallback",
+              detail: langRef.current === "en" ? "Automatic refresh stopped after five minutes. Open the sign-in window again to retry." : "\u81EA\u52A8\u5237\u65B0\u5DF2\u5728\u4E94\u5206\u949F\u540E\u505C\u6B62\uFF0C\u8BF7\u91CD\u65B0\u6253\u5F00\u767B\u5F55\u7A97\u53E3\u91CD\u8BD5\u3002"
+            });
+            return;
+          }
+          timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+        }).catch(() => {
+          if (alive) timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+        });
+      };
+      timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+      return () => {
+        alive = false;
+        if (timer) clearTimeout(timer);
+      };
+    }, [backendPref, loginState.channel, loginState.status, platform, tab]);
+    import_react47.default.useEffect(() => {
+      if (loginState.channel !== "cli" || loginState.status !== "verifying" || codexProbe === null) return;
+      setLoginState(codexProbe.loggedIn ? { channel: "", status: "idle", detail: "" } : {
+        channel: "cli",
+        status: "fallback",
+        detail: langRef.current === "en" ? "Codex sign-in could not be verified. Retry or use the copy-command fallback below." : "\u672A\u80FD\u9A8C\u8BC1 Codex \u767B\u5F55\u72B6\u6001\u3002\u8BF7\u91CD\u8BD5\uFF0C\u6216\u4F7F\u7528\u4E0B\u65B9\u7684\u590D\u5236\u547D\u4EE4\u5907\u7528\u64CD\u4F5C\u3002"
+      });
+    }, [codexProbe, loginState.channel, loginState.status]);
+    import_react47.default.useEffect(() => {
+      const loginBackend = loginState.channel === "cli" ? "codex" : "subscription";
+      if (loginState.status === "idle" || tab === "settings" && backendPref === loginBackend) return;
+      const current = codexLoginRef.current;
+      codexLoginRef.current = null;
+      if (current) current.cancel();
+      setLoginState({ channel: "", status: "idle", detail: "" });
+    }, [backendPref, loginState.channel, loginState.status, tab]);
+    import_react47.default.useEffect(() => () => {
+      const current = codexLoginRef.current;
+      codexLoginRef.current = null;
+      if (current) current.cancel();
+    }, []);
     const runOpenCodeProbe = import_react47.default.useCallback(() => {
       let alive = true;
       const runId = openCodeProbeRunRef.current + 1;
@@ -37662,6 +38233,8 @@ ${draft.baseUrl}`)) return;
                 runClaudeProbe();
               }
             },
+            onLoginChannel,
+            loginState,
             onRecheckBackend: () => {
               if (backendPref === "codex") runCodexProbe();
               else if (backendPref === "opencode") {

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -24,6 +24,7 @@ import { firstErrorDetailLine, serializeErrorDetail } from '../lib/errorDetail.j
 import { createMcpClient } from '../cep/mcpClient';
 import { createToolsApi } from '../cep/toolsApi';
 import { probeClaudeLogin } from '../cep/claudeAuth';
+import { startCodexLogin } from '../cep/codexHeadlessLogin.js';
 import { createClaudeAgentBackend } from '../cep/claudeAgentBackend';
 import { createCodexBackend } from '../cep/codexBackend';
 import { createOpenCodeBackend } from '../cep/openCodeBackend';
@@ -134,6 +135,8 @@ const T = {
 
 const pkgVersion = pkg.version;
 const PROBE_PENDING_GRACE_MS = 8000;
+const LOGIN_POLL_INTERVAL_MS = 5000;
+const LOGIN_POLL_LIMIT_MS = 5 * 60 * 1000;
 
 function readPref(key, fallback) {
   try {
@@ -143,6 +146,13 @@ function readPref(key, fallback) {
 }
 function writePref(key, value) {
   try { window.localStorage.setItem(key, value); } catch (e) { /* best-effort */ }
+}
+
+function openLoginUrl(url) {
+  if (typeof window?.cep?.util?.openURLInDefaultBrowser !== 'function') {
+    throw new Error('CEP browser opener is unavailable');
+  }
+  window.cep.util.openURLInDefaultBrowser(url);
 }
 
 const DEFAULT_MODEL = claudeSubDescriptor().defaultModelId;
@@ -339,6 +349,8 @@ function Shell({ cs }) {
   const [probe, setProbe] = React.useState(null);
   const [codexProbe, setCodexProbe] = React.useState(null);
   const [codexModels, setCodexModels] = React.useState(null);
+  const [loginState, setLoginState] = React.useState({ channel: '', status: 'idle', detail: '' });
+  const codexLoginRef = React.useRef(null);
   const [openCodeProbe, setOpenCodeProbe] = React.useState(null);
   const [openCodeProbeStale, setOpenCodeProbeStale] = React.useState(false);
   const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = React.useState(0);
@@ -426,8 +438,14 @@ function Shell({ cs }) {
     />
   );
   const channels = React.useMemo(() => ({
-    claude: claudeChannels({ probe }),
-    codex: codexChannels({ codexProbe }),
+    claude: claudeChannels({
+      probe,
+      canOpenLoginTerminal: typeof platform.openLoginTerminal === 'function',
+    }),
+    codex: codexChannels({
+      codexProbe,
+      loginFallback: loginState.channel === 'cli' && loginState.status === 'fallback',
+    }),
     opencode: openCodeChannels({
       probe: openCodeProbe,
       providers: openCodeAvailableProviders,
@@ -435,8 +453,11 @@ function Shell({ cs }) {
   }), [
     probe,
     codexProbe,
+    loginState.channel,
+    loginState.status,
     openCodeProbe,
     openCodeAvailableProviders,
+    platform,
   ]);
   const effective = pickBackend({ pref: backendPref, channels, channelChoices });
   const effectiveBackendRef = React.useRef(effective.backend);
@@ -869,6 +890,137 @@ function Shell({ cs }) {
     if (backendPref !== 'codex') return undefined;
     return runCodexProbe();
   }, [backendPref, runCodexProbe]);
+
+  const onLoginChannel = React.useCallback((_channel, action) => {
+    if (action?.kind === 'terminal') {
+      setLoginState({
+        channel: 'subscription',
+        status: 'launching',
+        detail: langRef.current === 'en' ? 'Opening the sign-in window…' : '正在打开登录窗口…',
+      });
+      Promise.resolve().then(() => platform.openLoginTerminal('claude')).then((result) => {
+        if (result && result.exitCode !== undefined && result.exitCode !== 0) {
+          throw new Error(result.stderr || 'The sign-in window could not be opened');
+        }
+        setLoginState({
+          channel: 'subscription',
+          status: 'waiting',
+          detail: langRef.current === 'en'
+            ? 'Waiting for Claude sign-in; status refreshes automatically.'
+            : '正在等待 Claude 登录，状态会自动刷新。',
+        });
+      }).catch((error) => {
+        setLoginState({
+          channel: 'subscription',
+          status: 'fallback',
+          detail: error?.message || String(error),
+        });
+      });
+      return;
+    }
+    if (action?.kind !== 'headless' || !codexProbe?.codexHome) return;
+
+    if (codexLoginRef.current) codexLoginRef.current.cancel();
+    setLoginState({
+      channel: 'cli',
+      status: 'waiting',
+      detail: langRef.current === 'en'
+        ? 'Starting Codex sign-in and waiting for browser verification…'
+        : '正在启动 Codex 登录并等待浏览器验证…',
+    });
+    const login = startCodexLogin({
+      adapter: platform,
+      codexHome: codexProbe.codexHome,
+      onUrl: openLoginUrl,
+    });
+    codexLoginRef.current = login;
+    login.promise.then(() => {
+      if (codexLoginRef.current !== login) return;
+      codexLoginRef.current = null;
+      setLoginState({
+        channel: 'cli',
+        status: 'verifying',
+        detail: langRef.current === 'en' ? 'Verifying Codex sign-in…' : '正在验证 Codex 登录状态…',
+      });
+      codexBackend.reset();
+      runCodexProbe();
+    }).catch((error) => {
+      if (codexLoginRef.current !== login) return;
+      codexLoginRef.current = null;
+      setLoginState({
+        channel: 'cli',
+        status: 'fallback',
+        detail: langRef.current === 'en'
+          ? 'Automatic sign-in stopped safely. Retry or use the copy-command fallback below.'
+          : '自动登录已安全停止。请重试，或使用下方的复制命令备用操作。',
+      });
+      panelLogRef.current?.(`Codex login failed: ${error?.message || String(error)}`);
+    });
+  }, [codexBackend, codexProbe?.codexHome, platform, runCodexProbe]);
+
+  React.useEffect(() => {
+    if (loginState.channel !== 'subscription' || loginState.status !== 'waiting') return undefined;
+    if (tab !== 'settings' || backendPref !== 'subscription') return undefined;
+    let alive = true;
+    let timer = null;
+    const deadline = Date.now() + LOGIN_POLL_LIMIT_MS;
+    const poll = () => {
+      probeClaudeLogin({ platform }).then((result) => {
+        if (!alive) return;
+        setProbe(result);
+        if (result?.loggedIn) {
+          setLoginState({ channel: '', status: 'idle', detail: '' });
+          return;
+        }
+        if (Date.now() >= deadline) {
+          setLoginState({
+            channel: 'subscription',
+            status: 'fallback',
+            detail: langRef.current === 'en'
+              ? 'Automatic refresh stopped after five minutes. Open the sign-in window again to retry.'
+              : '自动刷新已在五分钟后停止，请重新打开登录窗口重试。',
+          });
+          return;
+        }
+        timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+      }).catch(() => {
+        if (alive) timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+      });
+    };
+    timer = setTimeout(poll, LOGIN_POLL_INTERVAL_MS);
+    return () => {
+      alive = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [backendPref, loginState.channel, loginState.status, platform, tab]);
+
+  React.useEffect(() => {
+    if (loginState.channel !== 'cli' || loginState.status !== 'verifying' || codexProbe === null) return;
+    setLoginState(codexProbe.loggedIn
+      ? { channel: '', status: 'idle', detail: '' }
+      : {
+        channel: 'cli',
+        status: 'fallback',
+        detail: langRef.current === 'en'
+          ? 'Codex sign-in could not be verified. Retry or use the copy-command fallback below.'
+          : '未能验证 Codex 登录状态。请重试，或使用下方的复制命令备用操作。',
+      });
+  }, [codexProbe, loginState.channel, loginState.status]);
+
+  React.useEffect(() => {
+    const loginBackend = loginState.channel === 'cli' ? 'codex' : 'subscription';
+    if (loginState.status === 'idle' || (tab === 'settings' && backendPref === loginBackend)) return;
+    const current = codexLoginRef.current;
+    codexLoginRef.current = null;
+    if (current) current.cancel();
+    setLoginState({ channel: '', status: 'idle', detail: '' });
+  }, [backendPref, loginState.channel, loginState.status, tab]);
+
+  React.useEffect(() => () => {
+    const current = codexLoginRef.current;
+    codexLoginRef.current = null;
+    if (current) current.cancel();
+  }, []);
 
   const runOpenCodeProbe = React.useCallback(() => {
     let alive = true;
@@ -1485,6 +1637,8 @@ function Shell({ cs }) {
                 runClaudeProbe();
               }
             }}
+            onLoginChannel={onLoginChannel}
+            loginState={loginState}
             onRecheckBackend={() => {
               if (backendPref === 'codex') runCodexProbe();
               else if (backendPref === 'opencode') {

--- a/plugin/panel/src/app/wizardWiring.js
+++ b/plugin/panel/src/app/wizardWiring.js
@@ -6,6 +6,12 @@ import {
   runAction,
 } from '../cep/wizardActions.js';
 import {
+  addUserPathEntry,
+  isWindowsPlatform,
+  pathIncludesEntry,
+  readUserPath,
+} from '../cep/registryPath.js';
+import {
   CLI_STEPS,
   HOST_STEPS,
   OPTIONAL_CLIENT_STEPS,
@@ -19,13 +25,49 @@ export function useWizardWiring({
   platform,
 } = {}) {
   const [stepStates, dispatch] = React.useReducer(stepReducer, null, initialStepStates);
+  const [pathOffers, setPathOffers] = React.useState({});
   const commands = React.useMemo(
     () => buildInstallCommands({ platform }),
     [platform],
   );
   const commandPreviews = React.useMemo(() => ({
     node: commandPreview(commands.node),
+    claude: commandPreview(commands.claude),
   }), [commands]);
+
+  const updatePathOffer = React.useCallback(async (id, result) => {
+    if (!isWindowsPlatform(platform) || !result.ok || !result.path) {
+      setPathOffers((current) => {
+        if (!current[id]) return current;
+        const next = { ...current };
+        delete next[id];
+        return next;
+      });
+      return;
+    }
+    const directory = platform.paths?.dirname
+      ? platform.paths.dirname(result.path)
+      : String(result.path).replace(/[\\/][^\\/]*$/, '');
+    try {
+      const userPath = await readUserPath(platform);
+      const environment = platform.paths?.home
+        ? { USERPROFILE: platform.paths.home, HOME: platform.paths.home }
+        : {};
+      setPathOffers((current) => {
+        const next = { ...current };
+        if (pathIncludesEntry(userPath.value, directory, environment)) delete next[id];
+        else next[id] = { directory };
+        return next;
+      });
+    } catch {
+      setPathOffers((current) => {
+        if (!current[id]) return current;
+        const next = { ...current };
+        delete next[id];
+        return next;
+      });
+    }
+  }, [platform]);
 
   const detect = React.useCallback(async (id) => {
     dispatch({ type: 'detect-start', id });
@@ -40,9 +82,12 @@ export function useWizardWiring({
       ok: result.ok,
       version: result.version || '',
       detail: result.detail || '',
+      path: result.path || '',
+      source: result.source || '',
     });
+    await updatePathOffer(id, result);
     return result;
-  }, [fetchImpl, platform, port]);
+  }, [fetchImpl, platform, port, updatePathOffer]);
 
   const install = React.useCallback(async (id) => {
     const command = commands[id];
@@ -57,6 +102,21 @@ export function useWizardWiring({
     await detect(id);
     return result;
   }, [commands, detect, platform]);
+
+  const addToPath = React.useCallback(async (id) => {
+    const offer = pathOffers[id];
+    if (!offer) return { changed: false };
+    const result = await addUserPathEntry(platform, offer.directory);
+    if (result.changed) {
+      setPathOffers((current) => {
+        const next = { ...current };
+        delete next[id];
+        return next;
+      });
+      await detect(id);
+    }
+    return result;
+  }, [detect, pathOffers, platform]);
 
   const bootDetectRef = React.useRef(false);
   React.useEffect(() => {
@@ -74,6 +134,8 @@ export function useWizardWiring({
       commandPreviews,
       onDetect: detect,
       onInstall: install,
+      pathOffers,
+      onAddToPath: addToPath,
     },
   };
 }

--- a/plugin/panel/src/cep/codexHeadlessLogin.js
+++ b/plugin/panel/src/cep/codexHeadlessLogin.js
@@ -1,0 +1,156 @@
+const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_URL_TIMEOUT_MS = 20 * 1000;
+const URL_PATTERN = /https:\/\/[^\s<>"'`]+/;
+
+function loginError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+export function startCodexLogin({
+  adapter,
+  codexHome,
+  onUrl = () => {},
+  onDone = () => {},
+  timeoutMs = DEFAULT_LOGIN_TIMEOUT_MS,
+  urlTimeoutMs = DEFAULT_URL_TIMEOUT_MS,
+} = {}) {
+  if (!adapter || typeof adapter.resolveExecutable !== 'function' || typeof adapter.spawn !== 'function') {
+    throw new TypeError('A platform adapter is required');
+  }
+  if (!codexHome) throw new TypeError('codexHome is required');
+
+  let child = null;
+  let settled = false;
+  let cancelled = false;
+  let sawUrl = false;
+  let resolvePromise;
+  let rejectPromise;
+  let overallTimer = null;
+  let urlTimer = null;
+  const lineBuffers = { stdout: '', stderr: '' };
+
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  function killChild() {
+    if (!child || typeof child.kill !== 'function') return;
+    try { child.kill(); } catch {}
+  }
+
+  function clearTimers() {
+    if (overallTimer) clearTimeout(overallTimer);
+    if (urlTimer) clearTimeout(urlTimer);
+    overallTimer = null;
+    urlTimer = null;
+  }
+
+  function finishError(error, { kill = true } = {}) {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    if (kill) killChild();
+    rejectPromise(error);
+  }
+
+  function finishSuccess(result) {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    try {
+      onDone(result);
+    } catch (error) {
+      rejectPromise(error);
+      return;
+    }
+    resolvePromise(result);
+  }
+
+  function inspectLine(line) {
+    if (sawUrl) return;
+    const match = String(line || '').match(URL_PATTERN);
+    if (!match) return;
+    sawUrl = true;
+    if (urlTimer) clearTimeout(urlTimer);
+    urlTimer = null;
+    try {
+      onUrl(match[0]);
+    } catch (error) {
+      finishError(error);
+    }
+  }
+
+  function readLines(streamName, chunk, flush = false) {
+    lineBuffers[streamName] += String(chunk || '');
+    const lines = lineBuffers[streamName].split(/\r?\n/);
+    if (!flush) lineBuffers[streamName] = lines.pop() || '';
+    else lineBuffers[streamName] = '';
+    for (const line of lines) inspectLine(line);
+  }
+
+  function handleExit(code, signal) {
+    if (settled) return;
+    readLines('stdout', '', true);
+    readLines('stderr', '', true);
+    if (code !== 0) {
+      finishError(loginError(
+        'CODEX_LOGIN_EXITED',
+        `codex login exited with ${code === null || code === undefined ? signal || 'an unknown status' : `code ${code}`}`,
+      ), { kill: false });
+      return;
+    }
+    if (!sawUrl) {
+      finishError(loginError('CODEX_LOGIN_URL_MISSING', 'codex login exited without a sign-in URL'), { kill: false });
+      return;
+    }
+    finishSuccess({ exitCode: 0, urlSeen: true });
+  }
+
+  overallTimer = setTimeout(() => {
+    finishError(loginError('CODEX_LOGIN_TIMEOUT', 'codex login timed out'));
+  }, Math.max(0, Number(timeoutMs)));
+
+  (async () => {
+    try {
+      const env = adapter.completeSpawnEnv({}, { CODEX_HOME: codexHome });
+      const executable = await adapter.resolveExecutable('codex', { env });
+      if (cancelled || settled) return;
+      if (!executable || executable.ok !== true) {
+        finishError(loginError(
+          executable?.code || 'CODEX_LOGIN_RESOLUTION_FAILED',
+          executable?.detail || 'Codex CLI could not be resolved',
+        ), { kill: false });
+        return;
+      }
+      child = adapter.spawn(executable, ['login'], {
+        stdio: 'pipe',
+        windowsHide: true,
+        env,
+      });
+      child.stdout?.setEncoding?.('utf8');
+      child.stderr?.setEncoding?.('utf8');
+      child.stdout?.on?.('data', (chunk) => readLines('stdout', chunk));
+      child.stderr?.on?.('data', (chunk) => readLines('stderr', chunk));
+      child.on?.('error', (error) => finishError(error));
+      child.on?.('exit', handleExit);
+      child.on?.('close', handleExit);
+      urlTimer = setTimeout(() => {
+        finishError(loginError('CODEX_LOGIN_URL_TIMEOUT', 'codex login did not provide a sign-in URL'));
+      }, Math.max(0, Number(urlTimeoutMs)));
+    } catch (error) {
+      finishError(error);
+    }
+  })();
+
+  return {
+    promise,
+    cancel() {
+      if (settled) return;
+      cancelled = true;
+      finishError(loginError('CODEX_LOGIN_CANCELLED', 'codex login was cancelled'));
+    },
+  };
+}

--- a/plugin/panel/src/cep/platform/index.js
+++ b/plugin/panel/src/cep/platform/index.js
@@ -21,6 +21,26 @@ function windowsEnvValue(environment, name) {
   return key === undefined ? undefined : environment[key];
 }
 
+function extensionRootFromPage() {
+  try {
+    const root = globalThis.window?.__adobe_cep__?.getSystemPath?.('extension');
+    if (typeof root === 'string' && root.trim()) return root;
+  } catch {
+    // CEP hosts may expose the page before their system-path bridge is ready.
+  }
+  try {
+    const location = globalThis.location;
+    if (typeof location?.href !== 'string' || !location.href.startsWith('file:')) return null;
+    let pagePath = decodeURIComponent(new URL(location.href).pathname);
+    pagePath = pagePath.replace(/^\/([A-Za-z]:\/)/, '$1');
+    const clientDirectory = pagePath.slice(0, pagePath.lastIndexOf('/'));
+    const root = clientDirectory.slice(0, clientDirectory.lastIndexOf('/'));
+    return root || null;
+  } catch {
+    return null;
+  }
+}
+
 export function defaultPlatformDependencies() {
   const require = cepRequire();
   const processImpl = globalThis.window?.cep_node?.process || globalThis.process;
@@ -35,6 +55,7 @@ export function defaultPlatformDependencies() {
     pid: processImpl.pid,
     home,
     temp: os.tmpdir(),
+    extensionRoot: extensionRootFromPage(),
     env,
     fs: require('fs'),
     httpImpl: require('http'),

--- a/plugin/panel/src/cep/platform/macos.js
+++ b/plugin/panel/src/cep/platform/macos.js
@@ -9,7 +9,9 @@ function normalizedExecutableName(value) {
 export function createMacosAdapter(deps) {
   if (!deps || deps.platform !== 'darwin' || deps.arch !== 'arm64') throw new Error('macOS arm64 dependencies are required');
   const paths = createPathCatalog({ home: deps.home, temp: deps.temp, platform: deps.platform });
-  const boundary = createProcessBoundary({ deps, paths, platform: deps.platform });
+  const boundary = createProcessBoundary({
+    deps, paths, platform: deps.platform, extensionRoot: deps.extensionRoot,
+  });
   const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: 'standard', version: null, arch: 'arm64' });
   return Object.freeze({
     id: 'macos-arm64',

--- a/plugin/panel/src/cep/platform/process.js
+++ b/plugin/panel/src/cep/platform/process.js
@@ -120,7 +120,7 @@ function isNodeScript(path, bytes) {
   return /^#!.*\bnode(?:\.exe)?(?:\s|$)/i.test(firstLine);
 }
 
-export function createProcessBoundary({ deps, paths, platform }) {
+export function createProcessBoundary({ deps, paths, platform, extensionRoot = deps.extensionRoot }) {
   const windows = platform === 'win32';
   const separator = windows ? ';' : ':';
 
@@ -322,7 +322,9 @@ export function createProcessBoundary({ deps, paths, platform }) {
   }
 
   function runtimeCandidates(id) {
-    return [];
+    if (!windows || id !== 'opencode' || !extensionRoot) return [];
+    // The packaged CLI is the supported baseline; an explicit override still wins.
+    return [paths.join([extensionRoot, 'runtime', 'opencode', 'opencode.exe'])];
   }
 
   function pathCandidates(id, env) {

--- a/plugin/panel/src/cep/platform/windows.js
+++ b/plugin/panel/src/cep/platform/windows.js
@@ -20,7 +20,9 @@ function tasklistImage(stdout) {
 export function createWindowsAdapter(deps) {
   if (!deps || deps.platform !== 'win32' || deps.arch !== 'x64') throw new Error('Windows x64 dependencies are required');
   const paths = createPathCatalog({ home: deps.home, temp: deps.temp, platform: deps.platform });
-  const boundary = createProcessBoundary({ deps, paths, platform: deps.platform });
+  const boundary = createProcessBoundary({
+    deps, paths, platform: deps.platform, extensionRoot: deps.extensionRoot,
+  });
   const systemRoot = String(envValue(deps.env, 'SystemRoot') || envValue(deps.env, 'WINDIR') || 'C:\\Windows');
   const fixed = (id, path, argsPrefix = []) => ({ ok: true, id, path, argsPrefix, source: 'standard', version: null, arch: 'x64' });
   return Object.freeze({

--- a/plugin/panel/src/cep/registryPath.js
+++ b/plugin/panel/src/cep/registryPath.js
@@ -1,0 +1,152 @@
+const REG_EXECUTABLE = {
+  ok: true,
+  id: 'reg',
+  path: 'reg.exe',
+  argsPrefix: [],
+  source: 'override',
+  version: null,
+  arch: 'x64',
+};
+
+const USER_PATH_QUERY = ['query', 'HKCU\\Environment', '/v', 'Path'];
+const USER_PATH_DEFAULT = { value: '', type: 'REG_EXPAND_SZ' };
+
+export function isWindowsPlatform(adapter) {
+  return adapter?.id === 'windows-x64' || adapter?.platform === 'win32';
+}
+
+function requireWindows(adapter) {
+  if (!isWindowsPlatform(adapter)) {
+    throw new Error('User PATH updates are only supported on Windows');
+  }
+}
+
+function normalizedPathEntry(value) {
+  let result = String(value || '').trim().replace(/\//g, '\\');
+  while (result.length > 3 && result.endsWith('\\')) result = result.slice(0, -1);
+  return result.toLowerCase();
+}
+
+function expandEnvironmentEntry(value, environment) {
+  return String(value || '').replace(/%([^%]+)%/g, (match, name) => {
+    const key = Object.keys(environment || {}).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+    return key === undefined ? match : String(environment[key]);
+  });
+}
+
+export function pathIncludesEntry(rawValue, directory, environment = {}) {
+  const expected = normalizedPathEntry(directory);
+  if (!expected) return false;
+  return String(rawValue || '').split(';').some((entry) => (
+    normalizedPathEntry(entry) === expected
+    || normalizedPathEntry(expandEnvironmentEntry(entry, environment)) === expected
+  ));
+}
+
+async function resolvePowerShell(adapter) {
+  const executable = await adapter.resolveExecutable('powershell');
+  if (!executable || !executable.ok) {
+    throw new Error('powershell resolution failed: ' + (executable?.code || 'NOT_FOUND'));
+  }
+  return executable;
+}
+
+function spawnAndCollect(adapter, executable, args) {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (result, error) => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve({ ...result, stdout, stderr });
+    };
+    try {
+      const child = adapter.spawn(executable, args, { windowsHide: true });
+      child.stdout?.on?.('data', (chunk) => { stdout += String(chunk || ''); });
+      child.stderr?.on?.('data', (chunk) => { stderr += String(chunk || ''); });
+      child.on?.('error', (error) => finish({}, error));
+      child.on?.('close', (code) => finish({ code }, null));
+    } catch (error) {
+      finish({}, error);
+    }
+  });
+}
+
+function parseUserPath(output) {
+  const line = String(output || '').split(/\r?\n/).find((entry) => (
+    /^\s*Path\s+REG_(?:SZ|EXPAND_SZ)\s+/i.test(entry)
+  ));
+  if (!line) return null;
+  const match = line.match(/^\s*Path\s+(REG_(?:SZ|EXPAND_SZ))\s+(.*)$/i);
+  return match ? { value: match[2].trim(), type: match[1].toUpperCase() } : null;
+}
+
+export async function readUserPath(adapter) {
+  requireWindows(adapter);
+  const result = await spawnAndCollect(adapter, REG_EXECUTABLE, USER_PATH_QUERY);
+  if (result.code !== 0) return { ...USER_PATH_DEFAULT };
+  return parseUserPath(result.stdout) || { ...USER_PATH_DEFAULT };
+}
+
+async function addRegistryPath(adapter, value, type) {
+  const result = await spawnAndCollect(adapter, REG_EXECUTABLE, [
+    'add',
+    'HKCU\\Environment',
+    '/v',
+    'Path',
+    '/t',
+    type,
+    '/d',
+    value,
+    '/f',
+  ]);
+  if (result.code !== 0) {
+    throw new Error((result.stderr || result.stdout || 'reg add failed').trim());
+  }
+}
+
+const BROADCAST_SCRIPT = [
+  "Add-Type @'",
+  'using System;',
+  'using System.Runtime.InteropServices;',
+  'public static class EnvironmentChange {',
+  '  public static readonly IntPtr HWND_BROADCAST = new IntPtr(0xffff);',
+  '  public const uint WM_SETTINGCHANGE = 0x001A;',
+  '  public const uint SMTO_ABORTIFHUNG = 0x0002;',
+  '  [DllImport("user32.dll", CharSet = CharSet.Unicode)]',
+  '  public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);',
+  '}',
+  "'@",
+  '$result = [UIntPtr]::Zero',
+  '[EnvironmentChange]::SendMessageTimeout([EnvironmentChange]::HWND_BROADCAST, [EnvironmentChange]::WM_SETTINGCHANGE, [UIntPtr]::Zero, "Environment", [EnvironmentChange]::SMTO_ABORTIFHUNG, 2000, [ref]$result) | Out-Null',
+].join('\n');
+
+async function broadcastEnvironmentChange(adapter) {
+  const executable = await resolvePowerShell(adapter);
+  const result = await spawnAndCollect(adapter, executable, [
+    '-NoProfile',
+    '-Command',
+    BROADCAST_SCRIPT,
+  ]);
+  if (result.code !== 0) throw new Error((result.stderr || result.stdout || 'broadcast failed').trim());
+}
+
+export async function addUserPathEntry(adapter, directory) {
+  requireWindows(adapter);
+  const entry = String(directory || '').trim();
+  if (!entry) throw new Error('A non-empty PATH directory is required');
+  const current = await readUserPath(adapter);
+  if (pathIncludesEntry(current.value, entry)) return { changed: false };
+  // Preserve REG_EXPAND_SZ so existing %VAR% references remain expandable.
+  const newValue = current.value ? current.value + ';' + entry : entry;
+  // Do not use setx: it can truncate PATH values at 1024 characters.
+  await addRegistryPath(adapter, newValue, current.type);
+  try {
+    await broadcastEnvironmentChange(adapter);
+  } catch (error) {
+    globalThis.console?.warn?.('User PATH broadcast failed:', error);
+  }
+  return { changed: true };
+}

--- a/plugin/panel/src/cep/wizardActions.js
+++ b/plugin/panel/src/cep/wizardActions.js
@@ -49,13 +49,28 @@ export async function detectTool(id, options = {}) {
 
 export function buildInstallCommands({ platform } = {}) {
   const adapter = platform || createPlatformAdapter();
-  if (typeof adapter.legacyWizardInstallCommands !== 'function') return {};
-  const commands = adapter.legacyWizardInstallCommands({
-    panelVersion: '',
-    repoRoot: '',
-    repo: '',
-  });
-  return commands && commands.node ? { node: commands.node } : {};
+  const commands = typeof adapter.legacyWizardInstallCommands === 'function'
+    ? adapter.legacyWizardInstallCommands({
+      panelVersion: '',
+      repoRoot: '',
+      repo: '',
+    })
+    : {};
+  const result = commands && commands.node ? { node: commands.node } : {};
+  if (adapter.id === 'windows-x64' || adapter.platform === 'win32') {
+    result.claude = {
+      file: 'powershell',
+      executableId: 'powershell',
+      args: [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        'irm https://claude.ai/install.ps1 | iex',
+      ],
+    };
+  }
+  return result;
 }
 
 export async function runAction({

--- a/plugin/panel/src/components/settings/ChannelCard.jsx
+++ b/plugin/panel/src/components/settings/ChannelCard.jsx
@@ -27,6 +27,8 @@ export function ChannelCard({
   selectedChannel = '',
   onSelectChannel,
   onRecheck,
+  onLogin,
+  loginState = null,
   recheckLabel,
   recheckDisabled = false,
   readOnly = false,
@@ -62,6 +64,12 @@ export function ChannelCard({
         const texts = channelTexts(probe, lang);
         const isActive = probe.channel === activeChannel;
         const choice = channelChoiceState(probe.channel, selectedChannel, lang);
+        const loginAction = !probe.ok && !probe.checking ? probe.loginAction : null;
+        const activeLogin = loginState?.channel === probe.channel ? loginState : null;
+        const loginWaiting = ['launching', 'waiting', 'verifying'].includes(activeLogin?.status);
+        const loginLabel = loginWaiting
+          ? (lang === 'en' ? 'Waiting for sign-in…' : '等待登录…')
+          : (loginAction?.label?.[lang] || loginAction?.label?.zh || '');
         return (
           <div key={probe.channel} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '8px 10px', border: `1px solid ${isActive ? 'var(--border-strong)' : 'var(--border-subtle)'}`, borderRadius: 'var(--radius-md)', background: 'var(--bg-well)' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -75,6 +83,14 @@ export function ChannelCard({
               ) : null}
             </div>
             {texts.fixHint ? <div style={{ font: '400 10px/1.5 var(--font-ui)', color: 'var(--text-tertiary)', whiteSpace: 'pre-wrap' }}>{texts.fixHint}</div> : null}
+            {activeLogin?.detail ? <div role="status" style={{ font: '400 10px/1.5 var(--font-ui)', color: 'var(--text-secondary)' }}>{activeLogin.detail}</div> : null}
+            {!readOnly && loginAction && onLogin ? (
+              <div>
+                <Button variant="primary" size="sm" disabled={loginWaiting} onClick={() => onLogin(probe, loginAction)}>
+                  {loginLabel}
+                </Button>
+              </div>
+            ) : null}
             {!readOnly && texts.copyText ? (
               <div>
                 <Button variant="secondary" size="sm" icon="copy" onClick={() => copyLoginCommand(probe.channel, texts.copyText)}>

--- a/plugin/panel/src/lib/channels.js
+++ b/plugin/panel/src/lib/channels.js
@@ -1,10 +1,17 @@
 // Credential channels share one shape so backend selection can compare them.
-// ChannelProbe: { channel, source:{zh,en}, checking, ok, detail, fixHint:{zh,en}, copyAction?:{label:{zh,en},text} }
+// ChannelProbe: { channel, source:{zh,en}, checking, ok, detail, fixHint:{zh,en}, copyAction?:{label:{zh,en},text}, loginAction?:{label:{zh,en},kind} }
 
 import { codexLoginCommand } from './codexLogin.js';
 
-export function claudeChannels({ probe } = {}) {
+export function claudeChannels({ probe, canOpenLoginTerminal = true } = {}) {
   const probeFailed = ['probe-timeout', 'probe-failed'].includes(probe?.reason);
+  const needsLogin = Boolean(
+    probe
+    && probe.cliOk === true
+    && !probe.loggedIn
+    && !probeFailed
+    && probe.reason !== 'cli-too-old',
+  );
   return [{
     channel: 'subscription',
     source: { zh: '订阅登录', en: 'Subscription login' },
@@ -33,19 +40,28 @@ export function claudeChannels({ probe } = {}) {
             + 'panel PATH, set AE_MCP_CLAUDE_CLI and restart AE.',
         }
         : {
-          zh: '订阅未登录：在终端运行 claude /login 完成登录后重新检测；或改用 OpenCode Provider 通道。',
-          en: 'Not logged in: run claude /login in a terminal and re-check, or use the '
-            + 'OpenCode Provider channel.',
+          zh: canOpenLoginTerminal
+            ? '在打开的窗口中输入 /login 完成登录，本页会自动刷新。'
+            : '当前平台无法从面板打开 Claude 登录窗口，可改用 OpenCode Provider 通道。',
+          en: canOpenLoginTerminal
+            ? 'Enter /login in the window that opens. This page refreshes automatically after sign-in.'
+            : 'This platform cannot open the Claude sign-in window from the panel. Use the OpenCode Provider channel instead.',
         },
+    ...(needsLogin && canOpenLoginTerminal ? {
+      loginAction: {
+        label: { zh: '打开登录窗口', en: 'Open sign-in window' },
+        kind: 'terminal',
+      },
+    } : {}),
   }];
 }
 
-export function codexChannels({ codexProbe } = {}) {
+export function codexChannels({ codexProbe, loginFallback = false } = {}) {
   const cliFixHint = {
-    zh: '在终端完成 codex 登录后重新检测；若 codex 不在面板 PATH 上，设置环境变量 '
+    zh: '请先安装 Codex CLI；若 codex 不在面板 PATH 上，设置环境变量 '
       + 'AE_MCP_CODEX_CLI 指向 codex 可执行文件后重启 AE。',
-    en: 'Sign in with codex in a terminal and re-check; if codex is not on the panel '
-      + 'PATH, set AE_MCP_CODEX_CLI to the codex executable and restart AE.',
+    en: 'Install Codex CLI first. If codex is not on the panel PATH, set '
+      + 'AE_MCP_CODEX_CLI to the codex executable and restart AE.',
   };
   const needsIsolatedLogin = Boolean(
     codexProbe
@@ -70,14 +86,25 @@ export function codexChannels({ codexProbe } = {}) {
         codexProbe.cliVersion,
       ].filter(Boolean).join(' · ') : (codexProbe.detail || ''))
       : '',
-    fixHint: needsIsolatedLogin ? {
-      zh: `面板的 Codex 运行在隔离目录 ${codexProbe.codexHome}（不读取 ~/.codex），系统里已登录的 codex 对面板无效。在终端运行下面命令完成登录后点「重新检测」：\n${command}`,
-      en: `The panel runs Codex with its own CODEX_HOME at ${codexProbe.codexHome} (it never reads ~/.codex), so a system-wide codex login does not apply here. Run this in a terminal, then re-check:\n${command}`,
-    } : cliFixHint,
-    ...(needsIsolatedLogin ? {
+    fixHint: needsIsolatedLogin
+      ? (loginFallback ? {
+        zh: `自动登录未能打开验证页面。可重试「一键登录」；如仍失败，请复制登录命令完成面板隔离登录：\n${command}`,
+        en: `Automatic sign-in could not open the verification page. Retry One-click sign-in; if it still fails, copy the command to sign in to the panel's isolated Codex home:\n${command}`,
+      } : {
+        zh: `面板的 Codex 运行在隔离目录 ${codexProbe.codexHome}（不读取 ~/.codex），系统登录态对面板无效。点击「一键登录」后在浏览器中完成验证，本页会自动刷新。`,
+        en: `The panel runs Codex with its own CODEX_HOME at ${codexProbe.codexHome} (it never reads ~/.codex), so the system login does not apply. Choose One-click sign-in and finish verification in the browser; this page refreshes automatically.`,
+      })
+      : cliFixHint,
+    ...(needsIsolatedLogin && loginFallback ? {
       copyAction: {
         label: { zh: '复制登录命令', en: 'Copy login command' },
         text: command,
+      },
+    } : {}),
+    ...(needsIsolatedLogin ? {
+      loginAction: {
+        label: { zh: '一键登录', en: 'One-click sign-in' },
+        kind: 'headless',
       },
     } : {}),
   };
@@ -109,15 +136,17 @@ const CLAUDE_CHANNEL_IDS = ['subscription'];
 const CODEX_CHANNEL_IDS = ['cli'];
 
 export function migrateBackendPref(storage) {
-  let pref = 'subscription';
+  let pref = 'opencode';
   const channelChoices = { claude: 'subscription', codex: 'cli', opencode: 'provider' };
   try {
-    const raw = storage.getItem('ae_mcp_backend') || 'subscription';
+    const storedBackend = storage.getItem('ae_mcp_backend');
+    const raw = storedBackend || '';
     const storedClaude = storage.getItem('ae_mcp_channel_claude') || '';
     const storedCodex = storage.getItem('ae_mcp_channel_codex') || '';
     if (raw === 'opencode' || raw === 'codex' || raw === 'subscription') {
       pref = raw;
-    } else {
+    } else if (raw) {
+      pref = 'subscription';
       storage.setItem('ae_mcp_backend', pref);
     }
     if (CLAUDE_CHANNEL_IDS.includes(storedClaude)) channelChoices.claude = storedClaude;

--- a/plugin/panel/src/lib/errorCodes.js
+++ b/plugin/panel/src/lib/errorCodes.js
@@ -18,7 +18,7 @@ export const ERROR_CODES = Object.freeze({
   CLI_MISSING: entry('CLI_MISSING', 'backend', '请安装对应 CLI，并确认面板进程能从 PATH 找到它。', 'Install the CLI and make sure it is visible on the panel PATH.'),
   CLI_TOO_OLD: entry('CLI_TOO_OLD', 'backend', '请升级对应 CLI 后重新检测。', 'Upgrade the CLI and re-check.'),
   CLI_ARCH_MISMATCH: entry('CLI_ARCH_MISMATCH', 'backend', '请安装与当前 After Effects 主机架构一致的 CLI。', 'Install a CLI build matching the After Effects host architecture.'),
-  CLI_PROBE_FAILED: entry('CLI_PROBE_FAILED', 'backend', 'CLI 已找到但探针失败；请在终端确认它能正常启动。', 'The CLI was found but its probe failed; confirm it starts normally in a terminal.'),
+  CLI_PROBE_FAILED: entry('CLI_PROBE_FAILED', 'backend', 'CLI 已找到但探针失败；请回到“设置 → AI”使用通道卡上的操作重试。', 'The CLI was found but its probe failed. Return to Settings → AI and retry from the channel card.'),
   SPAWN_FAILED: entry('SPAWN_FAILED', 'backend', '请检查 CLI 路径、执行权限和安全软件拦截。', 'Check the CLI path, execute permission, and security-software blocks.'),
   PROCESS_EXITED: entry('PROCESS_EXITED', 'backend', '请查看折叠详情中的退出信息与 stderr 尾部。', 'Inspect the exit information and stderr tail in the collapsed details.'),
   AUTH_REQUIRED: entry('AUTH_REQUIRED', 'auth', '请按「设置 → AI」通道卡上的登录指引完成对应 CLI 登录后重新检测。', 'Follow the sign-in guidance on the channel card under Settings → AI for this CLI, then re-check.'),

--- a/plugin/panel/src/lib/wizardSteps.js
+++ b/plugin/panel/src/lib/wizardSteps.js
@@ -6,7 +6,7 @@ const LOG_TAIL = 4096;
 const ALL_STEPS = [...HOST_STEPS, ...CLI_STEPS, ...OPTIONAL_CLIENT_STEPS];
 
 function emptyState() {
-  return { status: 'idle', version: '', logTail: '' };
+  return { status: 'idle', version: '', path: '', source: '', logTail: '' };
 }
 
 export function initialStepStates() {
@@ -41,6 +41,8 @@ export function stepReducer(state, action) {
         status: action.ok ? 'ok' : 'missing',
         version: action.ok ? (action.version || '') : '',
         logTail: action.detail || current.logTail,
+        path: action.ok ? (action.path || '') : '',
+        source: action.ok ? (action.source || '') : '',
       });
     case 'run-start':
       return patchStep(state, action.id, { status: 'running', logTail: '' });

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -310,6 +310,8 @@ export function SettingsScreen({
   selectedChannel = '',
   onSelectChannel,
   onRecheckBackend,
+  onLoginChannel,
+  loginState = null,
   recheckDisabled = false,
   providerManager = null,
   providerInit = { state: 'checking', error: '' },
@@ -368,6 +370,8 @@ export function SettingsScreen({
           selectedChannel={selectedChannel}
           onSelectChannel={onSelectChannel}
           onRecheck={onRecheckBackend}
+          onLogin={onLoginChannel}
+          loginState={loginState}
           recheckLabel={t.recheck}
           recheckDisabled={recheckDisabled}
         />

--- a/plugin/panel/src/screens/WizardScreen.jsx
+++ b/plugin/panel/src/screens/WizardScreen.jsx
@@ -32,6 +32,9 @@ const W = {
     copyLog: '复制日志',
     optionalNode: '系统 Node（stdio 客户端可选）',
     optionalNodeHint: '只有 Claude Desktop 这类只支持 stdio 的客户端才需要。',
+    claudeInstallHint: '这会从 claude.ai 下载并运行 Anthropic 官方安装程序；面板使用已检测到的绝对路径，不依赖系统 PATH。',
+    pathHint: '加入后可在你自己的终端使用；面板使用已检测到的绝对路径，不依赖系统 PATH。',
+    addToPath: '加入系统 PATH（可选，方便你在自己的终端里使用）',
     panelOpenNote: '面板开着才能连接；关闭或重载面板后客户端需要重连。',
     directUrl: '或直接使用这个地址',
   },
@@ -54,6 +57,9 @@ const W = {
     copyLog: 'Copy log',
     optionalNode: 'System Node (optional for stdio clients)',
     optionalNodeHint: 'Only stdio-only clients such as Claude Desktop need this step.',
+    claudeInstallHint: "This downloads and runs Anthropic's official installer from claude.ai; the panel uses the detected absolute path and does not require PATH.",
+    pathHint: 'Add it to use this CLI in your own terminal; the panel uses the detected absolute path and does not require PATH.',
+    addToPath: 'Add to user PATH (optional, for your terminal)',
     panelOpenNote: 'The panel must stay open. Clients reconnect after it closes or reloads.',
     directUrl: 'Or use this address directly',
   },
@@ -109,7 +115,7 @@ function CodeBlock({ code, copyLabel, onCopy, wrap = false }) {
   );
 }
 
-function CheckRow({ label, state, t, onDetect, onInstall, commandPreview, hint }) {
+function CheckRow({ label, state, t, onDetect, onInstall, commandPreview, hint, pathEntry, onAddToPath }) {
   const status = state && state.status ? state.status : 'idle';
   const busy = status === 'checking' || status === 'running';
   const problem = status === 'missing' || status === 'fail';
@@ -183,6 +189,11 @@ function CheckRow({ label, state, t, onDetect, onInstall, commandPreview, hint }
             <Button variant="secondary" size="sm" onClick={onInstall}>{t.install}</Button>
           </div>
         ) : null}
+        {pathEntry && onAddToPath ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <Button variant="secondary" size="sm" onClick={onAddToPath}>{t.addToPath}</Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -204,6 +215,8 @@ export function WizardScreen({
   onDetect,
   onInstall,
   commandPreviews = {},
+  pathOffers = {},
+  onAddToPath,
 }) {
   const t = W[lang] || W.zh;
   const promptText = mcpReady ? externalClientSetupPrompt({
@@ -271,6 +284,11 @@ export function WizardScreen({
                 state={stepStates[id] || EMPTY_STEPS[id]}
                 t={t}
                 onDetect={() => onDetect && onDetect(id)}
+                hint={id === 'claude' ? t.claudeInstallHint : (pathOffers[id] ? t.pathHint : '')}
+                commandPreview={commandPreviews[id] || ''}
+                onInstall={() => onInstall && onInstall(id)}
+                pathEntry={pathOffers[id]}
+                onAddToPath={() => onAddToPath && onAddToPath(id)}
               />
             ))}
             <div>
@@ -347,10 +365,12 @@ export function WizardScreen({
                 label={t.optionalNode}
                 state={stepStates[id] || EMPTY_STEPS[id]}
                 t={t}
-                hint={t.optionalNodeHint}
+                hint={pathOffers[id] ? `${t.optionalNodeHint} ${t.pathHint}` : t.optionalNodeHint}
                 commandPreview={commandPreviews[id] || ''}
                 onDetect={() => onDetect && onDetect(id)}
                 onInstall={() => onInstall && onInstall(id)}
+                pathEntry={pathOffers[id]}
+                onAddToPath={() => onAddToPath && onAddToPath(id)}
               />
             ))}
           </React.Fragment>

--- a/plugin/panel/test/channelCard.test.js
+++ b/plugin/panel/test/channelCard.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import {
   channelChoiceState,
   channelCopiedLabel,
@@ -52,4 +53,24 @@ test('channelChoiceState marks exactly the enabled row (#229)', () => {
   assert.deepEqual(channelChoiceState('custom', 'cli', 'zh'), { label: '使用此通道', active: false });
   assert.deepEqual(channelChoiceState('cli', 'cli', 'en'), { label: 'In use', active: true });
   assert.deepEqual(channelChoiceState('custom', 'cli', 'en'), { label: 'Use this channel', active: false });
+});
+
+test('ChannelCard renders settled login actions as primary buttons with waiting state', () => {
+  const source = readFileSync(
+    new URL('../src/components/settings/ChannelCard.jsx', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /probe\.loginAction/);
+  assert.match(source, /variant="primary"/);
+  assert.match(source, /loginWaiting/);
+  assert.match(source, /onLogin\(probe, loginAction\)/);
+});
+
+test('Settings login actions are wired to App-level side effects', () => {
+  const settings = readFileSync(new URL('../src/screens/SettingsScreen.jsx', import.meta.url), 'utf8');
+  const app = readFileSync(new URL('../src/app/App.jsx', import.meta.url), 'utf8');
+  assert.match(settings, /onLogin=\{onLoginChannel\}/);
+  assert.match(app, /platform\.openLoginTerminal\('claude'\)/);
+  assert.match(app, /startCodexLogin\(\{/);
+  assert.match(app, /LOGIN_POLL_INTERVAL_MS = 5000/);
 });

--- a/plugin/panel/test/channels.test.js
+++ b/plugin/panel/test/channels.test.js
@@ -6,6 +6,7 @@ import {
   migrateBackendPref,
   openCodeChannels,
 } from '../src/lib/channels.js';
+import { ERROR_CODES } from '../src/lib/errorCodes.js';
 
 test('Claude and Codex expose one CLI-owned channel each', () => {
   assert.deepEqual(
@@ -33,7 +34,7 @@ test('Codex exposes failed probe detail instead of only successful identity fiel
   assert.equal(channels[0].detail, 'probe timeout: account/read');
 });
 
-test('Codex logged-out guidance exposes the isolated Windows login command', () => {
+test('Codex logged-out guidance exposes one-click isolated login', () => {
   const channel = codexChannels({
     codexProbe: {
       loggedIn: false,
@@ -42,11 +43,26 @@ test('Codex logged-out guidance exposes the isolated Windows login command', () 
       platformId: 'windows-x64',
     },
   })[0];
-  const command = "$env:CODEX_HOME='C:\\Users\\test\\.ae-mcp\\codex-home'; codex login";
   assert.match(channel.fixHint.zh, /C:\\Users\\test\\\.ae-mcp\\codex-home/);
-  assert.match(channel.fixHint.zh, /\$env:CODEX_HOME/);
   assert.match(channel.fixHint.en, /C:\\Users\\test\\\.ae-mcp\\codex-home/);
-  assert.match(channel.fixHint.en, /\$env:CODEX_HOME/);
+  assert.equal(channel.copyAction, undefined);
+  assert.deepEqual(channel.loginAction, {
+    label: { zh: '一键登录', en: 'One-click sign-in' },
+    kind: 'headless',
+  });
+});
+
+test('Codex automatic-login fallback exposes the isolated Windows command', () => {
+  const channel = codexChannels({
+    codexProbe: {
+      loggedIn: false,
+      runtimeOk: true,
+      codexHome: 'C:\\Users\\test\\.ae-mcp\\codex-home',
+      platformId: 'windows-x64',
+    },
+    loginFallback: true,
+  })[0];
+  const command = "$env:CODEX_HOME='C:\\Users\\test\\.ae-mcp\\codex-home'; codex login";
   assert.deepEqual(channel.copyAction, {
     label: { zh: '复制登录命令', en: 'Copy login command' },
     text: command,
@@ -61,6 +77,7 @@ test('Codex logged-out guidance uses POSIX syntax on macOS', () => {
       codexHome: '/Users/t/.ae-mcp/codex-home',
       platformId: 'macos-arm64',
     },
+    loginFallback: true,
   })[0];
   assert.equal(
     channel.copyAction.text,
@@ -92,6 +109,27 @@ test('Codex successful and pending probes do not expose copy actions', () => {
     },
   })[0].copyAction, undefined);
   assert.equal(codexChannels({ codexProbe: null })[0].copyAction, undefined);
+  assert.equal(codexChannels({ codexProbe: null })[0].loginAction, undefined);
+});
+
+test('Claude auth-required channel opens a login window from the card', () => {
+  const channel = claudeChannels({
+    probe: { loggedIn: false, cliOk: true, reason: 'not-logged-in' },
+  })[0];
+  assert.deepEqual(channel.loginAction, {
+    label: { zh: '打开登录窗口', en: 'Open sign-in window' },
+    kind: 'terminal',
+  });
+  assert.equal(channel.fixHint.zh, '在打开的窗口中输入 /login 完成登录，本页会自动刷新。');
+});
+
+test('Claude hides login action when the platform cannot open a terminal', () => {
+  const channel = claudeChannels({
+    probe: { loggedIn: false, cliOk: true, reason: 'not-logged-in' },
+    canOpenLoginTerminal: false,
+  })[0];
+  assert.equal(channel.loginAction, undefined);
+  assert.match(channel.fixHint.zh, /OpenCode Provider/);
 });
 
 test('Claude probe timeout guidance is different from not-logged-in guidance', () => {
@@ -117,4 +155,46 @@ test('unknown persisted backend choices reset to subscription', () => {
   const migrated = migrateBackendPref(storage);
   assert.equal(migrated.pref, 'subscription');
   assert.equal(values.get('ae_mcp_backend'), 'subscription');
+});
+
+test('fresh installs default to OpenCode while stored subscription remains unchanged', () => {
+  const freshValues = new Map();
+  const fresh = {
+    getItem: (key) => freshValues.get(key) ?? null,
+    setItem: (key, value) => freshValues.set(key, value),
+    removeItem: (key) => freshValues.delete(key),
+  };
+  assert.equal(migrateBackendPref(fresh).pref, 'opencode');
+
+  const storedValues = new Map([['ae_mcp_backend', 'subscription']]);
+  const stored = {
+    getItem: (key) => storedValues.get(key) ?? null,
+    setItem: (key, value) => storedValues.set(key, value),
+    removeItem: (key) => storedValues.delete(key),
+  };
+  assert.equal(migrateBackendPref(stored).pref, 'subscription');
+  assert.equal(storedValues.get('ae_mcp_backend'), 'subscription');
+});
+
+test('channel and error guidance never leaves a terminal instruction without an action', () => {
+  const channels = [
+    ...claudeChannels({ probe: { loggedIn: false, cliOk: true, reason: 'not-logged-in' } }),
+    ...codexChannels({
+      codexProbe: {
+        loggedIn: false,
+        runtimeOk: true,
+        codexHome: 'C:\\isolated-codex-home',
+        platformId: 'windows-x64',
+      },
+      loginFallback: true,
+    }),
+    ...openCodeChannels({ probe: { loggedIn: false }, providers: [{ needsApiKey: false }] }),
+  ];
+  for (const channel of channels) {
+    const hasTerminalInstruction = /在终端/.test(channel.fixHint?.zh || '');
+    assert.ok(!hasTerminalInstruction || channel.copyAction || channel.loginAction, channel.channel);
+  }
+  for (const item of Object.values(ERROR_CODES)) {
+    assert.doesNotMatch(item.hint.zh, /在终端/, item.code);
+  }
 });

--- a/plugin/panel/test/codexHeadlessLogin.test.js
+++ b/plugin/panel/test/codexHeadlessLogin.test.js
@@ -1,0 +1,108 @@
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startCodexLogin } from '../src/cep/codexHeadlessLogin.js';
+
+class FakeStream extends EventEmitter {
+  setEncoding() {}
+}
+
+class FakeChild extends EventEmitter {
+  constructor() {
+    super();
+    this.stdout = new FakeStream();
+    this.stderr = new FakeStream();
+    this.killCount = 0;
+  }
+
+  kill() {
+    this.killCount += 1;
+    return true;
+  }
+}
+
+function createAdapter(child = new FakeChild()) {
+  const calls = { resolve: [], spawn: [] };
+  return {
+    child,
+    calls,
+    adapter: {
+      completeSpawnEnv(base, additions) {
+        return { PATH: 'inherited-path', ...base, ...additions };
+      },
+      async resolveExecutable(id, options) {
+        calls.resolve.push({ id, options });
+        return { ok: true, id, path: 'codex', argsPrefix: [], source: 'path' };
+      },
+      spawn(executable, args, options) {
+        calls.spawn.push({ executable, args, options });
+        return child;
+      },
+    },
+  };
+}
+
+function spawned() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('startCodexLogin extracts the first complete https URL across chunks', async () => {
+  const fake = createAdapter();
+  const urls = [];
+  const login = startCodexLogin({
+    adapter: fake.adapter,
+    codexHome: 'C:\\panel-codex',
+    onUrl: (url) => urls.push(url),
+  });
+  await spawned();
+  fake.child.stdout.emit('data', 'Open https://example');
+  fake.child.stdout.emit('data', '.com/device\nIgnore https://second.example/\n');
+  fake.child.emit('exit', 0, null);
+  await login.promise;
+  assert.deepEqual(urls, ['https://example.com/device']);
+});
+
+test('startCodexLogin inherits the environment, completes, and calls onDone', async () => {
+  const fake = createAdapter();
+  const completed = [];
+  const login = startCodexLogin({
+    adapter: fake.adapter,
+    codexHome: '/panel/codex-home',
+    onUrl: () => {},
+    onDone: (result) => completed.push(result),
+  });
+  await spawned();
+  fake.child.stderr.emit('data', 'https://auth.example/device\n');
+  fake.child.emit('close', 0, null);
+  const result = await login.promise;
+  assert.deepEqual(fake.calls.spawn[0].args, ['login']);
+  assert.deepEqual(fake.calls.spawn[0].options.env, {
+    PATH: 'inherited-path',
+    CODEX_HOME: '/panel/codex-home',
+  });
+  assert.deepEqual(completed, [result]);
+});
+
+test('startCodexLogin kills the child when the URL timeout triggers fallback', async () => {
+  const fake = createAdapter();
+  const login = startCodexLogin({
+    adapter: fake.adapter,
+    codexHome: '/panel/codex-home',
+    urlTimeoutMs: 5,
+    timeoutMs: 1000,
+  });
+  await assert.rejects(login.promise, { code: 'CODEX_LOGIN_URL_TIMEOUT' });
+  assert.equal(fake.child.killCount, 1);
+});
+
+test('startCodexLogin cancel kills the active child', async () => {
+  const fake = createAdapter();
+  const login = startCodexLogin({
+    adapter: fake.adapter,
+    codexHome: '/panel/codex-home',
+  });
+  await spawned();
+  login.cancel();
+  await assert.rejects(login.promise, { code: 'CODEX_LOGIN_CANCELLED' });
+  assert.equal(fake.child.killCount, 1);
+});

--- a/plugin/panel/test/platform-process.test.js
+++ b/plugin/panel/test/platform-process.test.js
@@ -168,6 +168,71 @@ test('Windows standard candidates find common fresh CLI installer directories', 
   }
 });
 
+test('Windows prefers the bundled OpenCode runtime after an explicit override', async () => {
+  const calls = [];
+  const bundled = 'C:\\Extensions\\com.aemcp.panel\\runtime\\opencode\\opencode.exe';
+  const pathCopy = 'C:\\Tools\\opencode.exe';
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp',
+    extensionRoot: 'C:\\Extensions\\com.aemcp.panel', env: { Path: 'C:\\Tools' },
+    fs: fakeFs(new Set([bundled, pathCopy]), {}, { [bundled]: pe64(0x8664), [pathCopy]: pe64(0x8664) }),
+    spawnImpl: processFactory([{ stdout: 'opencode 1.18.23' }], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('opencode', { requiredArch: 'x64' });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.path, bundled);
+  assert.equal(result.source, 'runtime');
+  assert.deepEqual(calls.map((call) => call.file), [bundled]);
+});
+
+test('Windows OpenCode runtime lookup is empty without an extension root', async () => {
+  const calls = [];
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp', env: { Path: '' },
+    fs: fakeFs(new Set()), spawnImpl: processFactory([{ code: 1 }, { code: 1 }], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('opencode');
+
+  assert.equal(result.ok, false);
+  assertOnlyRegistryQueries(calls);
+});
+
+test('Windows OpenCode override wins over the bundled runtime', async () => {
+  const calls = [];
+  const override = 'C:\\Override\\opencode.exe';
+  const bundled = 'C:\\Extensions\\com.aemcp.panel\\runtime\\opencode\\opencode.exe';
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp',
+    extensionRoot: 'C:\\Extensions\\com.aemcp.panel', env: { Path: '' },
+    fs: fakeFs(new Set([override, bundled]), {}, { [override]: pe64(0x8664), [bundled]: pe64(0x8664) }),
+    spawnImpl: processFactory([{ stdout: 'opencode 1.19.0' }], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('opencode', { overridePath: override, requiredArch: 'x64' });
+
+  assert.equal(result.path, override);
+  assert.equal(result.source, 'override');
+});
+
+test('Windows OpenCode falls back to PATH when the bundled runtime is absent', async () => {
+  const calls = [];
+  const pathCopy = 'C:\\Tools\\opencode.exe';
+  const adapter = createWindowsAdapter({
+    platform: 'win32', arch: 'x64', home: 'C:\\Users\\a', temp: 'C:\\Temp',
+    extensionRoot: 'C:\\Extensions\\com.aemcp.panel', env: { Path: 'C:\\Tools' },
+    fs: fakeFs(new Set([pathCopy]), {}, { [pathCopy]: pe64(0x8664) }),
+    spawnImpl: processFactory([{ stdout: 'opencode 1.19.0' }], calls), now: () => 0,
+  });
+
+  const result = await adapter.resolveExecutable('opencode', { requiredArch: 'x64' });
+
+  assert.equal(result.path, pathCopy);
+  assert.equal(result.source, 'path');
+});
+
 test('Windows resolution reads expanded registry PATH entries for default environments', async () => {
   const calls = [];
   const executable = 'C:\\Users\\a\\.local\\bin\\claude.exe';

--- a/plugin/panel/test/registryPath.test.js
+++ b/plugin/panel/test/registryPath.test.js
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  addUserPathEntry,
+  readUserPath,
+} from '../src/cep/registryPath.js';
+
+function adapterFor(steps) {
+  const calls = [];
+  return {
+    id: 'windows-x64',
+    calls,
+    resolveExecutable: async (id) => ({
+      ok: true,
+      id,
+      path: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      argsPrefix: [],
+      source: 'standard',
+      version: null,
+      arch: 'x64',
+    }),
+    spawn: (executable, args, options) => {
+      calls.push({ executable, args, options });
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      const step = steps.shift() || {};
+      queueMicrotask(() => {
+        if (step.stdout) child.stdout.emit('data', step.stdout);
+        if (step.stderr) child.stderr.emit('data', step.stderr);
+        if (step.error) child.emit('error', step.error);
+        else child.emit('close', step.code ?? 0);
+      });
+      return child;
+    },
+  };
+}
+
+test('readUserPath parses REG_SZ values', async () => {
+  const adapter = adapterFor([
+    { stdout: '\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_SZ    C:\\Tools;C:\\Other\r\n' },
+  ]);
+
+  assert.deepEqual(await readUserPath(adapter), {
+    value: 'C:\\Tools;C:\\Other',
+    type: 'REG_SZ',
+  });
+});
+
+test('readUserPath parses REG_EXPAND_SZ values and defaults missing values', async () => {
+  const expanded = adapterFor([
+    { stdout: '    Path    REG_EXPAND_SZ    %USERPROFILE%\\.local\\bin\r\n' },
+  ]);
+  assert.deepEqual(await readUserPath(expanded), {
+    value: '%USERPROFILE%\\.local\\bin',
+    type: 'REG_EXPAND_SZ',
+  });
+
+  const missing = adapterFor([{ code: 1, stderr: 'ERROR: The system was unable to find the specified registry key.' }]);
+  assert.deepEqual(await readUserPath(missing), { value: '', type: 'REG_EXPAND_SZ' });
+});
+
+test('addUserPathEntry deduplicates case-insensitively and ignores trailing slashes', async () => {
+  const adapter = adapterFor([
+    { stdout: '    Path    REG_SZ    C:\\Tools\\;C:\\Other\r\n' },
+  ]);
+
+  assert.deepEqual(await addUserPathEntry(adapter, 'c:/tools'), { changed: false });
+  assert.equal(adapter.calls.length, 1);
+});
+
+test('addUserPathEntry preserves type, raw variables, semicolon joining, and broadcasts', async () => {
+  const adapter = adapterFor([
+    { stdout: '    Path    REG_EXPAND_SZ    %USERPROFILE%\\.local\\bin;C:\\Tools\r\n' },
+    {},
+    {},
+  ]);
+
+  assert.deepEqual(await addUserPathEntry(adapter, 'C:\\New Tools'), { changed: true });
+  assert.equal(adapter.calls.length, 3);
+  assert.equal(adapter.calls[0].executable.path, 'reg.exe');
+  assert.deepEqual(adapter.calls[0].args, ['query', 'HKCU\\Environment', '/v', 'Path']);
+  assert.equal(adapter.calls[1].executable.path, 'reg.exe');
+  assert.deepEqual(adapter.calls[1].args, [
+    'add', 'HKCU\\Environment', '/v', 'Path', '/t', 'REG_EXPAND_SZ',
+    '/d', '%USERPROFILE%\\.local\\bin;C:\\Tools;C:\\New Tools', '/f',
+  ]);
+  assert.match(adapter.calls[2].executable.path, /powershell\.exe$/i);
+  assert.equal(adapter.calls[2].args[0], '-NoProfile');
+  assert.equal(adapter.calls[2].args[1], '-Command');
+  assert.match(adapter.calls[2].args[2], /HWND_BROADCAST/);
+  assert.match(adapter.calls[2].args[2], /WM_SETTINGCHANGE/);
+  assert.match(adapter.calls[2].args[2], /SMTO_ABORTIFHUNG/);
+  assert.match(adapter.calls[2].args[2], /SendMessageTimeout/);
+  assert.equal(adapter.calls.some((call) => call.args.some((arg) => /setx/i.test(arg))), false);
+});
+
+test('broadcast failure does not turn a completed user PATH write into a failure', async () => {
+  const adapter = adapterFor([
+    { stdout: '    Path    REG_SZ    C:\\Tools\r\n' },
+    {},
+    { code: 1, stderr: 'broadcast failed' },
+  ]);
+
+  assert.deepEqual(await addUserPathEntry(adapter, 'C:\\New'), { changed: true });
+});

--- a/plugin/panel/test/wizardActions.test.js
+++ b/plugin/panel/test/wizardActions.test.js
@@ -7,9 +7,10 @@ import {
   runAction,
 } from '../src/cep/wizardActions.js';
 
-function platform(resolutions = {}) {
+function platform(resolutions = {}, id = 'windows-x64') {
   const calls = [];
   return {
+    id,
     calls,
     resolveExecutable: async (id, options) => {
       calls.push({ kind: 'resolve', id, options });
@@ -114,10 +115,24 @@ test('detectTool uses existing platform probes for all three AI CLIs', async () 
   assert.deepEqual(p.calls[3].options, { minimumVersion: '18.0.0' });
 });
 
-test('buildInstallCommands retains only the optional system Node command', () => {
+test('buildInstallCommands includes the official Claude installer on Windows', () => {
   const commands = buildInstallCommands({ platform: platform() });
-  assert.deepEqual(Object.keys(commands), ['node']);
+  assert.deepEqual(Object.keys(commands), ['node', 'claude']);
   assert.deepEqual(commands.node.args, ['install', '--id', 'OpenJS.NodeJS.LTS']);
+  assert.deepEqual(commands.claude, {
+    file: 'powershell',
+    executableId: 'powershell',
+    args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', 'irm https://claude.ai/install.ps1 | iex'],
+  });
+  assert.equal(
+    commandPreview(commands.claude),
+    'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://claude.ai/install.ps1 | iex"',
+  );
+});
+
+test('buildInstallCommands omits the Windows-only Claude installer on macOS', () => {
+  const commands = buildInstallCommands({ platform: platform({}, 'macos-arm64') });
+  assert.deepEqual(Object.keys(commands), ['node']);
 });
 
 test('runAction resolves the fixed installer and retains streamed output', async () => {

--- a/plugin/panel/test/wizardSteps.test.js
+++ b/plugin/panel/test/wizardSteps.test.js
@@ -54,3 +54,16 @@ test('optional Node install failure keeps its log tail', () => {
   assert.equal(state.node.status, 'fail');
   assert.ok(state.node.logTail.includes('boom'));
 });
+
+test('reducer retains detected executable path provenance', () => {
+  const state = stepReducer(initialStepStates(), {
+    type: 'detect-result',
+    id: 'claude',
+    ok: true,
+    version: '2.1.0',
+    path: 'C:\\Users\\a\\.local\\bin\\claude.exe',
+    source: 'standard',
+  });
+  assert.equal(state.claude.path, 'C:\\Users\\a\\.local\\bin\\claude.exe');
+  assert.equal(state.claude.source, 'standard');
+});

--- a/scripts/package/fetch-opencode-runtime.mjs
+++ b/scripts/package/fetch-opencode-runtime.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import { execFile as execFileCallback } from 'node:child_process';
+import fs from 'node:fs';
+import https from 'node:https';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { promisify } from 'node:util';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const execFile = promisify(execFileCallback);
+const SHA256 = /^[a-f0-9]{64}$/;
+const MAX_REDIRECTS = 5;
+
+function runtimeError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+export function validateRuntimeManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object'
+      || typeof manifest.version !== 'string'
+      || typeof manifest.url !== 'string'
+      || !SHA256.test(manifest.sha256 || '')
+      || !Number.isSafeInteger(manifest.sizeBytes)
+      || manifest.sizeBytes <= 0
+      || manifest.binary !== 'opencode.exe') {
+    throw runtimeError('OPENCODE_RUNTIME_MANIFEST_INVALID', 'OpenCode runtime manifest is invalid');
+  }
+  return manifest;
+}
+
+export async function verifyDownloadedArtifact({ filePath, manifest, fsPromises = fs.promises }) {
+  validateRuntimeManifest(manifest);
+  try {
+    const [stats, bytes] = await Promise.all([
+      fsPromises.stat(filePath),
+      fsPromises.readFile(filePath),
+    ]);
+    if (!stats.isFile() || stats.size !== manifest.sizeBytes || bytes.length !== manifest.sizeBytes) {
+      throw runtimeError('OPENCODE_RUNTIME_SIZE_MISMATCH', 'OpenCode runtime download size does not match the pinned manifest');
+    }
+    const sha256 = createHash('sha256').update(bytes).digest('hex');
+    if (sha256 !== manifest.sha256) {
+      throw runtimeError('OPENCODE_RUNTIME_HASH_MISMATCH', 'OpenCode runtime download SHA-256 does not match the pinned manifest');
+    }
+  } catch (error) {
+    await fsPromises.rm(filePath, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+function download(url, destination, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      const redirect = response.headers.location;
+      if ([301, 302, 303, 307, 308].includes(response.statusCode) && redirect) {
+        response.resume();
+        if (redirects >= MAX_REDIRECTS) {
+          reject(runtimeError('OPENCODE_RUNTIME_REDIRECT_LIMIT', 'OpenCode runtime download exceeded redirect limit'));
+          return;
+        }
+        download(new URL(redirect, url), destination, redirects + 1).then(resolve, reject);
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(runtimeError('OPENCODE_RUNTIME_DOWNLOAD_FAILED', `OpenCode runtime download returned HTTP ${response.statusCode}`));
+        return;
+      }
+      pipeline(response, fs.createWriteStream(destination, { flags: 'wx' })).then(resolve, reject);
+    });
+    request.once('error', reject);
+  });
+}
+
+async function hasValidReceipt(stagingRoot, manifest) {
+  try {
+    const [receiptBytes, binary] = await Promise.all([
+      fs.promises.readFile(path.join(stagingRoot, 'staged.json'), 'utf8'),
+      fs.promises.lstat(path.join(stagingRoot, manifest.binary)),
+    ]);
+    const receipt = JSON.parse(receiptBytes);
+    return binary.isFile() && !binary.isSymbolicLink()
+      && receipt.version === manifest.version
+      && receipt.sha256 === manifest.sha256
+      && typeof receipt.stagedAt === 'string';
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchOpenCodeRuntime({
+  manifestPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'opencode-runtime.json'),
+  stagingRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), 'runtime-staging', 'opencode'),
+  force = false,
+  execFileImpl = execFile,
+} = {}) {
+  const manifest = validateRuntimeManifest(JSON.parse(await fs.promises.readFile(manifestPath, 'utf8')));
+  if (!force && await hasValidReceipt(stagingRoot, manifest)) {
+    return { staged: false, stagingRoot, version: manifest.version };
+  }
+
+  const stagingParent = path.dirname(stagingRoot);
+  await fs.promises.mkdir(stagingParent, { recursive: true });
+  const archive = path.join(stagingParent, `.opencode-${process.pid}-${randomUUID()}.zip`);
+  const extracted = path.join(stagingParent, `.opencode-${process.pid}-${randomUUID()}`);
+  try {
+    await download(manifest.url, archive);
+    await verifyDownloadedArtifact({ filePath: archive, manifest });
+    await fs.promises.mkdir(extracted, { recursive: true });
+    // Zip extraction needs bsdtar. On Windows, Git for Windows often puts MSYS
+    // GNU tar first on PATH, which cannot read zip archives and parses the
+    // drive-letter colon in absolute paths as a remote host spec — so pin the
+    // System32 bsdtar and keep the arguments cwd-relative.
+    const tarExecutable = process.platform === 'win32'
+      ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe')
+      : 'tar';
+    await execFileImpl(tarExecutable, ['-xf', path.basename(archive), '-C', path.basename(extracted), manifest.binary], {
+      cwd: stagingParent,
+      windowsHide: true,
+      maxBuffer: 1024 * 1024,
+    });
+    const binary = path.join(extracted, manifest.binary);
+    const stats = await fs.promises.lstat(binary);
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+      throw runtimeError('OPENCODE_RUNTIME_EXTRACT_INVALID', 'OpenCode runtime archive did not contain one regular opencode.exe');
+    }
+    await fs.promises.writeFile(path.join(extracted, 'staged.json'), `${JSON.stringify({
+      version: manifest.version,
+      sha256: manifest.sha256,
+      stagedAt: new Date().toISOString(),
+    })}\n`, { flag: 'wx', mode: 0o600 });
+    await fs.promises.rm(stagingRoot, { recursive: true, force: true });
+    await fs.promises.rename(extracted, stagingRoot);
+    return { staged: true, stagingRoot, version: manifest.version };
+  } catch (error) {
+    await fs.promises.rm(extracted, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  } finally {
+    await fs.promises.rm(archive, { force: true }).catch(() => {});
+  }
+}
+
+function parseCli(argv) {
+  if (argv.length === 0) return { force: false };
+  if (argv.length === 1 && argv[0] === '--force') return { force: true };
+  throw runtimeError('OPENCODE_RUNTIME_ARGUMENT_INVALID', 'only --force is supported');
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  fetchOpenCodeRuntime(parseCli(process.argv.slice(2))).then((result) => {
+    process.stdout.write(result.staged
+      ? `OpenCode runtime staged: ${result.version}\n`
+      : `OpenCode runtime already staged: ${result.version}\n`);
+  }).catch((error) => {
+    process.stderr.write(`${error.code ?? 'OPENCODE_RUNTIME_FETCH_FAILED'}: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/package/opencode-runtime.json
+++ b/scripts/package/opencode-runtime.json
@@ -1,0 +1,7 @@
+{
+  "binary": "opencode.exe",
+  "sha256": "a2fe9e8c2d074d26975024d494927b966680b3efdc3e0377eadb9afb05f7e191",
+  "sizeBytes": 60643761,
+  "url": "https://github.com/sst/opencode/releases/download/v1.18.23/opencode-windows-x64.zip",
+  "version": "v1.18.23"
+}

--- a/scripts/package/stage-platform-bundle.mjs
+++ b/scripts/package/stage-platform-bundle.mjs
@@ -12,6 +12,7 @@ import {
   bundleError,
   collectManifestEntries,
   copyTree,
+  copyRegularFileStable,
   sha256File,
   validateBundleManifest,
   writeCanonicalJson,
@@ -22,12 +23,14 @@ import {
 } from './lib/native-plugin-manifest.mjs';
 import {
   DEVELOPMENT_IDENTITY_PROFILE,
+  RELEASE_AUDIT_IDENTITY_PROFILE,
   normalizeIdentityVerificationProfile,
 } from './lib/identity-verification-profile.mjs';
 import { verifyPlatformBundle } from './verify-platform-bundle.mjs';
 
 const execFileAsync = promisify(execFile);
 const PAYLOAD_DIRECTORIES = Object.freeze(['client', 'CSXS', 'host', 'icons', 'jsx', 'shared']);
+const OPENCODE_RUNTIME_RELATIVE_PATH = 'runtime/opencode/opencode.exe';
 
 function payloadFilter(relative) {
   const segments = relative.split('/');
@@ -91,6 +94,8 @@ export async function stagePlatformBundle({
   );
   const nativePluginRoot = inputs.nativePluginRoot === undefined
     ? undefined : path.resolve(inputs.nativePluginRoot);
+  const runtimeStagingRoot = path.resolve(inputs.runtimeStagingRoot
+    ?? path.join(resolvedRepoRoot, 'scripts', 'package', 'runtime-staging', 'opencode'));
   if (nativePluginRoot !== undefined && platform !== 'macos-arm64') {
     throw bundleError(
       'BUNDLE_NATIVE_PLUGIN_PLATFORM_INVALID',
@@ -114,6 +119,21 @@ export async function stagePlatformBundle({
         path.join(temporary, directory),
         { filter: payloadFilter },
       );
+    }
+    if (platform === 'windows-x64') {
+      const stagedRuntime = path.join(runtimeStagingRoot, 'opencode.exe');
+      const runtimeStats = await fs.promises.lstat(stagedRuntime).catch(() => null);
+      if (runtimeStats?.isFile() && !runtimeStats.isSymbolicLink() && runtimeStats.nlink === 1) {
+        const destinationRuntime = path.join(temporary, ...OPENCODE_RUNTIME_RELATIVE_PATH.split('/'));
+        await fs.promises.mkdir(path.dirname(destinationRuntime), { recursive: true });
+        await copyRegularFileStable(stagedRuntime, destinationRuntime, { expectedStats: runtimeStats });
+      } else {
+        const message = 'WARNING: OpenCode runtime is not staged; run node scripts/package/fetch-opencode-runtime.mjs before packaging.';
+        (dependencies.warnImpl ?? console.warn)(message);
+        if (profile === RELEASE_AUDIT_IDENTITY_PROFILE) {
+          throw bundleError('BUNDLE_OPENCODE_RUNTIME_MISSING', message);
+        }
+      }
     }
     await fs.promises.mkdir(path.join(temporary, 'metadata'), { recursive: true });
     await fs.promises.copyFile(

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -129,6 +129,11 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
   await fs.promises.mkdir(repoRoot, { recursive: true });
   await writePlugin(repoRoot);
   await writePackaging(repoRoot);
+  const runtimeStagingRoot = path.join(root, 'runtime-staging', 'opencode');
+  if (platform === 'windows-x64') {
+    await writeFixtureFile(runtimeStagingRoot, 'opencode.exe', 'fixture opencode runtime\n', 0o755);
+  }
+  const defaultInputs = platform === 'windows-x64' ? { runtimeStagingRoot } : {};
   const input = {
     platform,
     version: PRODUCT_VERSION,
@@ -137,6 +142,7 @@ export async function makeStageHarness(t, platform = 'macos-arm64', overrides = 
     sourceCommitSha: SOURCE_COMMIT_SHA,
     verificationProfile: 'release-audit',
     ...overrides,
+    inputs: { ...defaultInputs, ...(overrides.inputs || {}) },
   };
   return {
     root,

--- a/scripts/package/test/opencode-runtime-contract.test.mjs
+++ b/scripts/package/test/opencode-runtime-contract.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { verifyDownloadedArtifact } from '../fetch-opencode-runtime.mjs';
+import { stagePlatformBundle } from '../stage-platform-bundle.mjs';
+import { makeStageHarness, writeFixtureFile } from './helpers/platform-bundle-fixture.mjs';
+
+test('Windows stage includes the pinned OpenCode runtime when it is staged', async (t) => {
+  const h = await makeStageHarness(t, 'windows-x64');
+  await stagePlatformBundle(h.input);
+
+  assert.equal(h.exists('runtime/opencode/opencode.exe'), true);
+  assert.equal(h.manifest().files.some((entry) => entry.path === 'runtime/opencode/opencode.exe'), true);
+});
+
+test('Windows development stage warns while release-audit stage rejects a missing OpenCode runtime', async (t) => {
+  const development = await makeStageHarness(t, 'windows-x64', {
+    verificationProfile: 'development',
+    inputs: { runtimeStagingRoot: path.join(os.tmpdir(), 'missing-opencode-runtime') },
+  });
+  const warnings = [];
+  await stagePlatformBundle({
+    ...development.input,
+    dependencies: { warnImpl: (message) => warnings.push(message) },
+  });
+  assert.equal(development.exists('runtime/opencode/opencode.exe'), false);
+  assert.deepEqual(warnings, [
+    'WARNING: OpenCode runtime is not staged; run node scripts/package/fetch-opencode-runtime.mjs before packaging.',
+  ]);
+
+  const release = await makeStageHarness(t, 'windows-x64', {
+    inputs: { runtimeStagingRoot: path.join(os.tmpdir(), 'missing-opencode-runtime') },
+  });
+  await assert.rejects(stagePlatformBundle({
+    ...release.input,
+    dependencies: { warnImpl() {} },
+  }), { code: 'BUNDLE_OPENCODE_RUNTIME_MISSING' });
+  assert.equal(release.exists('runtime/opencode/opencode.exe'), false);
+});
+
+test('OpenCode runtime verification removes a hash-mismatched download', async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ae-mcp-opencode-runtime-'));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const archive = await writeFixtureFile(root, 'opencode.zip', Buffer.from('tiny'));
+  const manifest = {
+    version: 'v-test',
+    url: 'https://example.invalid/opencode.zip',
+    sizeBytes: 4,
+    sha256: createHash('sha256').update('different').digest('hex'),
+    binary: 'opencode.exe',
+  };
+
+  await assert.rejects(verifyDownloadedArtifact({ filePath: archive, manifest }), {
+    code: 'OPENCODE_RUNTIME_HASH_MISMATCH',
+  });
+  await assert.rejects(fs.access(archive));
+});

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -30,6 +30,7 @@ async function fixture(t) {
     'jsx/runtime.jsx',
     'shared/chat-attachments.mjs',
     'shared/tool-approval.mjs',
+    'runtime/opencode/opencode.exe',
   ];
   for (const file of files) {
     let value = '{}\n';
@@ -51,7 +52,7 @@ test('accepts the direct host and panel ZXP payload', async (t) => {
   const result = verifyWindowsZxpStage({ stageRoot: root, version: VERSION });
   assert.equal(result.platform, 'windows-x64');
   assert.equal(result.version, VERSION);
-  assert.equal(result.fileCount, 13);
+  assert.equal(result.fileCount, 14);
 });
 
 test('rejects retired roots and nested native binaries', async (t) => {
@@ -59,7 +60,7 @@ test('rejects retired roots and nested native binaries', async (t) => {
   await write(root, 'runtime/windows-x64/node/node.exe', 'node');
   assert.throws(
     () => verifyWindowsZxpStage({ stageRoot: root, version: VERSION }),
-    /retired ZXP payload root/,
+    /unexpected runtime payload/,
   );
 
   const nativeRoot = await fixture(t);

--- a/scripts/package/verify-platform-bundle.mjs
+++ b/scripts/package/verify-platform-bundle.mjs
@@ -19,8 +19,9 @@ import {
 } from './lib/identity-verification-profile.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const PAYLOAD_ROOTS = new Set(['CSXS', 'client', 'host', 'icons', 'jsx', 'metadata', 'shared']);
-const FORBIDDEN_ROOTS = new Set(['bin', 'helper', 'panel', 'platform', 'runtime', 'sidecar']);
+const PAYLOAD_ROOTS = new Set(['CSXS', 'client', 'host', 'icons', 'jsx', 'metadata', 'runtime', 'shared']);
+const FORBIDDEN_ROOTS = new Set(['bin', 'helper', 'panel', 'platform', 'sidecar']);
+const OPENCODE_RUNTIME_PATH = 'runtime/opencode/opencode.exe';
 
 async function verifyEntry(expected, actual, exactIdentity) {
   if (!actual || expected.type !== actual.type || expected.size !== actual.size
@@ -33,7 +34,7 @@ async function verifyEntry(expected, actual, exactIdentity) {
   }
 }
 
-function assertProductionFileSet(entries) {
+function assertProductionFileSet(platform, entries) {
   for (const entry of entries) {
     const root = entry.path.split('/')[0];
     if (FORBIDDEN_ROOTS.has(root)) {
@@ -42,8 +43,12 @@ function assertProductionFileSet(entries) {
     if (!PAYLOAD_ROOTS.has(root) && root !== 'artifacts') {
       throw bundleError('BUNDLE_UNEXPECTED_ROOT', `unexpected staged root: ${entry.path}`);
     }
+    if (root === 'runtime' && (platform !== 'windows-x64' || entry.path !== OPENCODE_RUNTIME_PATH)) {
+      throw bundleError('BUNDLE_RUNTIME_PAYLOAD_INVALID', `unexpected runtime payload: ${entry.path}`);
+    }
     if (/(?:\.dll|\.dylib|\.node|\.pyd|\.so|\.exe)$/i.test(entry.path)
-        && !entry.path.startsWith(`${NATIVE_PLUGIN_ROOT}/`)) {
+        && !entry.path.startsWith(`${NATIVE_PLUGIN_ROOT}/`)
+        && entry.path !== OPENCODE_RUNTIME_PATH) {
       throw bundleError(
         'BUNDLE_NATIVE_PAYLOAD_FORBIDDEN',
         `nested native payload is forbidden: ${entry.path}`,
@@ -118,7 +123,7 @@ export async function verifyPlatformBundle({
     throw bundleError('BUNDLE_FILE_SET_MISMATCH', 'bundle file set does not match manifest');
   }
   for (const entry of manifest.files) await verifyEntry(entry, actualByPath.get(entry.path), exactIdentity);
-  assertProductionFileSet(actual);
+  assertProductionFileSet(platform, actual);
   await verifyHostContract(resolvedRoot, actual);
 
   const nativeEntries = actual.filter((entry) => (

--- a/scripts/package/verify-windows-zxp-stage.mjs
+++ b/scripts/package/verify-windows-zxp-stage.mjs
@@ -26,9 +26,9 @@ const FORBIDDEN_TOP_LEVEL = new Set([
   'helper',
   'panel',
   'platform',
-  'runtime',
   'sidecar',
 ]);
+const OPENCODE_RUNTIME_PATH = 'runtime/opencode/opencode.exe';
 
 function contractError(message) {
   const error = new Error(message);
@@ -70,11 +70,15 @@ function validatePayloadBoundary(stageRoot, files) {
     if (FORBIDDEN_TOP_LEVEL.has(topLevel)) {
       throw contractError(`retired ZXP payload root is present: ${topLevel}`);
     }
-    if (/\.(?:dll|dylib|node|so|exe)$/i.test(relativePath)) {
+    if (topLevel === 'runtime' && relativePath !== OPENCODE_RUNTIME_PATH) {
+      throw contractError(`unexpected runtime payload is present: ${relativePath}`);
+    }
+    if (/\.(?:dll|dylib|node|so|exe)$/i.test(relativePath) && relativePath !== OPENCODE_RUNTIME_PATH) {
       throw contractError(`nested native binary is not allowed in ZXP: ${relativePath}`);
     }
   }
   for (const required of REQUIRED_FILES) regularFile(path.join(stageRoot, ...required.split('/')));
+  regularFile(path.join(stageRoot, ...OPENCODE_RUNTIME_PATH.split('/')));
   const manifest = JSON.parse(fs.readFileSync(path.join(stageRoot, 'host/package.json'), 'utf8'));
   if (manifest.dependencies?.express !== '4.22.2') {
     throw contractError('host Express dependency is not pinned to 4.22.2');


### PR DESCRIPTION
## 一句话

新用户从装上 ZXP 到用起来,全程不需要打开终端:OpenCode 随包内置、登录按钮化、Claude 一键代装、全新安装默认 OpenCode Provider。落地 #321 的产品向诉求与 owner 拍板的 D1–D5。

## 修了什么

- **内置 OpenCode(Terra)**:`scripts/package/fetch-opencode-runtime.mjs` 按钉死清单(v1.18.23,SHA-256 校验)拉取官方产物入 staging(gitignored);ZXP 打包收录 `runtime/opencode/opencode.exe`,**release 构建缺产物直接失败**;面板推导 extensionRoot 并把内置版作为 `runtime` 候选组(优先级:env 覆盖 > 内置 > PATH)。
- **登录按钮化 + 默认通道(Sol)**:Claude 通道「打开登录窗口」+ 5s 自动轮询刷新;Codex 通道「一键登录」(隔离 CODEX_HOME 内代跑 `codex login`、抓验证 URL 帮开浏览器、超时/取消清理、失败回退拷命令);全新安装默认 OpenCode Provider(已存偏好原义);所有 fixHint 不再出现无按钮的「在终端运行 X」,并有守卫测试。
- **向导一键装(Luna)**:复用现成安装引擎接入 Claude 官方安装器(来源明示);新 `registryPath` 库免管理员写 HKCU PATH(保 REG_EXPAND_SZ、禁 setx、广播 WM_SETTINGCHANGE),向导中为可选按钮。

## 验证(orchestrator 本机实跑)

- 集成分支:panel **577 过 / 0 挂 / 1 跳**,host **221 过 / 0 挂 / 16 跳**(基线一致),package 契约测试 7/7。
- `npm run build` + `verify-bundle` 绿,dist 已重建提交。
- **fetch 脚本实弹全通**:真实下载→SHA-256 校验→bsdtar 解包→171MB exe 入 staging→重跑秒级 no-op(顺带修了两个真机坑:MSYS GNU tar 读不了 zip 且把盘符冒号当远程主机——已钉 System32 bsdtar + cwd 相对路径)。
- 本轮也是 codex 沙箱修复(WindowsApps pwsh 隐藏)的端到端验证:三 worker 全程 **0 次 CreateProcessAsUserW 错误**。

## 真机验收建议

1. 干净 Windows 机装新 ZXP(先跑 `node scripts/package/fetch-opencode-runtime.mjs` 再打包):面板应默认 OpenCode Provider,填 Base URL+Key 即可用,全程零终端。
2. Claude 通道未登录时点「打开登录窗口」,在窗口里 /login,页面应自动刷新为已登录。
3. Codex 通道点「一键登录」,浏览器应自动打开验证页;完成后通道转绿。
4. 向导里点 Claude 的「安装」,装完复检应直接识别;试「加入系统 PATH」后新开终端 `claude --version` 可用。

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)