### PR TITLE
feat(host): capture successful exec scripts as rerunnable candidates (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 - **测试套件不再读写你的真实 `~/.ae-mcp`（#330）**——宿主状态目录统一经可注入的 `AE_MCP_STATE_DIR` 解析（保留 `AE_MCP_HOME` 兼容与 `AE_MCP_LOG_DIR`/`AE_MCP_TOOL_DIR`/`AE_MCP_SKILL_DIR` 细粒度覆盖），全部集成测试改用临时目录。此前开发机面板留下的黑名单等状态能让套件莫名必败，跑测试也可能反过来污染真实用户目录。
 - **OpenCode 不再抱着重启前的死连接（#333）**——面板每次启动生成宿主代次并写入实例标记，跨代次的常驻 OpenCode 实例会被回收重建；回合中识别 `-32000 Connection closed`/`Not connected` 类传输失败后自动重建并重试一次，仍失败则给出「重载面板或新建会话」的明确指引。此前面板重载后 ae 工具会整组静默消失，重启 AE 也未必自愈。
 - **「文档 / GitHub」按钮真的能打开了（#334）**——外链统一走三级回退（CEP → CSInterface → 宿主代开），全部失败时面板给出可见提示；文档地址按面板语言路由，中英链接后续可独立更新。
+- **成功执行的脚本自动留底，上下文被压缩后可一键重跑（#338）**——`ae_exec`/`ae_execRecover` 成功后把脚本自动存入 Tool Library 成为 candidate（同内容去重、已沉淀内容不重复建、不进默认搜索列表）；执行信封新增 `artifactId`；占位符守卫拒绝时直接列出本会话最近可重跑条目和 `ae_toolUse {"name":"<id>"}` 用法，对话历史被压缩也不再丢脚本。留底自动清理（7 天 / 每会话 20 条 / 全局 200 条），捕获失败绝不影响执行结果本身。
 
 ### [0.10.3] — 2026-08-26
 
@@ -367,6 +368,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 - **The test suites no longer read or write your real `~/.ae-mcp` (#330)** — host state paths resolve through an injectable `AE_MCP_STATE_DIR` root (with `AE_MCP_HOME` compatibility and the fine-grained `AE_MCP_LOG_DIR`/`AE_MCP_TOOL_DIR`/`AE_MCP_SKILL_DIR` overrides), and every integration fixture now uses a temp directory. Panel state left on a dev machine could previously make the suite fail inexplicably — and running the tests could pollute the real user directory.
 - **OpenCode no longer clings to a dead host connection after a restart (#333)** — the panel stamps each boot with a host generation and recycles persistent OpenCode instances across generations; mid-turn `-32000 Connection closed`/`Not connected` transport failures rebuild the instance and retry the turn once, with a clear "reload the panel or start a new session" hint if that also fails. Previously the ae tools silently vanished from the session after a panel reload, and even restarting AE did not always recover.
 - **The Docs / GitHub buttons actually open now (#334)** — external links go through a three-tier fallback (CEP → CSInterface → host-side open) with a visible error when every tier fails, and the docs link routes by panel language with independently updatable zh/en targets.
+- **Successful scripts are captured automatically and can be rerun after context compaction (#338)** — `ae_exec`/`ae_execRecover` now store each successful script in the Tool Library as a candidate (deduplicated by content, never duplicating promoted artifacts, hidden from default search); the exec envelope gains an `artifactId`, and the placeholder guard lists this conversation's recent rerunnable entries with the exact `ae_toolUse {"name":"<id>"}` call. Candidates prune themselves (7-day TTL / 20 per conversation / 200 global), and a capture failure never affects the execution result.
 
 ### [0.10.3] — 2026-08-26
 

--- a/plugin/host/cep-runtime-contract.test.js
+++ b/plugin/host/cep-runtime-contract.test.js
@@ -47,6 +47,7 @@ const CEP_EXECUTED_FILES = [
     'mcp/jsx-result.js',
     'mcp/template.js',
     'mcp/tool-library.js',
+    'mcp/candidate-artifacts.js',
     'mcp/tools.js',
     'mcp/tool-result.js',
     // One file per /mcp tool (see mcp/tools.js). Every new tool module must be

--- a/plugin/host/mcp/candidate-artifacts.js
+++ b/plugin/host/mcp/candidate-artifacts.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const crypto = require('crypto');
+const { computeContentHash } = require('./tool-library');
+
+const CANDIDATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const SESSION_LIMIT = 20;
+const GLOBAL_LIMIT = 200;
+
+function firstCharacters(value, limit) {
+    return Array.from(String(value || '')).slice(0, limit).join('');
+}
+
+function inferredName(code, args) {
+    const undoName = args && typeof args.undo_group_name === 'string'
+        ? args.undo_group_name.trim() : '';
+    if (undoName) return firstCharacters(undoName, 128);
+    const lines = String(code).split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i].trim();
+        if (line) return firstCharacters(line, 60);
+    }
+    const digest = crypto.createHash('sha256').update(String(code), 'utf8').digest('hex');
+    return 'ae_exec ' + digest.slice(0, 8);
+}
+
+function capturedCandidates(library) {
+    return library.list({ statuses: ['candidate'] }).map(function (summary) {
+        try { return library.getArtifact(summary.id); } catch (error) { return null; }
+    }).filter(function (artifact) {
+        return artifact && artifact.status === 'candidate'
+            && artifact.source.type === 'chat-tool-call';
+    });
+}
+
+function pruneCandidates(library, now) {
+    const removed = new Set();
+    let candidates = capturedCandidates(library);
+    candidates.filter(function (artifact) {
+        return artifact.updatedAt < now - CANDIDATE_TTL_MS;
+    }).forEach(function (artifact) {
+        library.removeArtifact(artifact.id);
+        removed.add(artifact.id);
+    });
+    candidates = candidates.filter(function (artifact) { return !removed.has(artifact.id); });
+
+    const byConversation = new Map();
+    candidates.forEach(function (artifact) {
+        const conversationId = artifact.source.provenance.conversationId;
+        if (conversationId === null || conversationId === undefined) return;
+        const rows = byConversation.get(conversationId) || [];
+        rows.push(artifact);
+        byConversation.set(conversationId, rows);
+    });
+    byConversation.forEach(function (rows) {
+        rows.sort(function (left, right) { return right.updatedAt - left.updatedAt; });
+        rows.slice(SESSION_LIMIT).forEach(function (artifact) {
+            library.removeArtifact(artifact.id);
+            removed.add(artifact.id);
+        });
+    });
+    candidates = candidates.filter(function (artifact) { return !removed.has(artifact.id); })
+        .sort(function (left, right) { return right.updatedAt - left.updatedAt; });
+    candidates.slice(GLOBAL_LIMIT).forEach(function (artifact) {
+        library.removeArtifact(artifact.id);
+    });
+}
+
+function pruneAfterCapture(library, now) {
+    try { pruneCandidates(library, now); } catch (error) { void error; }
+}
+
+function captureSuccessfulScript(code, args, context, deps, tool) {
+    try {
+        if (!deps || typeof deps.getToolLibrary !== 'function') return null;
+        const library = deps.getToolLibrary();
+        const capturedAt = Math.max(0, Math.floor(library.now()));
+        const argsSchema = {};
+        const contentHash = computeContentHash('jsx', code, argsSchema);
+        const matches = library.findByContentHash('jsx', contentHash);
+        const match = matches.find(function (summary) {
+            return summary.status === 'candidate';
+        });
+        const persisted = matches.find(function (summary) {
+            return summary.status === 'saved' || summary.status === 'pinned';
+        });
+        if (!match && persisted) {
+            pruneAfterCapture(library, capturedAt);
+            return persisted.id;
+        }
+        let artifact;
+        if (match) {
+            artifact = Object.assign({}, library.getArtifact(match.id), { updatedAt: capturedAt });
+        } else {
+            const session = context && context.session ? context.session : {};
+            artifact = {
+                schemaVersion: 1,
+                id: 'user:' + crypto.randomUUID(),
+                name: inferredName(code, args),
+                description: 'Captured from a successful MCP exec call.',
+                kind: 'jsx',
+                category: 'workflow',
+                tags: [],
+                compatibility: {},
+                declaredRisk: 'write',
+                source: {
+                    type: 'chat-tool-call',
+                    ref: tool,
+                    client: typeof session.clientName === 'string' ? session.clientName : null,
+                    productVersion: null,
+                    provenance: {
+                        capturedAt,
+                        conversationId: session.conversationId === undefined
+                            ? null : session.conversationId,
+                        tool,
+                    },
+                },
+                status: 'candidate',
+                verified: false,
+                verification: null,
+                content: code,
+                argsSchema,
+                contentHash,
+                revision: 1,
+                createdAt: capturedAt,
+                updatedAt: capturedAt,
+                lastUsedAt: null,
+            };
+        }
+        artifact = library.saveArtifact(artifact);
+        pruneAfterCapture(library, capturedAt);
+        return artifact.id;
+    } catch (error) {
+        return null;
+    }
+}
+
+function candidateGuidance(message, context, deps) {
+    try {
+        if (!deps || typeof deps.getToolLibrary !== 'function') return message;
+        const candidates = capturedCandidates(deps.getToolLibrary());
+        const session = context && context.session ? context.session : {};
+        const conversationId = session.conversationId === undefined ? null : session.conversationId;
+        const matching = candidates.filter(function (artifact) {
+            return artifact.source.provenance.conversationId === conversationId;
+        });
+        const recent = (matching.length ? matching : candidates).slice(0, 5);
+        if (!recent.length) return message;
+        const rows = recent.map(function (artifact) {
+            const value = artifact.source.provenance.capturedAt;
+            const capturedAt = Number.isFinite(value) ? value : artifact.updatedAt;
+            return '- artifactId=' + artifact.id
+                + ', chars=' + Array.from(artifact.content).length
+                + ', capturedAt=' + new Date(capturedAt).toISOString()
+                + ', content=' + JSON.stringify(firstCharacters(artifact.content, 60));
+        });
+        return message + '\n\nRecent successful scripts you can rerun:\n' + rows.join('\n')
+            + '\nRerun one verbatim with ae_toolUse {"name":"<artifactId>"}.';
+    } catch (error) {
+        return message;
+    }
+}
+
+module.exports = {
+    CANDIDATE_TTL_MS,
+    GLOBAL_LIMIT,
+    SESSION_LIMIT,
+    candidateGuidance,
+    captureSuccessfulScript,
+    inferredName,
+    pruneCandidates,
+};

--- a/plugin/host/mcp/candidate-artifacts.test.js
+++ b/plugin/host/mcp/candidate-artifacts.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    CANDIDATE_TTL_MS,
+    candidateGuidance,
+    captureSuccessfulScript,
+    pruneCandidates,
+} = require('./candidate-artifacts');
+const { ToolLibrary, computeContentHash } = require('./tool-library');
+
+function fixture(t, initialNow) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-candidates-'));
+    let current = initialNow === undefined ? 1000 : initialNow;
+    t.after(function () { fs.rmSync(root, { recursive: true, force: true }); });
+    return {
+        library: new ToolLibrary({
+            toolRoot: path.join(root, 'tools'),
+            skillRoot: path.join(root, 'skills'),
+            bundledRoot: path.join(__dirname, 'skills_bundled'),
+            now: function () { return current; },
+        }),
+        setNow: function (value) { current = value; },
+    };
+}
+
+function context(conversationId) {
+    return { session: { clientName: 'candidate-test', conversationId } };
+}
+
+function candidate(index, updatedAt, conversationId, overrides) {
+    const suffix = index.toString(16).padStart(12, '0');
+    const content = 'candidate-code-' + index;
+    const value = {
+        schemaVersion: 1,
+        id: 'user:00000000-0000-4000-8000-' + suffix,
+        name: 'Candidate ' + index,
+        description: 'Captured from a successful MCP exec call.',
+        kind: 'jsx',
+        category: 'workflow',
+        tags: [],
+        compatibility: {},
+        declaredRisk: 'write',
+        source: {
+            type: 'chat-tool-call',
+            ref: 'ae_exec',
+            client: 'candidate-test',
+            productVersion: null,
+            provenance: { capturedAt: updatedAt, conversationId, tool: 'ae_exec' },
+        },
+        status: 'candidate',
+        verified: false,
+        verification: null,
+        content,
+        argsSchema: {},
+        revision: 1,
+        createdAt: updatedAt,
+        updatedAt,
+        lastUsedAt: null,
+    };
+    Object.assign(value, overrides || {});
+    value.contentHash = computeContentHash(value.kind, value.content, value.argsSchema);
+    return value;
+}
+
+test('successful scripts capture the artifact contract and all name inference branches', (t) => {
+    const f = fixture(t);
+    const deps = { getToolLibrary: function () { return f.library; } };
+    const undoId = captureSuccessfulScript(
+        'app.project.activeItem;',
+        { undo_group_name: 'Build title' },
+        context('conversation-a'),
+        deps,
+        'ae_exec',
+    );
+    const undo = f.library.getArtifact(undoId);
+    assert.equal(undo.name, 'Build title');
+    assert.equal(undo.description, 'Captured from a successful MCP exec call.');
+    assert.equal(undo.status, 'candidate');
+    assert.equal(undo.verified, false);
+    assert.equal(undo.verification, null);
+    assert.deepEqual(undo.argsSchema, {});
+    assert.equal(undo.category, 'workflow');
+    assert.deepEqual(undo.tags, []);
+    assert.deepEqual(undo.compatibility, {});
+    assert.equal(undo.declaredRisk, 'write');
+    assert.equal(undo.content, 'app.project.activeItem;');
+    assert.equal(undo.source.type, 'chat-tool-call');
+    assert.equal(undo.source.client, 'candidate-test');
+    assert.deepEqual(undo.source.provenance, {
+        capturedAt: 1000,
+        conversationId: 'conversation-a',
+        tool: 'ae_exec',
+    });
+
+    const longLine = 'x'.repeat(70);
+    const lineId = captureSuccessfulScript('\n   \n  ' + longLine + '\nsecond;', {}, context('conversation-a'), deps, 'ae_exec');
+    assert.equal(f.library.getArtifact(lineId).name, 'x'.repeat(60));
+
+    const blankCode = '\n  \r\n';
+    const blankId = captureSuccessfulScript(blankCode, {}, context('conversation-a'), deps, 'ae_exec');
+    const hash = crypto.createHash('sha256').update(blankCode, 'utf8').digest('hex');
+    assert.equal(f.library.getArtifact(blankId).name, 'ae_exec ' + hash.slice(0, 8));
+});
+
+test('content hash deduplication only touches updatedAt and reuses the artifact id', (t) => {
+    const f = fixture(t, 1000);
+    const deps = { getToolLibrary: function () { return f.library; } };
+    const firstId = captureSuccessfulScript('same-code', { undo_group_name: 'Original' },
+        context('conversation-a'), deps, 'ae_exec');
+    const before = f.library.getArtifact(firstId);
+    f.setNow(2000);
+    const secondId = captureSuccessfulScript('same-code', { undo_group_name: 'Replacement' },
+        context('conversation-b'), deps, 'ae_execRecover');
+    const after = f.library.getArtifact(secondId);
+    assert.equal(secondId, firstId);
+    assert.equal(f.library.list({ statuses: ['candidate'] }).length, 1);
+    assert.deepEqual(Object.assign({}, after, { updatedAt: before.updatedAt }), before);
+    assert.equal(after.updatedAt, 2000);
+});
+
+test('saved and pinned content is reused without creating or touching a candidate', (t) => {
+    const f = fixture(t, 2000);
+    const deps = { getToolLibrary: function () { return f.library; } };
+    ['saved', 'pinned'].forEach(function (status, index) {
+        const persisted = candidate(40 + index, 1000 + index, 'conversation-a', { status });
+        f.library.saveArtifact(persisted);
+        const before = f.library.getArtifact(persisted.id);
+        const artifactId = captureSuccessfulScript(
+            persisted.content,
+            {},
+            context('conversation-b'),
+            deps,
+            'ae_exec',
+        );
+        assert.equal(artifactId, persisted.id);
+        assert.deepEqual(f.library.getArtifact(artifactId), before);
+    });
+    assert.equal(f.library.list({ statuses: ['candidate'] }).length, 0);
+});
+
+test('capture failures are silent', (t) => {
+    const f = fixture(t);
+    assert.equal(captureSuccessfulScript('code', {}, context('conversation'), {
+        getToolLibrary: function () { throw new Error('unavailable'); },
+    }, 'ae_exec'), null);
+    assert.equal(f.library.list({ statuses: ['candidate'] }).length, 0);
+});
+
+test('candidate pruning enforces TTL without touching saved or pinned artifacts', (t) => {
+    const f = fixture(t);
+    const oldCandidate = candidate(1, 0, 'conversation');
+    const saved = candidate(2, 0, 'conversation', { status: 'saved' });
+    const pinned = candidate(3, 0, 'conversation', { status: 'pinned' });
+    [oldCandidate, saved, pinned].forEach(function (artifact) { f.library.saveArtifact(artifact); });
+    pruneCandidates(f.library, CANDIDATE_TTL_MS + 1);
+    assert.throws(function () { f.library.getArtifact(oldCandidate.id); }, /tool not found/);
+    assert.equal(f.library.getArtifact(saved.id).status, 'saved');
+    assert.equal(f.library.getArtifact(pinned.id).status, 'pinned');
+});
+
+test('candidate pruning retains the newest 20 entries per conversation', (t) => {
+    const f = fixture(t);
+    for (let i = 1; i <= 21; i += 1) f.library.saveArtifact(candidate(i, i, 'conversation-a'));
+    const other = candidate(30, 30, 'conversation-b');
+    f.library.saveArtifact(other);
+    pruneCandidates(f.library, 31);
+    const ids = f.library.list({ statuses: ['candidate'] }).map(function (item) { return item.id; });
+    assert.equal(ids.length, 21);
+    assert.equal(ids.includes(candidate(1, 1, 'conversation-a').id), false);
+    assert.equal(ids.includes(other.id), true);
+});
+
+test('candidate pruning retains the newest 200 entries globally', (t) => {
+    const f = fixture(t);
+    for (let i = 1; i <= 201; i += 1) f.library.saveArtifact(candidate(i, i, null));
+    pruneCandidates(f.library, 202);
+    const ids = f.library.list({ statuses: ['candidate'] }).map(function (item) { return item.id; });
+    assert.equal(ids.length, 200);
+    assert.equal(ids.includes(candidate(1, 1, null).id), false);
+});
+
+test('placeholder guidance prefers the current conversation, falls back globally, and preserves empty text', (t) => {
+    const f = fixture(t);
+    for (let i = 1; i <= 6; i += 1) f.library.saveArtifact(candidate(i, i, 'current'));
+    const other = candidate(20, 20, 'other');
+    f.library.saveArtifact(other);
+    const deps = { getToolLibrary: function () { return f.library; } };
+    const local = candidateGuidance('base error', context('current'), deps);
+    assert.match(local, /Recent successful scripts you can rerun:/);
+    assert.match(local, /artifactId=user:/);
+    assert.match(local, /chars=16/);
+    assert.match(local, /capturedAt=1970-01-01T00:00:00\.00[2-6]Z/);
+    assert.match(local, /content="candidate-code-/);
+    assert.match(local, /Rerun one verbatim with ae_toolUse \{"name":"<artifactId>"\}\./);
+    assert.equal(local.includes(other.id), false);
+    assert.equal(local.includes(candidate(1, 1, 'current').id), false);
+
+    const global = candidateGuidance('base error', context('missing'), deps);
+    assert.equal(global.includes(other.id), true);
+    const empty = fixture(t);
+    assert.equal(candidateGuidance('base error', context('missing'), {
+        getToolLibrary: function () { return empty.library; },
+    }), 'base error');
+});

--- a/plugin/host/mcp/conversation-exec-integration.test.js
+++ b/plugin/host/mcp/conversation-exec-integration.test.js
@@ -7,12 +7,14 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const express = require('express');
+const { createStatePaths } = require('../state-paths');
 const mountMcp = require('./index');
 const { CheckpointStore } = require('./checkpoint-store');
 const { READONLY_DENIED } = require('./approval-gate');
 
 function start(options) {
     const input = options || {};
+    const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-conversation-state-'));
     const ownedStoreRoot = input.checkpointStore
         ? null : fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-conversation-store-'));
     const checkpointStore = input.checkpointStore
@@ -27,10 +29,14 @@ function start(options) {
         recoveryStore: input.recoveryStore,
         progressIntervalMs: input.progressIntervalMs,
         approvalTimeoutMs: input.approvalTimeoutMs,
+        statePaths: createStatePaths({
+            stateDir: stateRoot,
+            homedir: function () { throw new Error('conversation tests must not resolve the real home'); },
+        }),
     });
     return new Promise(function (resolve) {
         const listener = app.listen(0, '127.0.0.1', function () {
-            resolve({ listener, port: listener.address().port, mounted, ownedStoreRoot });
+            resolve({ listener, port: listener.address().port, mounted, ownedStoreRoot, stateRoot });
         });
     });
 }
@@ -92,6 +98,7 @@ async function closeFixture(fixture) {
     if (fixture.ownedStoreRoot) {
         fs.rmSync(fixture.ownedStoreRoot, { recursive: true, force: true });
     }
+    fs.rmSync(fixture.stateRoot, { recursive: true, force: true });
 }
 
 test('conversation tiers isolate calls, external calls bypass, updates are live, and unknown tokens 404', async () => {

--- a/plugin/host/mcp/conversation-exec-integration.test.js
+++ b/plugin/host/mcp/conversation-exec-integration.test.js
@@ -78,6 +78,15 @@ function toolCall(id, code, extra, meta) {
     };
 }
 
+function assertCapturedExecResult(actual, expected) {
+    const artifactId = actual.artifactId;
+    assert.equal(typeof artifactId, 'string');
+    assert.match(artifactId, /^user:/);
+    const envelope = Object.assign({}, actual);
+    delete envelope.artifactId;
+    assert.deepEqual(envelope, expected);
+}
+
 async function closeFixture(fixture) {
     await new Promise(function (resolve) { fixture.listener.close(resolve); });
     if (fixture.ownedStoreRoot) {
@@ -117,7 +126,7 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         const allowed = await request(fixture.port, 'POST', none.path, {
             'Mcp-Session-Id': noneSession.session,
         }, toolCall(2, 'json'));
-        assert.deepEqual(allowed.body.result.structuredContent, {
+        assertCapturedExecResult(allowed.body.result.structuredContent, {
             ok: true,
             content: '{"ok":true,"n":1}',
             contentType: 'json',
@@ -135,7 +144,7 @@ test('conversation tiers isolate calls, external calls bypass, updates are live,
         const externalResult = await request(fixture.port, 'POST', '/mcp', {
             'Mcp-Session-Id': external.session,
         }, toolCall(4, 'plain'));
-        assert.deepEqual(externalResult.body.result.structuredContent, {
+        assertCapturedExecResult(externalResult.body.result.structuredContent, {
             ok: true,
             content: 'hi',
             contentType: 'text',
@@ -214,7 +223,7 @@ test('manual conversation approval accepts with progress and declines without ex
                 && frame.params.progressToken === 'approval-progress';
         }));
         const terminal = frames.find(function (frame) { return frame.id === 2; });
-        assert.deepEqual(terminal.result.structuredContent, {
+        assertCapturedExecResult(terminal.result.structuredContent, {
             ok: true,
             content: '{"ok":true,"approved":true}',
             contentType: 'json',
@@ -289,7 +298,7 @@ test('checkpoint success probes, snapshots, persists metadata, then executes use
         }, toolCall(2, 'user-edit-code', {
             checkpoint_label: 'Before edit', undo_group_name: 'Edit', timeout_sec: 45,
         }));
-        assert.deepEqual(response.body.result.structuredContent, {
+        assertCapturedExecResult(response.body.result.structuredContent, {
             ok: true,
             content: '{"ok":true,"edited":true}',
             contentType: 'json',
@@ -348,7 +357,7 @@ test('untitled and failed checkpoints annotate the result but never block user J
     }
 
     const untitled = await runCase(null, false);
-    assert.deepEqual(untitled.result, {
+    assertCapturedExecResult(untitled.result, {
         ok: true,
         content: '{"ok":true,"edited":true}',
         contentType: 'json',
@@ -363,6 +372,12 @@ test('untitled and failed checkpoints annotate the result but never block user J
     try {
         const failed = await runCase(source, true);
         assert.match(failed.result.checkpointSkipped, /^checkpoint-failed:/);
+        assertCapturedExecResult(failed.result, {
+            ok: true,
+            content: '{"ok":true,"edited":true}',
+            contentType: 'json',
+            checkpointSkipped: failed.result.checkpointSkipped,
+        });
         assert.equal(failed.calls.length, 3);
         assert.equal(failed.calls[2].code, 'user-edit');
     } finally {

--- a/plugin/host/mcp/index.js
+++ b/plugin/host/mcp/index.js
@@ -99,6 +99,9 @@ function progressMessage(token, startedAt, now) {
 }
 
 function mountMcp(app, deps) {
+    if (!deps || !deps.statePaths) {
+        throw new TypeError('mountMcp requires deps.statePaths');
+    }
     const sessions = new SessionStore();
     const conversations = new ConversationStore(sessions);
     const approvals = deps.approvals || new ApprovalQueue({ timeoutMs: deps.approvalTimeoutMs });

--- a/plugin/host/mcp/index.test.js
+++ b/plugin/host/mcp/index.test.js
@@ -1,12 +1,17 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 const express = require('express');
+const { createStatePaths } = require('../state-paths');
 const mountMcp = require('./index');
 
 function start(options) {
+    const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-index-state-'));
     const app = express();
     app.use(express.json());
     const mounted = mountMcp(app, {
@@ -20,10 +25,14 @@ function start(options) {
         },
         progressIntervalMs: options && options.progressIntervalMs,
         sseOptions: options && options.sseOptions,
+        statePaths: createStatePaths({
+            stateDir: stateRoot,
+            homedir: function () { throw new Error('MCP index tests must not resolve the real home'); },
+        }),
     });
     return new Promise(function (resolve) {
         const listener = app.listen(0, '127.0.0.1', function () {
-            resolve({ listener, port: listener.address().port, mounted });
+            resolve({ listener, port: listener.address().port, mounted, stateRoot });
         });
     });
 }
@@ -108,7 +117,15 @@ test('MCP initializes, enforces loopback Origin/Host, and supports session lifec
         assert.equal(deleted.status, 204);
     } finally {
         await new Promise(function (resolve) { fixture.listener.close(resolve); });
+        fs.rmSync(fixture.stateRoot, { recursive: true, force: true });
     }
+});
+
+test('mountMcp requires explicit state paths', () => {
+    assert.throws(
+        function () { mountMcp(express(), {}); },
+        { name: 'TypeError', message: 'mountMcp requires deps.statePaths' },
+    );
 });
 
 test('progress notifications retain their token and report elapsed seconds', () => {

--- a/plugin/host/mcp/instructions-integration.test.js
+++ b/plugin/host/mcp/instructions-integration.test.js
@@ -2,8 +2,12 @@
 
 const assert = require('node:assert/strict');
 const express = require('express');
+const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
+const { createStatePaths } = require('../state-paths');
 const mountMcp = require('./index');
 
 function request(port, route) {
@@ -37,6 +41,7 @@ function request(port, route) {
     });
 }
 test('initialize uses conversation expertGuidance while external sessions retain the expert addendum', async function () {
+    const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-instructions-state-'));
     const app = express();
     app.use(express.json());
     const mounted = mountMcp(app, {
@@ -47,6 +52,10 @@ test('initialize uses conversation expertGuidance while external sessions retain
         executeJsx: async function () {
             return { payload: { ok: true, result: '{}' } };
         },
+        statePaths: createStatePaths({
+            stateDir: stateRoot,
+            homedir: function () { throw new Error('MCP instructions tests must not resolve the real home'); },
+        }),
     });
     const server = await new Promise(function (resolve) {
         const next = app.listen(0, '127.0.0.1', function () {
@@ -71,5 +80,6 @@ test('initialize uses conversation expertGuidance while external sessions retain
         await new Promise(function (resolve) {
             server.close(resolve);
         });
+        fs.rmSync(stateRoot, { recursive: true, force: true });
     }
 });

--- a/plugin/host/mcp/server-integration.test.js
+++ b/plugin/host/mcp/server-integration.test.js
@@ -77,11 +77,33 @@ test('MCP ae_exec shares paused/blocked gates and activity records with /exec', 
             jsonrpc: '2.0', id: 2, method: 'tools/call',
             params: { name: 'ae_exec', arguments: { code: '1 + 1', undo_group_name: 'MCP test' } },
         });
-        assert.deepEqual(success.body.result.structuredContent, {
+        const successfulExec = success.body.result.structuredContent;
+        assert.match(successfulExec.artifactId, /^user:/);
+        assert.deepEqual(Object.assign({}, successfulExec, { artifactId: undefined }), {
             ok: true,
             content: 'bridge-ok',
             contentType: 'text',
+            artifactId: undefined,
         });
+        const artifactId = successfulExec.artifactId;
+        const listed = await request(host.port, headers, {
+            jsonrpc: '2.0', id: 22, method: 'tools/call',
+            params: { name: 'ae_toolSearch', arguments: {} },
+        });
+        assert.equal(listed.body.result.structuredContent.artifacts.some(function (item) {
+            return item.id === artifactId;
+        }), false);
+        const inspected = await request(host.port, headers, {
+            jsonrpc: '2.0', id: 23, method: 'tools/call',
+            params: { name: 'ae_toolSearch', arguments: { name: artifactId } },
+        });
+        assert.equal(inspected.body.result.structuredContent.artifact.id, artifactId);
+        const used = await request(host.port, headers, {
+            jsonrpc: '2.0', id: 24, method: 'tools/call',
+            params: { name: 'ae_toolUse', arguments: { name: artifactId } },
+        });
+        assert.equal(used.body.result.structuredContent.ok, true);
+        assert.equal(used.body.result.structuredContent.content, 'bridge-ok');
         const invalidParams = await request(host.port, headers, {
             jsonrpc: '2.0', id: 21, method: 'tools/call', params: {},
         });
@@ -106,7 +128,7 @@ test('MCP ae_exec shares paused/blocked gates and activity records with /exec', 
         assert.match(paused.body.error.message, /paused/);
         assert.equal(host.server.activity.list().filter(function (event) {
             return event.client === client;
-        }).length, 3);
+        }).length, 6);
     } finally {
         host.server.setPaused(false);
         await new Promise(function (resolve) { host.listener.close(resolve); });

--- a/plugin/host/mcp/session-identity.test.js
+++ b/plugin/host/mcp/session-identity.test.js
@@ -52,6 +52,15 @@ function initializeMessage(id, name, version) {
     };
 }
 
+function assertCapturedExecResult(actual, expected) {
+    const artifactId = actual.artifactId;
+    assert.equal(typeof artifactId, 'string');
+    assert.match(artifactId, /^user:/);
+    const envelope = Object.assign({}, actual);
+    delete envelope.artifactId;
+    assert.deepEqual(envelope, expected);
+}
+
 async function fixture() {
     const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-identity-state-'));
     delete require.cache[require.resolve('../server')];
@@ -116,7 +125,7 @@ test('MCP identity blocks existing and new sessions, then restores after unblock
             jsonrpc: '2.0', id: 3, method: 'tools/call',
             params: { name: 'ae_exec', arguments: { code: '1 + 1' } },
         });
-        assert.deepEqual(restored.body.result.structuredContent, {
+        assertCapturedExecResult(restored.body.result.structuredContent, {
             ok: true,
             content: 'identity-ok',
             contentType: 'text',

--- a/plugin/host/mcp/tool-library.js
+++ b/plugin/host/mcp/tool-library.js
@@ -520,6 +520,31 @@ class ToolLibrary {
         return artifact;
     }
 
+    removeArtifact(id) {
+        const artifactPath = this.artifactPath(id);
+        const index = this.readIndex();
+        const entry = index.artifacts.find(function (item) { return item.id === id; });
+        if (!entry) return false;
+        let before;
+        try { before = fs.readFileSync(artifactPath, 'utf8'); } catch (error) {
+            throw new Error('tool store is corrupt');
+        }
+        const next = {
+            schemaVersion: 1,
+            revision: index.revision + 1,
+            artifacts: index.artifacts.filter(function (item) { return item.id !== id; }),
+        };
+        assertSecretFree(next, 'index.json');
+        fs.unlinkSync(artifactPath);
+        try {
+            atomicWrite(this.indexPath, canonicalJson(next) + '\n');
+        } catch (error) {
+            atomicWrite(artifactPath, before);
+            throw error;
+        }
+        return true;
+    }
+
     getArtifact(id) {
         const index = this.readIndex();
         const entry = index.artifacts.find(function (item) { return item.id === id; });

--- a/plugin/host/mcp/tool-library.test.js
+++ b/plugin/host/mcp/tool-library.test.js
@@ -123,6 +123,29 @@ test('canonical content addressing is order-independent and atomic writes leave 
     assert.equal(library.findByContentHash('jsx', first.contentHash).length, 2);
 });
 
+test('removeArtifact deletes both records and rolls back the file when the index update fails', (t) => {
+    const library = makeLibrary(t);
+    const saved = library.saveArtifact(artifact());
+    const originalRename = fs.renameSync;
+    let rejected = false;
+    fs.renameSync = function (source, destination) {
+        if (!rejected && destination === library.indexPath) {
+            rejected = true;
+            throw new Error('index write failed');
+        }
+        return originalRename(source, destination);
+    };
+    try {
+        assert.throws(function () { library.removeArtifact(saved.id); }, /index write failed/);
+    } finally {
+        fs.renameSync = originalRename;
+    }
+    assert.equal(library.getArtifact(saved.id).id, saved.id);
+    assert.equal(library.removeArtifact(saved.id), true);
+    assert.equal(library.removeArtifact(saved.id), false);
+    assert.throws(function () { library.getArtifact(saved.id); }, /tool not found/);
+});
+
 test('secret-shaped artifact content is rejected before it reaches disk', (t) => {
     const library = makeLibrary(t);
     const secret = artifact({ content: 'var key = "sk-secretvalue";' });
@@ -181,6 +204,42 @@ test('toolSearch combines index, query, and inspect modes', async (t) => {
         name: 'ae_toolSearch', arguments: { name: saved.id },
     }, context);
     assert.deepEqual(inspected.result.structuredContent.artifact, saved);
+});
+
+test('candidate artifacts stay out of default search but remain inspectable and executable by id', async (t) => {
+    const library = makeLibrary(t);
+    const captured = artifact({
+        status: 'candidate',
+        argsSchema: {},
+        content: 'app.project.activeItem;',
+        source: {
+            type: 'chat-tool-call',
+            ref: 'ae_exec',
+            client: 'test-client',
+            productVersion: null,
+            provenance: { capturedAt: 1000, conversationId: 'conversation-test', tool: 'ae_exec' },
+        },
+    });
+    library.saveArtifact(captured);
+    const registry = buildTools({
+        toolLibrary: library,
+        executeJsx: async function (request) {
+            assert.equal(request.code, captured.content);
+            return { payload: { ok: true, result: '{"ok":true}' } };
+        },
+    });
+    const listed = await registry.call({ name: 'ae_toolSearch', arguments: {} }, toolContext());
+    assert.equal(listed.result.structuredContent.artifacts.some(function (item) {
+        return item.id === captured.id;
+    }), false);
+    const inspected = await registry.call({
+        name: 'ae_toolSearch', arguments: { name: captured.id },
+    }, toolContext());
+    assert.equal(inspected.result.structuredContent.artifact.id, captured.id);
+    const used = await registry.call({
+        name: 'ae_toolUse', arguments: { name: captured.id },
+    }, toolContext());
+    assert.deepEqual(used.result.structuredContent, { ok: true });
 });
 
 test('toolUse rejects a changed artifact at approval consumption and before execution', async (t) => {

--- a/plugin/host/mcp/tools/exec.js
+++ b/plugin/host/mcp/tools/exec.js
@@ -6,6 +6,7 @@ const { VERB_ANNOTATIONS } = require('../annotations');
 const { enforce } = require('../approval-gate');
 const { parseExecResult } = require('../jsx-result');
 const { matchHint } = require('../error-hints');
+const { candidateGuidance, captureSuccessfulScript } = require('../candidate-artifacts');
 
 const HISTORY_REDACTION_MARKERS = [
     'omitted from prior model history',
@@ -71,6 +72,7 @@ const definition = {
             revision: { type: 'object' },
             attempt: { type: 'number' },
             restored: { type: 'string' },
+            artifactId: { type: 'string' },
         },
         required: ['ok'],
         additionalProperties: true,
@@ -310,6 +312,8 @@ async function runInitial(args, context, deps) {
         return createRecovery(args, context, deps, args.code, execution, failure, checkpointRun);
     }
     const parsed = parseExecResult(execution.payload.resultType, execution.payload.result);
+    const artifactId = captureSuccessfulScript(args.code, args, context, deps, 'ae_exec');
+    if (artifactId) parsed.artifactId = artifactId;
     return annotateCheckpoint(parsed, checkpointRun);
 }
 
@@ -447,16 +451,23 @@ async function runRecovery(args, context, deps) {
     }
     const parsed = parseExecResult(execution.payload.resultType, execution.payload.result);
     annotateCheckpoint(parsed, checkpointRun);
+    const artifactId = captureSuccessfulScript(code, resolvedArgs, context, deps, 'ae_execRecover');
     return Object.assign({}, parsed, {
         recoveryId: args.recoveryId,
         attempt: attemptNumber,
         restored: restoration.restored,
+        ...(artifactId ? { artifactId } : {}),
     });
 }
 
 async function call(args, context, deps) {
     if (isHistoryRedactionPlaceholder(args && args.code)) {
-        return { result: textResult({ ok: false, error: placeholderError(false) }, true) };
+        return {
+            result: textResult({
+                ok: false,
+                error: candidateGuidance(placeholderError(false), context, deps),
+            }, true),
+        };
     }
     const input = args || {};
     const invalid = initialValidationError(input);
@@ -473,7 +484,12 @@ async function call(args, context, deps) {
 
 async function recover(args, context, deps) {
     if (isHistoryRedactionPlaceholder(args && args.code)) {
-        return { result: textResult({ ok: false, error: placeholderError(true) }, true) };
+        return {
+            result: textResult({
+                ok: false,
+                error: candidateGuidance(placeholderError(true), context, deps),
+            }, true),
+        };
     }
     const input = args || {};
     const invalid = recoveryValidationError(input);

--- a/plugin/host/mcp/tools/exec.test.js
+++ b/plugin/host/mcp/tools/exec.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const test = require('node:test');
 const { CheckpointStore } = require('../checkpoint-store');
 const { RecoveryStore } = require('../recovery-store');
+const { ToolLibrary } = require('../tool-library');
 const { PROJECT_PATH_CODE } = require('../checkpoint-ops');
 const execTool = require('./exec');
 const execRecoverTool = require('./exec-recover');
@@ -51,11 +52,17 @@ function fixture() {
     fs.writeFileSync(project, 'current-project', 'utf8');
     const checkpointStore = new CheckpointStore({ root: path.join(root, 'checkpoints') });
     const recoveryStore = new RecoveryStore({ checkpointStore });
+    const toolLibrary = new ToolLibrary({
+        toolRoot: path.join(root, 'tools'),
+        skillRoot: path.join(root, 'skills'),
+        bundledRoot: path.join(__dirname, '..', 'skills_bundled'),
+    });
     const calls = [];
     let userHandler = async function () { return success({ ok: true }); };
     const deps = {
         getCheckpointStore: function () { return checkpointStore; },
         getRecoveryStore: function () { return recoveryStore; },
+        getToolLibrary: function () { return toolLibrary; },
         setUserHandler: function (handler) { userHandler = handler; },
         executeJsx: async function (input) {
             if (input.code === PROJECT_PATH_CODE) {
@@ -91,6 +98,7 @@ function fixture() {
         project,
         checkpointStore,
         recoveryStore,
+        toolLibrary,
         calls,
         deps,
         close: function () { fs.rmSync(root, { recursive: true, force: true }); },
@@ -107,6 +115,7 @@ test('ae_exec accepts only new executions and ae_execRecover owns the compact re
     assert.equal(execRecoverTool.definition.inputSchema.properties.recoveryId.maxLength, 6);
     assert.match(execRecoverTool.definition.inputSchema.properties.recoveryId.description, /Never invent|exact/i);
     assert.deepEqual(execRecoverTool.definition.inputSchema.properties.retryMode.enum, ['restore', 'continue']);
+    assert.equal(execTool.definition.outputSchema.properties.artifactId.type, 'string');
     assert.ok(Buffer.byteLength(JSON.stringify(execRecoverTool.definition), 'utf8') < 2500);
     const missing = value(await execTool.call({}, context(null), {}));
     assert.equal(missing.error, 'missing or empty `code`');
@@ -116,6 +125,27 @@ test('ae_exec accepts only new executions and ae_execRecover owns the compact re
     assert.equal(misplacedRecovery.error, 'recovery fields are only accepted by `ae_execRecover`');
     const missingRecoveryId = value(await execRecoverTool.call({ code: 'fixed' }, context(null), {}));
     assert.match(missingRecoveryId.error, /recoveryId.*must match/);
+});
+
+test('successful execution returns a captured artifact id while capture errors leave success unchanged', async () => {
+    const f = fixture();
+    try {
+        const captured = value(await execTool.call({
+            code: 'app.project.activeItem;', undo_group_name: 'Inspect project',
+        }, context(null), f.deps));
+        assert.equal(captured.ok, true);
+        assert.match(captured.artifactId, /^user:/);
+        const artifact = f.toolLibrary.getArtifact(captured.artifactId);
+        assert.equal(artifact.name, 'Inspect project');
+        assert.equal(artifact.source.provenance.tool, 'ae_exec');
+
+        f.deps.getToolLibrary = function () { throw new Error('capture unavailable'); };
+        const uncaptured = value(await execTool.call({ code: '2 + 2' }, context(null), f.deps));
+        assert.equal(uncaptured.ok, true);
+        assert.equal(Object.prototype.hasOwnProperty.call(uncaptured, 'artifactId'), false);
+    } finally {
+        f.close();
+    }
 });
 
 test('initial dispatched failure writes byte-identical recovery script and attempt metadata', async () => {
@@ -158,6 +188,7 @@ test('initial dispatched failure writes byte-identical recovery script and attem
         assert.equal(meta.attempts[0].errorLine, 2);
         assert.equal(meta.attempts[0].errorSource, 'throw new Error("bad");');
         assert.equal(meta.attempts[0].touchedLevel, 'layer_diff');
+        assert.equal(f.toolLibrary.list({ statuses: ['candidate'] }).length, 0);
     } finally {
         f.close();
     }
@@ -212,6 +243,8 @@ test('retry restores checkpoint, restores viewer, checkpoints again, then runs e
         assert.equal(retried.recoveryId, first.recoveryId);
         assert.equal(retried.attempt, 2);
         assert.equal(retried.restored, 'checkpoint');
+        assert.match(retried.artifactId, /^user:/);
+        assert.equal(f.toolLibrary.getArtifact(retried.artifactId).source.provenance.tool, 'ae_execRecover');
         assert.equal(approvals, 1);
         assert.deepEqual(f.calls, [
             'resolve', 'close', 'open', 'viewer', 'resolve', 'checkpoint', 'user:fixed',
@@ -393,6 +426,7 @@ test('history-guard placeholder code is rejected before execution and never over
         const rejected = value(await execTool.call({ code: freshMarker }, context(null), f.deps));
         assert.equal(rejected.ok, false);
         assert.match(rejected.error, /redaction placeholder/);
+        assert.doesNotMatch(rejected.error, /Recent successful scripts/);
         assert.equal(f.calls.length, 0);
 
         f.deps.setUserHandler(async function () {
@@ -402,6 +436,9 @@ test('history-guard placeholder code is rejected before execution and never over
         assert.ok(failure.recoveryId);
         const stored = fs.readFileSync(failure.scriptPath, 'utf8');
 
+        f.deps.setUserHandler(async function () { return success({ ok: true }); });
+        const captured = value(await execTool.call({ code: 'captured-success' }, context(null), f.deps));
+
         const callsBefore = f.calls.length;
         const blocked = value(await execRecoverTool.call({
             recoveryId: failure.recoveryId,
@@ -410,6 +447,8 @@ test('history-guard placeholder code is rejected before execution and never over
         assert.equal(blocked.ok, false);
         assert.match(blocked.error, /redaction placeholder/);
         assert.match(blocked.error, /omit `code`/);
+        assert.match(blocked.error, new RegExp(captured.artifactId));
+        assert.match(blocked.error, /chars=16/);
         assert.equal(f.calls.length, callsBefore);
         assert.equal(fs.readFileSync(failure.scriptPath, 'utf8'), stored);
     } finally {

--- a/plugin/host/mcp/tools/native-exec.test.js
+++ b/plugin/host/mcp/tools/native-exec.test.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 const express = require('express');
+const { createStatePaths } = require('../../state-paths');
 const mountMcp = require('../index');
 const { VERB_ANNOTATIONS } = require('../annotations');
 const {
@@ -113,6 +117,7 @@ function request(port, path, body, headers) {
 }
 
 async function fixture(options) {
+    const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-native-exec-state-'));
     const app = express();
     app.use(express.json());
     const input = options || {};
@@ -123,11 +128,20 @@ async function fixture(options) {
         version: '0.9.6-test',
         getStatus,
         executeJsx: async function () { return { payload: { ok: true, result: '{}' } }; },
+        statePaths: createStatePaths({
+            stateDir: stateRoot,
+            homedir: function () { throw new Error('native exec tests must not resolve the real home'); },
+        }),
     }, input));
     const listener = await new Promise(function (resolve) {
         const value = app.listen(0, '127.0.0.1', function () { resolve(value); });
     });
-    return { listener, port: listener.address().port, mounted };
+    return { listener, port: listener.address().port, mounted, stateRoot };
+}
+
+async function closeFixture(host) {
+    await new Promise(function (resolve) { host.listener.close(resolve); });
+    fs.rmSync(host.stateRoot, { recursive: true, force: true });
 }
 
 async function initialize(host, conversationPath) {
@@ -196,7 +210,7 @@ test('real Express MCP route runs ae_nativeExec through fake negotiate/invoke', 
         assert.deepEqual(write.undo, { available: true, groupLabel: 'Native write' });
         assert.equal(Object.hasOwn(write.audit, 'undoVerified'), false);
     } finally {
-        await new Promise(function (resolve) { host.listener.close(resolve); });
+        await closeFixture(host);
     }
 });
 
@@ -211,7 +225,7 @@ test('ae_nativeExec returns generated-schema errors before approval or native di
         assert.ok(Array.isArray(response.body.result.structuredContent.errors));
         assert.equal(invoked, false);
     } finally {
-        await new Promise(function (resolve) { host.listener.close(resolve); });
+        await closeFixture(host);
     }
 });
 
@@ -251,6 +265,6 @@ test('native errors retain the structured payload and approval gate blocks reado
         assert.equal(approvalCalls, 1);
         assert.equal(negotiateCalls, 1);
     } finally {
-        await new Promise(function (resolve) { host.listener.close(resolve); });
+        await closeFixture(host);
     }
 });


### PR DESCRIPTION
恢复 Python 时代遗失的成功脚本捕获链路，占位符死循环从"死胡同"变"一步自愈"。

Closes #338.

## 内容

- **捕获**：`ae_exec`/`ae_execRecover` 成功后，脚本经装配注入的 ToolLibrary 存为 `status:candidate`、`sourceType:chat-tool-call` 工件（独立模块 `candidate-artifacts.js`，全程 fail-open——捕获/修剪异常绝不影响执行结果）。name 三段推导（undo_group_name → 首行 60 字 → `ae_exec <sha8>`）。
- **去重**：contentHash 命中 candidate → 只 touch `updatedAt` 复用 id；命中已沉淀（saved/pinned）→ 不造重复，信封直接回该工件 id。
- **信封**：成功结果新增 `artifactId`（outputSchema 同步声明）。
- **守卫指路**：占位符拒绝错误列出本会话（conversationId 匹配，全局回退）最近 5 条可重跑工件 + `ae_toolUse {"name":"<id>"}` 用法；`plan()` 不校验 status，candidate 按精确 id 即可执行，tool-use 零改动。
- **清理**：TTL 7 天 / 每会话 20 条 / 全局 200 条，只动 `candidate & chat-tool-call`，绝不触碰 saved/pinned/legacy/bundled；ToolLibrary 新增最小 `removeArtifact(id)`（原子写 + 失败回滚）。
- **不污染索引**：candidates 不进 `ae_toolSearch` 默认列表（回归测试钉住：默认不可见 / 按 id 可查 / 按 id 可跑）。
- `ae_toolSave`（沉淀/创建动词）按计划留给 #344。

## 验证（编排者本机复跑）

- `plugin/host` `node --test`：**256 项，240 过 / 16 平台条件跳过 / 0 失败**（含新增 46 项单元与集成断言）。
- 回灌一轮：5 处既有集成断言随信封新字段更新（保持 exact-shape + `/^user:/` 校验）、description 固定文案、沉淀件去重、指路文案英文化。
- CEP 运行闭集（`cep-runtime-contract`）已含新模块。

## 待补

- 真机端到端（exec→信封 artifactId→守卫指路清单）随后在编排会话执行并回报。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
