### PR TITLE
fix(connector): exact-case mcpName and major.minor version pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### Unreleased
 
-- **新增 `ae-mcp-jkdg` npm 连接器与官方 MCP Registry 清单**——Claude Desktop 等仅支持 stdio 的客户端可通过 `npx -y ae-mcp-jkdg` 连接本机 AE 面板；连接器与产品版本同步发布，扩展本体仍须从 GitHub Releases 单独安装。
+- **新增 `ae-mcp-jkdg` npm 连接器与官方 MCP Registry 清单**——Claude Desktop 等仅支持 stdio 的客户端可通过 `npx -y ae-mcp-jkdg` 连接本机 AE 面板；连接器与产品 major.minor 配对，扩展本体仍须从 GitHub Releases 单独安装。
 - **面板不可达时给出可执行修复提示**——stdio 连接失败会直接提醒安装 ae-mcp 扩展并保持 After Effects 面板打开，不再只返回底层网络错误。
 - **接入文档更准确**——README 新增 Glama 徽章和 npx 接入方式，并清理已退役的 `ae_ping`、`ae_snapshot` 工具名。
 
@@ -358,7 +358,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### Unreleased
 
-- **Added the `ae-mcp-jkdg` npm connector and official MCP Registry manifest** — stdio-only clients such as Claude Desktop can connect to the local AE panel with `npx -y ae-mcp-jkdg`. The connector ships in lockstep with the product; the extension itself still comes separately from GitHub Releases.
+- **Added the `ae-mcp-jkdg` npm connector and official MCP Registry manifest** — stdio-only clients such as Claude Desktop can connect to the local AE panel with `npx -y ae-mcp-jkdg`. The connector is paired with the product by major.minor; the extension itself still comes separately from GitHub Releases.
 - **Unreachable-panel errors now include an actionable fix** — stdio connection failures tell users to install the ae-mcp extension and keep the After Effects panel open instead of exposing only a low-level network error.
 - **Connection docs are more accurate** — the READMEs add the Glama badge and npx setup while removing the retired `ae_ping` and `ae_snapshot` tool names.
 

--- a/clients/ae-mcp-jkdg/package.json
+++ b/clients/ae-mcp-jkdg/package.json
@@ -1,11 +1,11 @@
 {
   "name": "ae-mcp-jkdg",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A stdio connector for the local ae-mcp After Effects panel.",
   "bin": {
     "ae-mcp-jkdg": "bin/ae-mcp-jkdg.js"
   },
-  "mcpName": "io.github.junkdoge-joe/ae-mcp",
+  "mcpName": "io.github.JUNKDOGE-JOE/ae-mcp",
   "engines": {
     "node": ">=18"
   },

--- a/clients/ae-mcp-jkdg/test/package.test.mjs
+++ b/clients/ae-mcp-jkdg/test/package.test.mjs
@@ -6,6 +6,10 @@ async function json(url) {
   return JSON.parse(await readFile(url, 'utf8'));
 }
 
+function majorMinor(version) {
+  return version.split('.').slice(0, 2).join('.');
+}
+
 test('package metadata identifies the connector and registry server', async () => {
   const [connector, host] = await Promise.all([
     json(new URL('../package.json', import.meta.url)),
@@ -13,7 +17,7 @@ test('package metadata identifies the connector and registry server', async () =
   ]);
   assert.equal(connector.name, 'ae-mcp-jkdg');
   assert.deepEqual(connector.bin, { 'ae-mcp-jkdg': 'bin/ae-mcp-jkdg.js' });
-  assert.equal(connector.mcpName, 'io.github.junkdoge-joe/ae-mcp');
+  assert.equal(connector.mcpName, 'io.github.JUNKDOGE-JOE/ae-mcp');
   assert.deepEqual(connector.engines, { node: '>=18' });
-  assert.equal(connector.version, host.version);
+  assert.equal(majorMinor(connector.version), majorMinor(host.version));
 });

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,10 +14,12 @@ no retired package tree, private executable payload, or nested native binary.
 
 ## npm connector & MCP Registry
 
-Keep `plugin/host/package.json`, `plugin/panel/package.json`,
-`clients/ae-mcp-jkdg/package.json`, and both version fields in the root
-`server.json` in lockstep. The release version consistency test guards this
-contract.
+Keep the connector and product versions paired by major.minor. Both version
+fields in the root `server.json` must always equal
+`clients/ae-mcp-jkdg/package.json`. When a connector-only fix is needed, bump
+only the connector patch version and both `server.json` version fields; the
+product host and panel patch versions remain unchanged. The release version
+consistency test guards this contract.
 
 After the product release is ready, the owner publishes the connector and then
 the Registry entry in this order:

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -12,6 +12,12 @@ async function json(relative) {
   return JSON.parse(await text(relative));
 }
 
+function majorMinor(version) {
+  const match = /^(\d+)\.(\d+)\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.exec(version);
+  assert.ok(match, `expected semantic version, got ${version}`);
+  return `${match[1]}.${match[2]}`;
+}
+
 test('active Node package versions agree with the release version', async () => {
   const [host, hostLock, panel, connector, registry] = await Promise.all([
     json('plugin/host/package.json'),
@@ -24,9 +30,10 @@ test('active Node package versions agree with the release version', async () => 
   assert.equal(hostLock.version, VERSION);
   assert.equal(hostLock.packages[''].version, VERSION);
   assert.equal(panel.version, VERSION);
-  assert.equal(connector.version, host.version);
-  assert.equal(registry.version, host.version);
-  assert.equal(registry.packages[0].version, host.version);
+  assert.equal(registry.version, connector.version);
+  assert.equal(registry.packages[0].version, connector.version);
+  // npm versions are immutable, so connector-only fixes may advance its patch while remaining paired by major.minor.
+  assert.equal(majorMinor(connector.version), majorMinor(host.version));
   assert.equal(host.dependencies.express, '4.22.2');
 });
 

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.junkdoge-joe/ae-mcp",
-  "description": "The After Effects panel hosts the MCP server; this stdio connector requires the ae-mcp extension to be installed separately.",
+  "name": "io.github.JUNKDOGE-JOE/ae-mcp",
+  "description": "A stdio connector for the local ae-mcp After Effects panel; install the AE extension separately.",
   "repository": {
     "url": "https://github.com/JUNKDOGE-JOE/after-effects-mcp",
     "source": "github"
   },
-  "version": "0.10.3",
+  "version": "0.10.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "ae-mcp-jkdg",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## 内容

上架实战修正（npm `ae-mcp-jkdg@0.10.4` 与 Registry `io.github.JUNKDOGE-JOE/ae-mcp` v0.10.4 均已发布成功、状态 active）：

- **mcpName 精确大小写**：官方 Registry 对 npm 所有权校验是大小写敏感的，必须逐字符等于 GitHub 登录名命名空间 `io.github.JUNKDOGE-JOE/ae-mcp`；已发布的 0.10.3 带小写形式且 npm 版本不可变，连接器因此升至 0.10.4。
- **版本契约从严格 lockstep 改为配对**：connector 与 server.json 两处版本保持严格相等（Registry 硬要求）；connector 与产品按 major.minor 对齐，patch 允许连接器独立修复时领先。守卫与 RELEASE.md、CHANGELOG 措辞同步。
- **server.json description 缩到 Registry 的 100 字符上限**（原 122 字符被 422 拒收）。

## 验证

- `node --test` 连接器 5/5、`version-consistency` 6/6（编排者本机实跑）。
- 线上验证：`npm view ae-mcp-jkdg` latest=0.10.4；Registry API 查得条目 `active` / `isLatest`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)