### PR TITLE
fix(panel): keep the model choice per channel and gate Fable 5.1 on the installed Claude CLI (#355 part A)

### DIFF
--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -22468,6 +22468,7 @@
     {
       id: "claude-fable-5-1",
       label: "Fable 5.1",
+      minCliVersion: "2.1.251",
       effortLevels: ["low", "medium", "high", "xhigh", "max"],
       adaptive: true
     },
@@ -29273,6 +29274,26 @@ When you are done, remind me of two things: MCP tools load only in a new session
     if (adapter.id === "windows-x64") return "x64";
     return void 0;
   }
+  function compareVersions2(actual, minimum) {
+    const left = String(actual || "").match(/\d+(?:\.\d+){0,3}/);
+    const right = String(minimum || "").match(/\d+(?:\.\d+){0,3}/);
+    if (!left || !right) return null;
+    const a = left[0].split(".").map(Number);
+    const b = right[0].split(".").map(Number);
+    for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+      const delta = (a[index] || 0) - (b[index] || 0);
+      if (delta) return delta;
+    }
+    return 0;
+  }
+  function minimumCliVersionForModel(modelId) {
+    var _a;
+    return ((_a = CLAUDE_MODELS.find((model) => model.id === modelId)) == null ? void 0 : _a.minCliVersion) || null;
+  }
+  function unsupportedModelMessage(version, minimum, lang) {
+    const current = version || (lang === "zh" ? "\u672A\u77E5" : "unknown");
+    return lang === "zh" ? `\u5F53\u524D Claude Code ${current} \u4E0D\u652F\u6301\u8BE5\u6A21\u578B\uFF0C\u9700\u8981 \u2265 ${minimum}\uFF1A\u8FD0\u884C \`claude update\` \u5347\u7EA7\uFF0C\u6216\u6362\u4E00\u4E2A\u6A21\u578B\u3002` : `Claude Code ${current} does not support this model; version ${minimum} or newer is required. Run \`claude update\` to upgrade, or choose another model.`;
+  }
   function resolutionArchitecture(resolution) {
     for (const attempt of (resolution == null ? void 0 : resolution.attempts) || []) {
       const match = String((attempt == null ? void 0 : attempt.detail) || "").match(/architecture\s+(arm64|aarch64|x64|amd64|x86_64)\b/i);
@@ -30223,6 +30244,18 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
             code: classification.code,
             message: (resolved == null ? void 0 : resolved.detail) || cliResolutionMessage(resolved == null ? void 0 : resolved.code, resolvedLang, (resolved == null ? void 0 : resolved.resolution) || resolved),
             ...resolution ? { detail: { resolution } } : {}
+          });
+          return false;
+        }
+        const minimumCliVersion = minimumCliVersionForModel(session.model);
+        const versionComparison = minimumCliVersion ? compareVersions2(resolved.version, minimumCliVersion) : null;
+        if (minimumCliVersion && (versionComparison === null || versionComparison < 0)) {
+          const classification = classifyErrorCode({ code: "CLI_TOO_OLD" });
+          emitAfterText({
+            type: "error",
+            kind: classification.kind,
+            code: classification.code,
+            message: unsupportedModelMessage(resolved.version, minimumCliVersion, resolvedLang)
           });
           return false;
         }
@@ -35284,6 +35317,30 @@ ${command}`
     return descriptor.defaultModelId;
   }
 
+  // src/lib/modelPreference.js
+  init_cep_runtime_inject();
+  var LEGACY_MODEL_PREF_KEY = "ae_mcp_model";
+  var MODEL_PREF_KEYS = Object.freeze({
+    subscription: "ae_mcp_model_subscription",
+    codex: "ae_mcp_model_codex",
+    opencode: "ae_mcp_model_opencode"
+  });
+  function modelPreferenceKey(channel) {
+    return MODEL_PREF_KEYS[channel] || MODEL_PREF_KEYS.subscription;
+  }
+  function nonEmpty(value) {
+    const normalized = String(value || "").trim();
+    return normalized || "";
+  }
+  function resolveModelPreference({ channelValue, legacyValue, fallback } = {}) {
+    const current = nonEmpty(channelValue);
+    const legacy = nonEmpty(legacyValue);
+    return {
+      value: current || legacy || fallback,
+      migrateLegacy: !current && Boolean(legacy)
+    };
+  }
+
   // src/cep/useActivity.js
   init_cep_runtime_inject();
   var import_react46 = __toESM(require_react(), 1);
@@ -37139,12 +37196,17 @@ ${command}`
         activeMeta.titleSource = "auto";
       }
     }
