### PR TITLE
fix(opencode): stall watchdog ends silent provider turns instead of spinning forever (#327)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -156,6 +156,7 @@ stderr evidence is available.
 | `UPSTREAM_HTTP_<status>` | An upstream service returned a three-digit HTTP status. `401`/`403` are authentication failures. | Use the numeric status to check login, quota, model access, or relay health. |
 | `UPSTREAM_ERROR` | The model/upstream failed without a usable HTTP status. | Check model availability and provider service status. |
 | `EVENT_STREAM_FAILED` | The OpenCode SSE event stream disconnected. | Check the OpenCode process and local network. |
+| `PROVIDER_STREAM_STALLED` | The provider stream was silent for more than five minutes and the turn was stopped. | Check relay or proxy connectivity, then retry. |
 | `TURN_INPUT_INVALID` | The turn or one of its attachments is invalid/unavailable. | Re-select or remove the unavailable attachment. |
 | `TURN_ABORTED` | The user stopped the active turn. | Confirm no write remains unresolved before resending. |
 | `CANCELLED` | The backend cancelled, canceled, or interrupted the request. | Confirm the session is still usable, then retry. |

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -26003,6 +26003,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     UPSTREAM_ERROR: entry("UPSTREAM_ERROR", "model", "\u4E0A\u6E38\u6216\u6A21\u578B\u8FD4\u56DE\u5931\u8D25\uFF1B\u8BF7\u68C0\u67E5\u6A21\u578B\u53EF\u7528\u6027\u4E0E\u670D\u52A1\u72B6\u6001\u3002", "The upstream or model failed; check model availability and service status."),
     UPSTREAM_CONNECTION_CLOSED: entry("UPSTREAM_CONNECTION_CLOSED", "network", "\u4E0A\u6E38\u8FDE\u63A5\u5728\u8FD4\u56DE\u9519\u8BEF\u65F6\u88AB\u4E2D\u65AD\uFF1B\u672C\u8F6E\u4E0D\u4F1A\u81EA\u52A8\u91CD\u53D1\uFF0C\u4E0B\u4E00\u6761\u6D88\u606F\u5C06\u4F7F\u7528\u65B0\u4F1A\u8BDD\u3002", "The upstream connection closed while returning an error. This turn is not retried automatically; the next message uses a fresh session."),
     EVENT_STREAM_FAILED: entry("EVENT_STREAM_FAILED", "network", "\u4E8B\u4EF6\u6D41\u5DF2\u65AD\u5F00\uFF1B\u8BF7\u68C0\u67E5 OpenCode \u8FDB\u7A0B\u4E0E\u672C\u5730\u7F51\u7EDC\u3002", "The event stream disconnected; check the OpenCode process and local network."),
+    PROVIDER_STREAM_STALLED: entry("PROVIDER_STREAM_STALLED", "network", "\u63D0\u4F9B\u65B9\u6D41\u8D85\u8FC7 5 \u5206\u949F\u6CA1\u6709\u54CD\u5E94\uFF0C\u672C\u56DE\u5408\u5DF2\u505C\u6B62\uFF1B\u8BF7\u68C0\u67E5\u4E2D\u8F6C\u6216\u4EE3\u7406\u8FDE\u901A\u6027\u540E\u91CD\u8BD5\u3002", "The provider stream was silent for over five minutes, so the turn was stopped; check relay or proxy connectivity and retry."),
     TURN_INPUT_INVALID: entry("TURN_INPUT_INVALID", "attachment", "\u8BF7\u79FB\u9664\u4E0D\u53EF\u7528\u9644\u4EF6\u6216\u91CD\u65B0\u9009\u62E9\u6587\u4EF6\u3002", "Remove unavailable attachments or select the files again."),
     TURN_ABORTED: entry("TURN_ABORTED", "aborted", "\u672C\u56DE\u5408\u5DF2\u505C\u6B62\uFF0C\u53EF\u5728\u786E\u8BA4\u6CA1\u6709\u672A\u51B3\u5199\u5165\u540E\u91CD\u65B0\u53D1\u9001\u3002", "The turn was stopped; resend after confirming there is no unresolved write."),
     CANCELLED: entry("CANCELLED", "backend", "\u540E\u7AEF\u53D6\u6D88\u4E86\u8BF7\u6C42\uFF1B\u8BF7\u786E\u8BA4\u4F1A\u8BDD\u4ECD\u53EF\u7528\u540E\u91CD\u8BD5\u3002", "The backend cancelled the request; confirm the session is still usable before retrying."),
@@ -31687,6 +31688,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
   var PROBE_TIMEOUT_MS = 4e4;
   var READY_POLL_MS = 250;
   var READY_REQUEST_TIMEOUT_MS = 1500;
+  var OPENCODE_STALL_WARNING_MS = 18e4;
+  var OPENCODE_STALL_TIMEOUT_MS = 3e5;
   var DEFAULT_PROVIDER_ID = "opencode";
   var DEFAULT_MODEL_ID = "hy3-free";
   var STDERR_TAIL_LIMIT3 = 4096;
@@ -31945,12 +31948,20 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     probeTimeoutMs = PROBE_TIMEOUT_MS,
     readyPollMs = READY_POLL_MS,
     readyRequestTimeoutMs = READY_REQUEST_TIMEOUT_MS,
+    stallWarningMs = OPENCODE_STALL_WARNING_MS,
+    stallTimeoutMs = OPENCODE_STALL_TIMEOUT_MS,
+    now = () => Date.now(),
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
     sleepImpl = sleep,
     onSweepComplete
   } = {}) {
     const adapter = platform || createPlatformAdapter();
     if (!Number.isFinite(readyRequestTimeoutMs) || readyRequestTimeoutMs <= 0 || readyRequestTimeoutMs < readyPollMs) {
       throw new RangeError("OpenCode readiness request timeout must be at least the poll interval");
+    }
+    if (!Number.isFinite(stallWarningMs) || !Number.isFinite(stallTimeoutMs) || stallWarningMs <= 0 || stallTimeoutMs <= stallWarningMs) {
+      throw new RangeError("OpenCode stall timeout must be greater than its warning timeout");
     }
     const openCodeRoot = adapter.paths.join([adapter.paths.configRoot, "opencode"]);
     const workspaceDir = adapter.paths.join([openCodeRoot, "workspace"]);
@@ -31987,6 +31998,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     let messageDispatched = false;
     let turnStarted = false;
     let stopRequested = false;
+    let stallTimer = null;
+    let stallLastActivityAt = 0;
+    let stallWarningEmitted = false;
+    let messageAbortController = null;
     let generation = 0;
     let toolMeta = { annotations: {} };
     const pendingApprovals = /* @__PURE__ */ new Map();
@@ -32037,6 +32052,70 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     function emitAfterText(evt) {
       assistantDeltaRedactor.flush();
       emit(evt);
+    }
+    function clearStallWatchdog() {
+      if (stallTimer !== null) clearTimeoutImpl(stallTimer);
+      stallTimer = null;
+      stallLastActivityAt = 0;
+      stallWarningEmitted = false;
+    }
+    function armStallWatchdog() {
+      if (!activeRun || stopRequested || pendingQuestions.size > 0 || pendingApprovals.size > 0) return;
+      if (stallTimer !== null) clearTimeoutImpl(stallTimer);
+      stallLastActivityAt = now();
+      stallWarningEmitted = false;
+      scheduleStallWatchdog();
+    }
+    function touchStallWatchdog() {
+      if (activeRun && !stopRequested) armStallWatchdog();
+    }
+    function suspendStallWatchdogForPendingInteraction() {
+      clearStallWatchdog();
+    }
+    function resumeStallWatchdogAfterPendingInteraction() {
+      if (pendingQuestions.size === 0 && pendingApprovals.size === 0) {
+        armStallWatchdog();
+      }
+    }
+    function scheduleStallWatchdog() {
+      if (!activeRun || stopRequested) return;
+      const elapsedMs = Math.max(0, now() - stallLastActivityAt);
+      const deadline = stallWarningEmitted ? stallTimeoutMs : stallWarningMs;
+      stallTimer = setTimeoutImpl(() => {
+        stallTimer = null;
+        if (!activeRun || stopRequested) return;
+        const currentElapsedMs = Math.max(0, now() - stallLastActivityAt);
+        if (!stallWarningEmitted && currentElapsedMs >= stallWarningMs) {
+          stallWarningEmitted = true;
+          emit({ type: "turn-progress-warning", turnId: activeTurn == null ? void 0 : activeTurn.turnId, elapsedMs: currentElapsedMs, warningMs: stallWarningMs });
+        }
+        if (currentElapsedMs >= stallTimeoutMs) {
+          void terminateStalledTurn();
+        } else {
+          scheduleStallWatchdog();
+        }
+      }, Math.max(1, deadline - elapsedMs));
+    }
+    async function terminateStalledTurn() {
+      if (!activeRun || stopRequested) return;
+      stopRequested = true;
+      messageAbortController == null ? void 0 : messageAbortController.abort();
+      await rejectPendingQuestions();
+      if (sessionId) {
+        await postJson("/session/" + encodeURIComponent(sessionId) + "/abort", {}).catch(() => {
+        });
+      }
+      await drainApprovals();
+      if (activeRun) {
+        emitAfterText({
+          type: "error",
+          kind: "network",
+          code: "PROVIDER_STREAM_STALLED",
+          message: "The OpenCode provider stream was silent for over five minutes, so this turn was stopped.",
+          ...activeTurnFailureFields()
+        });
+        finishActive();
+      }
     }
     function emitTurnProgress(stage) {
       if (!activeRun || !activeTurn) return;
@@ -32248,6 +32327,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       return error;
     }
     function finishActive() {
+      clearStallWatchdog();
       if (!activeResolve) {
         activeRun = null;
         activeAssistantText = "";
@@ -32309,11 +32389,12 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       const response = await request(path, options, requestBaseUrl);
       return response.json ? response.json() : {};
     }
-    async function postJson(path, body) {
+    async function postJson(path, body, signal) {
       return requestJson(path, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(body || {})
+        body: JSON.stringify(body || {}),
+        ...signal ? { signal } : {}
       });
     }
     async function waitForMcp(requestBaseUrl, isCancelled = () => false) {
@@ -32747,6 +32828,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         return;
       }
       pendingApprovals.set(permissionId, { name, input });
+      suspendStallWatchdogForPendingInteraction();
       emitAfterText({
         type: "approval-required",
         toolUseId: permissionId,
@@ -32784,6 +32866,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       if (!type) return;
       const p = evt && evt.properties || {};
       if (p.sessionID && (!sessionId || p.sessionID !== sessionId)) return;
+      touchStallWatchdog();
       if (type === "session.status") {
         const st = p.status && p.status.type || "";
         if (st === "busy") {
@@ -32840,6 +32923,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           return;
         }
         pendingQuestions.set(questionId, { questions, settling: false });
+        suspendStallWatchdogForPendingInteraction();
         emitAfterText({
           type: "question-required",
           toolUseId: questionId,
@@ -32854,6 +32938,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         const pending = pendingQuestions.get(questionId);
         if (!pending) return;
         pendingQuestions.delete(questionId);
+        resumeStallWatchdogAfterPendingInteraction();
         if (type === "question.rejected") {
           emitAfterText({ type: "question-resolved", toolUseId: questionId, outcome: "cancelled" });
         } else {
@@ -32976,7 +33061,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         const messageBody = { parts: openCodeParts(turn) };
         try {
           messageDispatched = true;
-          const messageRequest = postJson("/session/" + encodeURIComponent(id) + "/message", messageBody);
+          armStallWatchdog();
+          const controller = new AbortController();
+          messageAbortController = controller;
+          const messageRequest = postJson("/session/" + encodeURIComponent(id) + "/message", messageBody, controller.signal);
           emitTurnProgress("dispatch");
           await messageRequest;
         } catch (error) {
@@ -32985,14 +33073,18 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           adoptedSessionId = null;
           sessionWasAdopted = false;
           const replacementId = await ensureSession();
+          const controller = new AbortController();
+          messageAbortController = controller;
           const replacementRequest = postJson(
             "/session/" + encodeURIComponent(replacementId) + "/message",
-            messageBody
+            messageBody,
+            controller.signal
           );
           emitTurnProgress("dispatch");
           await replacementRequest;
         }
       } catch (e) {
+        if (stopRequested || !activeRun) return;
         const httpStatus = extractHttpStatus(e == null ? void 0 : e.httpStatus);
         const fallbackCode = (e == null ? void 0 : e.fallbackCode) || (messageDispatched ? "TURN_START_FAILED" : "SESSION_START_FAILED");
         const classified = classifyErrorCode({
@@ -33038,6 +33130,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       const approval = pendingApprovals.get(id);
       if (!approval) return;
       pendingApprovals.delete(id);
+      resumeStallWatchdogAfterPendingInteraction();
       if (decision === "allow-session") sessionAllowedTools.add(approval.name);
       await replyPermission(id, decision);
       if (decision === "deny") emit({ type: "tool-denied", toolUseId: id });
@@ -33075,6 +33168,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       if (pendingQuestions.get(id) !== pending) return true;
       pendingQuestions.delete(id);
+      resumeStallWatchdogAfterPendingInteraction();
       emitAfterText({
         type: "question-resolved",
         toolUseId: id,
@@ -33096,6 +33190,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     }
     async function stop() {
       if (activeRun) stopRequested = true;
+      messageAbortController == null ? void 0 : messageAbortController.abort();
       await rejectPendingQuestions();
       if (sessionId) {
         await postJson("/session/" + encodeURIComponent(sessionId) + "/abort", {}).catch(() => {
@@ -33115,6 +33210,9 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       stopping = true;
       sseClosed = true;
       sseStarted = false;
+      clearStallWatchdog();
+      messageAbortController == null ? void 0 : messageAbortController.abort();
+      messageAbortController = null;
       settlePendingQuestions();
       pendingApprovals.clear();
       sessionAllowedTools.clear();

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -20,6 +20,8 @@ const READY_TIMEOUT_MS = 30000;
 const PROBE_TIMEOUT_MS = 40000;
 const READY_POLL_MS = 250;
 const READY_REQUEST_TIMEOUT_MS = 1500;
+export const OPENCODE_STALL_WARNING_MS = 180000;
+export const OPENCODE_STALL_TIMEOUT_MS = 300000;
 const DEFAULT_PROVIDER_ID = 'opencode';
 const DEFAULT_MODEL_ID = 'hy3-free';
 const STDERR_TAIL_LIMIT = 4096;
@@ -348,6 +350,11 @@ export function createOpenCodeBackend({
   probeTimeoutMs = PROBE_TIMEOUT_MS,
   readyPollMs = READY_POLL_MS,
   readyRequestTimeoutMs = READY_REQUEST_TIMEOUT_MS,
+  stallWarningMs = OPENCODE_STALL_WARNING_MS,
+  stallTimeoutMs = OPENCODE_STALL_TIMEOUT_MS,
+  now = () => Date.now(),
+  setTimeoutImpl = setTimeout,
+  clearTimeoutImpl = clearTimeout,
   sleepImpl = sleep,
   onSweepComplete,
 } = {}) {
@@ -356,6 +363,10 @@ export function createOpenCodeBackend({
     || readyRequestTimeoutMs <= 0
     || readyRequestTimeoutMs < readyPollMs) {
     throw new RangeError('OpenCode readiness request timeout must be at least the poll interval');
+  }
+  if (!Number.isFinite(stallWarningMs) || !Number.isFinite(stallTimeoutMs)
+    || stallWarningMs <= 0 || stallTimeoutMs <= stallWarningMs) {
+    throw new RangeError('OpenCode stall timeout must be greater than its warning timeout');
   }
   // OpenCode isolates sessions and its event bus by request directory. Keep
   // the default cwd stable so resumed sessions publish to this panel's bus.
@@ -392,6 +403,10 @@ export function createOpenCodeBackend({
   let messageDispatched = false;
   let turnStarted = false;
   let stopRequested = false;
+  let stallTimer = null;
+  let stallLastActivityAt = 0;
+  let stallWarningEmitted = false;
+  let messageAbortController = null;
   let generation = 0;
   let toolMeta = { annotations: {} };
   const pendingApprovals = new Map();
@@ -447,6 +462,76 @@ export function createOpenCodeBackend({
   function emitAfterText(evt) {
     assistantDeltaRedactor.flush();
     emit(evt);
+  }
+
+  function clearStallWatchdog() {
+    if (stallTimer !== null) clearTimeoutImpl(stallTimer);
+    stallTimer = null;
+    stallLastActivityAt = 0;
+    stallWarningEmitted = false;
+  }
+
+  function armStallWatchdog() {
+    if (!activeRun || stopRequested || pendingQuestions.size > 0 || pendingApprovals.size > 0) return;
+    if (stallTimer !== null) clearTimeoutImpl(stallTimer);
+    stallLastActivityAt = now();
+    stallWarningEmitted = false;
+    scheduleStallWatchdog();
+  }
+
+  function touchStallWatchdog() {
+    if (activeRun && !stopRequested) armStallWatchdog();
+  }
+
+  function suspendStallWatchdogForPendingInteraction() {
+    clearStallWatchdog();
+  }
+
+  function resumeStallWatchdogAfterPendingInteraction() {
+    if (pendingQuestions.size === 0 && pendingApprovals.size === 0) {
+      armStallWatchdog();
+    }
+  }
+
+  function scheduleStallWatchdog() {
+    if (!activeRun || stopRequested) return;
+    const elapsedMs = Math.max(0, now() - stallLastActivityAt);
+    const deadline = stallWarningEmitted ? stallTimeoutMs : stallWarningMs;
+    stallTimer = setTimeoutImpl(() => {
+      stallTimer = null;
+      if (!activeRun || stopRequested) return;
+      const currentElapsedMs = Math.max(0, now() - stallLastActivityAt);
+      if (!stallWarningEmitted && currentElapsedMs >= stallWarningMs) {
+        stallWarningEmitted = true;
+        emit({ type: 'turn-progress-warning', turnId: activeTurn?.turnId, elapsedMs: currentElapsedMs, warningMs: stallWarningMs });
+      }
+      if (currentElapsedMs >= stallTimeoutMs) {
+        void terminateStalledTurn();
+      } else {
+        scheduleStallWatchdog();
+      }
+    }, Math.max(1, deadline - elapsedMs));
+  }
+
+  async function terminateStalledTurn() {
+    if (!activeRun || stopRequested) return;
+    stopRequested = true;
+    messageAbortController?.abort();
+    await rejectPendingQuestions();
+    if (sessionId) {
+      await postJson('/session/' + encodeURIComponent(sessionId) + '/abort', {}).catch(() => {});
+    }
+    await drainApprovals();
+    if (activeRun) {
+      emitAfterText({
+        type: 'error',
+        kind: 'network',
+        code: 'PROVIDER_STREAM_STALLED',
+        message: 'The OpenCode provider stream was silent for over five minutes, so this turn was stopped.',
+        ...activeTurnFailureFields(),
+      });
+      finishActive();
+    }
   }
 
   function emitTurnProgress(stage) {
@@ -682,6 +767,7 @@ export function createOpenCodeBackend({
   }
 
   function finishActive() {
+    clearStallWatchdog();
     if (!activeResolve) {
       activeRun = null;
       activeAssistantText = '';
@@ -746,11 +832,12 @@ export function createOpenCodeBackend({
     return response.json ? response.json() : {};
   }
 
-  async function postJson(path, body) {
+  async function postJson(path, body, signal) {
     return requestJson(path, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body || {}),
+      ...(signal ? { signal } : {}),
     });
   }
 
@@ -1195,6 +1282,7 @@ export function createOpenCodeBackend({
     }
 
     pendingApprovals.set(permissionId, { name, input });
+    suspendStallWatchdogForPendingInteraction();
     emitAfterText({
       type: 'approval-required',
       toolUseId: permissionId,
@@ -1242,6 +1330,7 @@ export function createOpenCodeBackend({
     if (!type) return;
     const p = (evt && evt.properties) || {};
     if (p.sessionID && (!sessionId || p.sessionID !== sessionId)) return;
+    touchStallWatchdog();
 
     if (type === 'session.status') {
       const st = (p.status && p.status.type) || '';
@@ -1295,6 +1384,7 @@ export function createOpenCodeBackend({
         return;
       }
       pendingQuestions.set(questionId, { questions, settling: false });
+      suspendStallWatchdogForPendingInteraction();
       emitAfterText({
         type: 'question-required',
         toolUseId: questionId,
@@ -1309,6 +1399,7 @@ export function createOpenCodeBackend({
       const pending = pendingQuestions.get(questionId);
       if (!pending) return;
       pendingQuestions.delete(questionId);
+      resumeStallWatchdogAfterPendingInteraction();
       if (type === 'question.rejected') {
         emitAfterText({ type: 'question-resolved', toolUseId: questionId, outcome: 'cancelled' });
       } else {
@@ -1455,7 +1546,10 @@ export function createOpenCodeBackend({
       const messageBody = { parts: openCodeParts(turn) };
       try {
         messageDispatched = true;
-        const messageRequest = postJson('/session/' + encodeURIComponent(id) + '/message', messageBody);
+        armStallWatchdog();
+        const controller = new AbortController();
+        messageAbortController = controller;
+        const messageRequest = postJson('/session/' + encodeURIComponent(id) + '/message', messageBody, controller.signal);
         emitTurnProgress('dispatch');
         await messageRequest;
       } catch (error) {
@@ -1464,14 +1558,18 @@ export function createOpenCodeBackend({
         adoptedSessionId = null;
         sessionWasAdopted = false;
         const replacementId = await ensureSession();
+        const controller = new AbortController();
+        messageAbortController = controller;
         const replacementRequest = postJson(
           '/session/' + encodeURIComponent(replacementId) + '/message',
           messageBody,
+          controller.signal,
         );
         emitTurnProgress('dispatch');
         await replacementRequest;
       }
     } catch (e) {
+      if (stopRequested || !activeRun) return;
       const httpStatus = extractHttpStatus(e?.httpStatus);
       const fallbackCode = e?.fallbackCode
         || (messageDispatched ? 'TURN_START_FAILED' : 'SESSION_START_FAILED');
@@ -1519,6 +1617,7 @@ export function createOpenCodeBackend({
     const approval = pendingApprovals.get(id);
     if (!approval) return;
     pendingApprovals.delete(id);
+    resumeStallWatchdogAfterPendingInteraction();
     if (decision === 'allow-session') sessionAllowedTools.add(approval.name);
     await replyPermission(id, decision);
     if (decision === 'deny') emit({ type: 'tool-denied', toolUseId: id });
@@ -1561,6 +1660,7 @@ export function createOpenCodeBackend({
     // case it already settled the card, so do not emit a duplicate event.
     if (pendingQuestions.get(id) !== pending) return true;
     pendingQuestions.delete(id);
+    resumeStallWatchdogAfterPendingInteraction();
     emitAfterText({
       type: 'question-resolved',
       toolUseId: id,
@@ -1584,6 +1684,7 @@ export function createOpenCodeBackend({
 
   async function stop() {
     if (activeRun) stopRequested = true;
+    messageAbortController?.abort();
     await rejectPendingQuestions();
     if (sessionId) {
       await postJson('/session/' + encodeURIComponent(sessionId) + '/abort', {}).catch(() => {});
@@ -1602,6 +1703,9 @@ export function createOpenCodeBackend({
     stopping = true;
     sseClosed = true;
     sseStarted = false;
+    clearStallWatchdog();
+    messageAbortController?.abort();
+    messageAbortController = null;
     settlePendingQuestions();
     pendingApprovals.clear();
     sessionAllowedTools.clear();

--- a/plugin/panel/src/lib/errorCodes.js
+++ b/plugin/panel/src/lib/errorCodes.js
@@ -30,6 +30,7 @@ export const ERROR_CODES = Object.freeze({
   UPSTREAM_ERROR: entry('UPSTREAM_ERROR', 'model', '上游或模型返回失败；请检查模型可用性与服务状态。', 'The upstream or model failed; check model availability and service status.'),
   UPSTREAM_CONNECTION_CLOSED: entry('UPSTREAM_CONNECTION_CLOSED', 'network', '上游连接在返回错误时被中断；本轮不会自动重发，下一条消息将使用新会话。', 'The upstream connection closed while returning an error. This turn is not retried automatically; the next message uses a fresh session.'),
   EVENT_STREAM_FAILED: entry('EVENT_STREAM_FAILED', 'network', '事件流已断开；请检查 OpenCode 进程与本地网络。', 'The event stream disconnected; check the OpenCode process and local network.'),
+  PROVIDER_STREAM_STALLED: entry('PROVIDER_STREAM_STALLED', 'network', '提供方流超过 5 分钟没有响应，本回合已停止；请检查中转或代理连通性后重试。', 'The provider stream was silent for over five minutes, so the turn was stopped; check relay or proxy connectivity and retry.'),
   TURN_INPUT_INVALID: entry('TURN_INPUT_INVALID', 'attachment', '请移除不可用附件或重新选择文件。', 'Remove unavailable attachments or select the files again.'),
   TURN_ABORTED: entry('TURN_ABORTED', 'aborted', '本回合已停止，可在确认没有未决写入后重新发送。', 'The turn was stopped; resend after confirming there is no unresolved write.'),
   CANCELLED: entry('CANCELLED', 'backend', '后端取消了请求；请确认会话仍可用后重试。', 'The backend cancelled the request; confirm the session is still usable before retrying.'),

--- a/plugin/panel/test/errorCodes.test.js
+++ b/plugin/panel/test/errorCodes.test.js
@@ -19,6 +19,7 @@ test('error code table is frozen and contains the complete panel vocabulary', ()
     'EVENT_STREAM_FAILED',
     'MCP_UNREACHABLE',
     'PROCESS_EXITED',
+    'PROVIDER_STREAM_STALLED',
     'RPC_TIMEOUT',
     'SESSION_START_FAILED',
     'SPAWN_FAILED',

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import {
   createOpenCodeBackend,
   OPEN_CODE_DISABLED_BUILTIN_TOOL_NAMES,
+  OPENCODE_STALL_WARNING_MS,
+  OPENCODE_STALL_TIMEOUT_MS,
 } from '../src/cep/openCodeBackend.js';
 import {
   OPEN_CODE_HISTORY_GUARD_FILENAME,
@@ -132,7 +134,7 @@ function jsonResponse(value, ok = true, status = 200) {
   };
 }
 
-function makeFetch() {
+function makeFetch({ holdMessage = false } = {}) {
   const calls = [];
   const sseStreams = [];
   let sse = null;
@@ -147,6 +149,11 @@ function makeFetch() {
     }
     if (parsed.pathname === '/mcp') return jsonResponse({ ae: { status: 'connected' } });
     if (parsed.pathname === '/session' && options.method === 'POST') return jsonResponse({ id: 'session_1' });
+    if (parsed.pathname === '/session/session_1/message' && holdMessage) {
+      return new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+      });
+    }
     if (parsed.pathname === '/config/providers') {
       return jsonResponse({
         providers: [{
@@ -224,7 +231,7 @@ const OPEN_CODE_PROBE = {
 function makeBackend(options = {}) {
   const events = [];
   const spawned = makeSpawn();
-  const fetched = makeFetch();
+  const fetched = makeFetch(options.fetchOptions);
   const fsImpl = options.fsImpl || makeFs(options.fsOptions);
   const terminated = [];
   const platform = {
@@ -2211,4 +2218,179 @@ test('OpenCode deleteSessionRef deletes only while its server URL is live', asyn
   assert.deepEqual(await live.backend.deleteSessionRef({ kind: 'opencode-session', id: 'session_1' }), { ok: true });
   assert.ok(live.fetched.calls.some((call) => call.method === 'DELETE' && call.path === '/session/session_1'));
   live.backend.reset();
+});
+
+function watchdogTimers() {
+  const timers = [];
+  const cleared = [];
+  return {
+    timers,
+    cleared,
+    setTimeoutImpl(callback, delay) {
+      const timer = { callback, delay, cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeoutImpl(timer) {
+      timer.cleared = true;
+      cleared.push(timer);
+    },
+    latest() {
+      return timers.filter((timer) => !timer.cleared).at(-1);
+    },
+  };
+}
+
+test('OpenCode stream watchdog warns then aborts a silent dispatched turn once', async () => {
+  let clock = 0;
+  const timers = watchdogTimers();
+  const h = makeBackend({
+    fetchOptions: { holdMessage: true },
+    now: () => clock,
+    setTimeoutImpl: timers.setTimeoutImpl,
+    clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+  const run = h.backend.sendUser({ turnId: 'turn-stalled', text: 'wait', attachments: [] });
+  await flush();
+  await flush();
+
+  clock = OPENCODE_STALL_WARNING_MS;
+  timers.latest().callback();
+  assert.deepEqual(h.events.find((event) => event.type === 'turn-progress-warning'), {
+    type: 'turn-progress-warning',
+    turnId: 'turn-stalled',
+    elapsedMs: OPENCODE_STALL_WARNING_MS,
+    warningMs: OPENCODE_STALL_WARNING_MS,
+  });
+  assert.equal(h.events.filter((event) => event.type === 'error').length, 0);
+
+  clock = OPENCODE_STALL_TIMEOUT_MS;
+  timers.latest().callback();
+  await flush();
+  assert.ok(h.fetched.calls.some((call) => call.method === 'POST' && call.path === '/session/session_1/abort'));
+  assert.equal(h.events.filter((event) => event.type === 'error' && event.code === 'PROVIDER_STREAM_STALLED').length, 1);
+  h.fetched.sse.push({ type: 'session.status', properties: { sessionID: 'session_1', status: { type: 'idle' } } });
+  await run;
+  assert.equal(h.events.filter((event) => event.type === 'error').length, 1);
+});
+
+test('OpenCode stream watchdog is reset by relevant SSE deltas', async () => {
+  let clock = 0;
+  const timers = watchdogTimers();
+  const h = makeBackend({
+    fetchOptions: { holdMessage: true },
+    now: () => clock,
+    setTimeoutImpl: timers.setTimeoutImpl,
+    clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+  const run = h.backend.sendUser({ turnId: 'turn-active-stream', text: 'wait', attachments: [] });
+  await flush();
+  await flush();
+  for (const time of [150000, 300000, 450000, 600000]) {
+    clock = time;
+    h.fetched.sse.push({ type: 'message.part.delta', properties: { sessionID: 'session_1', field: 'text', delta: '.' } });
+    await flush();
+  }
+  assert.equal(h.events.some((event) => event.type === 'turn-progress-warning'), false);
+  assert.equal(h.events.some((event) => event.type === 'error'), false);
+  await h.backend.stop();
+  await run;
+});
+
+test('OpenCode stream watchdog suspends for a pending question and resumes after it resolves', async () => {
+  let clock = 0;
+  const timers = watchdogTimers();
+  const h = makeBackend({
+    fetchOptions: { holdMessage: true },
+    now: () => clock,
+    setTimeoutImpl: timers.setTimeoutImpl,
+    clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+  const run = h.backend.sendUser({ turnId: 'turn-question-pending', text: 'wait', attachments: [] });
+  await flush();
+  await flush();
+  h.fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'busy' } },
+  });
+  h.fetched.sse.push({
+    type: 'question.asked',
+    properties: {
+      sessionID: 'session_1',
+      id: 'que_stall',
+      questions: [{ question: 'Continue?', header: 'Continue', options: [] }],
+    },
+  });
+  await flush();
+
+  // A stray relevant event must not re-arm the suspended watchdog.
+  h.fetched.sse.push({
+    type: 'session.status',
+    properties: { sessionID: 'session_1', status: { type: 'busy' } },
+  });
+  await flush();
+  clock = OPENCODE_STALL_TIMEOUT_MS * 2;
+  assert.equal(timers.latest(), undefined);
+  assert.equal(h.events.some((event) => event.type === 'turn-progress-warning'), false);
+  assert.equal(h.events.some((event) => event.type === 'error'), false);
+
+  h.fetched.sse.push({
+    type: 'question.replied',
+    properties: { sessionID: 'session_1', requestID: 'que_stall', answers: [['Continue']] },
+  });
+  await flush();
+
+  clock += OPENCODE_STALL_WARNING_MS;
+  timers.latest().callback();
+  assert.equal(h.events.filter((event) => event.type === 'turn-progress-warning').length, 1);
+  clock += OPENCODE_STALL_TIMEOUT_MS - OPENCODE_STALL_WARNING_MS;
+  timers.latest().callback();
+  await flush();
+  await run;
+  assert.equal(h.events.filter((event) => event.code === 'PROVIDER_STREAM_STALLED').length, 1);
+});
+
+test('OpenCode stream watchdog suspends for a pending approval and resumes after a decision', async () => {
+  let clock = 0;
+  const timers = watchdogTimers();
+  const h = makeBackend({
+    fetchOptions: { holdMessage: true },
+    now: () => clock,
+    setTimeoutImpl: timers.setTimeoutImpl,
+    clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+  const run = h.backend.sendUser({ turnId: 'turn-approval-pending', text: 'wait', attachments: [] });
+  await flush();
+  await flush();
+  h.fetched.sse.push({
+    type: 'permission.asked',
+    properties: { sessionID: 'session_1', permissionID: 'perm_stall', tool: 'ae_ae_exec', input: {} },
+  });
+  await flush();
+
+  clock = OPENCODE_STALL_TIMEOUT_MS * 2;
+  assert.equal(timers.latest(), undefined);
+  assert.equal(h.events.some((event) => event.type === 'turn-progress-warning'), false);
+  assert.equal(h.events.some((event) => event.type === 'error'), false);
+
+  await h.backend.approve('perm_stall', 'allow');
+  clock += OPENCODE_STALL_WARNING_MS;
+  timers.latest().callback();
+  assert.equal(h.events.filter((event) => event.type === 'turn-progress-warning').length, 1);
+  clock += OPENCODE_STALL_TIMEOUT_MS - OPENCODE_STALL_WARNING_MS;
+  timers.latest().callback();
+  await flush();
+  await run;
+  assert.equal(h.events.filter((event) => event.code === 'PROVIDER_STREAM_STALLED').length, 1);
+});
+
+test('OpenCode completion clears the stream watchdog timer', async () => {
+  const timers = watchdogTimers();
+  const h = makeBackend({ setTimeoutImpl: timers.setTimeoutImpl, clearTimeoutImpl: timers.clearTimeoutImpl });
+  const run = h.backend.sendUser({ turnId: 'turn-complete-watchdog', text: 'done', attachments: [] });
+  await flush();
+  completeTurn(h.fetched);
+  await run;
+  assert.ok(timers.cleared.length > 0);
+  assert.equal(timers.latest(), undefined);
 });


### PR DESCRIPTION
Fixes #327.

## 问题

OpenCode Provider 通道的轮次派发后,若上游流建立却永不回事件(真机复现:中转经本地代理的半开连接),面板「等待模型回复…」无限旋转:message POST 无 signal 永不落定,三层(ai-sdk、backend、UI)都没有超时,唯一救济是手动停止。

## 修复

- **不活动看门狗**(照 claudeAgentBackend 的可注入时钟先例):轮次派发布防,每个过了会话过滤的 SSE 事件重置;静默 180s 发既有的 `turn-progress-warning` 通告(不改事件契约),静默 300s 走 `stop()` 同款中止路径(`stopRequested` 抑制 + abort POST + `drainApprovals`),经 `emitAfterText` 发 `PROVIDER_STREAM_STALLED` 错误卡(#322 冲刷纪律),`finishActive` 收尾。
- **根治挂死 fetch**:message POST 接 `AbortController`,看门狗触发 / `stop()` / `reset()` 时真正取消;被取消的 fetch 拒绝不产生第二张错误卡。
- **等用户不误杀**:问题卡/审批卡挂起即暂停看门狗,全部解决才复防;`armStallWatchdog` 自身守住"挂起期间永不布防"的不变量,杂散 SSE 事件无法在挂起期间重臂。工具执行静默不受影响(host 侧哨兵封顶在阈值之下)。
- 新错误码 `PROVIDER_STREAM_STALLED`(kind network,双语提示)三处联动:`errorCodes.js`、词表测试、`REFERENCE.md`。
- 工厂新增 `stallWarningMs`/`stallTimeoutMs`/`now`/`setTimeoutImpl`/`clearTimeoutImpl` 注入;确定性测试覆盖:静默告警→终止且迟到 idle 被抑制、活动持续不误杀、正常收尾无残留计时器、问题/审批挂起期间(含杂散事件)不触发、解决后恢复触发。

## 验证

`plugin/panel` 583/583 通过;`npm run build` 重建 dist 并过 `verify-bundle`。真机 stall 场景来自 2026-08-26 macOS #322 验证(#322 验收评论有完整时间线)。

明确不做(follow-up 素材):错误卡上的重试按钮(`ToolCallCard.onRetry` 已存在但保持未接线)、另两条通道的同类看门狗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
