### PR TITLE
release: bump the product version to 0.10.3 and cut its changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ## 中文
 
-### Unreleased
+### [0.10.3] — 2026-08-26
 
+- **OpenCode 静默回合有了停顿看门狗（#327）**——provider 长时间无输出、无工具活动时，回合会被明确终止并给出原因，不再无限显示"生成中"。正常的长任务不受影响：只要模型仍在推进（哪怕几分钟不吐字），回合照常继续。
+- **`ae_nativeExec` 不再返回恒为 false 的 `undo.verified` 字段（#310）**——该字段承诺的验证从未实现，返回它只会误导调用方；现从协议中移除，文档同步更新。
 - **ZXP 内置 OpenCode，全新安装开箱即有可用通道（#321）**——Windows 发布包随附经 SHA-256 校验的官方 OpenCode 可执行文件，面板自动优先使用内置版本（显式环境变量覆盖仍然最高优先），不再要求用户自行安装任何 CLI。构建期由钉版拉取脚本获取产物，正式构建缺产物会直接失败而不是悄悄发出不完整的包。
 - **登录不再需要终端**——Claude 通道新增「打开登录窗口」按钮（登录后本页自动刷新）；Codex 通道新增「一键登录」：面板在隔离环境里代跑登录、自动帮你打开浏览器验证页，失败时才回退为可复制命令。所有修复提示不再出现"请在终端运行 X"式的裸指令。
 - **向导一键安装 Claude Code**——首启向导可直接代跑 Anthropic 官方安装器（明确标注来源），装完点重新检测即可识别；另提供可选的「加入系统 PATH」按钮（免管理员、保留原有 PATH 变量类型、不用会截断 PATH 的 setx），方便你在自己的终端里也能使用。
@@ -348,8 +350,10 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ## English
 
-### Unreleased
+### [0.10.3] — 2026-08-26
 
