### PR TITLE
fix(native): stop surfacing the always-false undo.verified field (#310)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -50,9 +50,12 @@ Claude Desktop:
 
 `ae_exec` is the default route for maintained scripting semantics. Use
 `ae_nativeExec` for the frozen native primitives. Native writes require an
-operation key and Undo group, followed by an independent readback. A result
-that may have dispatched a write must be reconciled against After Effects
-state and audit evidence before retrying.
+operation key and Undo group, followed by an independent readback.
+`undo.available` means AEGP opened and closed a real After Effects Undo group
+with StartUndoGroup/EndUndoGroup; the response envelope does not certify that
+Undo restores state. Release discipline proves restoration separately through
+an explicit Undo and state readback. A result that may have dispatched a write
+must be reconciled against After Effects state and audit evidence before retrying.
 
 ### `ae_exec` failure recovery
 

--- a/plugin/host/mcp/native-program.js
+++ b/plugin/host/mcp/native-program.js
@@ -503,6 +503,8 @@ function nativeProgramResponse(execution) {
     const negotiation = execution.negotiation;
     const request = execution.request;
     const response = Object.assign({ ok: true }, result);
+    response.undo = { available: result.undo.available };
+    if (result.undo.groupLabel !== undefined) response.undo.groupLabel = result.undo.groupLabel;
     response.provenance = {
         engine: result.evidence.engine,
         selectedWireVersion: negotiation.selectedWireVersion,
@@ -524,7 +526,6 @@ function nativeProgramResponse(execution) {
         postconditionDigest: result.evidence.postcondition.digest,
         effect: result.evidence.effect,
         undoAvailable: result.undo.available,
-        undoVerified: result.undo.verified,
         replayed: result.replayed,
         startedAtUnixMs: result.evidence.startedAtUnixMs,
         completedAtUnixMs: result.evidence.completedAtUnixMs,

--- a/plugin/host/mcp/native-program.test.js
+++ b/plugin/host/mcp/native-program.test.js
@@ -9,6 +9,7 @@ const {
     invokeNativeProgram,
     invokeRequestDigest,
     nativeErrorPayload,
+    nativeProgramResponse,
     nativeProgramPostconditionDigest,
     sha256ClosedJson,
     validateInvokeErrorBinding,
@@ -180,6 +181,23 @@ test('valid read and write program results map to the Python response shape', as
     assert.equal(write.result.evidence.effect, 'committed');
     assert.equal(write.result.undo.available, true);
     assert.equal(write.result.undo.groupLabel, 'Set exact time');
+});
+
+test('outward responses omit wire-only Undo verification from result and audit', async () => {
+    const read = await run(readArgs());
+    const readResponse = nativeProgramResponse(read);
+    assert.deepEqual(readResponse.undo, { available: false });
+    assert.equal(Object.hasOwn(readResponse.audit, 'undoVerified'), false);
+
+    const write = await run(writeArgs());
+    const writeResponse = nativeProgramResponse(write);
+    assert.deepEqual(writeResponse.undo, { available: true, groupLabel: 'Set exact time' });
+    assert.equal(Object.hasOwn(writeResponse.audit, 'undoVerified'), false);
+    assert.deepEqual(write.result.undo, {
+        available: true,
+        verified: false,
+        groupLabel: 'Set exact time',
+    });
 });
 
 test('each native result binding check rejects its own mismatch', async () => {

--- a/plugin/host/mcp/tools/native-exec.test.js
+++ b/plugin/host/mcp/tools/native-exec.test.js
@@ -187,6 +187,14 @@ test('real Express MCP route runs ae_nativeExec through fake negotiate/invoke', 
         assert.equal(content.provenance.sessionId, NEGOTIATION.sessionId);
         assert.equal(content.audit.capabilityId, CAPABILITY_ID);
         assert.equal(content.audit.undoAvailable, false);
+        assert.deepEqual(content.undo, { available: false });
+        assert.equal(Object.hasOwn(content.audit, 'undoVerified'), false);
+
+        const writeResponse = await callTool(host, session, 'ae_nativeExec', writeArguments());
+        const write = writeResponse.body.result.structuredContent;
+        assert.equal(writeResponse.status, 200);
+        assert.deepEqual(write.undo, { available: true, groupLabel: 'Native write' });
+        assert.equal(Object.hasOwn(write.audit, 'undoVerified'), false);
     } finally {
         await new Promise(function (resolve) { host.listener.close(resolve); });
     }


### PR DESCRIPTION
Fixes #310.

## 问题

`ae_nativeExec` 成功信封里的 `undo.verified` 被线协议钉死为 `false`(schema `const false` + `validUndo()` 强制),审计记录的 `undoVerified` 因此恒假——字段不承载信息,命名却暗示"撤销已验证"。

## 修复(issue 方案 2,裁剪到宿主边界)

- **原生面零改动**:不碰 `native/ae-plugin/**`(C++、协议 schema、二进制),线协议照旧上报并校验 `verified: false`,`native-aegp-client.js` 的线侧验证器原样保留;
- 宿主 `nativeProgramResponse` 把对外 `undo` 重投影为 `{available, groupLabel?}`,审计记录删除 `undoVerified`;
- `docs/REFERENCE.md` 写明诚实语义:`undo.available` 表示 AEGP 真实开合了 AE 撤销组;信封不自证撤销可还原,还原由发布纪律带外证明(显式 Undo + 状态回读);
- 单元 + Express 集成两层断言:对外读/写信封无 `verified`、审计无 `undoVerified`、线侧内部形状不变。

## 验证

`plugin/host` 238/238 通过(Codex 沙箱下 45 个 HTTP 集成测试因回环监听 EPERM 未跑,本机免沙箱全量复跑确认全绿);`git diff --check` 干净。残留引用核查:仅线协议校验器与历史规划文档仍提及 `verified`,均属应留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