+    function refreshActiveModel() {
+      if (!activeMeta || typeof deps.currentModel !== "function") return;
+      activeMeta.model = deps.currentModel() || null;
+    }
     function persistActive() {
       if (!activeMeta || !activeId) return false;
       const currentRef = backendRef(
         typeof deps.getBackendRef === "function" ? deps.getBackendRef() : null
       );
       if (currentRef) activeMeta.backendRef = currentRef;
+      refreshActiveModel();
       refreshActiveMeta();
       if (!materialized()) {
         if (index.activeId === activeId) {
@@ -37298,6 +37360,7 @@ ${command}`
       if (!activeMeta) return;
       latestEntries = clone4(Array.isArray(entries) ? entries : []);
       activeMeta.updatedAt = isoTime(now);
+      refreshActiveModel();
       refreshActiveMeta();
       if (latestEntries.length) upsertActiveMeta();
       dirty = true;
@@ -37698,6 +37761,24 @@ ${command}`
     } catch (e) {
     }
   }
+  function removePref(key) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (e) {
+    }
+  }
+  function loadModelPref(channel, fallback) {
+    const key = modelPreferenceKey(channel);
+    const legacyValue = readPref(LEGACY_MODEL_PREF_KEY, "");
+    const resolved = resolveModelPreference({
+      channelValue: readPref(key, ""),
+      legacyValue,
+      fallback
+    });
+    if (resolved.migrateLegacy) writePref(key, resolved.value);
+    if (legacyValue) removePref(LEGACY_MODEL_PREF_KEY);
+    return resolved.value;
+  }
   function openLoginUrl(url) {
     var _a, _b;
     if (typeof ((_b = (_a = window == null ? void 0 : window.cep) == null ? void 0 : _a.util) == null ? void 0 : _b.openURLInDefaultBrowser) !== "function") {
@@ -37787,7 +37868,8 @@ ${command}`
     const pendingTurnRef = import_react48.default.useRef(null);
     const acceptedTurnRef = import_react48.default.useRef(null);
     import_react48.default.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
-    const [model, setModel] = import_react48.default.useState(() => readPref("ae_mcp_model", DEFAULT_MODEL));
+    const backendMigration = import_react48.default.useMemo(() => migrateBackendPref(window.localStorage), []);
+    const [model, setModel] = import_react48.default.useState(() => loadModelPref(backendMigration.pref, DEFAULT_MODEL));
     const [logLevel, setLogLevel] = import_react48.default.useState(() => readPref("ae_mcp_log_level", "info"));
     const logLevelRef = import_react48.default.useRef(logLevel);
     logLevelRef.current = logLevel;
@@ -37830,7 +37912,6 @@ ${command}`
       const guard = createPanelFileDropGuard({ target: window });
       return guard.dispose;
     }, []);
-    const backendMigration = import_react48.default.useMemo(() => migrateBackendPref(window.localStorage), []);
     const [backendPref, setBackendPref] = import_react48.default.useState(() => backendMigration.pref);
     const [channelChoices, setChannelChoices] = import_react48.default.useState(() => backendMigration.channelChoices);
     const openCodeProviderStore = import_react48.default.useMemo(() => createOpenCodeProviderStore({ platform }), [platform]);