+- **Silent OpenCode turns get a stall watchdog (#327)** — when a provider produces no output and no tool activity for an extended period, the turn now ends with a clear reason instead of spinning "generating" forever. Healthy long tasks are unaffected: as long as the model keeps progressing, the turn continues.
+- **`ae_nativeExec` no longer returns the always-false `undo.verified` field (#310)** — the promised verification never existed, so the field only misled callers; it is removed from the protocol and the reference updated.
 - **OpenCode ships inside the ZXP — a fresh install has a working channel out of the box (#321)** — the Windows package bundles the official OpenCode executable (SHA-256-verified, pinned version fetched at build time; release builds fail rather than silently ship without it). The panel prefers the bundled copy automatically, with the explicit env-var override still winning.
 - **Signing in no longer needs a terminal** — the Claude channel gains an Open-sign-in-window button (the page refreshes automatically once you're in); the Codex channel gains one-click sign-in that runs the login inside the panel's isolated environment and opens the browser verification page for you, falling back to a copyable command only when that fails. No fix hint tells you to "run X in a terminal" anymore.
 - **The wizard installs Claude Code for you** — one click runs Anthropic's official installer (provenance clearly labeled); Re-check finds it immediately. An optional add-to-PATH button registers CLI directories on the user PATH without admin rights, preserving the value type and never using the PATH-truncating setx.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ English | [简体中文](README.zh-CN.md)
 **One-line setup prompt — paste this into Claude Code or another AI agent:**
 
 ```text
-Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.2
+Install the ae-mcp ZXP and the native plug-in for my platform from the v0.10.3
 release, open Window > Extensions
 > ae-mcp in After Effects, then connect Claude Code with `claude mcp add
 --transport http ae http://127.0.0.1:11488/mcp`; for Claude Desktop, configure

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 **一行安装提示词——复制给 Claude Code 或其它 AI agent：**
 
 ```text
-请从 v0.10.2 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
+请从 v0.10.3 发布页安装 ae-mcp 的 ZXP 和对应平台的原生插件，在 After Effects
 中打开
 Window > Extensions > ae-mcp，然后用 `claude mcp add --transport http ae
 http://127.0.0.1:11488/mcp` 接入 Claude Code；Claude Desktop 则使用系统 Node

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.10.2"
+                   ExtensionBundleVersion="0.10.3"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.10.2" />
+        <Extension Id="com.aemcp.panel" Version="0.10.3" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20412,7 +20412,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.10.2",
+    version: "0.10.3",
     private: true,
     type: "module",
     scripts: {
@@ -27923,7 +27923,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   // src/cep/mcpClient.js
   init_cep_runtime_inject();
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.10.2";
+  var PANEL_VERSION = "0.10.3";
   function defaultFetch() {
     if (globalThis.window && globalThis.window.fetch) {
       return globalThis.window.fetch.bind(globalThis.window);

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1048,7 +1048,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-                version: input.version || '0.10.2',
+                version: input.version || '0.10.3',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "express": "4.22.2"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,5 +1,5 @@
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.10.2';
+export const PANEL_VERSION = '0.10.3';
 
 function defaultFetch() {
   if (globalThis.window && globalThis.window.fetch) {

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -11,7 +11,7 @@ param(
     [string]$CertPassword = '',
     [string]$CertPath = '',
     [string]$OutputPath = '',
-    [string]$Version = '0.10.2',
+    [string]$Version = '0.10.3',
     [string]$Tsa = 'http://timestamp.digicert.com',
     [switch]$SkipSigning
 )

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -51,6 +51,17 @@ foreach ($payload in $payloadRoots) {
         -Destination (Join-Path $stageDir $payload) -Recurse -Force
 }
 
+# The release ZXP ships the bundled OpenCode runtime; only the executable
+# enters the payload (the staging receipt stays local). This script is the
+# release-grade path, so a missing staged runtime is a hard failure.
+$openCodeRuntime = Join-Path $repoRoot 'scripts\package\runtime-staging\opencode\opencode.exe'
+if (-not (Test-Path -LiteralPath $openCodeRuntime -PathType Leaf)) {
+    throw "Bundled OpenCode runtime is missing: $openCodeRuntime - run 'node scripts/package/fetch-opencode-runtime.mjs' first"
+}
+New-Item -ItemType Directory -Force -Path (Join-Path $stageDir 'runtime\opencode') | Out-Null
+Copy-Item -LiteralPath $openCodeRuntime `
+    -Destination (Join-Path $stageDir 'runtime\opencode\opencode.exe') -Force
+
 # Tests and development-only fixtures never belong in the signed host payload.
 $hostTests = Join-Path $stageDir 'host\tests'
 if (Test-Path $hostTests) {
@@ -112,9 +123,11 @@ if ($LASTEXITCODE -ne 0) {
 if ($LASTEXITCODE -ne 0) {
     throw 'ZXP signature verification failed'
 }
+# The bundled OpenCode runtime puts the signed payload around 60 MB; the
+# ceiling exists only to catch runaway bloat, not to police the runtime.
 $zxpSize = (Get-Item -LiteralPath $OutputPath).Length
-if ($zxpSize -ge 20MB) {
-    throw "ZXP exceeds the 20 MB limit: $zxpSize bytes"
+if ($zxpSize -ge 80MB) {
+    throw "ZXP exceeds the 80 MB limit: $zxpSize bytes"
 }
 
 Write-Host "Wrote $OutputPath"

--- a/scripts/package/test/freeze-signed-manifests.test.mjs
+++ b/scripts/package/test/freeze-signed-manifests.test.mjs
@@ -22,7 +22,7 @@ test('writes canonical freeze evidence bound to the direct extension stage', asy
   const evidence = await freezeSignedManifestsWithEvidence({
     root: signingRoot,
     platform: 'windows-x64',
-    version: '0.10.2',
+    version: '0.10.3',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
     evidencePath,
@@ -56,21 +56,21 @@ test('freezes a changed direct payload without adding retired payload roots', as
   await assert.rejects(verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.2',
+    version: '0.10.3',
     sourceCommitSha: h.input.sourceCommitSha,
   }), { code: 'BUNDLE_FILE_METADATA_MISMATCH' });
 
   const result = await freezeSignedManifests({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.2',
+    version: '0.10.3',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256,
   });
   await verifyPlatformBundle({
     root: signingRoot,
     platform: 'macos-arm64',
-    version: '0.10.2',
+    version: '0.10.3',
     sourceCommitSha: h.input.sourceCommitSha,
   });
   assert.equal(result.signedBundleManifestSha256, await sha256File(
@@ -91,7 +91,7 @@ test('refuses to freeze when the asserted source digest is malformed', async (t)
   await assert.rejects(freezeSignedManifests({
     root: h.outDir,
     platform: 'windows-x64',
-    version: '0.10.2',
+    version: '0.10.3',
     sourceCommitSha: h.input.sourceCommitSha,
     sourceStageSha256: 'bad',
   }), /source stage digest/i);

--- a/scripts/package/test/helpers/platform-bundle-fixture.mjs
+++ b/scripts/package/test/helpers/platform-bundle-fixture.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { canonicalJson } from '../../lib/manifest.mjs';
 
 export const SOURCE_COMMIT_SHA = '0123456789abcdef0123456789abcdef01234567';
-export const PRODUCT_VERSION = '0.10.2';
+export const PRODUCT_VERSION = '0.10.3';
 
 export function sha256Bytes(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -69,8 +69,8 @@ async function writePlugin(repoRoot) {
   const plugin = path.join(repoRoot, 'plugin');
   await writeFixtureFile(plugin, 'CSXS/manifest.xml', [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.2">',
-    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.2" /></ExtensionList>',
+    '<ExtensionManifest ExtensionBundleId="com.aemcp.panel" ExtensionBundleVersion="0.10.3">',
+    '  <ExtensionList><Extension Id="com.aemcp.panel" Version="0.10.3" /></ExtensionList>',
     '  <ExecutionEnvironment><HostList><Host Name="AEFT" Version="[23.0,26.9]" />',
     '  </HostList></ExecutionEnvironment>',
     '</ExtensionManifest>',

--- a/scripts/package/test/verify-windows-zxp-stage.test.mjs
+++ b/scripts/package/test/verify-windows-zxp-stage.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { verifyWindowsZxpStage } from '../verify-windows-zxp-stage.mjs';
 
-const VERSION = '0.10.2';
+const VERSION = '0.10.3';
 
 async function write(root, relative, value) {
   const file = path.join(root, ...relative.split('/'));

--- a/scripts/release/run-signing-plan.mjs
+++ b/scripts/release/run-signing-plan.mjs
@@ -23,7 +23,7 @@ import { freezeSignedManifests as foundationFreezeSignedManifests } from '../pac
 import { sha256Directory as foundationSha256Directory } from '../package/lib/files.mjs';
 import { collectManifestEntries, copyTree } from '../package/lib/manifest.mjs';
 
-const RELEASE_VERSION = '0.10.2';
+const RELEASE_VERSION = '0.10.3';
 const CANDIDATE_SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const PLATFORMS = new Set(['macos-arm64', 'windows-x64']);

--- a/scripts/release/signing-report.mjs
+++ b/scripts/release/signing-report.mjs
@@ -176,7 +176,7 @@ function expectedOutputRoles(platform) {
 }
 
 function expectedOutputName(platform, role) {
-  return `ae-mcp-panel-v0.10.2-${platform}.${role}`;
+  return `ae-mcp-panel-v0.10.3-${platform}.${role}`;
 }
 
 function validateIdentityFields(input) {

--- a/scripts/release/test/artifact-manifest.test.mjs
+++ b/scripts/release/test/artifact-manifest.test.mjs
@@ -12,7 +12,7 @@ import { makeArtifactManifestFixture } from './helpers/artifact-manifest-fixture
 test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.2',
+    version: '0.10.3',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,
@@ -32,7 +32,7 @@ test('artifact manifest binds direct ZXP/DMG outputs and dual-platform evidence'
 test('artifact manifest rejects an unsupported artifact role and malformed evidence', async (t) => {
   const fixture = await makeArtifactManifestFixture(t);
   const manifest = await buildArtifactManifest({
-    version: '0.10.2',
+    version: '0.10.3',
     candidateSha: fixture.candidateSha,
     workflowRunId: '42',
     artifacts: fixture.artifacts,

--- a/scripts/release/test/attestation.test.mjs
+++ b/scripts/release/test/attestation.test.mjs
@@ -20,7 +20,7 @@ const MAC_COMMANDS = [
 ];
 
 function report(platform = 'windows-x64', result = 'PASS') {
-  const name = `ae-mcp-panel-v0.10.2-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
+  const name = `ae-mcp-panel-v0.10.3-${platform}.${platform === 'macos-arm64' ? 'dmg' : 'zxp'}`;
   return {
     schemaVersion: 1,
     platform,

--- a/scripts/release/test/helpers/artifact-manifest-fixture.mjs
+++ b/scripts/release/test/helpers/artifact-manifest-fixture.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { canonicalJson } from '../../../package/lib/manifest.mjs';
 import { canonicalStringify, sha256File } from '../../artifact-manifest.mjs';
 
-export const PRODUCT_VERSION = '0.10.2';
+export const PRODUCT_VERSION = '0.10.3';
 export const PRODUCT_SCENARIOS = [
   'clean-install-and-upgrade-rollback',
   'permission-denial-and-recovery',

--- a/scripts/release/test/signing-plan.test.mjs
+++ b/scripts/release/test/signing-plan.test.mjs
@@ -21,7 +21,7 @@ async function signingInput(t, platform) {
   t.after(() => rm(root, { recursive: true, force: true }));
   const input = {
     platform,
-    version: '0.10.2',
+    version: '0.10.3',
     candidateSha: CANDIDATE_SHA,
     stageRoot: path.join(root, 'stage'),
     signingRoot: path.join(root, 'signing'),

--- a/scripts/release/test/validate-attestation-comment.test.mjs
+++ b/scripts/release/test/validate-attestation-comment.test.mjs
@@ -22,7 +22,7 @@ function report(result = 'PASS') {
     candidateSha: 'b'.repeat(40),
     workflowRunId: '42',
     artifactId: '101',
-    artifactName: 'ae-mcp-panel-v0.10.2-windows-x64.zxp',
+    artifactName: 'ae-mcp-panel-v0.10.3-windows-x64.zxp',
     artifactSha256: 'c'.repeat(64),
     osVersion: 'Windows 10.0.26100',
     codexVersion: '0.144.0-alpha.4',

--- a/scripts/release/test/verify-release-inputs.test.mjs
+++ b/scripts/release/test/verify-release-inputs.test.mjs
@@ -26,7 +26,7 @@ const MAC_COMMANDS = [
 function artifact(platform, id) {
   return {
     artifactId: String(id),
-    name: `ae-mcp-panel-v0.10.2-${platform}.zxp`,
+    name: `ae-mcp-panel-v0.10.3-${platform}.zxp`,
     platform,
     role: 'zxp',
     sha256: String(id).repeat(64).slice(0, 64),
@@ -62,7 +62,7 @@ function fixture() {
   const windows = artifact('windows-x64', 102);
   const manifest = {
     schemaVersion: 1,
-    version: '0.10.2',
+    version: '0.10.3',
     candidateSha: CANDIDATE_SHA,
     workflowRunId: '42',
     artifacts: [mac, windows],

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import test from 'node:test';
 
-const VERSION = '0.10.2';
+const VERSION = '0.10.3';
 
 async function text(relative) {
   return fs.readFile(relative, 'utf8');

--- a/scripts/release/verify-release-inputs.mjs
+++ b/scripts/release/verify-release-inputs.mjs
@@ -6,7 +6,7 @@ const SHA = /^[a-f0-9]{40}$/;
 const DIGEST = /^[a-f0-9]{64}$/;
 const DECIMAL_ID = /^\d+$/;
 const POSITIVE_DECIMAL_ID = /^[1-9]\d*$/;
-const VERSION = '0.10.2';
+const VERSION = '0.10.3';
 
 function recordIdentity(record, field) {
   return record?.[field] ?? record?.report?.[field];


### PR DESCRIPTION
0.10.3 收纳自 v0.10.2 以来的全部四个 PR:#325(流式裁切/CLI 检测/exec 反馈回路/工具名)、#326(零终端批:ZXP 内置 OpenCode、一键登录与安装、默认 OpenCode Provider)、#328(OpenCode 停顿看门狗)、#329(移除恒 false 的 undo.verified)。

- 版本面:host/panel 包与锁、CSXS、PANEL_VERSION、native client 握手默认值、package/release 脚本与测试锚点(与 0.10.2 bump 同面)。
- CHANGELOG:Unreleased 切为 0.10.3 双语段,并补上 Mac 侧合并漏记的 #327/#328 与 #310/#329 两条(git log 对账:v0.10.2..HEAD 四个 PR 全部入段)。
- 原生插件自 0.10.0 未变,本版继续携带 AeMcpNative-v0.10.0 产物,不重建。

验证(本机):panel 582/0、host 222/0、version-consistency 6/6(从仓库根跑)、verify-bundle 绿。发版前长任务门禁已全绿(25 分钟真机回合完整存活、零工具失败)。排查中顺带立了 #330(宿主集成测试未隔离用户真实 ~/.ae-mcp 状态,本机黑名单残留可让套件必败)。

合并后我从合并 sha 构建带内置 OpenCode 的 ZXP(预期 ~60MB)、生成 SHA256SUMS、建 draft release 供你发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)