### PR TITLE
fix(host): keep ae_previewFrame usable on 16 bpc projects and under the 16 MB MCP event cap (#352)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -126,8 +126,10 @@ its existing request and response shape.
 
 `ae_previewFrame` uses After Effects `CompItem.saveFrameToPng` and performs all
 PNG decoding, scaling, contact-sheet composition, and comparison in the CEP
-host with no browser canvas or image-library dependency. It supports three
-forms:
+host with no browser canvas or image-library dependency. RGB and RGBA source
+frames from 16 bpc projects are decoded in the host and replace their source
+file as an 8-bit PNG before any requested scaling or composition. It supports
+three forms:
 
 - A single `time` or `times` array returns the existing per-frame MCP image
   content and `structuredContent.frames` records. Separate output accepts at
@@ -154,9 +156,24 @@ and `layout`. The process keeps the most recent 50 successful capture records;
 a referenced PNG must still match its recorded SHA-256 or the comparison fails.
 Grid, diff, and side-by-side output is bounded to a 2048-pixel long side (or the
 smaller `grid_max_side` for grids). Existing `comp_id`, `out_dir`,
-`include_base64`, `scale`, and `repaint_delay_ms` behavior is unchanged, and
-`frames` contains every newly captured frame even when the call returns a
-single derived image.
+`scale`, and `repaint_delay_ms` behavior is unchanged, and `frames` contains
+every newly captured frame even when the call returns a single derived image.
+
+All image content blocks and optional `include_base64` frame copies share a
+12 MiB base64-character budget, with a 4.5 MiB limit for each image. The host
+reduces inline copies in 0.75 steps down to a 256-pixel minimum edge and reports
+`budgetScale`, inline dimensions, and warnings without modifying the file named
+by `path`. If a frame still cannot fit, its full-resolution 8-bit `path` remains
+available, `frame.base64` is omitted, and the image content block becomes a
+thumbnail whose long side is at most 512 pixels. Thus `path`, `sizeBytes`, and
+`sha256` always describe the full-resolution 8-bit disk file, while inline
+fields describe any response-budget reduction.
+
+On the first preview call in a host process, the default preview root removes
+`.png` files older than seven days from other session directories. If all
+session PNGs still exceed 300 MiB, it deletes the oldest eligible files until
+the total is at or below that limit. The current process session is never
+deleted, and only empty directories are removed afterward.
 
 ## Host response shape
 

--- a/plugin/host/cep-runtime-contract.test.js
+++ b/plugin/host/cep-runtime-contract.test.js
@@ -57,6 +57,7 @@ const CEP_EXECUTED_FILES = [
     'mcp/tools/exec-recover.js',
     'mcp/tools/preview-frame.js',
     'mcp/png.js',
+    'mcp/preview-prune.js',
     'mcp/image-ops.js',
     'mcp/tools/read.js',
     'mcp/tools/checkpoint.js',

--- a/plugin/host/mcp/index.js
+++ b/plugin/host/mcp/index.js
@@ -86,14 +86,15 @@ function missingSession(message, status, detail) {
     return { status, response: jsonrpc.error(jsonrpc.requestId(message), -32600, 'Invalid Request', detail) };
 }
 
-function progressMessage(token, startedAt, now) {
+function progressMessage(token, toolName, startedAt, now) {
+    const name = typeof toolName === 'string' && toolName ? toolName : 'ae_exec';
     return {
         jsonrpc: '2.0',
         method: 'notifications/progress',
         params: {
             progressToken: token,
             progress: Math.floor(((now === undefined ? Date.now() : now) - startedAt) / 1000),
-            message: 'ae_exec is still running',
+            message: name + ' is still running',
         },
     };
 }
@@ -306,12 +307,13 @@ function mountMcp(app, deps) {
             const writer = new SseWriter(res, sseOptions).start();
             const startedAt = Date.now();
             const token = body.params._meta.progressToken;
+            const toolName = body.params.name;
             // Progress for an in-flight request travels only on that request's
             // own SSE response; publishing it on the standalone GET stream too
             // makes official clients deliver every notification twice
             // (observed live with the TS SDK against AE 2026).
             const notify = function () {
-                writer.send(progressMessage(token, startedAt));
+                writer.send(progressMessage(token, toolName, startedAt));
             };
             notify();
             const timer = setInterval(notify, progressIntervalMs);

--- a/plugin/host/mcp/index.test.js
+++ b/plugin/host/mcp/index.test.js
@@ -129,9 +129,14 @@ test('mountMcp requires explicit state paths', () => {
 });
 
 test('progress notifications retain their token and report elapsed seconds', () => {
-    assert.deepEqual(mountMcp.progressMessage('progress-1', 1000, 6200), {
+    assert.deepEqual(mountMcp.progressMessage('progress-1', 'ae_previewFrame', 1000, 6200), {
         jsonrpc: '2.0',
         method: 'notifications/progress',
-        params: { progressToken: 'progress-1', progress: 5, message: 'ae_exec is still running' },
+        params: { progressToken: 'progress-1', progress: 5, message: 'ae_previewFrame is still running' },
+    });
+    assert.deepEqual(mountMcp.progressMessage('progress-2', null, 1000, 6200), {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: { progressToken: 'progress-2', progress: 5, message: 'ae_exec is still running' },
     });
 });

--- a/plugin/host/mcp/png.js
+++ b/plugin/host/mcp/png.js
@@ -1,8 +1,7 @@
 'use strict';
 
-// Dependency-free PNG subset used by ae_previewFrame. AE's saveFrameToPng
-// produces 8-bit, non-interlaced RGB/RGBA PNGs, which is intentionally the
-// only pixel format we decode and resample here.
+// Dependency-free PNG subset used by ae_previewFrame. After Effects emits
+// 8-bit or 16-bit non-interlaced RGB/RGBA PNGs depending on the project depth.
 
 const zlib = require('zlib');
 
@@ -75,11 +74,15 @@ function paeth(a, b, c) {
 
 function decodeRgba(buffer) {
     const info = readPngInfo(buffer);
-    if (info.bitDepth !== 8 || info.interlace !== 0 || (info.colorType !== 2 && info.colorType !== 6)) {
+    if ((info.bitDepth !== 8 && info.bitDepth !== 16) || info.interlace !== 0
+        || info.compression !== 0 || info.filter !== 0
+        || (info.colorType !== 2 && info.colorType !== 6)) {
         throw new Error('unsupported png');
     }
     const channels = info.colorType === 6 ? 4 : 3;
-    const stride = info.width * channels;
+    const bytesPerSample = info.bitDepth / 8;
+    const bytesPerPixel = channels * bytesPerSample;
+    const stride = info.width * bytesPerPixel;
     const raw = zlib.inflateSync(Buffer.concat(info.idat));
     if (raw.length !== info.height * (stride + 1)) throw new Error('invalid PNG pixel data');
     const rows = Buffer.alloc(info.height * stride);
@@ -90,9 +93,9 @@ function decodeRgba(buffer) {
         const prior = row - stride;
         for (let x = 0; x < stride; x += 1) {
             const source = raw[input++];
-            const left = x >= channels ? rows[row + x - channels] : 0;
+            const left = x >= bytesPerPixel ? rows[row + x - bytesPerPixel] : 0;
             const up = y ? rows[prior + x] : 0;
-            const upLeft = y && x >= channels ? rows[prior + x - channels] : 0;
+            const upLeft = y && x >= bytesPerPixel ? rows[prior + x - bytesPerPixel] : 0;
             if (filter === 0) rows[row + x] = source;
             else if (filter === 1) rows[row + x] = (source + left) & 0xff;
             else if (filter === 2) rows[row + x] = (source + up) & 0xff;
@@ -103,10 +106,11 @@ function decodeRgba(buffer) {
     }
     const rgba = Buffer.alloc(info.width * info.height * 4);
     for (let pixel = 0; pixel < info.width * info.height; pixel += 1) {
-        rgba[pixel * 4] = rows[pixel * channels];
-        rgba[pixel * 4 + 1] = rows[pixel * channels + 1];
-        rgba[pixel * 4 + 2] = rows[pixel * channels + 2];
-        rgba[pixel * 4 + 3] = channels === 4 ? rows[pixel * channels + 3] : 255;
+        const source = pixel * bytesPerPixel;
+        rgba[pixel * 4] = rows[source];
+        rgba[pixel * 4 + 1] = rows[source + bytesPerSample];
+        rgba[pixel * 4 + 2] = rows[source + bytesPerSample * 2];
+        rgba[pixel * 4 + 3] = channels === 4 ? rows[source + bytesPerSample * 3] : 255;
     }
     return { rgba: rgba, width: info.width, height: info.height };
 }

--- a/plugin/host/mcp/png.test.js
+++ b/plugin/host/mcp/png.test.js
@@ -2,7 +2,58 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const zlib = require('node:zlib');
 const png = require('./png');
+
+function chunk(type, data) {
+    const head = Buffer.alloc(8);
+    head.writeUInt32BE(data.length, 0);
+    head.write(type, 4, 4, 'ascii');
+    const tail = Buffer.alloc(4);
+    tail.writeUInt32BE(png.crc32(Buffer.concat([head.subarray(4), data])), 0);
+    return Buffer.concat([head, data, tail]);
+}
+
+function paeth(a, b, c) {
+    const p = a + b - c;
+    const pa = Math.abs(p - a);
+    const pb = Math.abs(p - b);
+    const pc = Math.abs(p - c);
+    return pa <= pb && pa <= pc ? a : (pb <= pc ? b : c);
+}
+
+function png16(width, height, colorType, samples, filters) {
+    const channels = colorType === 6 ? 4 : 3;
+    const bytesPerPixel = channels * 2;
+    const stride = width * bytesPerPixel;
+    const rows = Buffer.alloc(height * stride);
+    samples.forEach(function (sample, index) { rows.writeUInt16BE(sample, index * 2); });
+    const filtered = Buffer.alloc(height * (stride + 1));
+    for (let y = 0; y < height; y += 1) {
+        const filter = filters[y];
+        filtered[y * (stride + 1)] = filter;
+        for (let x = 0; x < stride; x += 1) {
+            const source = rows[y * stride + x];
+            const left = x >= bytesPerPixel ? rows[y * stride + x - bytesPerPixel] : 0;
+            const up = y ? rows[(y - 1) * stride + x] : 0;
+            const upLeft = y && x >= bytesPerPixel ? rows[(y - 1) * stride + x - bytesPerPixel] : 0;
+            let predictor = 0;
+            if (filter === 1) predictor = left;
+            else if (filter === 2) predictor = up;
+            else if (filter === 3) predictor = Math.floor((left + up) / 2);
+            else if (filter === 4) predictor = paeth(left, up, upLeft);
+            filtered[y * (stride + 1) + x + 1] = (source - predictor) & 0xff;
+        }
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 16;
+    ihdr[9] = colorType;
+    return Buffer.concat([
+        png.SIGNATURE, chunk('IHDR', ihdr), chunk('IDAT', zlib.deflateSync(filtered)), chunk('IEND', Buffer.alloc(0)),
+    ]);
+}
 
 test('PNG subset round-trips RGBA and validates chunks', () => {
     const source = Buffer.from([255, 0, 0, 255, 0, 255, 0, 128, 0, 0, 255, 64, 255, 255, 255, 0]);
@@ -18,4 +69,31 @@ test('boxDownscale uses rounded dimensions and averages source pixels', () => {
     assert.equal(resized.width, 2);
     assert.equal(resized.height, 2);
     assert.equal(resized.rgba.length, 16);
+});
+
+test('decodeRgba converts filtered 16-bit RGBA samples to their high bytes', () => {
+    const encoded = png16(2, 2, 6, [
+        0x1234, 0x5678, 0x9abc, 0xdef0, 0xff01, 0x8002, 0x4003, 0x2004,
+        0x0105, 0x0206, 0x0307, 0x0408, 0xa109, 0xb20a, 0xc30b, 0xd40c,
+    ], [1, 4]);
+    assert.deepEqual(png.decodeRgba(encoded), {
+        rgba: Buffer.from([
+            0x12, 0x56, 0x9a, 0xde, 0xff, 0x80, 0x40, 0x20,
+            0x01, 0x02, 0x03, 0x04, 0xa1, 0xb2, 0xc3, 0xd4,
+        ]),
+        width: 2,
+        height: 2,
+    });
+});
+
+test('decodeRgba converts 16-bit RGB to opaque 8-bit RGBA and keeps corruption errors', () => {
+    const encoded = png16(2, 1, 2, [0x1020, 0x3040, 0x5060, 0xa0b0, 0xc0d0, 0xe0f0], [3]);
+    assert.deepEqual(png.decodeRgba(encoded), {
+        rgba: Buffer.from([0x10, 0x30, 0x50, 0xff, 0xa0, 0xc0, 0xe0, 0xff]),
+        width: 2,
+        height: 1,
+    });
+    const corrupt = Buffer.from(encoded);
+    corrupt[corrupt.length - 5] ^= 0xff;
+    assert.throws(function () { png.decodeRgba(corrupt); }, /CRC mismatch/);
 });

--- a/plugin/host/mcp/preview-prune.js
+++ b/plugin/host/mcp/preview-prune.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_TOTAL_BYTES = 300 * 1024 * 1024;
+const completed = new Set();
+
+function scanDirectory(directory, sessionName, currentSessionId, files, directories) {
+    let entries;
+    try { entries = fs.readdirSync(directory, { withFileTypes: true }); } catch (_) { return; }
+    entries.forEach(function (entry) {
+        const item = path.join(directory, entry.name);
+        if (entry.isSymbolicLink()) return;
+        if (entry.isDirectory()) {
+            directories.push(item);
+            scanDirectory(item, sessionName, currentSessionId, files, directories);
+            return;
+        }
+        if (!entry.isFile() || path.extname(entry.name).toLowerCase() !== '.png') return;
+        try {
+            const stat = fs.statSync(item);
+            files.push({ path: item, size: stat.size, mtimeMs: stat.mtimeMs, current: sessionName === currentSessionId });
+        } catch (_) {}
+    });
+}
+
+function inventory(root, currentSessionId) {
+    let sessions;
+    try { sessions = fs.readdirSync(root, { withFileTypes: true }); } catch (_) { return { files: [], directories: [] }; }
+    const files = [];
+    const directories = [];
+    sessions.forEach(function (entry) {
+        if (!entry.isDirectory() || entry.isSymbolicLink()) return;
+        const directory = path.join(root, entry.name);
+        directories.push(directory);
+        scanDirectory(directory, entry.name, currentSessionId, files, directories);
+    });
+    return { files: files, directories: directories };
+}
+
+function removeFile(file) {
+    try { fs.unlinkSync(file.path); return true; } catch (_) { return false; }
+}
+
+function removeEmptyDirectories(directories, currentDirectory) {
+    directories.sort(function (a, b) { return b.length - a.length; }).forEach(function (directory) {
+        if (path.resolve(directory) === currentDirectory) return;
+        try { fs.rmdirSync(directory); } catch (_) {}
+    });
+}
+
+function prunePreviewRoot(root, currentSessionId, options) {
+    const setting = options || {};
+    const now = setting.now === undefined ? Date.now() : setting.now;
+    const maxAgeMs = setting.maxAgeMs === undefined ? MAX_AGE_MS : setting.maxAgeMs;
+    const maxTotalBytes = setting.maxTotalBytes === undefined ? MAX_TOTAL_BYTES : setting.maxTotalBytes;
+    const currentDirectory = path.resolve(root, currentSessionId);
+    const first = inventory(root, currentSessionId);
+    first.files.forEach(function (file) {
+        if (!file.current && file.mtimeMs < now - maxAgeMs) removeFile(file);
+    });
+
+    const second = inventory(root, currentSessionId);
+    let totalBytes = second.files.reduce(function (total, file) { return total + file.size; }, 0);
+    second.files.filter(function (file) { return !file.current; }).sort(function (a, b) {
+        return a.mtimeMs - b.mtimeMs;
+    }).some(function (file) {
+        if (totalBytes <= maxTotalBytes) return true;
+        if (removeFile(file)) totalBytes -= file.size;
+        return false;
+    });
+    removeEmptyDirectories(inventory(root, currentSessionId).directories, currentDirectory);
+}
+
+function prunePreviewRootOnce(root, currentSessionId, options) {
+    const key = path.resolve(root, currentSessionId);
+    if (completed.has(key)) return;
+    completed.add(key);
+    try { prunePreviewRoot(root, currentSessionId, options); } catch (_) {}
+}
+
+module.exports = {
+    MAX_AGE_MS: MAX_AGE_MS,
+    MAX_TOTAL_BYTES: MAX_TOTAL_BYTES,
+    prunePreviewRoot: prunePreviewRoot,
+    prunePreviewRootOnce: prunePreviewRootOnce,
+};

--- a/plugin/host/mcp/preview-prune.test.js
+++ b/plugin/host/mcp/preview-prune.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const prune = require('./preview-prune');
+
+function tempDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-preview-prune-test-')); }
+
+function file(root, session, name, size, mtimeMs) {
+    const directory = path.join(root, session);
+    fs.mkdirSync(directory, { recursive: true });
+    const target = path.join(directory, name);
+    fs.writeFileSync(target, Buffer.alloc(1));
+    fs.truncateSync(target, size);
+    fs.utimesSync(target, mtimeMs / 1000, mtimeMs / 1000);
+    return target;
+}
+
+test('preview pruning removes expired PNGs but preserves current-session and non-PNG files', () => {
+    const root = tempDir();
+    const now = Date.now();
+    const expired = file(root, 'old-session', 'expired.png', 10, now - prune.MAX_AGE_MS - 1);
+    const fresh = file(root, 'old-session', 'fresh.png', 10, now - 1000);
+    const nonPng = file(root, 'old-session', 'keep.txt', 10, now - prune.MAX_AGE_MS - 1);
+    const current = file(root, 'current', 'expired.png', 10, now - prune.MAX_AGE_MS - 1);
+    prune.prunePreviewRoot(root, 'current', { now: now });
+    assert.equal(fs.existsSync(expired), false);
+    assert.equal(fs.existsSync(fresh), true);
+    assert.equal(fs.existsSync(nonPng), true);
+    assert.equal(fs.existsSync(current), true);
+});
+
+test('preview pruning enforces 300 MiB oldest-first without deleting the current session', () => {
+    const root = tempDir();
+    const now = Date.now();
+    const oldest = file(root, 'session-a', 'oldest.png', 160, now - 3000);
+    const newer = file(root, 'session-b', 'newer.png', 160, now - 2000);
+    const current = file(root, 'current', 'current.png', 1, now - 4000);
+    assert.equal(prune.MAX_TOTAL_BYTES, 300 * 1024 * 1024);
+    prune.prunePreviewRoot(root, 'current', { now: now, maxTotalBytes: 300 });
+    assert.equal(fs.existsSync(oldest), false);
+    assert.equal(fs.existsSync(newer), true);
+    assert.equal(fs.existsSync(current), true);
+});
+
+test('preview pruning removes empty session directories and tolerates a missing root', () => {
+    const root = tempDir();
+    const now = Date.now();
+    const directory = path.join(root, 'expired-session');
+    file(root, 'expired-session', 'only.png', 1, now - prune.MAX_AGE_MS - 1);
+    prune.prunePreviewRoot(root, 'current', { now: now });
+    assert.equal(fs.existsSync(directory), false);
+    assert.doesNotThrow(function () { prune.prunePreviewRoot(path.join(root, 'missing'), 'current'); });
+});
+
+test('preview pruning runs once for each host-session root', () => {
+    const root = tempDir();
+    const now = Date.now();
+    prune.prunePreviewRootOnce(root, 'current', { now: now });
+    const expired = file(root, 'old-session', 'late.png', 1, now - prune.MAX_AGE_MS - 1);
+    prune.prunePreviewRootOnce(root, 'current', { now: now });
+    assert.equal(fs.existsSync(expired), true);
+});

--- a/plugin/host/mcp/tools/preview-frame.js
+++ b/plugin/host/mcp/tools/preview-frame.js
@@ -8,6 +8,7 @@ const zlib = require('zlib');
 const { textResult } = require('../tool-result');
 const imageOps = require('../image-ops');
 const png = require('../png');
+const previewPrune = require('../preview-prune');
 
 const TEMPLATE = fs.readFileSync(path.join(__dirname, '../../../jsx/templates/preview_viewer.jsx'), 'utf8');
 const PREVIEW_ROOT = path.join(os.tmpdir(), 'ae_mcp_previews');
@@ -16,6 +17,11 @@ const BASE_TIMEOUT_MS = 45000;
 const PER_FRAME_TIMEOUT_MS = 35000;
 const MAX_TIMEOUT_MS = 300000;
 const CAPTURE_HISTORY_LIMIT = 50;
+const IMAGE_BUDGET_TOTAL_BASE64 = 12 * 1024 * 1024;
+const IMAGE_BUDGET_PER_IMAGE_BASE64 = 4.5 * 1024 * 1024;
+const BUDGET_SCALE_STEP = 0.75;
+const BUDGET_MIN_EDGE = 256;
+const THUMBNAIL_MAX_SIDE = 512;
 const captureHistory = new Map();
 
 const compareSelectorSchema = {
@@ -30,7 +36,7 @@ const compareSelectorSchema = {
 
 const definition = {
     name: 'ae_previewFrame',
-    description: 'Read real composition pixels after a write, use compare to prove only the intended region changed, or use range with grid to inspect an animation interval. Transparent pixels retain the composition background RGB even though After Effects does not composite that background into exported alpha.',
+    description: 'Read real composition pixels after a write, use compare to prove only the intended region changed, or use range with grid to inspect an animation interval. 16-bit source PNGs are returned as 8-bit. Inline images share a 12 MiB base64-character budget with a 4.5 MiB per-image limit; oversized images are reduced or represented by a thumbnail while path retains the full-resolution 8-bit PNG. Transparent pixels retain the composition background RGB even though After Effects does not composite that background into exported alpha.',
     inputSchema: {
         type: 'object', properties: {
             comp_id: { type: 'string', minLength: 1, description: 'AE comp id. Omit for the active comp.' },
@@ -47,7 +53,7 @@ const definition = {
                 description: 'Evenly sample 2 to 16 times; mutually exclusive with time and times.',
             },
             layout: { type: 'string', enum: ['separate', 'grid'], default: 'separate', description: 'Return each frame separately or one labeled contact sheet.' },
-            grid_max_side: { type: 'integer', minimum: 256, maximum: 2048, default: 1280, description: 'Maximum width or height of a grid PNG.' },
+            grid_max_side: { type: 'integer', minimum: 256, maximum: 2048, default: 1280, description: 'Maximum width or height of the full-resolution 8-bit grid PNG before the shared inline-image byte budget is applied.' },
             compare: {
                 type: 'object',
                 properties: {
@@ -60,8 +66,8 @@ const definition = {
                 description: 'Compare two captured times or prior capture frames; mutually exclusive with ordinary frame output arguments.',
             },
             out_dir: { type: 'string', minLength: 1, description: 'Output directory. Default: temp ae_mcp_previews session directory.' },
-            include_base64: { type: 'boolean', default: false, description: 'Also include PNG base64 in each JSON frame. Image content is always returned.' },
-            scale: { type: 'number', exclusiveMinimum: 0, maximum: 4, default: 1, description: 'Output scale factor (0 < scale <= 4), applied after capture.' },
+            include_base64: { type: 'boolean', default: false, description: 'Also include PNG base64 in each JSON frame. These copies count toward the 12 MiB total and 4.5 MiB per-image base64-character budgets; an oversized frame may omit this field and return path plus a thumbnail.' },
+            scale: { type: 'number', exclusiveMinimum: 0, maximum: 4, default: 1, description: 'Full-resolution output scale factor (0 < scale <= 4), applied after capture. Inline images may be reduced further to fit the response budget; path still identifies the full-resolution 8-bit file.' },
             repaint_delay_ms: { type: 'integer', minimum: 0, maximum: 5000, default: 300, description: 'Retained for compatibility; has no effect because viewer screenshot fallback is not supported.' },
         }, additionalProperties: false,
     },
@@ -131,15 +137,16 @@ async function awaitWrittenPng(file, timeoutMs) {
                 const bytes = fs.readFileSync(file);
                 if (bytes.subarray(-8).equals(Buffer.from([73, 69, 78, 68, 174, 66, 96, 130]))) {
                     try {
+                        const info = png.readPngInfo(bytes);
                         const decoded = png.decodeRgba(bytes);
-                        return { width: decoded.width, height: decoded.height };
+                        return { width: decoded.width, height: decoded.height, bitDepth: info.bitDepth };
                     } catch (error) {
                         // AE can emit complete PNG variants outside the pixel subset
                         // this dependency-free path can safely resample.
                         if (!error || error.message !== 'unsupported png') throw error;
                         const info = png.readPngInfo(bytes);
                         zlib.inflateSync(Buffer.concat(info.idat));
-                        return { width: info.width, height: info.height, unsupported: true };
+                        return { width: info.width, height: info.height, bitDepth: info.bitDepth, unsupported: true };
                     }
                 }
             }
@@ -258,9 +265,15 @@ async function captureFrames(args, context, deps, expression, requests, deadline
             let width = dimensions.width;
             let height = dimensions.height;
             let downsampleSkipped = dimensions.unsupported ? 'unsupported-png-format' : undefined;
+            let decoded = null;
+            if (!dimensions.unsupported) decoded = png.decodeRgba(bytes);
+            if (dimensions.bitDepth === 16) {
+                bytes = png.encodePng(decoded.rgba, decoded.width, decoded.height);
+                fs.writeFileSync(outputPath, bytes);
+            }
             if (Math.abs(scale - 1) > 1e-9) {
                 try {
-                    const decoded = png.decodeRgba(bytes);
+                    if (!decoded) decoded = png.decodeRgba(bytes);
                     const resized = png.boxDownscale(decoded.rgba, decoded.width, decoded.height, scale);
                     if (resized.width !== decoded.width || resized.height !== decoded.height) {
                         bytes = png.encodePng(resized.rgba, resized.width, resized.height);
@@ -278,6 +291,7 @@ async function captureFrames(args, context, deps, expression, requests, deadline
             const frame = {
                 time: prepared.time, path: outputPath, width: width, height: height, sizeBytes: bytes.length,
                 sha256: crypto.createHash('sha256').update(bytes).digest('hex'), source: 'comp', method: 'saveFrameToPng', compId: compId,
+                sourceBitDepth: dimensions.bitDepth, bitDepth: verified.bitDepth,
             };
             if (Number.isInteger(prepared.compWidth) && Number.isInteger(prepared.compHeight)) {
                 frame.compWidth = prepared.compWidth; frame.compHeight = prepared.compHeight;
@@ -286,7 +300,6 @@ async function captureFrames(args, context, deps, expression, requests, deadline
             if (Array.isArray(prepared.resolutionFactor)) frame.resolutionFactor = prepared.resolutionFactor;
             if (Math.abs(scale - 1) > 1e-9 && !downsampleSkipped && (width !== dimensions.width || height !== dimensions.height)) frame.downsampled = true;
             if (downsampleSkipped) frame.downsampleSkipped = downsampleSkipped;
-            if (args.include_base64 === true) frame.base64 = bytes.toString('base64');
             branch.ok = true;
             frames.push(frame);
         } catch (error) {
@@ -306,14 +319,6 @@ function verifiedFrame(frame, changedMessage, decodePixels) {
     return { bytes: bytes, image: decodePixels === false ? null : png.decodeRgba(bytes), digest: digest };
 }
 
-function frameContent(frame, captureId, index) {
-    const verified = verifiedFrame(frame, 'preview frame changed after capture', false);
-    return {
-        type: 'image', data: verified.bytes.toString('base64'), mimeType: 'image/png',
-        _meta: { captureId: captureId, frameIndex: index, sha256: verified.digest, width: frame.width, height: frame.height },
-    };
-}
-
 function writeImage(file, image) {
     const bytes = png.encodePng(image.rgba, image.width, image.height);
     fs.writeFileSync(file, bytes);
@@ -323,15 +328,177 @@ function writeImage(file, image) {
     };
 }
 
-function artifactContent(artifact, captureId, kind) {
+function verifiedArtifact(artifact) {
     const bytes = fs.readFileSync(artifact.path);
     const dimensions = png.readPngInfo(bytes);
     const digest = crypto.createHash('sha256').update(bytes).digest('hex');
     if (dimensions.width !== artifact.width || dimensions.height !== artifact.height || digest !== artifact.sha256) throw new Error('preview artifact changed after creation');
+    return { bytes: bytes, image: png.decodeRgba(bytes), digest: digest };
+}
+
+function frameInlineGroup(frame, captureId, index, includeBase64, contentRequired) {
+    const verified = verifiedFrame(frame, 'preview frame changed after capture', false);
+    let image = null;
+    try { image = png.decodeRgba(verified.bytes); } catch (error) {
+        if (!error || error.message !== 'unsupported png') throw error;
+    }
     return {
-        type: 'image', data: bytes.toString('base64'), mimeType: 'image/png',
-        _meta: { captureId: captureId, kind: kind, sha256: digest, width: artifact.width, height: artifact.height },
+        owner: frame, label: 'Frame ' + index, path: frame.path,
+        image: image, bytes: verified.bytes, digest: verified.digest,
+        width: frame.width, height: frame.height, scale: 1,
+        includeBase64: includeBase64, contentRequired: contentRequired,
+        meta: { captureId: captureId, frameIndex: index, sha256: verified.digest },
     };
+}
+
+function artifactInlineGroup(artifact, owner, captureId, kind) {
+    const verified = verifiedArtifact(artifact);
+    return {
+        owner: owner, label: kind + ' image', path: artifact.path,
+        image: verified.image, bytes: verified.bytes, digest: verified.digest,
+        width: artifact.width, height: artifact.height, scale: 1,
+        includeBase64: false, contentRequired: true,
+        meta: { captureId: captureId, kind: kind, sha256: verified.digest },
+    };
+}
+
+function base64Length(group) { return 4 * Math.ceil(group.bytes.length / 3); }
+
+function copyCount(group) {
+    return (group.contentRequired ? 1 : 0) + (group.includeBase64 ? 1 : 0);
+}
+
+function minimumBudgetScale(group) {
+    const shortest = Math.min(group.width, group.height);
+    return shortest <= BUDGET_MIN_EDGE ? 1 : BUDGET_MIN_EDGE / shortest;
+}
+
+function canBudgetDownscale(group) {
+    return !!group.image && !group.fallback && group.scale - minimumBudgetScale(group) > 1e-9;
+}
+
+function downscaleInlineGroup(group) {
+    const nextScale = Math.max(minimumBudgetScale(group), group.scale * BUDGET_SCALE_STEP);
+    if (nextScale >= group.scale - 1e-9) return false;
+    const resized = png.boxDownscale(group.image.rgba, group.image.width, group.image.height, nextScale);
+    if (resized.width === group.inlineWidth && resized.height === group.inlineHeight) return false;
+    group.bytes = png.encodePng(resized.rgba, resized.width, resized.height);
+    group.inlineWidth = resized.width;
+    group.inlineHeight = resized.height;
+    group.scale = nextScale;
+    return true;
+}
+
+function useThumbnail(group) {
+    if (!group.image) {
+        group.bytes = Buffer.alloc(0);
+        group.inlineWidth = 0;
+        group.inlineHeight = 0;
+        group.includeBase64 = false;
+        group.contentRequired = false;
+        group.fallback = true;
+        group.pathOnly = true;
+        return;
+    }
+    const longest = Math.max(group.image.width, group.image.height);
+    const scale = Math.min(1, THUMBNAIL_MAX_SIDE / longest);
+    const thumbnail = scale < 1
+        ? png.boxDownscale(group.image.rgba, group.image.width, group.image.height, scale)
+        : group.image;
+    group.bytes = png.encodePng(thumbnail.rgba, thumbnail.width, thumbnail.height);
+    group.inlineWidth = thumbnail.width;
+    group.inlineHeight = thumbnail.height;
+    group.scale = Math.min(group.image.width / group.width, group.image.height / group.height, scale);
+    group.includeBase64 = false;
+    group.contentRequired = true;
+    group.fallback = true;
+}
+
+function totalBase64Length(groups) {
+    return groups.reduce(function (total, group) { return total + base64Length(group) * copyCount(group); }, 0);
+}
+
+function largestGroup(groups, predicate) {
+    return groups.filter(predicate).sort(function (a, b) {
+        return base64Length(b) * copyCount(b) - base64Length(a) * copyCount(a);
+    })[0] || null;
+}
+
+function fitInlineBudget(groups) {
+    groups.forEach(function (group) {
+        group.inlineWidth = group.width;
+        group.inlineHeight = group.height;
+    });
+    let iterations = 0;
+    while (iterations < 256) {
+        iterations += 1;
+        const oversized = largestGroup(groups, function (group) {
+            return copyCount(group) > 0 && base64Length(group) > IMAGE_BUDGET_PER_IMAGE_BASE64;
+        });
+        if (oversized) {
+            if (!downscaleInlineGroup(oversized)) useThumbnail(oversized);
+            continue;
+        }
+        if (totalBase64Length(groups) <= IMAGE_BUDGET_TOTAL_BASE64) break;
+        const reducible = largestGroup(groups, canBudgetDownscale);
+        if (reducible) {
+            downscaleInlineGroup(reducible);
+            continue;
+        }
+        const fallback = largestGroup(groups, function (group) { return !group.fallback && copyCount(group) > 0; });
+        if (!fallback) break;
+        useThumbnail(fallback);
+    }
+}
+
+function applyInlineBudget(result, groups, warnings) {
+    fitInlineBudget(groups);
+    let scaled = false;
+    const content = [];
+    groups.forEach(function (group) {
+        const data = group.bytes.toString('base64');
+        if (group.scale < 1 - 1e-9 || group.fallback) {
+            scaled = true;
+            group.owner.budgetScale = Number(group.scale.toFixed(6));
+            group.owner.inlineWidth = group.inlineWidth;
+            group.owner.inlineHeight = group.inlineHeight;
+            group.owner.inlineSizeBytes = group.bytes.length;
+            group.owner.downsampled = true;
+        }
+        if (group.fallback) {
+            group.owner.inlineKind = group.pathOnly ? 'path-only' : 'thumbnail';
+            if (group.owner.base64 !== undefined) delete group.owner.base64;
+            if (group.pathOnly) warnings.push(group.label + ' exceeded the inline image budget in an unsupported PNG format; returned path without inline pixels.');
+            else warnings.push(group.label + ' exceeded the inline image budget; returned path plus a '
+                + group.inlineWidth + 'x' + group.inlineHeight + ' thumbnail instead.');
+        } else if (group.includeBase64) {
+            group.owner.base64 = data;
+        }
+        if (group.contentRequired) {
+            content.push({
+                type: 'image', data: data, mimeType: 'image/png',
+                _meta: Object.assign({}, group.meta, {
+                    width: group.inlineWidth, height: group.inlineHeight,
+                    fullWidth: group.width, fullHeight: group.height, path: group.path,
+                    thumbnail: group.fallback === true,
+                }),
+            });
+        }
+    });
+    if (scaled) warnings.unshift('Inline preview images were downscaled to fit the 12 MiB total and 4.5 MiB per-image base64-character budgets; path still identifies each full-resolution 8-bit PNG.');
+    result.imageBudget = {
+        totalBase64Chars: totalBase64Length(groups),
+        totalLimitBase64Chars: IMAGE_BUDGET_TOTAL_BASE64,
+        perImageLimitBase64Chars: IMAGE_BUDGET_PER_IMAGE_BASE64,
+    };
+    return content;
+}
+
+function resultText(result) {
+    return JSON.stringify(result, function (key, value) {
+        if (key === 'base64' && this && own(this, 'path')) return undefined;
+        return value;
+    });
 }
 
 function rememberCapture(captureId, frames, compId, compName) {
@@ -408,13 +575,13 @@ async function compareResult(args, context, deps, expression, outDir, captureId)
     const diff = imageOps.diffImages(sides[0].image, bImage, { threshold: threshold, maxSide: 2048 });
     if (resampled) diff.metrics.resampled = true;
     const result = makeBaseResult(captureId, captured);
-    const content = [];
+    const groups = [];
     let scaled = false;
     const comparison = { a: sides[0].descriptor, b: sides[1].descriptor, metrics: diff.metrics };
     if (mode === 'diff' || mode === 'both') {
         const artifact = writeImage(path.join(outDir, captureId + '-diff.png'), diff.image);
         comparison.diffPath = artifact.path;
-        content.push(artifactContent(artifact, captureId, 'diff'));
+        groups.push(artifactInlineGroup(artifact, artifact, captureId, 'diff'));
         if (diff.scaled) {
             scaled = true;
             warnings.push('The diff heatmap was scaled to fit within 2048 pixels.');
@@ -424,7 +591,7 @@ async function compareResult(args, context, deps, expression, outDir, captureId)
         const sideBySide = imageOps.composeSideBySide(sides[0].image, bImage, 8, ['A', 'B'], 2048);
         const artifact = writeImage(path.join(outDir, captureId + '-sbs.png'), sideBySide.image);
         comparison.sideBySidePath = artifact.path;
-        content.push(artifactContent(artifact, captureId, 'side-by-side'));
+        groups.push(artifactInlineGroup(artifact, artifact, captureId, 'side-by-side'));
         if (sideBySide.scaled) {
             scaled = true;
             warnings.push('The side-by-side image was scaled to fit within 2048 pixels.');
@@ -432,8 +599,12 @@ async function compareResult(args, context, deps, expression, outDir, captureId)
     }
     comparison.scaled = scaled;
     result.compare = comparison;
+    if (args.include_base64 === true) captured.frames.forEach(function (frame, index) {
+        groups.push(frameInlineGroup(frame, captureId, index, true, false));
+    });
+    const content = applyInlineBudget(result, groups, warnings);
     addWarnings(result, warnings);
-    content.push({ type: 'text', text: JSON.stringify(result) });
+    content.push({ type: 'text', text: resultText(result) });
     rememberCapture(captureId, captured.frames, captured.compId, captured.compName);
     return { result: { content: content, structuredContent: result } };
 }
@@ -444,7 +615,7 @@ async function ordinaryResult(args, context, deps, expression, outDir, captureId
     const captured = await captureFrames(args, context, deps, expression, requests, deadline);
     const result = makeBaseResult(captureId, captured);
     const warnings = [];
-    let content;
+    const groups = [];
     if ((args.layout || 'separate') === 'grid') {
         const entries = captured.frames.map(function (frame, index) {
             return { image: verifiedFrame(frame, 'preview frame changed after capture').image, label: '#' + index + ' ' + Number(frame.time).toFixed(3) + 's' };
@@ -460,12 +631,18 @@ async function ordinaryResult(args, context, deps, expression, outDir, captureId
             }),
         };
         if (composed.scaled) warnings.push('The grid image was scaled to fit within grid_max_side.');
-        content = [artifactContent(artifact, captureId, 'grid')];
+        groups.push(artifactInlineGroup(artifact, result.grid, captureId, 'grid'));
+        if (args.include_base64 === true) captured.frames.forEach(function (frame, index) {
+            groups.push(frameInlineGroup(frame, captureId, index, true, false));
+        });
     } else {
-        content = captured.frames.map(function (frame, index) { return frameContent(frame, captureId, index); });
+        captured.frames.forEach(function (frame, index) {
+            groups.push(frameInlineGroup(frame, captureId, index, args.include_base64 === true, true));
+        });
     }
+    const content = applyInlineBudget(result, groups, warnings);
     addWarnings(result, warnings);
-    content.push({ type: 'text', text: JSON.stringify(result) });
+    content.push({ type: 'text', text: resultText(result) });
     rememberCapture(captureId, captured.frames, captured.compId, captured.compName);
     return { result: { content: content, structuredContent: result } };
 }
@@ -475,7 +652,10 @@ async function call(args, context, deps) {
     try { validateArgs(args); } catch (error) { return errorResult(error); }
     let expression;
     try { expression = compExpr(args.comp_id); } catch (error) { return errorResult(error); }
-    const outDir = args.out_dir || path.join(PREVIEW_ROOT, SESSION_ID);
+    const previewRoot = deps.previewRoot || PREVIEW_ROOT;
+    const sessionId = deps.previewSessionId || SESSION_ID;
+    previewPrune.prunePreviewRootOnce(previewRoot, sessionId);
+    const outDir = args.out_dir || path.join(previewRoot, sessionId);
     const captureId = crypto.randomBytes(16).toString('hex');
     try {
         fs.mkdirSync(outDir, { recursive: true });
@@ -486,4 +666,10 @@ async function call(args, context, deps) {
     }
 }
 
-module.exports = { definition, call, renderTemplate, compExpr, expandRange, frameRequests, previewTimeoutMs, awaitWrittenPng, nativeStatus };
+module.exports = {
+    definition: definition, call: call, renderTemplate: renderTemplate, compExpr: compExpr,
+    expandRange: expandRange, frameRequests: frameRequests, previewTimeoutMs: previewTimeoutMs,
+    awaitWrittenPng: awaitWrittenPng, nativeStatus: nativeStatus,
+    IMAGE_BUDGET_TOTAL_BASE64: IMAGE_BUDGET_TOTAL_BASE64,
+    IMAGE_BUDGET_PER_IMAGE_BASE64: IMAGE_BUDGET_PER_IMAGE_BASE64,
+};

--- a/plugin/host/mcp/tools/preview-frame.test.js
+++ b/plugin/host/mcp/tools/preview-frame.test.js
@@ -26,6 +26,30 @@ function pngChunk(type, data) {
     return Buffer.concat([head, data, tail]);
 }
 
+function rgba16Png(width, height) {
+    const stride = width * 8;
+    const raw = Buffer.alloc(height * (stride + 1));
+    let value = 0x13579bdf;
+    for (let y = 0; y < height; y += 1) for (let x = 0; x < stride; x += 2) {
+        value = (value * 1664525 + 1013904223) >>> 0;
+        raw[y * (stride + 1) + x + 1] = value >>> 24;
+        raw[y * (stride + 1) + x + 2] = value >>> 16;
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0); ihdr.writeUInt32BE(height, 4); ihdr[8] = 16; ihdr[9] = 6;
+    return Buffer.concat([png.SIGNATURE, pngChunk('IHDR', ihdr), pngChunk('IDAT', zlib.deflateSync(raw)), pngChunk('IEND', Buffer.alloc(0))]);
+}
+
+function noisyPng(width, height, seed) {
+    const rgba = Buffer.alloc(width * height * 4);
+    let value = seed >>> 0;
+    for (let index = 0; index < rgba.length; index += 1) {
+        value = (value * 1664525 + 1013904223) >>> 0;
+        rgba[index] = value >>> 24;
+    }
+    return png.encodePng(rgba, width, height);
+}
+
 function grayscalePng() {
     const ihdr = Buffer.alloc(13);
     ihdr.writeUInt32BE(2, 0); ihdr.writeUInt32BE(1, 4); ihdr[8] = 8; ihdr[9] = 0;
@@ -35,6 +59,8 @@ function grayscalePng() {
 function makeDeps(calls, logs, options) {
     const setting = options || {};
     return {
+        previewRoot: setting.previewRoot || tempDir(),
+        previewSessionId: setting.previewSessionId || 'test-session',
         hostLog: { record: function (entry) { logs.push(entry); } },
         executeJsx: async function (request) {
             calls.push(request);
@@ -101,6 +127,42 @@ test('ae_previewFrame applies scale, honors out_dir, and rejects excessive times
     assert.match(rejected.result.structuredContent.error, /at most 8/);
 });
 
+test('ae_previewFrame replaces a 16-bit source with the returned 8-bit PNG', async () => {
+    const source = rgba16Png(4, 2);
+    const expected = png.decodeRgba(source);
+    const output = await preview.call({ out_dir: tempDir() }, context, makeDeps([], [], {
+        bytes: source, compWidth: 4, compHeight: 2,
+    }));
+    const frame = output.result.structuredContent.frames[0];
+    const disk = fs.readFileSync(frame.path);
+    assert.equal(png.readPngInfo(disk).bitDepth, 8);
+    assert.deepEqual(png.decodeRgba(disk), expected);
+    assert.equal(frame.sourceBitDepth, 16);
+    assert.equal(frame.bitDepth, 8);
+    assert.equal(frame.sizeBytes, disk.length);
+    assert.equal(frame.sha256, crypto.createHash('sha256').update(disk).digest('hex'));
+    assert.notDeepEqual(disk, source);
+});
+
+test('ae_previewFrame scales and grids 16-bit source frames', async () => {
+    const source = rgba16Png(8, 4);
+    const scaled = await preview.call({ scale: 0.5, out_dir: tempDir() }, context, makeDeps([], [], {
+        bytes: source, compWidth: 8, compHeight: 4,
+    }));
+    const frame = scaled.result.structuredContent.frames[0];
+    assert.equal(frame.width, 4);
+    assert.equal(frame.height, 2);
+    assert.equal(frame.bitDepth, 8);
+    assert.equal(frame.downsampleSkipped, undefined);
+
+    const grid = await preview.call({ times: [0, 1], layout: 'grid', out_dir: tempDir() }, context, makeDeps([], [], {
+        bytes: source, compWidth: 8, compHeight: 4,
+    }));
+    assert.equal(grid.result.structuredContent.ok, true);
+    assert.equal(grid.result.structuredContent.frames.every(function (item) { return item.bitDepth === 8; }), true);
+    assert.deepEqual(grid.result.content.map(function (item) { return item.type; }), ['image', 'text']);
+});
+
 test('ae_previewFrame keeps a complete unsupported PNG and records skipped downsampling', async () => {
     const output = await preview.call({ out_dir: tempDir(), scale: 0.5 }, context, makeDeps([], [], { bytes: grayscalePng(), compWidth: 2, compHeight: 1 }));
     const frame = output.result.structuredContent.frames[0];
@@ -125,6 +187,61 @@ test('ae_previewFrame turns a changed frame during image assembly into a tool er
     const output = await preview.call({ out_dir: tempDir() }, context, deps);
     assert.equal(output.result.isError, true);
     assert.match(output.result.structuredContent.error, /preview frame changed after capture/);
+});
+
+test('ae_previewFrame downscales multiple inline images to the total response budget', async () => {
+    const output = await preview.call({ times: [0, 1, 2, 3, 4, 5], out_dir: tempDir() }, context, makeDeps([], [], {
+        width: 800, height: 600, compWidth: 800, compHeight: 600,
+        frameForTime: function (time, index) { return noisyPng(800, 600, index + 1); },
+    }));
+    const value = output.result.structuredContent;
+    const images = output.result.content.filter(function (item) { return item.type === 'image'; });
+    const total = images.reduce(function (sum, item) { return sum + item.data.length; }, 0);
+    assert.ok(total <= preview.IMAGE_BUDGET_TOTAL_BASE64);
+    assert.ok(images.every(function (item) { return item.data.length <= preview.IMAGE_BUDGET_PER_IMAGE_BASE64; }));
+    assert.equal(value.imageBudget.totalBase64Chars, total);
+    assert.equal(value.frames.some(function (frame) { return frame.budgetScale < 1 && frame.downsampled === true; }), true);
+    assert.match(value.warnings.join(' '), /downscaled.*budget/i);
+    value.frames.forEach(function (frame) {
+        const bytes = fs.readFileSync(frame.path);
+        assert.equal(frame.sizeBytes, bytes.length);
+        assert.equal(frame.sha256, crypto.createHash('sha256').update(bytes).digest('hex'));
+    });
+});
+
+test('ae_previewFrame counts include_base64 copies in the shared budget', async () => {
+    const output = await preview.call({ times: [0, 1, 2], include_base64: true, out_dir: tempDir() }, context, makeDeps([], [], {
+        width: 800, height: 600, compWidth: 800, compHeight: 600,
+        frameForTime: function (time, index) { return noisyPng(800, 600, index + 20); },
+    }));
+    const value = output.result.structuredContent;
+    const contentTotal = output.result.content.filter(function (item) { return item.type === 'image'; }).reduce(function (sum, item) {
+        return sum + item.data.length;
+    }, 0);
+    const jsonTotal = value.frames.reduce(function (sum, frame) { return sum + (frame.base64 ? frame.base64.length : 0); }, 0);
+    assert.equal(value.imageBudget.totalBase64Chars, contentTotal + jsonTotal);
+    assert.ok(contentTotal + jsonTotal <= preview.IMAGE_BUDGET_TOTAL_BASE64);
+    assert.ok(Buffer.byteLength(JSON.stringify(output.result)) < 16 * 1024 * 1024);
+    assert.equal(value.frames.some(function (frame) { return frame.budgetScale < 1; }), true);
+    assert.equal(output.result.content[output.result.content.length - 1].text.includes('"base64":'), false);
+});
+
+test('ae_previewFrame falls back to a path and bounded thumbnail at the minimum edge', async () => {
+    const source = noisyPng(5000, 256, 99);
+    assert.ok(source.toString('base64').length > preview.IMAGE_BUDGET_PER_IMAGE_BASE64);
+    const output = await preview.call({ include_base64: true, out_dir: tempDir() }, context, makeDeps([], [], {
+        bytes: source, compWidth: 5000, compHeight: 256,
+    }));
+    const value = output.result.structuredContent;
+    const frame = value.frames[0];
+    const image = output.result.content[0];
+    assert.equal(frame.path.length > 0, true);
+    assert.equal(png.readPngInfo(fs.readFileSync(frame.path)).width, 5000);
+    assert.equal(frame.base64, undefined);
+    assert.equal(frame.inlineKind, 'thumbnail');
+    assert.equal(image._meta.thumbnail, true);
+    assert.ok(Math.max(image._meta.width, image._meta.height) <= 512);
+    assert.match(value.warnings.join(' '), /path plus.*thumbnail/i);
 });
 
 test('preview helpers implement Template dollar escapes and increasing frame budgets', () => {


### PR DESCRIPTION
Closes #352.

## 更改日志

- **previewFrame 在 16 bpc 工程上可用，且不再撞 Claude Code 的 16 MB 单事件上限**——宿主解码 16-bit RGB/RGBA PNG（取高字节）；预览一律回传 8-bit（16-bit 捕获在计量、哈希、缩放、拼图前先重编码落盘）；每次响应受 12 MiB 总量 / 4.5 MiB 单图（base64 字符数）预算约束：超限时按 0.75 步长逐级缩帧到最小边 256 px，仍装不下的帧改为返回路径加 ≤ 512 px 缩略图，`warnings` 与每帧字段（`budgetScale`、`inlineWidth/Height`、`inlineKind`）记录处理，`path` 永远指向全分辨率文件，`include_base64` 副本计入预算且只出现在 `structuredContent`；进度通知写真实工具名；同一宿主进程首次预览时清理其它 session 中 7 天前或超出 300 MB 的临时帧。
- **previewFrame works on 16 bpc projects and stays under Claude Code's 16 MB event cap** — the host decodes 16-bit PNG, always returns 8-bit previews, and fits every response into a 12 MiB total / 4.5 MiB per-image base64 budget by downscaling (path + thumbnail as the last resort); progress notifications name the running tool; stale temp frames are pruned on first use.

## 验证

- `plugin/host` `npm test`：298 tests, 282 pass, 0 fail, 16 skipped（新增 png 16-bit 夹具、预算、缩略图回退、清理策略、进度文案共 11 个用例）。
- 真机验证：待编排者在 16 bpc 工程（1920×1080，分形噪波 + 颗粒 + 文本，8 层）上补充：`scale: 0.5` 真缩小、`layout: grid` 成功、6 帧 `separate` 经 Claude Code CLI 一次拿回。

## 实现者

Sol（gpt-5.6-sol，effort high）实现；Fable 审 diff、把新模块登记进 `cep-runtime-contract.test.js` 的显式清单并运行测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