@@ -38291,6 +38372,7 @@ ${draft.baseUrl}`)) return;
         },
         getEntries: () => chatEntriesRef.current,
         selectBackend: async (backend) => {
+          setModel(loadModelPref(backend, DEFAULT_MODEL));
           setBackendPref(backend);
           writePref("ae_mcp_backend", backend);
           await new Promise((resolve) => {
@@ -38347,11 +38429,11 @@ ${draft.baseUrl}`)) return;
       const nextDescriptor = selectDescriptor(facts);
       setDescriptor(nextDescriptor);
       const reconciled = reconcileModelPref(model, nextDescriptor, {
-        providerFactsPending: backendPref === "opencode" && (providerInit.state !== "ready" || openCodeProbe === null)
+        providerFactsPending: backendPref === "codex" ? codexProbe === null || codexModels === null : backendPref === "opencode" && (providerInit.state !== "ready" || openCodeProbe === null)
       });
       if (reconciled !== model) {
         setModel(reconciled);
-        writePref("ae_mcp_model", reconciled);
+        writePref(modelPreferenceKey(backendPref), reconciled);
       }
     }, [
       effective.backend,
@@ -38359,8 +38441,10 @@ ${draft.baseUrl}`)) return;
       backendPref,
       baseDescriptor,
       codexModels,
+      codexProbe,
       openCodeAvailableProviders,
       openCodeProbe,
+      model,
       providerInit.state
     ]);
     const lastRealBackendRef = import_react48.default.useRef(null);
@@ -38392,6 +38476,7 @@ ${draft.baseUrl}`)) return;
     const runCodexProbe = import_react48.default.useCallback(() => {
       let alive = true;
       setCodexProbe(null);
+      setCodexModels(null);
       codexBackend.probeAccount().then((result) => {
         if (!alive) return;
         if (containsExactSecret(result, ["aemcp-secret://"])) {
@@ -38404,7 +38489,10 @@ ${draft.baseUrl}`)) return;
           setCodexModels(result.models);
         }
       }).catch((e) => {
-        if (alive) setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
+        if (alive) {
+          setCodexModels(null);
+          setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
+        }
       });
       return () => {
         alive = false;
@@ -39124,11 +39212,12 @@ ${draft.baseUrl}`)) return;
             modelSwitchable: descriptor.perTurnModelSwitch !== false,
             onModelChange: (m) => {
               setModel(m);
-              writePref("ae_mcp_model", m);
+              writePref(modelPreferenceKey(backendPref), m);
             },
             backend: backendPref,
             onBackendChange: (m) => {
               sessionController.flush();
+              setModel(loadModelPref(m, DEFAULT_MODEL));
               setBackendPref(m);
               writePref("ae_mcp_backend", m);
             },

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -39110,7 +39110,11 @@ ${draft.baseUrl}`)) return;
               fast: effectiveFast,
               permissionMode
             },
-            onChipModel: setSessionModel,
+            onChipModel: (m) => {
+              setSessionModel(m);
+              setModel(m);
+              writePref(modelPreferenceKey(backendPref), m);
+            },
             onChipEffort: setSessionEffort,
             onChipFast: (v) => setSessionFast(Boolean(v)),
             onChipApproval: (m) => {

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -1587,7 +1587,7 @@ function Shell({ cs }) {
               fast: effectiveFast,
               permissionMode,
             }}
-            onChipModel={setSessionModel}
+            onChipModel={(m) => { setSessionModel(m); setModel(m); writePref(modelPreferenceKey(backendPref), m); }}
             onChipEffort={setSessionEffort}
             onChipFast={(v) => setSessionFast(Boolean(v))}
             onChipApproval={(m) => { setPermissionMode(m); writePref('ae_mcp_perm_mode', m); }}

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -45,6 +45,11 @@ import {
 import { createAttachmentStore } from '../cep/attachmentStore.js';
 import { claudeSubDescriptor, resolveEffectiveEffort } from '../lib/backendCapabilities';
 import { selectDescriptor, reconcileModelPref } from '../lib/descriptorSelect';
+import {
+  LEGACY_MODEL_PREF_KEY,
+  modelPreferenceKey,
+  resolveModelPreference,
+} from '../lib/modelPreference.js';
 import { baseDescriptorFor } from '../cep/backends/index.js';
 import { costBadge } from '../lib/composerOptions';
 import { useActivity } from '../cep/useActivity';
@@ -148,6 +153,23 @@ function writePref(key, value) {
   try { window.localStorage.setItem(key, value); } catch (e) { /* best-effort */ }
 }
 
+function removePref(key) {
+  try { window.localStorage.removeItem(key); } catch (e) { /* best-effort */ }
+}
+
+function loadModelPref(channel, fallback) {
+  const key = modelPreferenceKey(channel);
+  const legacyValue = readPref(LEGACY_MODEL_PREF_KEY, '');
+  const resolved = resolveModelPreference({
+    channelValue: readPref(key, ''),
+    legacyValue,
+    fallback,
+  });
+  if (resolved.migrateLegacy) writePref(key, resolved.value);
+  if (legacyValue) removePref(LEGACY_MODEL_PREF_KEY);
+  return resolved.value;
+}
+
 function openLoginUrl(url) {
   if (typeof window?.cep?.util?.openURLInDefaultBrowser !== 'function') {
     throw new Error('CEP browser opener is unavailable');
@@ -248,7 +270,8 @@ function Shell({ cs }) {
   const pendingTurnRef = React.useRef(null);
   const acceptedTurnRef = React.useRef(null);
   React.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
-  const [model, setModel] = React.useState(() => readPref('ae_mcp_model', DEFAULT_MODEL));
+  const backendMigration = React.useMemo(() => migrateBackendPref(window.localStorage), []);
+  const [model, setModel] = React.useState(() => loadModelPref(backendMigration.pref, DEFAULT_MODEL));
   const [logLevel, setLogLevel] = React.useState(() => readPref('ae_mcp_log_level', 'info'));
   const logLevelRef = React.useRef(logLevel);
   logLevelRef.current = logLevel;
@@ -295,7 +318,6 @@ function Shell({ cs }) {
     const guard = createPanelFileDropGuard({ target: window });
     return guard.dispose;
   }, []);
-  const backendMigration = React.useMemo(() => migrateBackendPref(window.localStorage), []);
   const [backendPref, setBackendPref] = React.useState(() => backendMigration.pref);
   // #229: channels are user-enabled per backend; routing follows the choice
   // exactly (no auto-pick, no lock, no pinning by provider selection).
@@ -766,6 +788,7 @@ function Shell({ cs }) {
       },
       getEntries: () => chatEntriesRef.current,
       selectBackend: async (backend) => {
+        setModel(loadModelPref(backend, DEFAULT_MODEL));
         setBackendPref(backend);
         writePref('ae_mcp_backend', backend);
         await new Promise((resolve) => {
@@ -822,12 +845,14 @@ function Shell({ cs }) {
     // fallback descriptor would clobber a valid provider-model pref at boot
     // (live-seen: pref reset to the first relay model on every restart).
     const reconciled = reconcileModelPref(model, nextDescriptor, {
-      providerFactsPending: backendPref === 'opencode'
-        && (providerInit.state !== 'ready' || openCodeProbe === null),
+      providerFactsPending: backendPref === 'codex'
+        ? codexProbe === null || codexModels === null
+        : backendPref === 'opencode'
+          && (providerInit.state !== 'ready' || openCodeProbe === null),
     });
     if (reconciled !== model) {
       setModel(reconciled);
-      writePref('ae_mcp_model', reconciled);
+      writePref(modelPreferenceKey(backendPref), reconciled);
     }
   }, [
     effective.backend,
@@ -835,8 +860,10 @@ function Shell({ cs }) {
     backendPref,
     baseDescriptor,
     codexModels,
+    codexProbe,
     openCodeAvailableProviders,
     openCodeProbe,
+    model,
     providerInit.state,
   ]);
   const lastRealBackendRef = React.useRef(null);
@@ -869,6 +896,7 @@ function Shell({ cs }) {
   const runCodexProbe = React.useCallback(() => {
     let alive = true;
     setCodexProbe(null);
+    setCodexModels(null);
     codexBackend.probeAccount().then((result) => {
       if (!alive) return;
       if (containsExactSecret(result, ['aemcp-secret://'])) {
@@ -881,7 +909,10 @@ function Shell({ cs }) {
         setCodexModels(result.models);
       }
     }).catch((e) => {
-      if (alive) setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
+      if (alive) {
+        setCodexModels(null);
+        setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
+      }
     });
     return () => { alive = false; };
   }, [codexBackend]);
@@ -1659,10 +1690,11 @@ function Shell({ cs }) {
             model={effectiveModel}
             modelOptions={modelOptions}
             modelSwitchable={descriptor.perTurnModelSwitch !== false}
-            onModelChange={(m) => { setModel(m); writePref('ae_mcp_model', m); }}
+            onModelChange={(m) => { setModel(m); writePref(modelPreferenceKey(backendPref), m); }}
             backend={backendPref}
             onBackendChange={(m) => {
               sessionController.flush();
+              setModel(loadModelPref(m, DEFAULT_MODEL));
               setBackendPref(m);
               writePref('ae_mcp_backend', m);
             }}

--- a/plugin/panel/src/cep/claudeAgentBackend.js
+++ b/plugin/panel/src/cep/claudeAgentBackend.js
@@ -22,6 +22,7 @@ import {
   displayAnswers,
   questionsFromAskUserQuestion,
 } from '../lib/questionForm.js';
+import { CLAUDE_MODELS } from '../lib/backendCapabilities.js';
 
 export const CLAUDE_MINIMUM_VERSION = '2.0.0';
 export const CLAUDE_NO_PROGRESS_WARNING_MS = 180000;
@@ -102,6 +103,30 @@ function requiredArchitecture(adapter) {
   if (adapter.id === 'macos-arm64') return 'arm64';
   if (adapter.id === 'windows-x64') return 'x64';
   return undefined;
+}
+
+function compareVersions(actual, minimum) {
+  const left = String(actual || '').match(/\d+(?:\.\d+){0,3}/);
+  const right = String(minimum || '').match(/\d+(?:\.\d+){0,3}/);
+  if (!left || !right) return null;
+  const a = left[0].split('.').map(Number);
+  const b = right[0].split('.').map(Number);
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const delta = (a[index] || 0) - (b[index] || 0);
+    if (delta) return delta;
+  }
+  return 0;
+}
+
+function minimumCliVersionForModel(modelId) {
+  return CLAUDE_MODELS.find((model) => model.id === modelId)?.minCliVersion || null;
+}
+
+function unsupportedModelMessage(version, minimum, lang) {
+  const current = version || (lang === 'zh' ? '未知' : 'unknown');
+  return lang === 'zh'
+    ? `当前 Claude Code ${current} 不支持该模型，需要 ≥ ${minimum}：运行 \`claude update\` 升级，或换一个模型。`
+    : `Claude Code ${current} does not support this model; version ${minimum} or newer is required. Run \`claude update\` to upgrade, or choose another model.`;
 }
 
 function resolutionArchitecture(resolution) {
@@ -1124,6 +1149,20 @@ export function createClaudeAgentBackend({
           code: classification.code,
           message: resolved?.detail || cliResolutionMessage(resolved?.code, resolvedLang, resolved?.resolution || resolved),
           ...(resolution ? { detail: { resolution } } : {}),
+        });
+        return false;
+      }
+      const minimumCliVersion = minimumCliVersionForModel(session.model);
+      const versionComparison = minimumCliVersion
+        ? compareVersions(resolved.version, minimumCliVersion)
+        : null;
+      if (minimumCliVersion && (versionComparison === null || versionComparison < 0)) {
+        const classification = classifyErrorCode({ code: 'CLI_TOO_OLD' });
+        emitAfterText({
+          type: 'error',
+          kind: classification.kind,
+          code: classification.code,
+          message: unsupportedModelMessage(resolved.version, minimumCliVersion, resolvedLang),
         });
         return false;
       }

--- a/plugin/panel/src/lib/backendCapabilities.js
+++ b/plugin/panel/src/lib/backendCapabilities.js
@@ -2,9 +2,8 @@
 // these, with no hardcoded model ids or tier names elsewhere.
 //
 // Claude ids are the API aliases (no date suffixes); the CLI passes them
-// through unchanged. Claude Fable 5.1 needs Claude Code >= 2.1.251 — older
-// CLIs reject it with an upstream 400 that the panel shows verbatim — so the
-// default stays on Opus 5, which every current CLI accepts.
+// through unchanged. The default stays on Opus 5, which every current CLI
+// accepts.
 export const CLAUDE_PRICE_USD_PER_MTOK = {
   'claude-fable-5-1': { input: 10, output: 50 },
   'claude-opus-5': { input: 5, output: 25 },
@@ -15,6 +14,7 @@ export const CLAUDE_PRICE_USD_PER_MTOK = {
 export const CLAUDE_MODELS = [
   {
     id: 'claude-fable-5-1', label: 'Fable 5.1',
+    minCliVersion: '2.1.251',
     effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'], adaptive: true,
   },
   {

--- a/plugin/panel/src/lib/modelPreference.js
+++ b/plugin/panel/src/lib/modelPreference.js
@@ -1,0 +1,25 @@
+export const LEGACY_MODEL_PREF_KEY = 'ae_mcp_model';
+
+const MODEL_PREF_KEYS = Object.freeze({
+  subscription: 'ae_mcp_model_subscription',
+  codex: 'ae_mcp_model_codex',
+  opencode: 'ae_mcp_model_opencode',
+});
+
+export function modelPreferenceKey(channel) {
+  return MODEL_PREF_KEYS[channel] || MODEL_PREF_KEYS.subscription;
+}
+
+function nonEmpty(value) {
+  const normalized = String(value || '').trim();
+  return normalized || '';
+}
+
+export function resolveModelPreference({ channelValue, legacyValue, fallback } = {}) {
+  const current = nonEmpty(channelValue);
+  const legacy = nonEmpty(legacyValue);
+  return {
+    value: current || legacy || fallback,
+    migrateLegacy: !current && Boolean(legacy),
+  };
+}

--- a/plugin/panel/src/lib/sessionController.js
+++ b/plugin/panel/src/lib/sessionController.js
@@ -145,12 +145,18 @@ export function createSessionController({
     }
   }
 
+  function refreshActiveModel() {
+    if (!activeMeta || typeof deps.currentModel !== 'function') return;
+    activeMeta.model = deps.currentModel() || null;
+  }
+
   function persistActive() {
     if (!activeMeta || !activeId) return false;
     const currentRef = backendRef(
       typeof deps.getBackendRef === 'function' ? deps.getBackendRef() : null,
     );
     if (currentRef) activeMeta.backendRef = currentRef;
+    refreshActiveModel();
     refreshActiveMeta();
     if (!materialized()) {
       if (index.activeId === activeId) {
@@ -307,6 +313,7 @@ export function createSessionController({
     if (!activeMeta) return;
     latestEntries = clone(Array.isArray(entries) ? entries : []);
     activeMeta.updatedAt = isoTime(now);
+    refreshActiveModel();
     refreshActiveMeta();
     if (latestEntries.length) upsertActiveMeta();
     dirty = true;

--- a/plugin/panel/test/backendCapabilities.test.js
+++ b/plugin/panel/test/backendCapabilities.test.js
@@ -32,6 +32,13 @@ test('Claude ids are current API aliases and the default is selectable', () => {
   assert.ok(ids.includes(claudeSubDescriptor().defaultModelId));
 });
 
+test('only Fable 5.1 declares its minimum Claude CLI version', () => {
+  assert.equal(CLAUDE_MODELS.find((model) => model.id === 'claude-fable-5-1').minCliVersion, '2.1.251');
+  for (const model of CLAUDE_MODELS.filter((model) => model.id !== 'claude-fable-5-1')) {
+    assert.equal(Object.hasOwn(model, 'minCliVersion'), false, model.id);
+  }
+});
+
 test('cost tiers derive from the Claude price map', () => {
   assert.equal(costTier('claude-haiku-4-5'), 1);
   assert.equal(costTier('claude-sonnet-5'), 2);

--- a/plugin/panel/test/claudeAgentBackend.test.js
+++ b/plugin/panel/test/claudeAgentBackend.test.js
@@ -103,7 +103,7 @@ function createFs() {
   };
 }
 
-function resolvedClaude() {
+function resolvedClaude(version = '2.1.257') {
   const executable = {
     ok: true,
     id: 'claude',
@@ -111,7 +111,7 @@ function resolvedClaude() {
     displayPath: 'C:\\npm\\claude.cmd',
     argsPrefix: [],
     source: 'path',
-    version: '2.1.227',
+    version,
     arch: 'x64',
   };
   return {
@@ -482,6 +482,40 @@ test('Claude serializes every advertised model and effort pair', async () => {
       await run;
       h.backend.reset();
     }
+  }
+});
+
+test('Claude blocks a model when the resolved CLI is below its declared minimum', async () => {
+  const h = makeHarness({
+    state: { model: 'claude-fable-5-1' },
+    resolveClaude: async () => resolvedClaude('2.1.227'),
+  });
+  const run = h.backend.sendUser('should not spawn');
+  await flush();
+  assert.equal(h.spawns.length, 0);
+  const error = h.events.find((event) => event.type === 'error');
+  assert.equal(error.code, 'CLI_TOO_OLD');
+  assert.match(error.message, /2\.1\.227/);
+  assert.match(error.message, /2\.1\.251/);
+  assert.match(error.message, /claude update/i);
+  assert.match(error.message, /换一个模型|another model/i);
+  await run;
+});
+
+test('Claude spawns Fable on a supported CLI and Opus on an older supported CLI', async () => {
+  for (const state of [
+    { model: 'claude-fable-5-1', version: '2.1.257' },
+    { model: 'claude-opus-5', version: '2.1.227' },
+  ]) {
+    const h = makeHarness({
+      state: { model: state.model },
+      resolveClaude: async () => resolvedClaude(state.version),
+    });
+    const run = h.backend.sendUser('spawn');
+    await flush();
+    assert.equal(h.spawns.length, 1, state.model);
+    finishTurn(h.processes[0]);
+    await run;
   }
 });
 

--- a/plugin/panel/test/descriptorSelect.test.js
+++ b/plugin/panel/test/descriptorSelect.test.js
@@ -2,6 +2,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { selectDescriptor, reconcileModelPref } from '../src/lib/descriptorSelect.js';
 import {
+  LEGACY_MODEL_PREF_KEY,
+  modelPreferenceKey,
+  resolveModelPreference,
+} from '../src/lib/modelPreference.js';
+import {
   claudeSubDescriptor,
   codexStaticDescriptor,
   openCodeStaticDescriptor,
@@ -46,4 +51,34 @@ test('reconcileModelPref resets stale models but waits for pending facts', () =>
     reconcileModelPref('missing', descriptor, { providerFactsPending: true }),
     'missing',
   );
+});
+
+test('model preferences use independent channel keys and migrate legacy storage once', () => {
+  assert.equal(modelPreferenceKey('subscription'), 'ae_mcp_model_subscription');
+  assert.equal(modelPreferenceKey('codex'), 'ae_mcp_model_codex');
+  assert.equal(modelPreferenceKey('opencode'), 'ae_mcp_model_opencode');
+  assert.equal(LEGACY_MODEL_PREF_KEY, 'ae_mcp_model');
+  assert.deepEqual(resolveModelPreference({
+    channelValue: '',
+    legacyValue: 'claude-fable-5-1',
+    fallback: 'claude-opus-5',
+  }), {
+    value: 'claude-fable-5-1',
+    migrateLegacy: true,
+  });
+  assert.deepEqual(resolveModelPreference({
+    channelValue: 'gpt-5.6-sol',
+    legacyValue: 'claude-fable-5-1',
+    fallback: 'claude-opus-5',
+  }), {
+    value: 'gpt-5.6-sol',
+    migrateLegacy: false,
+  });
+});
+
+test('reconcileModelPref preserves Codex preferences while live facts are pending', () => {
+  assert.equal(reconcileModelPref('gpt-live-only', {
+    defaultModelId: 'gpt-5.6-sol',
+    models: [{ id: 'gpt-5.6-sol' }],
+  }, { providerFactsPending: true }), 'gpt-live-only');
 });

--- a/plugin/panel/test/sessionController.test.js
+++ b/plugin/panel/test/sessionController.test.js
@@ -31,6 +31,7 @@ function harness({ index, transcripts = {}, backend = 'codex', sessionRef = null
   const timers = [];
   let entries = [];
   let currentBackend = backend;
+  let currentModel = 'model-1';
   let uuidSequence = 0;
   let clock = Date.parse('2026-08-22T00:00:00.000Z');
   const store = {
@@ -72,7 +73,7 @@ function harness({ index, transcripts = {}, backend = 'codex', sessionRef = null
       currentBackend = value;
     },
     currentBackend: () => currentBackend,
-    currentModel: () => 'model-1',
+    currentModel: () => currentModel,
     currentChannel: () => (currentBackend === 'codex' ? 'cli' : 'subscription'),
     log: (line) => calls.push(`log:${line}`),
   };
@@ -99,6 +100,7 @@ function harness({ index, transcripts = {}, backend = 'codex', sessionRef = null
     timers,
     get entries() { return entries; },
     setClock(value) { clock = value; },
+    setModel(value) { currentModel = value; },
   };
 }
 
@@ -223,6 +225,15 @@ test('recordEntries debounces ordinary updates and flushes turn settlement immed
   assert.equal(h.savedTranscripts.length, 1);
   h.controller.recordEntries([{ type: 'user-text', text: 'hello' }, { type: 'ai-text', text: 'done' }], { type: 'turn-end' });
   assert.equal(h.savedTranscripts.length, 2);
+});
+
+test('persistence refreshes session metadata after the active model changes', async () => {
+  const h = harness();
+  await h.controller.boot();
+  h.setModel('model-2');
+  h.controller.recordEntries([{ type: 'user-text', text: 'hello' }], { type: 'turn-end' });
+  assert.equal(h.controller.snapshot().sessions[0].model, 'model-2');
+  assert.equal(h.savedIndexes.at(-1).sessions[0].model, 'model-2');
 });
 
 test('sanitizeRestored cancels non-resumable UI state and clears streaming flags', () => {

--- a/plugin/panel/test/sessionWiring.test.js
+++ b/plugin/panel/test/sessionWiring.test.js
@@ -54,6 +54,11 @@ test('OpenCode pending probes become retryable and stale rechecks reset idle run
   assert.match(APP, /openCodeProbe === null && !openCodeProbeStale/);
 });
 
+test('model preferences are channel-scoped and Codex waits for live model facts', () => {
+  assert.doesNotMatch(APP, /['"]ae_mcp_model['"]/);
+  assert.match(APP, /providerFactsPending:[\s\S]*backendPref === 'codex'[\s\S]*codexProbe === null[\s\S]*codexModels === null/);
+});
+
 test('turn progress is reduced in App and rendered below the transcript', () => {
   assert.match(APP, /const \[turnStage, setTurnStage\] = React\.useState\(null\)/);
   assert.match(APP, /setTurnStage\(\(current\) => reduceTurnStage\(current, evt,/);

--- a/plugin/panel/test/sessionWiring.test.js
+++ b/plugin/panel/test/sessionWiring.test.js
@@ -59,6 +59,12 @@ test('model preferences are channel-scoped and Codex waits for live model facts'
   assert.match(APP, /providerFactsPending:[\s\S]*backendPref === 'codex'[\s\S]*codexProbe === null[\s\S]*codexModels === null/);
 });
 
+test('model chips persist the selected model as the current channel default', () => {
+  assert.match(APP, /onChipModel=\{\(m\) => \{ setSessionModel\(m\); setModel\(m\); writePref\(modelPreferenceKey\(backendPref\), m\); \}\}/);
+  assert.match(APP, /onChipEffort=\{setSessionEffort\}/);
+  assert.match(APP, /onChipFast=\{\(v\) => setSessionFast\(Boolean\(v\)\)\}/);
+});
+
 test('turn progress is reduced in App and rendered below the transcript', () => {
   assert.match(APP, /const \[turnStage, setTurnStage\] = React\.useState\(null\)/);
   assert.match(APP, /setTurnStage\(\(current\) => reduceTurnStage\(current, evt,/);


### PR DESCRIPTION
Part A of #355 (items 2, 3, 6). Part B (cross-backend session switch race, OpenCode stop/reset timeouts, transport-rebuild replay) follows in a separate PR.

## 更改日志

- **模型选择按通道保存，旧版 Claude Code 选 Fable 5.1 会被拦下并告知**——模型偏好改为每条通道各自一个 key（旧的单一 key 只迁移到当时的通道一次）；切通道时读取目标通道自己的选择，claude 选 Fable 5.1 再绕一圈 codex 回来仍是 Fable 5.1；codex 在探针或实时模型清单未返回时不再把只在实时清单里的模型重置成静态默认；模型描述符新增 `minCliVersion`（Fable 5.1 = 2.1.251），Claude 通道发送前与已安装 CLI 版本比对，不满足时给出"运行 `claude update` 升级或换模型"的双语提示而不是裸的上游 400；会话元数据在每次持久化时刷新当前模型，中途换过模型的会话切回来恢复的是实际在用的模型。
- **Per-channel model choice and a Claude CLI version gate for Fable 5.1** — preferences are keyed per channel with a one-time migration; codex treats a pending probe as "facts pending"; `minCliVersion` on the descriptor blocks Fable 5.1 on Claude Code < 2.1.251 with a bilingual hint; session metadata tracks the model actually in use.

## 验证

- `plugin/panel` `npm test`：608 tests, 607 pass, 0 fail, 1 skipped（新增：偏好 key / 迁移纯函数、codex facts pending、`minCliVersion` 描述符守卫、旧版 CLI 不 spawn 且发出提示、会话元数据模型刷新、App 接线断言）。
- `npm run build` + `verify-bundle` 通过，`plugin/client/dist/app.js` 已随本 PR 重建。
- 真机验证：待编排者补充。

## 实现者

Luna（gpt-5.6-luna，effort high）实现；Fable 审 diff、运行测试并重建 bundle。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #355
