### PR TITLE
fix(host): stop the Tool Library secret scanner from rejecting ordinary ExtendScript (#353)

### DIFF
--- a/plugin/host/mcp/tool-library.js
+++ b/plugin/host/mcp/tool-library.js
@@ -312,13 +312,20 @@ function assertSecretFree(value, name) {
     ];
     const credentialAssignment = new RegExp([
         "(?<![A-Za-z0-9_.-])['\"]?([A-Za-z][A-Za-z0-9_.-]*)['\"]?[ \\t]*[:=][ \\t]*",
-        "(?:['\"][^'\"\\r\\n]+['\"]|[^'\"\\s,;&{}\\[\\]]+)",
+        "(?:\"([^\"\\r\\n]*)\"|'([^'\\r\\n]*)'|([^\\r\\n,;&{}\\[\\]]+))",
     ].join(''), 'gm');
+    const credentialValuePrefix = /^(?:sk-|Bearer[ \t]+\S+|ghp_|gho_|xoxb-|xoxp-|AKIA|AIza|-----BEGIN)/i;
+    function secretShapedAssignmentValue(match) {
+        const quoted = match[2] === undefined ? match[3] : match[2];
+        const value = (quoted === undefined ? match[4] : quoted).trim();
+        return credentialValuePrefix.test(value)
+            || (quoted !== undefined && Array.from(value).length >= 16);
+    }
     function hasCredentialAssignment(current) {
         credentialAssignment.lastIndex = 0;
         let match = credentialAssignment.exec(current);
         while (match) {
-            if (sensitiveName(match[1])) return true;
+            if (sensitiveName(match[1]) && secretShapedAssignmentValue(match)) return true;
             match = credentialAssignment.exec(current);
         }
         return false;
@@ -471,6 +478,7 @@ class ToolLibrary {
         this.indexPath = path.join(this.toolRoot, 'index.json');
         this.artifactsRoot = path.join(this.toolRoot, 'artifacts');
         this.now = input.now || function () { return Date.now(); };
+        this.warn = typeof input.warn === 'function' ? input.warn : function () {};
         fs.mkdirSync(this.artifactsRoot, { recursive: true, mode: 0o700 });
         fs.mkdirSync(this.skillRoot, { recursive: true, mode: 0o700 });
     }
@@ -646,15 +654,27 @@ class ToolLibrary {
         });
     }
 
-    readSkillDirectory(root, source) {
+    warnLegacyArtifact(filePath, error) {
+        this.warn({
+            type: 'tool-library-legacy-artifact-skipped',
+            path: path.resolve(filePath),
+            error: error && error.message ? error.message : String(error),
+        });
+    }
+
+    readSkillDirectory(root, source, onError) {
         if (!fs.existsSync(root)) return [];
         return fs.readdirSync(root).filter(function (name) {
             return name.endsWith('.json') && !(source === 'bundled' && name === 'manifest.json');
         }).sort().map(function (name) {
+            const filePath = path.join(root, name);
             try {
-                const skill = skillFromWire(JSON.parse(fs.readFileSync(path.join(root, name), 'utf8')));
-                return { skill, source, path: path.join(root, name) };
-            } catch (error) { return null; }
+                const skill = skillFromWire(JSON.parse(fs.readFileSync(filePath, 'utf8')));
+                return { skill, source, path: filePath };
+            } catch (error) {
+                if (onError) onError(filePath, error);
+                return null;
+            }
         }).filter(Boolean);
     }
 
