### PR TITLE
fix(host): honour the 30 s native window, cap MCP sessions, negotiate protocol from initialize, guard dispatch (#354 part B)

### DIFF
--- a/plugin/host/mcp/index.js
+++ b/plugin/host/mcp/index.js
@@ -13,7 +13,7 @@ const { buildInstructions } = require('./instructions');
 const { TOOL_MODULES } = require('./tools');
 
 const PROTOCOLS = ['2025-06-18', '2025-03-26'];
-const DEFAULT_PROTOCOL = '2025-03-26';
+const DEFAULT_PROTOCOL = PROTOCOLS[0];
 const MCP_PATHS = ['/mcp', '/mcp/c/:token'];
 const EXTERNAL_POLICY = Object.freeze({
     approvalTier: null,
@@ -35,8 +35,9 @@ function allowedLocalRequest(req) {
     return ['http://127.0.0.1:' + port, 'http://localhost:' + port].indexOf(origin.toLowerCase()) !== -1;
 }
 
-function selectProtocol(req) {
-    const requested = req.get('mcp-protocol-version');
+function selectProtocol(req, params) {
+    const requested = params && typeof params.protocolVersion === 'string'
+        ? params.protocolVersion : req.get('mcp-protocol-version');
     return PROTOCOLS.indexOf(requested) !== -1 ? requested : DEFAULT_PROTOCOL;
 }
 
@@ -102,7 +103,10 @@ function mountMcp(app, deps) {
     if (!deps || !deps.statePaths) {
         throw new TypeError('mountMcp requires deps.statePaths');
     }
-    const sessions = new SessionStore();
+    const sessions = new SessionStore({
+        logger: deps.hostLog && typeof deps.hostLog.record === 'function'
+            ? function (event) { deps.hostLog.record(event); } : null,
+    });
     const conversations = new ConversationStore(sessions);
     const approvals = deps.approvals || new ApprovalQueue({ timeoutMs: deps.approvalTimeoutMs });
     let checkpointStore = deps.checkpointStore || null;
@@ -198,7 +202,9 @@ function mountMcp(app, deps) {
         const params = message.params || {};
         if (message.method === 'initialize') {
             if (!jsonrpc.isObject(params)) return { status: 200, response: jsonrpc.invalidParams(message, 'initialize params must be an object') };
-            const protocolVersion = selectProtocol(req);
+            const priorSessionId = sessionId(req);
+            if (sessions.get(priorSessionId)) sessions.delete(priorSessionId);
+            const protocolVersion = selectProtocol(req, params);
             const session = sessions.create(
                 protocolVersion,
                 'pending',
@@ -330,13 +336,13 @@ function mountMcp(app, deps) {
         let initializedSession = null;
         for (let i = 0; i < messages.length; i += 1) {
             const output = await dispatch(req, messages[i], req.mcpConversation);
-            status = Math.max(status, output.status);
+            status = output.status;
             if (output.session && output.session.id) initializedSession = output.session;
             if (output.response) responses.push(output.response);
         }
         if (initializedSession) res.set('Mcp-Session-Id', initializedSession.id);
         if (responses.length === 0) return res.status(202).end();
-        res.status(status).json(batch ? responses : responses[0]);
+        res.status(batch ? 200 : status).json(batch ? responses : responses[0]);
     });
 
     app.use('/mcp', function (error, req, res, next) {

--- a/plugin/host/mcp/index.test.js
+++ b/plugin/host/mcp/index.test.js
@@ -128,6 +128,52 @@ test('mountMcp requires explicit state paths', () => {
     );
 });
 
+test('initialize negotiates its declared protocol and replaces a supplied existing session', async () => {
+    const fixture = await start();
+    try {
+        const selected = await request(fixture.port, 'POST', '/mcp', {}, {
+            jsonrpc: '2.0', id: 1, method: 'initialize',
+            params: { protocolVersion: '2025-06-18', clientInfo: { name: 'new-protocol' } },
+        });
+        assert.equal(selected.body.result.protocolVersion, '2025-06-18');
+        const priorId = selected.headers['mcp-session-id'];
+        const replacement = await request(fixture.port, 'POST', '/mcp', {
+            'Mcp-Session-Id': priorId,
+        }, {
+            jsonrpc: '2.0', id: 2, method: 'initialize',
+            params: { protocolVersion: 'unsupported-version', clientInfo: { name: 'replacement' } },
+        });
+        assert.equal(replacement.body.result.protocolVersion, '2025-06-18');
+        assert.notEqual(replacement.headers['mcp-session-id'], priorId);
+        assert.equal(fixture.mounted.sessions.get(priorId), null);
+        assert.equal(fixture.mounted.sessions.size, 1);
+    } finally {
+        await new Promise(function (resolve) { fixture.listener.close(resolve); });
+        fs.rmSync(fixture.stateRoot, { recursive: true, force: true });
+    }
+});
+
+test('batch requests with a notification return a successful response body when another request responds', async () => {
+    const fixture = await start();
+    try {
+        const initial = await initialize(fixture.port);
+        const batch = await request(fixture.port, 'POST', '/mcp', {
+            'Mcp-Session-Id': initial.session,
+        }, [
+            { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+            { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        ]);
+        assert.equal(batch.status, 200);
+        assert.equal(Array.isArray(batch.body), true);
+        assert.equal(batch.body.some(function (entry) {
+            return entry.id === 2 && Array.isArray(entry.result.tools);
+        }), true);
+    } finally {
+        await new Promise(function (resolve) { fixture.listener.close(resolve); });
+        fs.rmSync(fixture.stateRoot, { recursive: true, force: true });
+    }
+});
+
 test('progress notifications retain their token and report elapsed seconds', () => {
     assert.deepEqual(mountMcp.progressMessage('progress-1', 1000, 6200), {
         jsonrpc: '2.0',

--- a/plugin/host/mcp/session.js
+++ b/plugin/host/mcp/session.js
@@ -2,16 +2,43 @@
 
 const crypto = require('crypto');
 
+const MAX_SESSIONS = 64;
+
 function createSessionId() {
     return crypto.randomBytes(16).toString('hex');
 }
 
 class SessionStore {
-    constructor() {
+    constructor(options) {
+        const input = options || {};
         this.sessions = new Map();
+        this.logger = typeof input.logger === 'function' ? input.logger : null;
+    }
+
+    evictInactiveSessions() {
+        while (this.sessions.size >= MAX_SESSIONS) {
+            let oldest = null;
+            this.sessions.forEach(function (session) {
+                if (session.writers.size > 0) return;
+                if (!oldest || session.lastActivityAt < oldest.lastActivityAt) oldest = session;
+            });
+            if (!oldest) {
+                if (this.logger) {
+                    this.logger({
+                        level: 'warn',
+                        source: 'mcp-session-store',
+                        message: 'MCP session limit reached with active writers',
+                        maxSessions: MAX_SESSIONS,
+                    });
+                }
+                return;
+            }
+            this.delete(oldest.id);
+        }
     }
 
     create(protocolVersion, clientName, conversationId) {
+        this.evictInactiveSessions();
         const id = createSessionId();
         const session = {
             id,
@@ -80,4 +107,4 @@ class SessionStore {
     }
 }
 
-module.exports = { SessionStore, createSessionId };
+module.exports = { SessionStore, createSessionId, MAX_SESSIONS };

--- a/plugin/host/mcp/session.test.js
+++ b/plugin/host/mcp/session.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { SessionStore } = require('./session');
+const { MAX_SESSIONS, SessionStore } = require('./session');
 
 test('session store creates random session ids and tears down SSE writers', () => {
     const store = new SessionStore();
@@ -25,4 +25,35 @@ test('session store creates random session ids and tears down SSE writers', () =
     onClose();
     assert.equal(store.size, 0);
     assert.equal(store.delete(session.id), false);
+});
+
+test('session store evicts the least recently active session without a writer at capacity', () => {
+    const store = new SessionStore();
+    const oldest = store.create('2025-06-18', 'oldest');
+    oldest.lastActivityAt = 1;
+    for (let index = 1; index < MAX_SESSIONS; index += 1) {
+        const session = store.create('2025-06-18', 'client-' + index);
+        session.lastActivityAt = index + 1;
+    }
+    const replacement = store.create('2025-06-18', 'replacement');
+    assert.equal(store.size, MAX_SESSIONS);
+    assert.equal(store.get(oldest.id), null);
+    assert.equal(store.get(replacement.id), replacement);
+});
+
+test('session store permits an additional session when every retained session has a writer', () => {
+    const warnings = [];
+    const store = new SessionStore({ logger: function (event) { warnings.push(event); } });
+    for (let index = 0; index < MAX_SESSIONS; index += 1) {
+        const session = store.create('2025-06-18', 'client-' + index);
+        store.addWriter(session, { onClose: function () {}, close: function () {} });
+    }
+    store.create('2025-06-18', 'overflow');
+    assert.equal(store.size, MAX_SESSIONS + 1);
+    assert.deepEqual(warnings, [{
+        level: 'warn',
+        source: 'mcp-session-store',
+        message: 'MCP session limit reached with active writers',
+        maxSessions: MAX_SESSIONS,
+    }]);
 });

--- a/plugin/host/mcp/tools.js
+++ b/plugin/host/mcp/tools.js
@@ -90,6 +90,9 @@ function buildTools(deps) {
         } catch (error) {
             output = { result: textResult({ ok: false, error: error && error.message ? error.message : String(error) }, true) };
         }
+        if (!output || output.result === undefined) {
+            output = { result: textResult({ ok: false, error: 'tool returned no result' }, true) };
+        }
         const structured = output && output.result && output.result.structuredContent;
         const errorText = structured && typeof structured.error === 'string' ? structured.error : '';
         if (activityRef.id && errorText.indexOf(HINT_MARK) !== -1

--- a/plugin/host/mcp/tools.test.js
+++ b/plugin/host/mcp/tools.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { assertPatternDescriptions, buildTools, noTopLevelCombinator } = require('./tools');
+const { assertPatternDescriptions, buildTools, noTopLevelCombinator, TOOL_MODULES } = require('./tools');
 
 test('MCP input-schema patterns must explain their value constraint', () => {
     assert.doesNotThrow(function () {
@@ -142,4 +142,24 @@ test('registry passes the MCP tool identity to the execution dependency', async 
     });
     assert.equal(request.tool, 'ae_exec');
     assert.equal(request.transport, 'mcp');
+});
+
+test('tool calls returning no output are converted to a structured tool error', async () => {
+    const tool = TOOL_MODULES.find(function (item) { return item.definition.name === 'ae_status'; });
+    const originalCall = tool.call;
+    tool.call = async function () { return undefined; };
+    try {
+        const registry = buildTools({ sessionCount: function () { return 1; } });
+        const output = await registry.call({ name: 'ae_status', arguments: {} }, {
+            session: { clientName: 'test', protocolVersion: '2025-06-18' },
+            port: 1,
+        });
+        assert.equal(output.result.isError, true);
+        assert.deepEqual(output.result.structuredContent, {
+            ok: false,
+            error: 'tool returned no result',
+        });
+    } finally {
+        tool.call = originalCall;
+    }
 });

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -10,6 +10,8 @@ const os = require('os');
 const path = require('path');
 
 const MAX_FRAME_BYTES = 524288;
+const EXPIRED_REQUEST_TTL_MS = 60000;
+const MAX_EXPIRED_REQUEST_IDS = 256;
 const MAX_BUFFERED_BYTES = MAX_FRAME_BYTES * 8;
 const MAX_ENDPOINT_ENTRIES = 128;
 const AUTH_CHALLENGE_BYTES = 57;
@@ -688,6 +690,30 @@ function createNativeAegpClient(options) {
     let connectedReject;
     let connectedPromise = null;
     const pendingRequests = new Map();
+    const expiredRequestIds = new Map();
+
+    function pruneExpiredRequestIds() {
+        const cutoff = now();
+        for (const [requestId, expiresAt] of expiredRequestIds) {
+            if (expiresAt > cutoff) break;
+            expiredRequestIds.delete(requestId);
+        }
+    }
+
+    function rememberExpiredRequestId(requestId) {
+        pruneExpiredRequestIds();
+        expiredRequestIds.set(requestId, now() + EXPIRED_REQUEST_TTL_MS);
+        while (expiredRequestIds.size > MAX_EXPIRED_REQUEST_IDS) {
+            expiredRequestIds.delete(expiredRequestIds.keys().next().value);
+        }
+    }
+
+    function consumeExpiredRequestId(requestId) {
+        pruneExpiredRequestIds();
+        if (!expiredRequestIds.has(requestId)) return false;
+        expiredRequestIds.delete(requestId);
+        return true;
+    }
 
     function pendingTransportFailure(pending, error, message) {
         return pending?.mutating
@@ -869,6 +895,7 @@ function createNativeAegpClient(options) {
         }
         if (response.kind === 'event') return;
         const pending = pendingRequests.get(response.requestId);
+        if (!pending && consumeExpiredRequestId(response.requestId)) return;
         const replayValid = pending?.method === 'invoke'
             ? typeof response.replayed === 'boolean'
             : response.replayed === false;
@@ -974,6 +1001,7 @@ function createNativeAegpClient(options) {
                 ? requestTimeoutMs : Math.max(1, deadlineUnixMs - now());
             const timer = setTimeout(function () {
                 pendingRequests.delete(requestId);
+                rememberExpiredRequestId(requestId);
                 reject(mutating
                     ? nativeMutationUncertain(
                         'Native mutation response timed out after dispatch.',

--- a/plugin/host/native-aegp-client.test.js
+++ b/plugin/host/native-aegp-client.test.js
@@ -198,6 +198,7 @@ async function endpointFixture(t) {
 function installProtocol(server, options) {
     const input = options || {};
     const requests = [];
+    let invokeCount = 0;
     server.on('connection', function (socket) {
         let bytes = Buffer.alloc(0);
         let authenticated = false;
@@ -283,6 +284,7 @@ function installProtocol(server, options) {
                         terminalResponseExpected: true,
                     };
                 } else if (request.method === 'invoke') {
+                    invokeCount += 1;
                     if (input.invokeError) {
                         error = typeof input.invokeError === 'function'
                             ? input.invokeError(request) : input.invokeError;
@@ -364,7 +366,11 @@ function installProtocol(server, options) {
                     ...(error === null ? { result } : { error }),
                 };
                 if (input.mutateEnvelope) input.mutateEnvelope(response, request);
-                socket.write(frame(response));
+                if (input.delayFirstInvokeMs && request.method === 'invoke' && invokeCount === 1) {
+                    setTimeout(function () { socket.write(frame(response)); }, input.delayFirstInvokeMs);
+                } else {
+                    socket.write(frame(response));
+                }
             }
         }
     });
@@ -775,6 +781,33 @@ test('client rejects a response rebound to another native session', UNIX_SOCKET_
             return error.code === 'NATIVE_CONTRACT_MISMATCH';
         },
     );
+});
+
+test('client rejects a response for an unknown request id', UNIX_SOCKET_TEST, async (t) => {
+    const { client } = await connectedFixture(t, {
+        mutateEnvelope: function (response, request) {
+            if (request.method === 'invoke') response.requestId = 'native-program-unknown-0001';
+        },
+    });
+    await assert.rejects(
+        invoke(client, 'native-program-known-0001', readProgram()),
+        function (error) { return error.code === 'NATIVE_CONTRACT_MISMATCH'; },
+    );
+});
+
+test('client ignores a late timed-out response and remains connected', UNIX_SOCKET_TEST, async (t) => {
+    const { client } = await connectedFixture(t, {
+        requestTimeoutMs: 20,
+        delayFirstInvokeMs: 60,
+    });
+    await assert.rejects(
+        invoke(client, 'native-program-late-0001', readProgram()),
+        function (error) { return error.code === 'DEADLINE_EXCEEDED'; },
+    );
+    await new Promise(function (resolve) { setTimeout(resolve, 80); });
+    assert.equal(client.status().state, 'connected');
+    const capabilities = await client.capabilities({ detail: 'summary', limit: 50 });
+    assert.equal(capabilities.items.length, 1);
 });
 
 test('client surfaces a duplicate request id as a typed error, not a contract mismatch', UNIX_SOCKET_TEST, async (t) => {

--- a/plugin/host/server.js
+++ b/plugin/host/server.js
@@ -8,6 +8,7 @@ const authToken = require('./auth-token');
 const activity = require('./activity');
 const hostLog = require('./host-log');
 const nativeAegp = require('./native-aegp-client');
+const { NATIVE_EXEC_TIMEOUT_MS } = require('./mcp/native-program');
 const mountMcp = require('./mcp');
 const { createClientBlocklist } = require('./mcp/client-blocklist');
 const { ToolLibrary } = require('./mcp/tool-library');
@@ -28,6 +29,7 @@ let nativeAegpClientFactory = null;
 let nativeAegpRuntime = null;
 let restoreHostConsole = null;
 let unsubscribeHostActivity = null;
+let unhandledRejectionHandler = null;
 const clients = new Map();
 const blocked = new Set();
 let clientBlocklist = null;
@@ -152,6 +154,7 @@ function makeNativeAegpClient() {
         version: PKG_VERSION,
         component: 'core-broker',
         runtime: nativeAegpRuntime,
+        requestTimeoutMs: NATIVE_EXEC_TIMEOUT_MS,
     });
     if (!nativeAegpClient
         || typeof nativeAegpClient.connect !== 'function'
@@ -169,6 +172,27 @@ function makeNativeAegpClient() {
         throw error;
     }
     return nativeAegpClient;
+}
+
+function registerUnhandledRejectionHandler() {
+    if (unhandledRejectionHandler) return;
+    unhandledRejectionHandler = recordUnhandledRejection;
+    process.on('unhandledRejection', unhandledRejectionHandler);
+}
+
+function recordUnhandledRejection(reason) {
+    const message = reason && reason.message ? reason.message : String(reason);
+    hostLog.record({
+        level: 'error',
+        source: 'process',
+        message: 'Unhandled promise rejection: ' + message,
+    });
+}
+
+function clearUnhandledRejectionHandler() {
+    if (!unhandledRejectionHandler) return;
+    process.removeListener('unhandledRejection', unhandledRejectionHandler);
+    unhandledRejectionHandler = null;
 }
 
 async function invalidateConnectedNativeProjectGraph(deadlineUnixMs) {
@@ -1230,6 +1254,7 @@ function start(port, callback) {
         return callback(new Error('already started; call restart() to change port'));
     }
     hostLog.init({ statePaths: statePathsForHost() });
+    registerUnhandledRejectionHandler();
     restoreHostConsole = hostLog.captureConsole(console);
     unsubscribeHostActivity = hostLog.subscribeActivity(activity);
     // Ensure the shared-secret token exists (generate on first run) before we
@@ -1315,4 +1340,8 @@ module.exports = {
         closeNativeAegpClient();
         nativeAegpClientFactory = factory;
     },
+    _makeNativeAegpClientForTest: makeNativeAegpClient,
+    _registerUnhandledRejectionHandlerForTest: registerUnhandledRejectionHandler,
+    _clearUnhandledRejectionHandlerForTest: clearUnhandledRejectionHandler,
+    _recordUnhandledRejectionForTest: recordUnhandledRejection,
 };

--- a/plugin/host/server.test.js
+++ b/plugin/host/server.test.js
@@ -15,6 +15,7 @@ const FULL_REGISTRY = require(
 const authToken = require('./auth-token');
 const { createStatePaths } = require('./state-paths');
 const { computeContentHash } = require('./mcp/tool-library');
+const { NATIVE_EXEC_TIMEOUT_MS } = require('./mcp/native-program');
 
 const HOST = '22222222-2222-4222-8222-222222222222';
 const SESSION = '11111111-1111-4111-8111-111111111111';
@@ -1435,5 +1436,31 @@ test('/exec distinguishes uncertain timeout from a queued not_dispatched call', 
     } finally {
         if (sentinelCallback) sentinelCallback('2');
         await closeFixture(fixture);
+    }
+});
+
+test('native client factory receives the public native execution timeout', () => {
+    const server = loadServer();
+    let options = null;
+    server._setNativeAegpClientFactoryForTest(function (input) {
+        options = input;
+        return fakeNativeClient();
+    });
+    server._makeNativeAegpClientForTest();
+    assert.equal(options.requestTimeoutMs, NATIVE_EXEC_TIMEOUT_MS);
+});
+
+test('unhandled rejections are recorded in the host log without crashing the host', () => {
+    const server = loadServer();
+    server.hostLog.init({ statePaths: isolatedStatePaths() });
+    server._registerUnhandledRejectionHandlerForTest();
+    try {
+        server._recordUnhandledRejectionForTest(new Error('test rejection'));
+        const event = server.hostLog.tail(1)[0];
+        assert.equal(event.level, 'error');
+        assert.equal(event.source, 'process');
+        assert.equal(event.message, 'Unhandled promise rejection: test rejection');
+    } finally {
+        server._clearUnhandledRejectionHandlerForTest();
     }
 });

--- a/plugin/host/tests/node15-spike.js
+++ b/plugin/host/tests/node15-spike.js
@@ -98,7 +98,9 @@ async function main() {
         });
         assert.strictEqual(initialized.status, 200);
         const initBody = JSON.parse(initialized.text);
-        assert.strictEqual(initBody.result.protocolVersion, '2025-03-26');
+        // No protocolVersion in the request: the host answers with its newest
+        // supported version (MCP negotiation), which is what CEP clients get.
+        assert.strictEqual(initBody.result.protocolVersion, '2025-06-18');
         const session = initialized.headers['mcp-session-id'];
         assert(/^[0-9a-f]{32}$/.test(session));
         const headers = { 'Mcp-Session-Id': session };


### PR DESCRIPTION
Part B of #354 (items 3, 7, 8 and the dispatch guards). Together with #363 (part A) and #365 (part C, native) this closes #354.

## 更改日志

- **宿主可靠性（第二批）**——`ae_nativeExec` 真正享有 30 秒请求时限（此前客户端缺省 7 秒），已超时请求的迟到应答被忽略而不再判为契约不匹配、断开 socket；MCP 会话封顶 64 条，优先淘汰最旧且无事件流的会话，带旧 `Mcp-Session-Id` 的 initialize 先替换旧会话；协议版本从 initialize 的 `params.protocolVersion` 协商（未知版本回落到最新支持版本）；含通知的批量请求返回 200 与结果；工具无返回值时给出结构化错误；宿主记录 unhandled rejection 而不崩溃。
- **Host reliability, batch B** — 30 s native window with late-reply tolerance, a 64-session cap with oldest-idle eviction, protocol negotiation from initialize params, batch responses fixed, dispatch guards.

## 验证

- `plugin/host` `npm test`：296 tests, 278 pass, 0 fail, 18 skipped。两条新增的原生迟到/未知 id 回归与既有原生客户端用例一样依赖 Unix-domain socket 夹具，在 Windows 上跳过；CI 目前只在 Windows job 跑 host 套件，这是既有覆盖缺口（建议后续让 macOS job 也跑 `plugin/host` `npm test`）。
- 真机：待编排者补充（协议协商、批量 200、会话上限）。

## 实现者

Terra（gpt-5.6-terra，effort high）实现；Fable 审 diff 并运行测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
