### PR TITLE
test(release): the bundled OpenCode runtime is a supported ZXP payload

### DIFF
--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -51,12 +51,15 @@ test('the public setup text names the two supported connection forms', async () 
   assert.match(readmeZh, /claude mcp add --transport http ae http:\/\/127\.0\.0\.1:11488\/mcp/u);
 });
 
-test('the direct ZXP package script has no retired payload staging', async () => {
+test('the direct ZXP package script stages only the bundled runtime, no retired payloads', async () => {
   const source = await text('scripts/package-zxp.ps1');
   assert.match(source, /\$payloadRoots = @\('client', 'CSXS', 'host', 'icons', 'jsx', 'shared'\)/u);
   assert.match(source, /npm ci --omit=dev/u);
   assert.match(source, /Signing ZXP once/u);
-  assert.doesNotMatch(source, /sidecar|runtime\\|helper|ae-mcp\.exe/iu);
+  // The bundled OpenCode runtime is a supported payload since 0.10.3; the
+  // retired sidecar/helper executables must never return to this script.
+  assert.match(source, /runtime-staging\\opencode\\opencode\.exe/u);
+  assert.doesNotMatch(source, /sidecar|helper|ae-mcp\.exe/iu);
 });
 
 test('CI has no package-server workflow', async () => {


### PR DESCRIPTION
v0.10.3 的 tag 触发 Release 工作流后,`version-consistency.test.mjs` 的「退役 payload 守卫」把 0.10.3 新增的内置 OpenCode staging(`runtime\opencode`)误判为退役载荷回归而失败——该守卫只在 tag 触发的 release evidence contracts 里跑,PR CI 不含,所以发版 PR 三绿、tag 才红。发布本身无恙(资产完好、main CI 绿)。

修法:负向清单收窄到真正退役的 `sidecar|helper|ae-mcp.exe`,并把内置运行时 staging 行改为**正向钉住**(`runtime-staging\opencode\opencode.exe` 必须存在),守卫意图完整保留。

已按 release.yml 原样命令逐条本机验证:artifact-manifest / attestation / version-consistency 三套全过。v0.10.3 tag 上那次红色运行是永久历史(工作流 checkout tag 树,rerun 无解),本修复保证 v0.10.4+ 的 tag 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)