@@ -681,7 +701,7 @@ class ToolLibrary {
 
     allSkillRecords() {
         return this.readSkillDirectory(this.bundledRoot, 'bundled').concat(
-            this.readSkillDirectory(this.skillRoot, 'user'),
+            this.readSkillDirectory(this.skillRoot, 'user', this.warnLegacyArtifact.bind(this)),
         );
     }
 
@@ -704,60 +724,66 @@ class ToolLibrary {
         const hashes = new Map(manifest.artifacts.map(function (item) {
             return [item.path, item.sha256];
         }));
-        return this.allSkillRecords().map(function (record) {
-            const skill = record.skill;
-            const kind = skill.template_type === 'jsx' ? 'jsx' : 'prompt-skill';
-            if (skill.template_type !== 'jsx' && skill.template_type !== 'prompt') {
-                throw new Error('legacy skill template type is unsupported');
+        return this.allSkillRecords().reduce(function (artifacts, record) {
+            try {
+                const skill = record.skill;
+                const kind = skill.template_type === 'jsx' ? 'jsx' : 'prompt-skill';
+                if (skill.template_type !== 'jsx' && skill.template_type !== 'prompt') {
+                    throw new Error('legacy skill template type is unsupported');
+                }
+                const contentHash = computeContentHash(kind, skill.template, skill.args_schema);
+                const info = fs.statSync(record.path);
+                const createdAt = Math.max(0, Math.floor(info.birthtimeMs));
+                const updatedAt = Math.max(0, Math.floor(info.mtimeMs));
+                const bundled = record.source === 'bundled';
+                const digest = bundled ? hashes.get(path.basename(record.path)) : null;
+                if (bundled && (!SHA256.test(digest || '') || crypto.createHash('sha256')
+                    .update(fs.readFileSync(record.path)).digest('hex') !== digest)) {
+                    throw new Error('bundled skill manifest is invalid');
+                }
+                const artifact = {
+                    schemaVersion: 1,
+                    id: bundled ? 'builtin:skill:' + skill.name : 'legacy:'
+                        + crypto.createHash('sha256').update(path.resolve(record.path).normalize('NFC'), 'utf8')
+                            .digest('hex').slice(0, 24),
+                    name: skill.name,
+                    description: skill.description,
+                    kind,
+                    category: 'workflow',
+                    tags: [],
+                    compatibility: {},
+                    declaredRisk: kind === 'jsx' ? 'write' : 'read',
+                    source: {
+                        type: bundled ? 'bundled' : 'legacy',
+                        ref: path.resolve(record.path),
+                        client: null,
+                        productVersion: bundled ? manifest.productVersion : null,
+                        provenance: bundled ? { manifestSha256: digest } : { contentHash },
+                    },
+                    status: 'saved',
+                    verified: bundled,
+                    verification: bundled ? {
+                        method: 'signed-manifest',
+                        verifiedAt: 0,
+                        evidenceHash: digest,
+                    } : null,
+                    content: skill.template,
+                    argsSchema: skill.args_schema,
+                    contentHash,
+                    revision: 1,
+                    createdAt,
+                    updatedAt,
+                    lastUsedAt: null,
+                    useCount: 0,
+                };
+                assertSecretFree(artifact, 'legacy-artifact.json');
+                artifacts.push(validateArtifact(artifact));
+            } catch (error) {
+                if (record.source === 'bundled') throw error;
+                this.warnLegacyArtifact(record.path, error);
             }
-            const contentHash = computeContentHash(kind, skill.template, skill.args_schema);
-            const info = fs.statSync(record.path);
-            const createdAt = Math.max(0, Math.floor(info.birthtimeMs));
-            const updatedAt = Math.max(0, Math.floor(info.mtimeMs));
-            const bundled = record.source === 'bundled';
-            const digest = bundled ? hashes.get(path.basename(record.path)) : null;
-            if (bundled && (!SHA256.test(digest || '') || crypto.createHash('sha256')
-                .update(fs.readFileSync(record.path)).digest('hex') !== digest)) {
-                throw new Error('bundled skill manifest is invalid');
-            }
-            const artifact = {
-                schemaVersion: 1,
-                id: bundled ? 'builtin:skill:' + skill.name : 'legacy:'
-                    + crypto.createHash('sha256').update(path.resolve(record.path).normalize('NFC'), 'utf8')
-                        .digest('hex').slice(0, 24),
-                name: skill.name,
-                description: skill.description,
-                kind,
-                category: 'workflow',
-                tags: [],
-                compatibility: {},
-                declaredRisk: kind === 'jsx' ? 'write' : 'read',
-                source: {
-                    type: bundled ? 'bundled' : 'legacy',
-                    ref: path.resolve(record.path),
-                    client: null,
-                    productVersion: bundled ? manifest.productVersion : null,
-                    provenance: bundled ? { manifestSha256: digest } : { contentHash },
-                },
-                status: 'saved',
-                verified: bundled,
-                verification: bundled ? {
-                    method: 'signed-manifest',
-                    verifiedAt: 0,
-                    evidenceHash: digest,
-                } : null,
-                content: skill.template,
-                argsSchema: skill.args_schema,
-                contentHash,
-                revision: 1,
-                createdAt,
-                updatedAt,
-                lastUsedAt: null,
-                useCount: 0,
-            };
-            assertSecretFree(artifact, 'legacy-artifact.json');
-            return validateArtifact(artifact);
-        });
+            return artifacts;
+        }.bind(this), []);
     }
 
     allSummaries() {

--- a/plugin/host/mcp/tool-library.test.js
+++ b/plugin/host/mcp/tool-library.test.js
@@ -13,6 +13,7 @@ const { skillPlan, assertSkillPlanCurrent } = skillUse;
 const {
     ENVIRONMENT,
     ToolLibrary,
+    assertSecretFree,
     canonicalJson,
     computeContentHash,
     validateArgsSchema,
@@ -176,6 +177,57 @@ test('secret-shaped artifact content is rejected before it reaches disk', (t) =>
     secret.contentHash = computeContentHash(secret.kind, secret.content, secret.argsSchema);
     assert.throws(function () { library.saveArtifact(secret); }, /secret-shaped content/i);
     assert.equal(fs.existsSync(path.join(library.toolRoot, 'index.json')), false);
+});
+
+test('secret scanner distinguishes ExtendScript values from credential-shaped assignments', () => {
+    [
+        'var key = prop.keyTime(1);',
+        'var key = layer.property("Position").addKey(1);',
+        'var token = layer.name.split("_")[0];',
+        'var session = app.project;',
+        'for (var i = 1; i <= prop.numKeys; i++) { var t = prop.keyTime(i); }',
+    ].forEach(function (content) {
+        assert.doesNotThrow(function () { assertSecretFree(content, 'artifact.json'); });
+    });
+    [
+        'Authorization: Bearer secret-value',
+        'x-api-key: secret-value',
+        'aaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbb.cccccccc',
+        '-----BEGIN PRIVATE KEY-----',
+        'sk-abcdefghijklmnop',
+        'var apiKey = "sk-abcdefghijklmnop";',
+        'token: "ghp_abcdefghijklmnop"',
+        'var token = "Bearer abc";',
+        'auth: "AKIAIOSFODNN7"',
+    ].forEach(function (content) {
+        assert.throws(function () { assertSecretFree(content, 'artifact.json'); }, /secret-shaped/i);
+    });
+});
+
+test('legacy artifact scan skips one unsafe file and records a warning', (t) => {
+    const root = tempRoot(t);
+    const warnings = [];
+    const library = new ToolLibrary({
+        statePaths: createStatePaths({ stateDir: root }),
+        bundledRoot: path.join(__dirname, 'skills_bundled'),
+        now: function () { return 1000; },
+        warn: function (warning) { warnings.push(warning); },
+    });
+    library.writeSkill({
+        name: 'safe-legacy', description: 'Safe legacy skill.', template_type: 'jsx',
+        template: 'var key = prop.keyTime(1);', args_schema: {},
+    });
+    library.writeSkill({
+        name: 'unsafe-legacy', description: 'Unsafe legacy skill.', template_type: 'jsx',
+        template: 'var apiKey = "sk-abcdefghijklmnop";', args_schema: {},
+    });
+    const names = library.allSummaries().map(function (item) { return item.name; });
+    assert.equal(names.includes('safe-legacy'), true);
+    assert.equal(names.includes('unsafe-legacy'), false);
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0].type, 'tool-library-legacy-artifact-skipped');
+    assert.match(warnings[0].path, /unsafe-legacy\.json$/);
+    assert.match(warnings[0].error, /secret-shaped content/i);
 });
 
 test('argsSchema accepts descriptions and fails closed on unsupported keys', () => {
@@ -730,7 +782,7 @@ test('library import verifies content, rejects duplicates, and records imported 
     assert.throws(function () { target.importArtifact(tampered); }, /contentHash does not match/i);
 
     const secret = JSON.parse(JSON.stringify(exported));
-    secret.artifact.content = 'var apiKey = "not-allowed";';
+    secret.artifact.content = 'var apiKey = "sk-abcdefghijklmnop";';
     secret.artifact.contentHash = computeContentHash(
         secret.artifact.kind,
         secret.artifact.content,
@@ -768,4 +820,3 @@ test('library management transitions and deletion respect artifact lifecycle', (
     assert.equal(library.managementList().candidates[0].contentCharacters > 0, true);
     assert.deepEqual(library.clearCandidates(), { removedIds: [secondCandidate.id], count: 1 });
 });
-

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -785,7 +785,17 @@ function buildApp() {
     ensureClientBlocklist();
     const a = express();
     a.use(express.json({ limit: '5mb' }));
-    const toolLibrary = new ToolLibrary({ statePaths: statePathsForHost() });
+    const toolLibrary = new ToolLibrary({
+        statePaths: statePathsForHost(),
+        warn: function (event) {
+            hostLog.record({
+                level: 'warn',
+                source: 'host',
+                message: 'Tool Library skipped a legacy skill file: ' + event.path + ' (' + event.error + ')',
+                event: event.type,
+            });
+        },
+    });
     async function nativeNegotiate(deadlineUnixMs) {
         const client = await connectedNativeClient(deadlineUnixMs);
         const hello = await client.negotiate({ deadlineUnixMs });


### PR DESCRIPTION
Closes #353.

## 更改日志

- **Tool Library 密钥扫描不再误伤普通脚本**——`var key = prop.keyTime(1)`、`var token = layer.name…`、`var session = app.project` 这类赋值不再被判为凭证：敏感变量名只在右值像密钥时才命中（16 字符以上的字符串字面量，或 `sk-` / `Bearer` / `ghp_` / `xoxb-` / `AKIA` / `AIza` / PEM 头等前缀）；所有独立模式（Authorization / API-key 头、JWT、PEM、`sk-` 令牌）保持不变。legacy skill 目录里读不了、解析不了或扫描不过的文件改为跳过并记宿主日志警告，不再让 `ae_toolSearch` / `ae_toolUse` 整体失败。
- **Tool Library secret scanning no longer rejects ordinary scripts** — sensitive identifiers only trip when the assigned value looks like a secret (16+ character literal or a known credential prefix); every standalone pattern is unchanged. Unreadable legacy skill files are skipped with a host-log warning instead of failing the whole search.

## 验证

- `plugin/host` `npm test`：289 tests, 273 pass, 0 fail, 16 skipped（新增 2 个用例）。
- 假阳性矩阵（4 条普通关键帧/属性脚本）通过；真阳性矩阵（头、JWT、PEM、`sk-`、`ghp_`、短 `Bearer abc`、`AKIA…`）仍抛。
- legacy 目录含一个坏文件时 `allSummaries()` 返回其余条目并记录一条 `tool-library-legacy-artifact-skipped` 警告；宿主侧已把该回调接到 host log。
- 真机验证：待编排者在 AE 26.3 上用 `ae_exec` 跑含 `var key = prop.addKey(1)` 的脚本并沉淀后补充到本 PR。

## 实现者

Terra（gpt-5.6-terra，effort medium）实现；Fable 审 diff 后修正了一处正则字面量双重转义（`Bearer` 前缀规则失效）并接线 `warn` 回调到宿主日志，测试由 Fable 运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
