### PR TITLE
fix(host): decode localized ExtendScript error text instead of mojibake (#356)

### DIFF
--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -605,6 +605,40 @@ function wrapForEvalScriptTransport(code, options) {
         : wrapForEvalScriptTransportDefault(code);
 }
 
+function repairLatin1Utf8(text) {
+    const value = String(text);
+    for (let i = 0; i < value.length; i += 1) {
+        if (value.charCodeAt(i) > 0xff) return value;
+    }
+    const bytes = Buffer.from(value, 'latin1');
+    let hasMultibyte = false;
+    for (let i = 0; i < bytes.length; i += 1) {
+        if (bytes[i] >= 0xc2 && bytes[i] <= 0xf4) {
+            hasMultibyte = true;
+            break;
+        }
+    }
+    if (!hasMultibyte) return value;
+    try {
+        return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch (e) {
+        return value;
+    }
+}
+
+function repairTransportJson(value) {
+    if (typeof value === 'string') return repairLatin1Utf8(value);
+    if (Array.isArray(value)) return value.map(repairTransportJson);
+    if (value && typeof value === 'object') {
+        const repaired = {};
+        Object.keys(value).forEach(function (key) {
+            repaired[key] = repairTransportJson(value[key]);
+        });
+        return repaired;
+    }
+    return value;
+}
+
 function decodeEvalScriptTransportResult(text) {
     let payload = null;
     if (String(text || '').trim() === '') {
@@ -640,9 +674,12 @@ function decodeEvalScriptTransportResult(text) {
         // error: the script executed, so this is `failed`, not `uncertain`
         // (#260 real-machine check). Undecodable / empty output stays untagged
         // and is classified as uncertain by the caller.
-        const error = new Error('ExtendScript error: ' + payload.error);
+        const error = new Error('ExtendScript error: ' + repairLatin1Utf8(payload.error));
         error.disposition = 'failed';
         if (Object.prototype.hasOwnProperty.call(payload, 'line')) error.line = payload.line;
+        if (Object.prototype.hasOwnProperty.call(payload, 'errorSource')) {
+            error.errorSource = repairLatin1Utf8(payload.errorSource);
+        }
         if (Object.prototype.hasOwnProperty.call(payload, 'touched')) error.touched = payload.touched;
         if (Object.prototype.hasOwnProperty.call(payload, 'logs')) error.logs = payload.logs;
         if (Object.prototype.hasOwnProperty.call(payload, 'logsTruncated')) {
@@ -658,7 +695,17 @@ function decodeEvalScriptTransportResult(text) {
     if (payload.resultType !== 'string' && payload.resultType !== 'json') {
         throw new Error('invalid evalScript transport envelope resultType');
     }
-    const decoded = { resultType: payload.resultType, result: payload.result };
+    let result = payload.result;
+    if (payload.resultType === 'string') {
+        result = repairLatin1Utf8(result);
+    } else {
+        try {
+            result = JSON.stringify(repairTransportJson(JSON.parse(result)));
+        } catch (e) {
+            result = payload.result;
+        }
+    }
+    const decoded = { resultType: payload.resultType, result };
     if (Object.prototype.hasOwnProperty.call(payload, 'logs')) decoded.logs = payload.logs;
     if (Object.prototype.hasOwnProperty.call(payload, 'logsTruncated')) {
         decoded.logsTruncated = payload.logsTruncated;
@@ -769,6 +816,9 @@ async function executeJsx(request) {
             jsxBridge: bridgeState,
         };
         if (Object.prototype.hasOwnProperty.call(e, 'line')) payload.errorLine = e.line;
+        if (Object.prototype.hasOwnProperty.call(e, 'errorSource')) {
+            payload.errorSource = e.errorSource;
+        }
         ['touched', 'logs', 'logsTruncated', 'revision', 'projectPath'].forEach(function (field) {
             if (Object.prototype.hasOwnProperty.call(e, field)) payload[field] = e[field];
         });
@@ -1293,6 +1343,7 @@ module.exports = {
     // Exported for unit-testing the wrap shape without spinning up Express.
     wrapWithUndoGroup,
     wrapForEvalScriptTransport,
+    repairLatin1Utf8,
     decodeEvalScriptTransportResult,
     executeJsx,
     mcp: null,

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -1233,6 +1233,11 @@ test('ExtendScript transport fails deterministically for cycles and serializatio
 
 test('evalScript transport decoder requires typed successes and preserves error envelopes', () => {
     const server = loadServer();
+    const chinese = '在需要数字、数组或属性的位置找到类型为“Error”的对象';
+    const mojibake = Buffer.from(chinese, 'utf8').toString('latin1');
+    assert.equal(server.repairLatin1Utf8(mojibake), chinese);
+    assert.equal(server.repairLatin1Utf8('plain ASCII'), 'plain ASCII');
+    assert.equal(server.repairLatin1Utf8('café ÿþ'), 'café ÿþ');
     assert.deepEqual(
         server.decodeEvalScriptTransportResult(
             '{"ok":true,"resultType":"string","result":"你好"}',
@@ -1245,6 +1250,24 @@ test('evalScript transport decoder requires typed successes and preserves error 
         ),
         { resultType: 'json', result: '{"n":42}' },
     );
+    assert.deepEqual(
+        server.decodeEvalScriptTransportResult(JSON.stringify({
+            ok: true,
+            resultType: 'string',
+            result: mojibake,
+        })),
+        { resultType: 'string', result: chinese },
+    );
+    const jsonResult = JSON.stringify({
+        ok: true,
+        resultType: 'json',
+        result: JSON.stringify({ text: mojibake, items: [mojibake, { ok: true }] }),
+    });
+    const decodedJsonResult = server.decodeEvalScriptTransportResult(jsonResult);
+    assert.deepEqual(JSON.parse(decodedJsonResult.result), {
+        text: chinese,
+        items: [chinese, { ok: true }],
+    });
     assert.throws(
         function () {
             server.decodeEvalScriptTransportResult('{"ok":true,"result":"legacy"}');
@@ -1267,6 +1290,18 @@ test('evalScript transport decoder requires typed successes and preserves error 
     }
     assert.match(legacyError.message, /boom/);
     assert.equal(legacyError.disposition, 'failed');
+    let localizedError;
+    try {
+        server.decodeEvalScriptTransportResult(JSON.stringify({
+            ok: false,
+            error: mojibake,
+            errorSource: mojibake,
+        }));
+    } catch (error) {
+        localizedError = error;
+    }
+    assert.equal(localizedError.message, 'ExtendScript error: ' + chinese);
+    assert.equal(localizedError.errorSource, chinese);
 });
 
 test('diagnostic decoder and executeJsx preserve optional success and failure evidence', async () => {


### PR DESCRIPTION
Closes #356.

## 更改日志

- **修复中文版 AE 报错乱码**——ExtendScript 的本地化错误串以 UTF-8 字节进入 ASCII 传输信封后被当成 Latin-1 还原；宿主现在在解码后识别"全部字符 ≤ 0xFF 且按 Latin-1 取字节是含多字节序列的合法 UTF-8"这一形态并转码，覆盖错误消息、`errorSource`、字符串返回值与 JSON 字符串叶子；纯 ASCII、真 Latin-1、已正确的文本原样不动。
- **Fix mojibake in localized AE errors** — localized ExtendScript error strings arrive as UTF-8 bytes and were rebuilt as Latin-1; the host now repairs that exact shape after decoding (error message, `errorSource`, string results, JSON string leaves) and leaves ASCII, genuine Latin-1, and correct text untouched.

## 验证

- `plugin/host` `npm test`：287 tests, 271 pass, 0 fail, 16 skipped（改前基线一致）。
- 新增用例：真实样例「在需要数字、数组或属性的位置找到类型为“Error”的对象」的 Latin-1 形态 → 中文；ASCII 不变；`café ÿþ` 这类非法 UTF-8 的 Latin-1 不变；JSON 结果叶子修复且结构不变。
- 真机验证：待编排者在中文版 AE 26.3 上 POST `/exec` 抛本地化错误的脚本后补充到本 PR。

## 实现者

Luna（gpt-5.6-luna，effort medium），Fable 审 diff 并跑测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
