### PR TITLE
fix(native): keep bytes across cancelled pipe reads, publish endpoints atomically, bound JSON depth (#354 part C)

### DIFF
--- a/native/ae-plugin/src/core/native_program.cpp
+++ b/native/ae-plugin/src/core/native_program.cpp
@@ -15,6 +15,8 @@
 namespace aemcp::native {
 namespace {
 
+constexpr std::size_t kMaximumJsonDepth = 32;
+
 [[noreturn]] void invalid(std::string message) {
   throw std::runtime_error("invalid native program: " + std::move(message));
 }
@@ -237,7 +239,7 @@ public:
 
   JsonValue parse() {
     space();
-    JsonValue result = value();
+    JsonValue result = value(1);
     space();
     if (offset_ != text_.size())
       invalid("trailing JSON");
@@ -257,14 +259,16 @@ private:
     }
     return false;
   }
-  JsonValue value() {
+  JsonValue value(std::size_t depth) {
+    if (depth > kMaximumJsonDepth)
+      invalid("JSON depth exceeded");
     if (offset_ == text_.size())
       invalid("missing JSON value");
     switch (text_[offset_]) {
     case '{':
-      return JsonValue{object()};
+      return JsonValue{object(depth)};
     case '[':
-      return JsonValue{array()};
+      return JsonValue{array(depth)};
     case '"':
       return JsonValue{string()};
     case 't':
@@ -285,7 +289,7 @@ private:
       invalid("invalid literal");
     offset_ += literal_value.size();
   }
-  JsonObject object() {
+  JsonObject object(std::size_t depth) {
     ++offset_;
     space();
     JsonObject result;
@@ -302,7 +306,7 @@ private:
       if (!consume(':'))
         invalid("object colon");
       space();
-      result.emplace_back(std::move(key), value());
+      result.emplace_back(std::move(key), value(depth + 1));
       space();
       if (consume('}'))
         return result;
@@ -311,14 +315,14 @@ private:
       space();
     }
   }
-  JsonValue::Array array() {
+  JsonValue::Array array(std::size_t depth) {
     ++offset_;
     space();
     JsonValue::Array result;
     if (consume(']'))
       return result;
     while (true) {
-      result.push_back(value());
+      result.push_back(value(depth + 1));
       space();
       if (consume(']'))
         return result;

--- a/native/ae-plugin/src/platform/windows/endpoint_registry_windows.cpp
+++ b/native/ae-plugin/src/platform/windows/endpoint_registry_windows.cpp
@@ -265,9 +265,22 @@ EndpointResult WindowsEndpointRegistry::cleanup_stale() {
     if (++entries > config_.maximum_directory_entries) {
       return {EndpointCode::kDirectoryLimitExceeded, "endpoint-directory-overflow"};
     }
-    if (!item.is_regular_file(error) || error || item.path().extension() != ".endpoint") {
+    if (!item.is_regular_file(error) || error) {
       continue;
     }
+    const std::wstring name = item.path().filename().wstring();
+    const bool temporary = name.compare(0, 5, L".tmp-") == 0;
+    if (temporary) {
+      if (DeleteFileW(item.path().c_str()) == 0) {
+        const DWORD removal_error = GetLastError();
+        // A sharing violation means another publisher still owns this temporary file.
+        if (removal_error != ERROR_FILE_NOT_FOUND && removal_error != ERROR_SHARING_VIOLATION) {
+          return {EndpointCode::kStaleEntryUnsafe, "stale-descriptor-remove-failed"};
+        }
+      }
+      continue;
+    }
+    if (item.path().extension() != ".endpoint") continue;
     std::string text;
     {
       std::ifstream input(item.path(), std::ios::binary);
@@ -275,7 +288,9 @@ EndpointResult WindowsEndpointRegistry::cleanup_stale() {
     }
     NativeEndpointDescriptor candidate{};
     if (!WindowsEndpointRegistry::parse_descriptor(text, candidate)) {
-      return {EndpointCode::kStaleEntryUnsafe, "stale-descriptor-unparseable"};
+      std::filesystem::remove(item.path(), error);
+      if (error) return {EndpointCode::kStaleEntryUnsafe, "stale-descriptor-remove-failed"};
+      continue;
     }
     if (!host_descriptor_alive(candidate)) {
       std::filesystem::remove(item.path(), error);
@@ -329,16 +344,43 @@ HANDLE WindowsEndpointRegistry::take_listener_pipe() noexcept {
 EndpointResult WindowsEndpointRegistry::publish_descriptor() {
   // Descriptor files carry the host instance UUID (d-<uuid>.endpoint), the
   // same naming the macOS registry and the shared client discovery use.
-  descriptor_path_ =
-      (std::filesystem::path(directory_path_) / ("d-" + descriptor_.host_instance_id + ".endpoint"))
-          .string();
+  const std::filesystem::path final_path =
+      std::filesystem::path(directory_path_) /
+      ("d-" + descriptor_.host_instance_id + ".endpoint");
+  descriptor_path_ = final_path.string();
   const std::string body = serialize_descriptor(descriptor_);
-  {
-    std::ofstream output(descriptor_path_, std::ios::binary | std::ios::trunc);
-    if (!output) return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
-    output << body;
-    output.flush();
-    if (!output) return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
+  const std::filesystem::path temporary_path =
+      std::filesystem::path(directory_path_) / (".tmp-" + config_.endpoint_nonce);
+  HANDLE file = CreateFileW(temporary_path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH, nullptr);
+  if (file == INVALID_HANDLE_VALUE) {
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
+  }
+  std::size_t written = 0;
+  while (written < body.size()) {
+    DWORD count = 0;
+    if (WriteFile(file, body.data() + written,
+                  static_cast<DWORD>(body.size() - written), &count, nullptr) == 0 ||
+        count == 0) {
+      (void)CloseHandle(file);
+      std::error_code error;
+      std::filesystem::remove(temporary_path, error);
+      return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
+    }
+    written += count;
+  }
+  const bool flushed = FlushFileBuffers(file) != 0;
+  const bool closed = CloseHandle(file) != 0;
+  if (!flushed || !closed) {
+    std::error_code error;
+    std::filesystem::remove(temporary_path, error);
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
+  }
+  if (MoveFileExW(temporary_path.c_str(), final_path.c_str(),
+                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0) {
+    std::error_code error;
+    std::filesystem::remove(temporary_path, error);
+    return {EndpointCode::kDescriptorPublishFailed, "descriptor-write-failed"};
   }
   std::ifstream verify_input(descriptor_path_, std::ios::binary);
   std::string reread((std::istreambuf_iterator<char>(verify_input)),

--- a/native/ae-plugin/src/platform/windows/transport_io_windows.cpp
+++ b/native/ae-plugin/src/platform/windows/transport_io_windows.cpp
@@ -14,13 +14,7 @@
 #include <limits>
 
 namespace aemcp::native {
-namespace {
-
-[[nodiscard]] HANDLE pipe_handle(int fd) noexcept {
-  const HANDLE pipe = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-  return pipe == INVALID_HANDLE_VALUE ? nullptr : pipe;
-}
-
+namespace detail {
 [[nodiscard]] int error_result(DWORD error, bool reading) noexcept {
   switch (error) {
     case ERROR_BROKEN_PIPE:
@@ -39,6 +33,23 @@ namespace {
       errno = EIO;
       return -1;
   }
+}
+
+int complete_overlapped_io(HANDLE pipe, OVERLAPPED *operation, DWORD &transferred,
+                           bool reading) noexcept {
+  if (GetOverlappedResult(pipe, operation, &transferred, FALSE) == 0) {
+    return error_result(GetLastError(), reading);
+  }
+  return static_cast<int>(transferred);
+}
+
+}  // namespace detail
+
+namespace {
+
+[[nodiscard]] HANDLE pipe_handle(int fd) noexcept {
+  const HANDLE pipe = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  return pipe == INVALID_HANDLE_VALUE ? nullptr : pipe;
 }
 
 [[nodiscard]] int overlapped_io(int fd, void *buffer, std::size_t size, int timeout_ms,
@@ -72,31 +83,26 @@ namespace {
   const DWORD start_error = GetLastError();
   if (start_error != ERROR_IO_PENDING) {
     CloseHandle(event);
-    return error_result(start_error, reading);
+    return detail::error_result(start_error, reading);
   }
   const DWORD waited = WaitForSingleObject(event, static_cast<DWORD>(timeout_ms));
-  if (waited == WAIT_TIMEOUT) {
+  if (waited != WAIT_OBJECT_0) {
     (void)CancelIoEx(pipe, &operation);
     // The OVERLAPPED storage must outlive cancellation completion.
     (void)WaitForSingleObject(event, INFINITE);
+    const int result = detail::complete_overlapped_io(pipe, &operation, transferred, reading);
     CloseHandle(event);
-    errno = ETIMEDOUT;
+    if (result >= 0) return result;
+    if (waited == WAIT_TIMEOUT && errno == ECANCELED) {
+      errno = ETIMEDOUT;
+    } else if (waited != WAIT_TIMEOUT) {
+      errno = EIO;
+    }
     return -1;
   }
-  if (waited != WAIT_OBJECT_0) {
-    (void)CancelIoEx(pipe, &operation);
-    (void)WaitForSingleObject(event, INFINITE);
-    CloseHandle(event);
-    errno = EIO;
-    return -1;
-  }
-  if (GetOverlappedResult(pipe, &operation, &transferred, FALSE) == 0) {
-    const DWORD completion_error = GetLastError();
-    CloseHandle(event);
-    return error_result(completion_error, reading);
-  }
+  const int result = detail::complete_overlapped_io(pipe, &operation, transferred, reading);
   CloseHandle(event);
-  return static_cast<int>(transferred);
+  return result;
 }
 
 }  // namespace
@@ -117,7 +123,7 @@ int transport_wait_readable(int fd, int timeout_ms) noexcept {
   for (;;) {
     DWORD available = 0;
     if (PeekNamedPipe(pipe, nullptr, 0, nullptr, &available, nullptr) == 0) {
-      return error_result(GetLastError(), false);
+      return detail::error_result(GetLastError(), false);
     }
     if (available > 0) return 1;
     if (std::chrono::steady_clock::now() >= deadline) return 0;

--- a/native/ae-plugin/tests/endpoint_registry_windows_test.cpp
+++ b/native/ae-plugin/tests/endpoint_registry_windows_test.cpp
@@ -139,6 +139,80 @@ void stale_owned_endpoint_is_recovered() {
   require(!std::filesystem::exists(stale_path, error), "stale descriptor was not removed");
 }
 
+void unparseable_descriptor_is_collected() {
+  TempRoot root;
+  FakeBackend backend;
+  const std::string stale_path = (std::filesystem::path(root.path) / "aemcp-n1" /
+                                  "d-22222222-2222-4222-8222-222222222222.endpoint")
+                                     .string();
+  std::filesystem::create_directories(std::filesystem::path(stale_path).parent_path());
+  {
+    std::ofstream stale(stale_path, std::ios::binary | std::ios::trunc);
+    stale << "truncated";
+  }
+  WindowsEndpointRegistry fresh(backend, EndpointRegistryConfig{root.path, "ddddeeeeffff", 2, 32});
+  require(fresh.start(descriptor()).ok(), "fresh endpoint did not recover an unparseable descriptor");
+  std::error_code error;
+  require(!std::filesystem::exists(stale_path, error),
+          "unparseable descriptor was not removed");
+}
+
+void residual_temporary_descriptor_is_collected() {
+  TempRoot root;
+  FakeBackend backend;
+  const std::filesystem::path directory = std::filesystem::path(root.path) / "aemcp-n1";
+  std::error_code error;
+  std::filesystem::create_directories(directory, error);
+  require(!error, "could not create temporary descriptor directory");
+  const std::filesystem::path temporary_path = directory / ".tmp-aaaabbbbcccc";
+  {
+    std::ofstream temporary(temporary_path, std::ios::binary | std::ios::trunc);
+    temporary << "partial";
+  }
+  WindowsEndpointRegistry fresh(backend, EndpointRegistryConfig{root.path, "ddddeeeeffff", 2, 32});
+  require(fresh.start(descriptor()).ok(), "fresh endpoint did not recover a temporary descriptor");
+  require(!std::filesystem::exists(temporary_path, error),
+          "residual temporary descriptor was not removed");
+}
+
+void active_temporary_descriptor_is_not_collected() {
+  TempRoot root;
+  FakeBackend backend;
+  const std::filesystem::path directory = std::filesystem::path(root.path) / "aemcp-n1";
+  std::error_code error;
+  std::filesystem::create_directories(directory, error);
+  require(!error, "could not create active temporary descriptor directory");
+  const std::filesystem::path temporary_path = directory / ".tmp-aaaabbbbcccc";
+  const HANDLE temporary = CreateFileW(temporary_path.c_str(), GENERIC_WRITE, 0, nullptr,
+                                       CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+  require(temporary != INVALID_HANDLE_VALUE, "could not create active temporary descriptor");
+  WindowsEndpointRegistry fresh(backend, EndpointRegistryConfig{root.path, "ddddeeeeffff", 2, 32});
+  const auto started = fresh.start(descriptor());
+  CloseHandle(temporary);
+  require(started.ok(), "fresh endpoint did not ignore an active temporary descriptor");
+  require(std::filesystem::exists(temporary_path, error),
+          "cleanup removed an active temporary descriptor");
+}
+
+void failed_publication_leaves_no_truncated_descriptor() {
+  TempRoot root;
+  FakeBackend backend;
+  const std::filesystem::path directory = std::filesystem::path(root.path) / "aemcp-n1";
+  const std::filesystem::path final_path =
+      directory / "d-11111111-1111-4111-8111-111111111111.endpoint";
+  std::error_code error;
+  std::filesystem::create_directories(final_path, error);
+  require(!error, "could not reserve descriptor final path");
+  WindowsEndpointRegistry registry(backend,
+                                   EndpointRegistryConfig{root.path, "ddddeeeeffff", 2, 32});
+  require(!registry.start(descriptor()).ok(), "publication unexpectedly replaced a directory");
+  require(!std::filesystem::is_regular_file(final_path, error),
+          "failed publication left a truncated final descriptor");
+  const std::filesystem::path temporary_path = directory / ".tmp-ddddeeeeffff";
+  require(!std::filesystem::exists(temporary_path, error),
+          "failed publication left its temporary descriptor");
+}
+
 void live_endpoint_is_never_collected() {
   TempRoot root;
   FakeBackend backend;
@@ -197,6 +271,10 @@ int main() {
   publish_verify_and_cleanup();
   replacement_is_detected_and_not_deleted();
   stale_owned_endpoint_is_recovered();
+  unparseable_descriptor_is_collected();
+  residual_temporary_descriptor_is_collected();
+  active_temporary_descriptor_is_not_collected();
+  failed_publication_leaves_no_truncated_descriptor();
   live_endpoint_is_never_collected();
   descriptor_parser_is_closed();
   std::cout << "endpoint_registry_windows_test: PASS\n";

--- a/native/ae-plugin/tests/native_program_test.cpp
+++ b/native/ae-plugin/tests/native_program_test.cpp
@@ -68,6 +68,19 @@ std::vector<std::uint8_t> frame(const std::string &json) {
   return result;
 }
 
+std::string json_value_at_depth(std::size_t depth) {
+  std::string result(depth > 0 ? depth - 1 : 0, '[');
+  result += '0';
+  result.append(depth > 0 ? depth - 1 : 0, ']');
+  return result;
+}
+
+void json_parser_enforces_depth_limit() {
+  (void)aemcp::native::parse_json(json_value_at_depth(32));
+  rejects([] { (void)aemcp::native::parse_json(json_value_at_depth(33)); },
+          "33-level JSON value");
+}
+
 void read_program_needs_no_write_key() {
   const ProgramAdmission admission =
       admit(R"({"operations":[{"op":"composition.resolve","args":{"locator":)" +
@@ -484,6 +497,7 @@ void property_and_keyframe_adapters_emit_generated_time_shapes() {
 
 int main() {
   try {
+    json_parser_enforces_depth_limit();
     read_program_needs_no_write_key();
     read_program_rejects_write_metadata();
     write_program_requires_operation_key_and_undo_group();

--- a/native/ae-plugin/tests/win_ipc_server_windows_test.cpp
+++ b/native/ae-plugin/tests/win_ipc_server_windows_test.cpp
@@ -20,6 +20,11 @@
 #include "aemcp_native/transport_io.hpp"
 #include "aemcp_native/win_ipc_server.hpp"
 
+namespace aemcp::native::detail {
+int complete_overlapped_io(HANDLE pipe, OVERLAPPED *operation, DWORD &transferred,
+                           bool reading) noexcept;
+}
+
 namespace {
 
 using namespace std::chrono_literals;
@@ -344,12 +349,37 @@ void non_reading_client_write_times_out() {
   require(elapsed < 1s, "backpressure write exceeded its bounded timeout");
 }
 
+void cancellation_after_completed_read_preserves_bytes() {
+  ConnectedPipePair pair = create_connected_pipe_pair();
+  constexpr std::array<std::uint8_t, 4> expected = {1, 2, 3, 4};
+  std::array<std::uint8_t, expected.size()> received{};
+  OwnedHandle event(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+  require(event.get() != nullptr, "could not create completed-read event");
+  OVERLAPPED operation{};
+  operation.hEvent = event.get();
+  DWORD transferred = 0;
+  const BOOL completed = ReadFile(pair.server.get(), received.data(),
+                                  static_cast<DWORD>(received.size()), &transferred, &operation);
+  require(completed == 0 && GetLastError() == ERROR_IO_PENDING,
+          "completed-read fixture did not begin an overlapped read");
+  require(write_all(pair.client.get(), expected), "client could not satisfy completed read");
+  require(WaitForSingleObject(event.get(), 2000) == WAIT_OBJECT_0,
+          "completed read did not signal");
+  require(CancelIoEx(pair.server.get(), &operation) == 0 && GetLastError() == ERROR_NOT_FOUND,
+          "cancellation did not observe the completed read");
+  const int count = aemcp::native::detail::complete_overlapped_io(
+      pair.server.get(), &operation, transferred, true);
+  require(count == static_cast<int>(expected.size()) && received == expected,
+          "completed read bytes were not preserved after cancellation");
+}
+
 }  // namespace
 
 int main() {
   waiting_listener_shutdown_is_bounded();
   idle_authenticated_client_shutdown_is_bounded();
   non_reading_client_write_times_out();
+  cancellation_after_completed_read_preserves_bytes();
   std::cout << "win_ipc_server_windows_test: PASS\n";
   return 0;
 }


### PR DESCRIPTION
Part C of #354 (the two Windows native transport defects, item 4) plus the JSON-depth item from #358. Frozen native plane: no primitive, protocol, or header generation changes; C++ sources and their unit tests only.

## 更改日志

- **Windows 原生 IPC 稳定性**——命名管道读取在超时取消的竞态下不再丢字节（取消后用 `GetOverlappedResult` 收尾，已到达的字节照常返回，只有真正超时且取消成功才报 ETIMEDOUT）；端点描述符改为临时文件 + `FlushFileBuffers` + `MoveFileExW` 原子发布，启动时清理不可解析的 `.endpoint` 与残留的 `.tmp-*`（另一发布者仍持有的跳过），AE 崩溃留下的截断描述符不再让原生平面静默不可用直到手删目录；原生 JSON 解析器限制 32 层嵌套，与宿主一致。
- **Windows native IPC resilience** — preserve bytes across cancellation races, publish and recover endpoint descriptors atomically, and bound native JSON parsing depth.

## 验证

- 三个原生单元测试由编排者用 MSVC 14.44 编译并运行：`win_ipc_server_windows_test` PASS（含新增"已完成读被取消后字节保留"）、`endpoint_registry_windows_test` PASS（含坏描述符清理后可启动、发布中断不留截断最终文件、残留临时件下次启动清理、并发持有的临时件不删）、`native_program_test` PASS（32 层通过、33 层拒绝）。
- `node native/ae-plugin/build-windows.mjs` 用钉死的 SDK 输入构建成功（MSVC 14.44.35207 / Windows SDK 10.0.26100.0，`productVersion 0.10.5`）。
- 真机：待编排者装入 AE 2026 后补充（含"先放一个损坏的 .endpoint 文件再启动 AE，原生平面仍可用"的场景）。

## 实现者

Terra（gpt-5.6-terra，effort xhigh）实现，Fable 审 diff 后要求两处收紧（临时件不带 `.endpoint` 扩展名以免被并发扫描误删；非超时的等待失败保持 EIO），编译、测试、构建由 Fable 运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #354
