### PR TITLE
fix(host): unblock port restarts, order recovery writes after approval, bound /exec timeouts (#354 part A)

### DIFF
--- a/plugin/host/mcp/checkpoint-ops.js
+++ b/plugin/host/mcp/checkpoint-ops.js
@@ -1,5 +1,6 @@
 'use strict';
 const { appendHint } = require('./error-hints');
+const crypto = require('crypto');
 
 // Shared checkpoint mechanics. ae_exec uses the best-effort wrapper while
 // ae_checkpoint and ae_revert use the explicit result-producing primitives.
@@ -100,8 +101,27 @@ function atomicReplace(source, destination, fsImpl) {
     const io = fsImpl || fs;
     const directory = path.dirname(destination);
     io.mkdirSync(directory, { recursive: true });
-    const temporary =
-        io.mkdtempSync(path.join(directory, '.' + path.basename(destination) + '.')) + '.aep.tmp';
+    let temporary = null;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+        const candidate = path.join(
+            directory,
+            '.' + path.basename(destination) + '.' + crypto.randomBytes(8).toString('hex') + '.aep.tmp',
+        );
+        try {
+            const descriptor = io.openSync(candidate, 'wx');
+            io.closeSync(descriptor);
+            temporary = candidate;
+            break;
+        } catch (error) {
+            try {
+                if (io.existsSync(candidate)) io.unlinkSync(candidate);
+            } catch (cleanupError) {
+                /* best effort */
+            }
+            if (!error || error.code !== 'EEXIST') throw error;
+        }
+    }
+    if (!temporary) throw new Error('could not create an atomic replacement temp file');
     try {
         io.copyFileSync(source, temporary);
         io.renameSync(temporary, destination);

--- a/plugin/host/mcp/checkpoint-ops.test.js
+++ b/plugin/host/mcp/checkpoint-ops.test.js
@@ -8,35 +8,31 @@ const { atomicReplace, autoCheckpoint, createCheckpoint } = require('./checkpoin
 function reply(value) {
     return { payload: { ok: true, result: JSON.stringify(value) } };
 }
-test('atomicReplace uses a sibling temp file, replaces atomically, and cleans a failed copy', function () {
+test('atomicReplace uses a sibling temp file and leaves no temporary file or directory', function () {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-atomic-'));
     const src = path.join(root, 'source.aep');
     const dst = path.join(root, 'target.aep');
     fs.writeFileSync(src, 'new');
     fs.writeFileSync(dst, 'old');
-    let temporary = '';
-    const io = Object.assign({}, fs, {
-        mkdtempSync: function (prefix) {
-            assert.equal(path.dirname(prefix), root);
-            temporary = fs.mkdtempSync(prefix);
-            return temporary;
-        },
-    });
-    atomicReplace(src, dst, io);
-    assert.equal(fs.readFileSync(dst, 'utf8'), 'new');
-    assert.equal(fs.existsSync(temporary + '.aep.tmp'), false);
-    fs.writeFileSync(dst, 'old-again');
-    const failing = Object.assign({}, fs, {
-        mkdtempSync: fs.mkdtempSync,
-        copyFileSync: function () {
-            throw new Error('disk full');
-        },
-    });
-    assert.throws(function () {
-        atomicReplace(src, dst, failing);
-    }, /disk full/);
-    assert.equal(fs.readFileSync(dst, 'utf8'), 'old-again');
-    fs.rmSync(root, { recursive: true, force: true });
+    try {
+        atomicReplace(src, dst);
+        assert.equal(fs.readFileSync(dst, 'utf8'), 'new');
+        assert.deepEqual(fs.readdirSync(root).sort(), ['source.aep', 'target.aep']);
+
+        fs.writeFileSync(dst, 'old-again');
+        const failing = Object.assign({}, fs, {
+            copyFileSync: function () {
+                throw new Error('disk full');
+            },
+        });
+        assert.throws(function () {
+            atomicReplace(src, dst, failing);
+        }, /disk full/);
+        assert.equal(fs.readFileSync(dst, 'utf8'), 'old-again');
+        assert.deepEqual(fs.readdirSync(root).sort(), ['source.aep', 'target.aep']);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
 });
 test('createCheckpoint and autoCheckpoint share the same successful persistence path', async function () {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ae-mcp-ops-'));

--- a/plugin/host/mcp/tools/exec.js
+++ b/plugin/host/mcp/tools/exec.js
@@ -457,7 +457,6 @@ async function runRecovery(args, context, deps) {
     const meta = store.readMeta(entry);
     const code = hasOwn(args, 'code') ? args.code : store.readScript(entry);
     if (!code) return { ok: false, error: 'recovery script is empty: ' + args.recoveryId };
-    if (hasOwn(args, 'code')) store.writeScript(entry, code);
     const retryMode = args.retryMode || 'restore';
     const resolvedArgs = effectiveArgs(meta, args);
     const approvalArguments = Object.assign({}, resolvedArgs, {
@@ -472,6 +471,7 @@ async function runRecovery(args, context, deps) {
         deps,
     );
     if (denied) return denied;
+    if (hasOwn(args, 'code')) store.writeScript(entry, code);
     const restoration = await restoreForRetry(args.recoveryId, retryMode, meta, context, deps);
     if (!restoration.ok) return restoration;
     const checkpointRun = await autoCheckpoint(resolvedArgs, context, deps);

--- a/plugin/host/mcp/tools/exec.test.js
+++ b/plugin/host/mcp/tools/exec.test.js
@@ -288,6 +288,42 @@ test('continue skips restore and inline code replaces the recovery script', asyn
     }
 });
 
+test('declined ae_execRecover approval preserves the stored recovery script', async () => {
+    const f = fixture();
+    try {
+        f.deps.setUserHandler(async function () {
+            return failed('boom', { revision: { before: 1, after: 1 }, projectPath: f.project });
+        });
+        const first = value(await execTool.call({ code: 'stored-script' }, context(null), f.deps));
+        const entry = f.recoveryStore.lookup(first.recoveryId, f.project);
+        f.deps.approvals = { request: async function () { return 'decline'; } };
+
+        const declined = value(await execRecoverTool.call({
+            recoveryId: first.recoveryId,
+            retryMode: 'continue',
+            code: 'rejected-replacement',
+        }, context('manual'), f.deps));
+        assert.equal(declined.ok, false);
+        assert.match(declined.error, /User denied/);
+        assert.equal(f.recoveryStore.readScript(entry), 'stored-script');
+
+        f.deps.approvals = { request: async function () { return 'accept'; } };
+        f.deps.setUserHandler(async function (input) {
+            assert.equal(input.code, 'approved-replacement');
+            return success({ ok: true }, { projectPath: f.project });
+        });
+        const approved = value(await execRecoverTool.call({
+            recoveryId: first.recoveryId,
+            retryMode: 'continue',
+            code: 'approved-replacement',
+        }, context('manual'), f.deps));
+        assert.equal(approved.ok, true);
+        assert.equal(f.recoveryStore.readScript(entry), 'approved-replacement');
+    } finally {
+        f.close();
+    }
+});
+
 test('retry rejects unknown ids, project mismatch, and changed projects without checkpoints', async () => {
     const f = fixture();
     try {

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -36,6 +36,9 @@ let clientBlocklist = null;
 const INTERNAL_CLIENT = 'panel-diagnostics/internal';
 const NATIVE_MAX_REQUEST_WINDOW_MS = 30000;
 const NATIVE_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+const EXEC_TIMEOUT_MAX_MS = 600000;
+const STOP_FALLBACK_TIMEOUT_MS = 3000;
+const trackedSockets = new Set();
 
 function setRuntimeDependencies(dependencies) {
     if (!dependencies || typeof dependencies.express !== 'function') {
@@ -710,7 +713,9 @@ async function executeJsx(request) {
             payload: { ok: false, error: '`nativeProjectGraphEffect` must be invalidate or preserve' },
         };
     }
-    const t = Number.isFinite(input.timeoutMs) && input.timeoutMs > 0 ? input.timeoutMs : 30000;
+    const requestedTimeoutMs = Number.isFinite(input.timeoutMs) && input.timeoutMs > 0
+        ? input.timeoutMs : 30000;
+    const t = Math.min(Math.max(requestedTimeoutMs, 1), EXEC_TIMEOUT_MAX_MS);
     const wrapped = undoGroup ? wrapWithUndoGroup(code, undoGroup) : code;
     const transported = wrapForEvalScriptTransport(wrapped, {
         diagnostics: input.diagnostics === true,
@@ -1248,9 +1253,23 @@ function start(port, callback) {
     httpServer.on('error', (err) => {
         if (callback) callback(err);
     });
+    httpServer.on('connection', function (socket) {
+        trackedSockets.add(socket);
+        socket.on('close', function () { trackedSockets.delete(socket); });
+    });
 }
 
 function stop(callback) {
+    let finished = false;
+    let fallbackTimer = null;
+    const finish = function () {
+        if (finished) return;
+        finished = true;
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        httpServer = null;
+        currentPort = null;
+        if (callback) callback();
+    };
     if (restoreHostConsole) {
         try { restoreHostConsole(); } catch (error) { /* best effort */ }
         restoreHostConsole = null;
@@ -1260,12 +1279,33 @@ function stop(callback) {
         unsubscribeHostActivity = null;
     }
     closeNativeAegpClient();
-    if (!httpServer) return callback ? callback() : null;
-    httpServer.close(() => {
-        httpServer = null;
-        currentPort = null;
-        if (callback) callback();
-    });
+    const server = httpServer;
+    if (!server) return finish();
+
+    const mounted = module.exports.mcp;
+    if (mounted && mounted.sessions && typeof mounted.sessions.list === 'function'
+        && typeof mounted.sessions.delete === 'function') {
+        mounted.sessions.list().forEach(function (session) {
+            mounted.sessions.delete(session.sessionId);
+        });
+    }
+
+    try {
+        server.close(finish);
+    } catch (error) {
+        finish();
+        return;
+    }
+
+    if (typeof server.closeAllConnections === 'function') {
+        server.closeAllConnections();
+    } else {
+        // CEP hosts can predate closeAllConnections; keep their long-lived SSE
+        // sockets visible so close cannot wait forever on a client stream.
+        trackedSockets.forEach(function (socket) { socket.destroy(); });
+    }
+    fallbackTimer = setTimeout(finish, STOP_FALLBACK_TIMEOUT_MS);
+    if (fallbackTimer && typeof fallbackTimer.unref === 'function') fallbackTimer.unref();
 }
 
 function restart(port, callback) {

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -13,6 +13,7 @@ const FULL_REGISTRY = require(
     '../../native/ae-plugin/protocol/fixtures/capability-registry-full.json'
 );
 const authToken = require('./auth-token');
+const jsxBridge = require('./jsx-bridge');
 const { createStatePaths } = require('./state-paths');
 const { computeContentHash } = require('./mcp/tool-library');
 
@@ -363,6 +364,7 @@ function request(port, method, pathname, headers, body) {
                 resolve({
                     status: res.statusCode,
                     body: JSON.parse(chunks || '{}'),
+                    headers: res.headers,
                 });
             });
         });
@@ -383,6 +385,51 @@ function get(port, pathname, headers) {
 async function closeFixture(fixture) {
     await new Promise(function (resolve) { fixture.instance.close(resolve); });
     fixture.server.stop();
+}
+
+function openSse(port, sessionId) {
+    return new Promise(function (resolve, reject) {
+        const req = http.request({
+            host: '127.0.0.1',
+            port,
+            path: '/mcp',
+            method: 'GET',
+            headers: {
+                Accept: 'text/event-stream',
+                'Mcp-Session-Id': sessionId,
+            },
+        });
+        req.on('error', reject);
+        req.on('response', function (res) {
+            const ended = new Promise(function (finish) {
+                res.on('end', finish);
+                res.on('close', finish);
+                res.resume();
+            });
+            resolve({ ended, response: res });
+        });
+        req.end();
+    });
+}
+
+function settlesWithin(promise, timeoutMs) {
+    return Promise.race([
+        promise,
+        new Promise(function (_resolve, reject) {
+            setTimeout(function () { reject(new Error('timed out after ' + timeoutMs + 'ms')); }, timeoutMs);
+        }),
+    ]);
+}
+
+function unusedPort() {
+    return new Promise(function (resolve, reject) {
+        const probe = http.createServer();
+        probe.on('error', reject);
+        probe.listen(0, '127.0.0.1', function () {
+            const port = probe.address().port;
+            probe.close(function () { resolve(port); });
+        });
+    });
 }
 
 test('token matching is exact and rejects non-string input', () => {
@@ -731,6 +778,94 @@ test('/exec preserves the graph only when explicitly requested', async () => {
         assert.equal(invalid.status, 400);
     } finally {
         await closeFixture(fixture);
+    }
+});
+
+test('/exec clamps oversized timeouts before passing them to the JSX bridge', async () => {
+    const scheduled = [];
+    jsxBridge._setTimingForTest({
+        setTimeout: function (fn, timeoutMs) {
+            scheduled.push(timeoutMs);
+            return setTimeout(fn, timeoutMs);
+        },
+        clearTimeout,
+    });
+    const fixture = await startApp();
+    try {
+        const response = await post(fixture.port, '/exec', HEADERS, {
+            code: '1 + 1',
+            timeoutMs: 1e10,
+        });
+        assert.equal(response.status, 200);
+        assert.equal(response.body.ok, true);
+        assert.equal(scheduled.includes(600000), true);
+        assert.equal(scheduled.includes(1e10), false);
+    } finally {
+        jsxBridge._setTimingForTest({ setTimeout, clearTimeout });
+        await closeFixture(fixture);
+    }
+});
+
+test('restart closes active MCP SSE sessions and starts again exactly once', async () => {
+    const server = loadServer();
+    server.setCSInterface({
+        evalScript: function (_jsx, callback) {
+            callback('{"ok":true,"resultType":"string","result":"stub-result"}');
+        },
+    });
+    const start = function (port) {
+        return new Promise(function (resolve, reject) {
+            server.start(port, function (error) {
+                if (error) reject(error);
+                else resolve(server.getConnectionInfo().port);
+            });
+        });
+    };
+    try {
+        const firstPort = await start(await unusedPort());
+        const initialized = await post(firstPort, '/mcp', {
+            'Mcp-Protocol-Version': '2025-03-26',
+        }, {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: { protocolVersion: '2025-03-26', clientInfo: { name: 'restart-test' } },
+        });
+        assert.equal(initialized.status, 200);
+        const sessionId = initialized.headers['mcp-session-id'];
+        assert.equal(typeof sessionId, 'string');
+        const stream = await openSse(firstPort, sessionId);
+        assert.equal(stream.response.statusCode, 200);
+
+        let callbacks = 0;
+        await settlesWithin(new Promise(function (resolve, reject) {
+            unusedPort().then(function (secondPort) {
+                server.restart(secondPort, function (error) {
+                    callbacks += 1;
+                    if (error) reject(error);
+                    else resolve();
+                });
+            }, reject);
+        }), 1000);
+        assert.equal(callbacks, 1);
+        await settlesWithin(stream.ended, 1000);
+        await new Promise(function (resolve) { setTimeout(resolve, 20); });
+        assert.equal(callbacks, 1);
+
+        const secondPort = server.getConnectionInfo().port;
+        assert.equal(typeof secondPort, 'number');
+        const restarted = await post(secondPort, '/mcp', {
+            'Mcp-Protocol-Version': '2025-03-26',
+        }, {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'initialize',
+            params: { protocolVersion: '2025-03-26', clientInfo: { name: 'restart-test-2' } },
+        });
+        assert.equal(restarted.status, 200);
+        assert.equal(typeof restarted.headers['mcp-session-id'], 'string');
+    } finally {
+        await new Promise(function (resolve) { server.stop(resolve); });
     }
 });
 


### PR DESCRIPTION
Part A of #354 (the four confirmed items: 1, 2, 5, 6). Part B (native request timeout, session cap, protocol details) and the Windows native fixes follow in separate PRs.

## 更改日志

- **宿主生命周期与恢复安全（第一批）**——改端口重启不再被在线 MCP 客户端卡死：`stop()` 先关闭全部会话与事件流，再 `closeAllConnections()`（旧 Node 上销毁登记的 socket），3 秒兜底且回调只触发一次；`ae_execRecover` 只在审批通过后才覆写恢复脚本，被拒绝的重试不再把被拒代码留在磁盘上；`ae_revert` 不再在工程旁留下空的隐藏目录（临时文件改为独占随机文件名）；`/exec` 的 `timeoutMs` 夹到 1–600000 ms。
- **Host lifecycle and recovery safety (batch A)** — port restarts no longer hang behind live MCP event streams; recovery scripts are written only after approval; `ae_revert` stops leaving hidden directories; `/exec` timeouts are bounded like the MCP ceiling.

## 验证

- `plugin/host` `npm test`：290 tests, 274 pass, 0 fail, 16 skipped（新增：真实 HTTP + SSE 会话下 `restart()` 回调恰好一次、流结束、重启后可再次 initialize；`/exec` 超时夹取；拒绝审批后恢复脚本原样；`atomicReplace` 成功/失败路径均无残留目录）。
- 真机验证：待编排者补充。

## 实现者

Terra（gpt-5.6-terra，effort high）实现；Fable 审 diff 并运行测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #354
