### PR TITLE
fix(panel): keep tool actions visible in bounded layouts

### DIFF
--- a/plugin/client/dist/app.css
+++ b/plugin/client/dist/app.css
@@ -1302,17 +1302,20 @@ body {
 }
 .tools-header {
   min-width: 0;
-  min-height: 38px;
+  min-height: 28px;
   flex: none;
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-15) var(--space-2);
+  padding: 4px 6px;
   border-bottom: 1px solid var(--border-subtle);
 }
 .tools-header__title {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: var(--text-primary);
   font: var(--weight-semibold) var(--text-heading)/var(--leading-tight) var(--font-ui);
 }
@@ -1331,11 +1334,11 @@ body {
 .tools-filters {
   flex: none;
   display: grid;
-  grid-template-columns: minmax(120px, 2fr) repeat(5, minmax(86px, 1fr));
+  grid-template-columns: auto minmax(0, 1fr);
   gap: var(--space-15);
-  padding: var(--space-2);
+  padding: 4px 6px;
   border-bottom: 1px solid var(--border-subtle);
-  overflow-x: auto;
+  min-width: 0;
 }
 .tools-error {
   flex: none;
@@ -1343,6 +1346,9 @@ body {
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
+  max-height: 30px;
+  overflow: auto;
+  overflow-wrap: anywhere;
   padding: var(--space-15) var(--space-2);
   color: var(--error);
   background: var(--error-bg);
@@ -1378,7 +1384,112 @@ body {
   border-right: 1px solid var(--border-default);
 }
 .tools-detail {
-  padding: var(--space-3);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+}
+.tools-selector {
+  display: none;
+}
+.tools-header__actions {
+  flex: none;
+  flex-wrap: nowrap;
+  gap: 2px;
+}
+.tools-screen .tools-header__actions button {
+  padding: 0 4px !important;
+  font-size: 10px !important;
+}
+.tools-detail__heading,
+.tools-detail__tabs {
+  flex: none;
+  min-width: 0;
+}
+.tools-detail__tabs > div {
+  max-width: 100%;
+}
+.tools-detail__heading h2 {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tools-detail__heading > span {
+  flex: none;
+}
+.tools-detail__actions,
+.tools-library-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.tools-detail .tools-detail__actions {
+  flex: none;
+  margin: 0;
+  justify-content: flex-start;
+}
+.tools-runner__actions:empty,
+.tools-library-actions:empty {
+  display: none;
+}
+.tools-text-area {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  overflow-wrap: anywhere;
+}
+.tools-text-area h3,
+.tools-text-area p {
+  margin: 0 0 6px;
+}
+.tools-text-area .tools-content {
+  overflow: visible;
+}
+.tools-args {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.tools-result-error {
+  color: var(--error);
+}
+.tools-feedback {
+  display: flex;
+  flex: none;
+  min-width: 0;
+  gap: 4px;
+  padding: 2px 6px;
+  font-size: 10px;
+}
+.tools-feedback > span {
+  flex: 1;
+  min-width: 0;
+  max-height: 28px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+}
+.tools-feedback > button {
+  flex: none;
+}
+.tools-import-view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px;
+}
+.tools-import-view .tools-import__actions {
+  flex: none;
+  justify-content: flex-start;
+  gap: 4px;
+}
+.tools-import-view textarea {
+  resize: none !important;
 }
 .tools-artifact-row {
   width: 100%;
@@ -1623,36 +1734,54 @@ body {
   width: min(420px, 100%);
 }
 @media (max-width: 560px) {
+  .tools-split {
+    display: flex;
+  }
+  .tools-list {
+    display: none;
+  }
+  .tools-detail {
+    flex: 1;
+  }
+  .tools-detail__heading {
+    display: none;
+  }
+  .tools-selector {
+    display: block;
+    flex: none;
+    width: calc(100% - 12px);
+    min-width: 0;
+    height: 24px;
+    margin: 2px 6px;
+    background: var(--bg-well);
+    color: var(--text-primary);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    font: inherit;
+  }
+}
+@media (max-height: 360px) {
+  .tools-header {
+    min-height: 24px;
+    padding: 2px 6px;
+  }
   .tools-filters {
-    grid-template-columns: repeat(3, minmax(104px, 1fr));
+    padding: 2px 6px;
+  }
+  .tools-selector {
+    height: 20px;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .tools-detail {
+    padding: 4px 6px;
+    gap: 2px;
+  }
+  .tools-feedback > span {
+    max-height: 20px;
   }
 }
 @media (max-width: 360px) {
-  .tools-header {
-    align-items: flex-start;
-  }
-  .tools-header__actions {
-    justify-content: flex-end;
-  }
-  .tools-filters {
-    grid-template-columns: repeat(2, minmax(112px, 1fr));
-  }
-  .tools-split {
-    display: flex;
-    flex-direction: column;
-    overflow: auto;
-  }
-  .tools-list {
-    flex: 0 0 min(42%, 260px);
-    min-height: 140px;
-    border-right: 0;
-    border-bottom: 1px solid var(--border-default);
-  }
-  .tools-detail {
-    flex: 1 0 auto;
-    min-height: 240px;
-    overflow: visible;
-  }
   .tools-editor__grid,
   .tools-runner__target,
   .tools-import__hashes {

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -27942,6 +27942,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
       select: "\u9009\u62E9\u4E00\u4E2A\u6761\u76EE",
       selectCap: "\u5148\u4ECE\u5DE6\u4FA7\u9009\u62E9\uFF0C\u518D\u67E5\u770B\u8BE6\u60C5\u6216\u8FD0\u884C\u3002",
       args: "\u53C2\u6570\uFF08JSON\uFF09",
+      argsTab: "\u53C2\u6570",
+      cancel: "\u53D6\u6D88",
       run: "\u8FD0\u884C",
       render: "\u6E32\u67D3\u5E76\u590D\u5236",
       result: "\u7ED3\u679C",
@@ -27988,6 +27990,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
       select: "Select an item",
       selectCap: "Choose an item on the left to inspect or run it.",
       args: "Arguments (JSON)",
+      argsTab: "Args",
+      cancel: "Cancel",
       run: "Run",
       render: "Render & copy",
       result: "Result",
@@ -28117,7 +28121,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function LibraryActionButtons({ artifact, t, onAction, disabled }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { display: "flex", gap: 5, flexWrap: "wrap" }, children: toolLibraryActions(artifact.status).map((action) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-library-actions", children: toolLibraryActions(artifact.status).map((action) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
       Button,
       {
         variant: action === "delete" ? "danger" : "secondary",
@@ -28135,16 +28139,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
       "div",
       {
         role: feedback.type === "error" ? "alert" : "status",
-        style: {
-          padding: "7px 8px",
-          border: "1px solid var(--border-subtle)",
-          borderRadius: "var(--radius-md)",
-          color: feedback.type === "error" ? "var(--error)" : "var(--text-secondary)",
-          font: "400 10px/1.45 var(--font-ui)",
-          overflowWrap: "anywhere"
-        },
+        className: "tools-feedback",
+        style: { color: feedback.type === "error" ? "var(--error)" : "var(--text-secondary)" },
         children: [
-          feedback.message,
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { children: feedback.message }),
           feedback.path ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: onCopy, children: t.copyPath }) : null
         ]
       }
@@ -28165,6 +28163,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const [feedback, setFeedback] = import_react42.default.useState(null);
     const [showImport, setShowImport] = import_react42.default.useState(false);
     const [importText, setImportText] = import_react42.default.useState("");
+    const [pane, setPane] = import_react42.default.useState("content");
     const loadSequence = import_react42.default.useRef(0);
     const selectSequence = import_react42.default.useRef(0);
     const fileInputRef = import_react42.default.useRef(null);
@@ -28216,6 +28215,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       const timer = setTimeout(load, 120);
       return () => clearTimeout(timer);
     }, [load]);
+    import_react42.default.useEffect(() => {
+      if (result || error) setPane("result");
+    }, [result, error]);
     const changeMode = (next) => {
       setMode(next);
       setSelectedId("");
@@ -28230,6 +28232,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       setSelectedId(id);
       setResult(null);
       setError("");
+      setPane("content");
       try {
         const value = mode === "skills" ? item : (await api.inspect(item.id)).artifact;
         if (sequence !== selectSequence.current) return;
@@ -28258,6 +28261,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       } catch (cause) {
         setError(cause instanceof SyntaxError ? t.invalidArgs : cause.message || String(cause));
       } finally {
+        setPane("result");
         setBusy(false);
       }
     };
@@ -28341,17 +28345,16 @@ When you are done, remind me of two things: MCP tools load only in a new session
       }
     };
     const selected = detail && detail.value;
-    const selectedSchema = selected && (detail.mode === "skills" ? selected.args_schema : selected.argsSchema);
     const selectedContent = selected && (detail.mode === "skills" ? selected.template : selected.content);
     const canExecuteSkill = detail && detail.mode === "skills" && selected.template_type === "jsx";
     const canExecuteTool = detail && detail.mode === "tools" && !["candidate", "archived", "deprecated"].includes(selected.status);
     const groups = mode === "tools" ? groupToolLibraryItems(items) : [];
     return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-screen", children: [
       /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("header", { className: "tools-header", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-header__title", children: t.title }),
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-header__title", title: t.title, children: t.title }),
         /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-header__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", icon: "rotate-cw", onClick: load, disabled: busy, children: t.refresh }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", icon: "upload", onClick: () => setShowImport(!showImport), disabled: busy, children: t.import }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: load, disabled: busy, children: t.refresh }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setShowImport(!showImport), disabled: busy, children: t.import }),
           /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "danger", onClick: clearCandidates, disabled: busy || !libraryRows.candidates.length, children: t.clearCandidates })
         ] })
       ] }),
@@ -28376,16 +28379,6 @@ When you are done, remind me of two things: MCP tools load only in a new session
           }
         )
       ] }),
-      showImport ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-import", style: { display: "flex", flexDirection: "column", gap: 6, marginBottom: 8 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: t.import }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { font: "400 10px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.importHint }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Textarea, { mono: true, value: importText, onChange: setImportText, rows: 4 }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { style: { display: "flex", gap: 6, alignItems: "center" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("input", { ref: fileInputRef, type: "file", accept: "application/json,.json", onChange: chooseFile, style: { display: "none" } }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "secondary", disabled: busy, onClick: () => fileInputRef.current && fileInputRef.current.click(), children: t.selectFile }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "secondary", disabled: busy || !importText.trim(), onClick: importArtifact, children: t.importJson })
-        ] })
-      ] }) : null,
       /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
         Feedback,
         {
@@ -28397,11 +28390,57 @@ When you are done, remind me of two things: MCP tools load only in a new session
           )
         }
       ),
-      error ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-error", role: "alert", children: error }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-split", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-list", "aria-label": mode === "skills" ? t.skills : t.tools, children: mode === "tools" && groups.length ? groups.map((group) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { margin: "4px 2px 2px", color: "var(--text-tertiary)", font: "600 10px/1.35 var(--font-ui)", textTransform: "uppercase" }, children: statusLabel(t, group.status) }),
-          group.items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+      error && !selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-error", role: "alert", children: error }) : null,
+      showImport ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-import-view", "aria-label": t.import, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-text-area", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("p", { children: t.importHint }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { children: [
+            t.importJson,
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Textarea, { mono: true, value: importText, onChange: setImportText, rows: 4 })
+          ] })
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-import__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("input", { ref: fileInputRef, type: "file", accept: "application/json,.json", onChange: chooseFile, style: { display: "none" } }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy, onClick: () => fileInputRef.current && fileInputRef.current.click(), children: t.selectFile }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy || !importText.trim(), onClick: importArtifact, children: t.importJson }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy, onClick: () => setShowImport(false), children: t.cancel })
+        ] })
+      ] }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(
+          "select",
+          {
+            className: "tools-selector ds-focusable",
+            "aria-label": t.select,
+            value: selectedId,
+            onChange: (event) => {
+              const item = items.find((entry2) => itemId(mode, entry2) === event.target.value);
+              if (item) select(item);
+            },
+            children: [
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("option", { value: "", disabled: true, children: t.select }),
+              selectedId && !items.some((item) => itemId(mode, item) === selectedId) ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("option", { value: selectedId, children: (selected == null ? void 0 : selected.name) || selectedId }) : null,
+              items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("option", { value: itemId(mode, item), children: [
+                mode === "tools" ? statusLabel(t, item.status) + " \xB7 " : "",
+                item.name || item.id
+              ] }, itemId(mode, item)))
+            ]
+          }
+        ),
+        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-split", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-list", "aria-label": mode === "skills" ? t.skills : t.tools, children: mode === "tools" && groups.length ? groups.map((group) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { margin: "4px 2px 2px", color: "var(--text-tertiary)", font: "600 10px/1.35 var(--font-ui)", textTransform: "uppercase" }, children: statusLabel(t, group.status) }),
+            group.items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+              ItemRow,
+              {
+                mode,
+                item,
+                selected: itemId(mode, item) === selectedId,
+                onSelect: select,
+                t
+              },
+              itemId(mode, item)
+            ))
+          ] }, group.status)) : mode === "skills" && items.length ? items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
             ItemRow,
             {
               mode,
@@ -28411,56 +28450,47 @@ When you are done, remind me of two things: MCP tools load only in a new session
               t
             },
             itemId(mode, item)
-          ))
-        ] }, group.status)) : mode === "skills" && items.length ? items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
-          ItemRow,
-          {
-            mode,
-            item,
-            selected: itemId(mode, item) === selectedId,
-            onSelect: select,
-            t
-          },
-          itemId(mode, item)
-        )) : /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.empty, compact: true }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-detail", children: !selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-detail__heading", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h2", { children: selected.name }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("p", { children: selected.description })
+          )) : /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.empty, compact: true }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-detail", children: !selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-detail__heading", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h2", { title: selected.name, children: selected.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: detail.mode === "tools" ? statusBadgeStatus(selected.status) : selected.verified ? "ok" : "neutral", children: detail.mode === "tools" ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: detail.mode === "tools" ? statusBadgeStatus(selected.status) : selected.verified ? "ok" : "neutral", children: detail.mode === "tools" ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt })
-          ] }),
-          detail.mode === "tools" && toolLibraryActions(selected.status).length ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-detail__section", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: t.status }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(LibraryActionButtons, { artifact: selected, t, onAction: runLibraryAction, disabled: busy })
-          ] }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-detail__section", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: t.content }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: selectedContent || "\u2014" })
-          ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-detail__section tools-runner", children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: t.args }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
-              Textarea,
-              {
-                mono: true,
-                value: argsText,
-                onChange: setArgsText,
-                rows: Math.max(4, Object.keys((selectedSchema == null ? void 0 : selectedSchema.properties) || {}).length + 2),
-                disabled: detail.mode === "tools" && !canExecuteTool
-              }
-            ),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-runner__actions", children: [
-              detail.mode === "skills" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "secondary", onClick: () => invoke("render"), disabled: busy, children: t.render }) : null,
-              canExecuteTool || canExecuteSkill ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { variant: "primary", onClick: () => invoke("execute"), disabled: busy, children: t.run }) : null
-            ] }),
-            result ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: t.result }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: JSON.stringify(result, null, 2) })
-            ] }) : null
-          ] })
-        ] }) })
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-detail__tabs", children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Segmented, { value: pane, onChange: setPane, options: [
+              { value: "content", label: t.content },
+              { value: "args", label: t.argsTab },
+              { value: "result", label: t.result }
+            ] }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-text-area", "aria-label": t[pane], children: pane === "content" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: selected.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("p", { children: selected.description }),
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: selectedContent || "\u2014" })
+            ] }) : pane === "args" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { className: "tools-args", children: [
+              t.args,
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+                Textarea,
+                {
+                  mono: true,
+                  value: argsText,
+                  onChange: setArgsText,
+                  rows: 4,
+                  style: { flex: 1, minHeight: 0, resize: "none" },
+                  disabled: detail.mode === "tools" && !canExecuteTool
+                }
+              )
+            ] }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
+              error ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-result-error", role: "alert", children: error }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: result ? JSON.stringify(result, null, 2) : "\u2014" })
+            ] }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("footer", { className: "tools-detail__actions", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-runner__actions", children: [
+                detail.mode === "skills" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => invoke("render"), disabled: busy, children: t.render }) : null,
+                canExecuteTool || canExecuteSkill ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "primary", onClick: () => invoke("execute"), disabled: busy, children: t.run }) : null
+              ] }),
+              detail.mode === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(LibraryActionButtons, { artifact: selected, t, onAction: runLibraryAction, disabled: busy }) : null
+            ] })
+          ] }) })
+        ] })
       ] })
     ] });
   }

--- a/plugin/panel/src/screens/ToolsScreen.jsx
+++ b/plugin/panel/src/screens/ToolsScreen.jsx
@@ -28,6 +28,8 @@ const TEXT = {
     select: '选择一个条目',
     selectCap: '先从左侧选择，再查看详情或运行。',
     args: '参数（JSON）',
+    argsTab: '参数',
+    cancel: '取消',
     run: '运行',
     render: '渲染并复制',
     result: '结果',
@@ -74,6 +76,8 @@ const TEXT = {
     select: 'Select an item',
     selectCap: 'Choose an item on the left to inspect or run it.',
     args: 'Arguments (JSON)',
+    argsTab: 'Args',
+    cancel: 'Cancel',
     run: 'Run',
     render: 'Render & copy',
     result: 'Result',
@@ -208,7 +212,7 @@ function ItemRow({ mode, item, selected, onSelect, t }) {
 
 function LibraryActionButtons({ artifact, t, onAction, disabled }) {
   return (
-    <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+    <div className="tools-library-actions">
       {toolLibraryActions(artifact.status).map((action) => (
         <Button
           key={action}
@@ -229,16 +233,10 @@ function Feedback({ feedback, t, onCopy }) {
   return (
     <div
       role={feedback.type === 'error' ? 'alert' : 'status'}
-      style={{
-        padding: '7px 8px',
-        border: '1px solid var(--border-subtle)',
-        borderRadius: 'var(--radius-md)',
-        color: feedback.type === 'error' ? 'var(--error)' : 'var(--text-secondary)',
-        font: '400 10px/1.45 var(--font-ui)',
-        overflowWrap: 'anywhere',
-      }}
+      className="tools-feedback"
+      style={{ color: feedback.type === 'error' ? 'var(--error)' : 'var(--text-secondary)' }}
     >
-      {feedback.message}
+      <span>{feedback.message}</span>
       {feedback.path ? (
         <Button size="sm" variant="ghost" onClick={onCopy}>{t.copyPath}</Button>
       ) : null}
@@ -261,6 +259,7 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
   const [feedback, setFeedback] = React.useState(null);
   const [showImport, setShowImport] = React.useState(false);
   const [importText, setImportText] = React.useState('');
+  const [pane, setPane] = React.useState('content');
   const loadSequence = React.useRef(0);
   const selectSequence = React.useRef(0);
   const fileInputRef = React.useRef(null);
@@ -322,6 +321,10 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
     return () => clearTimeout(timer);
   }, [load]);
 
+  React.useEffect(() => {
+    if (result || error) setPane('result');
+  }, [result, error]);
+
   const changeMode = (next) => {
     setMode(next);
     setSelectedId('');
@@ -337,6 +340,7 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
     setSelectedId(id);
     setResult(null);
     setError('');
+    setPane('content');
     try {
       const value = mode === 'skills'
         ? item
@@ -370,6 +374,7 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
     } catch (cause) {
       setError(cause instanceof SyntaxError ? t.invalidArgs : cause.message || String(cause));
     } finally {
+      setPane('result');
       setBusy(false);
     }
   };
@@ -458,9 +463,6 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
   };
 
   const selected = detail && detail.value;
-  const selectedSchema = selected && (detail.mode === 'skills'
-    ? selected.args_schema
-    : selected.argsSchema);
   const selectedContent = selected && (detail.mode === 'skills'
     ? selected.template
     : selected.content);
@@ -473,12 +475,12 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
   return (
     <div className="tools-screen">
       <header className="tools-header">
-        <div className="tools-header__title">{t.title}</div>
+        <div className="tools-header__title" title={t.title}>{t.title}</div>
         <div className="tools-header__actions">
-          <Button size="sm" variant="ghost" icon="rotate-cw" onClick={load} disabled={busy}>
+          <Button size="sm" variant="ghost" onClick={load} disabled={busy}>
             {t.refresh}
           </Button>
-          <Button size="sm" variant="ghost" icon="upload" onClick={() => setShowImport(!showImport)} disabled={busy}>
+          <Button size="sm" variant="ghost" onClick={() => setShowImport(!showImport)} disabled={busy}>
             {t.import}
           </Button>
           <Button size="sm" variant="danger" onClick={clearCandidates} disabled={busy || !libraryRows.candidates.length}>
@@ -501,18 +503,6 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
           placeholder={mode === 'skills' ? t.searchSkills : t.searchTools}
         />
       </div>
-      {showImport ? (
-        <section className="tools-import" style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 8 }}>
-          <div style={{ font: '500 11px/1.35 var(--font-ui)', color: 'var(--text-secondary)' }}>{t.import}</div>
-          <div style={{ font: '400 10px/1.4 var(--font-ui)', color: 'var(--text-tertiary)' }}>{t.importHint}</div>
-          <Textarea mono value={importText} onChange={setImportText} rows={4} />
-          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-            <input ref={fileInputRef} type="file" accept="application/json,.json" onChange={chooseFile} style={{ display: 'none' }} />
-            <Button size="sm" variant="secondary" disabled={busy} onClick={() => fileInputRef.current && fileInputRef.current.click()}>{t.selectFile}</Button>
-            <Button size="sm" variant="secondary" disabled={busy || !importText.trim()} onClick={importArtifact}>{t.importJson}</Button>
-          </div>
-        </section>
-      ) : null}
       <Feedback
         feedback={feedback}
         t={t}
@@ -521,15 +511,49 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
           (cause) => setFeedback({ type: 'error', message: cause.message || String(cause) }),
         )}
       />
-      {error ? <div className="tools-error" role="alert">{error}</div> : null}
-      <div className="tools-split">
-        <section className="tools-list" aria-label={mode === 'skills' ? t.skills : t.tools}>
-          {mode === 'tools' && groups.length ? groups.map((group) => (
-            <React.Fragment key={group.status}>
-              <div style={{ margin: '4px 2px 2px', color: 'var(--text-tertiary)', font: '600 10px/1.35 var(--font-ui)', textTransform: 'uppercase' }}>
-                {statusLabel(t, group.status)}
-              </div>
-              {group.items.map((item) => (
+      {error && !selected ? <div className="tools-error" role="alert">{error}</div> : null}
+      {showImport ? (
+        <section className="tools-import-view" aria-label={t.import}>
+          <div className="tools-text-area">
+            <p>{t.importHint}</p>
+            <label>{t.importJson}
+              <Textarea mono value={importText} onChange={setImportText} rows={4} />
+            </label>
+          </div>
+          <div className="tools-import__actions">
+            <input ref={fileInputRef} type="file" accept="application/json,.json" onChange={chooseFile} style={{ display: 'none' }} />
+            <Button size="sm" disabled={busy} onClick={() => fileInputRef.current && fileInputRef.current.click()}>{t.selectFile}</Button>
+            <Button size="sm" disabled={busy || !importText.trim()} onClick={importArtifact}>{t.importJson}</Button>
+            <Button size="sm" disabled={busy} onClick={() => setShowImport(false)}>{t.cancel}</Button>
+          </div>
+        </section>
+      ) : (
+        <React.Fragment>
+          <select className="tools-selector ds-focusable" aria-label={t.select} value={selectedId}
+            onChange={(event) => { const item = items.find((entry) => itemId(mode, entry) === event.target.value); if (item) select(item); }}>
+            <option value="" disabled>{t.select}</option>
+            {selectedId && !items.some((item) => itemId(mode, item) === selectedId) ? <option value={selectedId}>{selected?.name || selectedId}</option> : null}
+            {items.map((item) => <option key={itemId(mode, item)} value={itemId(mode, item)}>{mode === 'tools' ? statusLabel(t, item.status) + ' · ' : ''}{item.name || item.id}</option>)}
+          </select>
+          <div className="tools-split">
+            <section className="tools-list" aria-label={mode === 'skills' ? t.skills : t.tools}>
+              {mode === 'tools' && groups.length ? groups.map((group) => (
+                <React.Fragment key={group.status}>
+                  <div style={{ margin: '4px 2px 2px', color: 'var(--text-tertiary)', font: '600 10px/1.35 var(--font-ui)', textTransform: 'uppercase' }}>
+                    {statusLabel(t, group.status)}
+                  </div>
+                  {group.items.map((item) => (
+                    <ItemRow
+                      key={itemId(mode, item)}
+                      mode={mode}
+                      item={item}
+                      selected={itemId(mode, item) === selectedId}
+                      onSelect={select}
+                      t={t}
+                    />
+                  ))}
+                </React.Fragment>
+              )) : mode === 'skills' && items.length ? items.map((item) => (
                 <ItemRow
                   key={itemId(mode, item)}
                   mode={mode}
@@ -538,75 +562,61 @@ export function ToolsScreen({ api, lang = 'zh', port = 11488 }) {
                   onSelect={select}
                   t={t}
                 />
-              ))}
-            </React.Fragment>
-          )) : mode === 'skills' && items.length ? items.map((item) => (
-            <ItemRow
-              key={itemId(mode, item)}
-              mode={mode}
-              item={item}
-              selected={itemId(mode, item) === selectedId}
-              onSelect={select}
-              t={t}
-            />
-          )) : <EmptyState icon="box" title={t.empty} compact />}
-        </section>
-        <section className="tools-detail">
-          {!selected ? (
-            <EmptyState icon="box" title={t.select} caption={t.selectCap} />
-          ) : (
-            <React.Fragment>
-              <div className="tools-detail__heading">
-                <div>
-                  <h2>{selected.name}</h2>
-                  <p>{selected.description}</p>
-                </div>
-                <Badge status={detail.mode === 'tools' ? statusBadgeStatus(selected.status) : selected.verified ? 'ok' : 'neutral'}>
-                  {detail.mode === 'tools' ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt}
-                </Badge>
-              </div>
-              {detail.mode === 'tools' && toolLibraryActions(selected.status).length ? (
-                <section className="tools-detail__section">
-                  <h3>{t.status}</h3>
-                  <LibraryActionButtons artifact={selected} t={t} onAction={runLibraryAction} disabled={busy} />
-                </section>
-              ) : null}
-              <section className="tools-detail__section">
-                <h3>{t.content}</h3>
-                <pre className="tools-content">{selectedContent || '—'}</pre>
-              </section>
-              <section className="tools-detail__section tools-runner">
-                <h3>{t.args}</h3>
-                <Textarea
-                  mono
-                  value={argsText}
-                  onChange={setArgsText}
-                  rows={Math.max(4, Object.keys(selectedSchema?.properties || {}).length + 2)}
-                  disabled={detail.mode === 'tools' && !canExecuteTool}
-                />
-                <div className="tools-runner__actions">
-                  {detail.mode === 'skills' ? (
-                    <Button variant="secondary" onClick={() => invoke('render')} disabled={busy}>
-                      {t.render}
-                    </Button>
-                  ) : null}
-                  {canExecuteTool || canExecuteSkill ? (
-                    <Button variant="primary" onClick={() => invoke('execute')} disabled={busy}>
-                      {t.run}
-                    </Button>
-                  ) : null}
-                </div>
-                {result ? (
-                  <React.Fragment>
-                    <h3>{t.result}</h3>
-                    <pre className="tools-content">{JSON.stringify(result, null, 2)}</pre>
-                  </React.Fragment>
-                ) : null}
-              </section>
-            </React.Fragment>
-          )}
-        </section>
-      </div>
+              )) : <EmptyState icon="box" title={t.empty} compact />}
+            </section>
+            <section className="tools-detail">
+              {!selected ? (
+                <EmptyState icon="box" title={t.select} caption={t.selectCap} />
+              ) : (
+                <React.Fragment>
+                  <div className="tools-detail__heading">
+                    <h2 title={selected.name}>{selected.name}</h2>
+                    <Badge status={detail.mode === 'tools' ? statusBadgeStatus(selected.status) : selected.verified ? 'ok' : 'neutral'}>
+                      {detail.mode === 'tools' ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt}
+                    </Badge>
+                  </div>
+                  <div className="tools-detail__tabs">
+                    <Segmented value={pane} onChange={setPane} options={[
+                      { value: 'content', label: t.content },
+                      { value: 'args', label: t.argsTab },
+                      { value: 'result', label: t.result },
+                    ]} />
+                  </div>
+                  <section className="tools-text-area" aria-label={t[pane]}>
+                    {pane === 'content' ? <React.Fragment>
+                      <h3>{selected.name}</h3>
+                      <p>{selected.description}</p>
+                      <pre className="tools-content">{selectedContent || '—'}</pre>
+                    </React.Fragment> : pane === 'args' ? <label className="tools-args">{t.args}
+                      <Textarea mono value={argsText} onChange={setArgsText} rows={4}
+                        style={{ flex: 1, minHeight: 0, resize: 'none' }}
+                        disabled={detail.mode === 'tools' && !canExecuteTool} />
+                    </label> : <React.Fragment>
+                      {error ? <div className="tools-result-error" role="alert">{error}</div> : null}
+                      <pre className="tools-content">{result ? JSON.stringify(result, null, 2) : '—'}</pre>
+                    </React.Fragment>}
+                  </section>
+                  <footer className="tools-detail__actions">
+                    <div className="tools-runner__actions">
+                      {detail.mode === 'skills' ? (
+                        <Button size="sm" variant="secondary" onClick={() => invoke('render')} disabled={busy}>
+                          {t.render}
+                        </Button>
+                      ) : null}
+                      {canExecuteTool || canExecuteSkill ? (
+                        <Button size="sm" variant="primary" onClick={() => invoke('execute')} disabled={busy}>
+                          {t.run}
+                        </Button>
+                      ) : null}
+                    </div>
+                    {detail.mode === 'tools' ? <LibraryActionButtons artifact={selected} t={t} onAction={runLibraryAction} disabled={busy} /> : null}
+                  </footer>
+                </React.Fragment>
+              )}
+            </section>
+          </div>
+        </React.Fragment>
+      )}
     </div>
   );
 }

--- a/plugin/panel/src/styles/index.css
+++ b/plugin/panel/src/styles/index.css
@@ -118,18 +118,21 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
 
 .tools-header {
   min-width: 0;
-  min-height: 38px;
+  min-height: 28px;
   flex: none;
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-15) var(--space-2);
+  padding: 4px 6px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
 .tools-header__title {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: var(--text-primary);
   font: var(--weight-semibold) var(--text-heading)/var(--leading-tight) var(--font-ui);
 }
@@ -150,11 +153,11 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
 .tools-filters {
   flex: none;
   display: grid;
-  grid-template-columns: minmax(120px, 2fr) repeat(5, minmax(86px, 1fr));
+  grid-template-columns: auto minmax(0, 1fr);
   gap: var(--space-15);
-  padding: var(--space-2);
+  padding: 4px 6px;
   border-bottom: 1px solid var(--border-subtle);
-  overflow-x: auto;
+  min-width: 0;
 }
 
 .tools-error {
@@ -163,6 +166,9 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
+  max-height: 30px;
+  overflow: auto;
+  overflow-wrap: anywhere;
   padding: var(--space-15) var(--space-2);
   color: var(--error);
   background: var(--error-bg);
@@ -190,7 +196,35 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
 }
 
 .tools-list { border-right: 1px solid var(--border-default); }
-.tools-detail { padding: var(--space-3); }
+.tools-detail {
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.tools-selector { display: none; }
+.tools-header__actions { flex: none; flex-wrap: nowrap; gap: 2px; }
+.tools-screen .tools-header__actions button { padding: 0 4px !important; font-size: 10px !important; }
+.tools-detail__heading, .tools-detail__tabs { flex: none; min-width: 0; }
+.tools-detail__tabs > div { max-width: 100%; }
+.tools-detail__heading h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tools-detail__heading > span { flex: none; }
+.tools-detail__actions, .tools-library-actions { display: flex; flex-wrap: wrap; gap: 4px; }
+.tools-detail .tools-detail__actions { flex: none; margin: 0; justify-content: flex-start; }
+.tools-runner__actions:empty, .tools-library-actions:empty { display: none; }
+.tools-text-area { flex: 1; min-width: 0; min-height: 0; overflow: auto; overflow-wrap: anywhere; }
+.tools-text-area h3, .tools-text-area p { margin: 0 0 6px; }
+.tools-text-area .tools-content { overflow: visible; }
+.tools-args { height: 100%; display: flex; flex-direction: column; gap: 4px; }
+.tools-result-error { color: var(--error); }
+.tools-feedback { display: flex; flex: none; min-width: 0; gap: 4px; padding: 2px 6px; font-size: 10px; }
+.tools-feedback > span { flex: 1; min-width: 0; max-height: 28px; overflow: auto; overflow-wrap: anywhere; }
+.tools-feedback > button { flex: none; }
+.tools-import-view { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 6px; padding: 6px; }
+.tools-import-view .tools-import__actions { flex: none; justify-content: flex-start; gap: 4px; }
+.tools-import-view textarea { resize: none !important; }
 
 .tools-artifact-row {
   width: 100%;
@@ -388,16 +422,26 @@ body { background: var(--bg-panel); color: var(--text-primary); font: var(--weig
 .tools-approval { width: min(420px, 100%); }
 
 @media (max-width: 560px) {
-  .tools-filters { grid-template-columns: repeat(3, minmax(104px, 1fr)); }
+  .tools-split { display: flex; }
+  .tools-list { display: none; }
+  .tools-detail { flex: 1; }
+  .tools-detail__heading { display: none; }
+  .tools-selector {
+    display: block; flex: none; width: calc(100% - 12px); min-width: 0; height: 24px; margin: 2px 6px;
+    background: var(--bg-well); color: var(--text-primary); border: 1px solid var(--border-default);
+    border-radius: var(--radius-md); font: inherit;
+  }
+}
+
+@media (max-height: 360px) {
+  .tools-header { min-height: 24px; padding: 2px 6px; }
+  .tools-filters { padding: 2px 6px; }
+  .tools-selector { height: 20px; margin-top: 0; margin-bottom: 0; }
+  .tools-detail { padding: 4px 6px; gap: 2px; }
+  .tools-feedback > span { max-height: 20px; }
 }
 
 @media (max-width: 360px) {
-  .tools-header { align-items: flex-start; }
-  .tools-header__actions { justify-content: flex-end; }
-  .tools-filters { grid-template-columns: repeat(2, minmax(112px, 1fr)); }
-  .tools-split { display: flex; flex-direction: column; overflow: auto; }
-  .tools-list { flex: 0 0 min(42%, 260px); min-height: 140px; border-right: 0; border-bottom: 1px solid var(--border-default); }
-  .tools-detail { flex: 1 0 auto; min-height: 240px; overflow: visible; }
   .tools-editor__grid,
   .tools-runner__target,
   .tools-import__hashes { grid-template-columns: 1fr; }

--- a/plugin/panel/validation/tools-layout.mjs
+++ b/plugin/panel/validation/tools-layout.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+// Uses an externally installed Playwright and Chrome; never connects to AE.
+const require = createRequire(import.meta.url);
+const { chromium } = require(process.env.PLAYWRIGHT_MODULE || 'playwright');
+const panel = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const output = path.resolve(process.argv[2]);
+await fs.mkdir(output, { recursive: true });
+const fixture = await build({
+  absWorkingDir: panel, bundle: true, write: false, format: 'iife', jsx: 'automatic',
+  define: { 'process.env.NODE_ENV': '"production"' },
+  stdin: { resolveDir: panel, loader: 'jsx', contents: `
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { ToolsScreen } from './src/screens/ToolsScreen.jsx';
+    import { StatusBar } from './src/components/shell/StatusBar.jsx';
+    import { TabBar } from './src/components/shell/TabBar.jsx';
+    const root = createRoot(document.getElementById('root'));
+    window.reset = (lang, kind, status, notice) => {
+      const long = 'VeryLongName超长名称'.repeat(120);
+      const schema = {properties:Object.fromEntries(Array.from({length:80},(_,i)=>['p'+i,{default:long}]))};
+      window.item = {id:'fixture',name:long,description:long,content:('var x = 1; // '+long+'\\n').repeat(40),
+        template:long.repeat(10),argsSchema:schema,args_schema:schema,status,kind:'jsx',template_type:kind,verified:true};
+      window.calls=[]; window.fail=false;
+      const output = () => { window.calls.push('run'); if(window.fail) throw new Error(long); return {rendered:long,result:long.repeat(10)}; };
+      const api = {index:async()=>({artifacts:[window.item]}),search:async()=>({artifacts:[window.item]}),
+        inspect:async()=>({artifact:window.item}),listSkills:async()=>({skills:[window.item]}),
+        executeTool:async()=>output(),executeSkill:async()=>output(),renderSkill:async()=>output()};
+      root.render(<React.Fragment key={Math.random()}>
+        <StatusBar label="Connected"/><div style={{height:notice,flex:'none'}}>Notice 提示</div>
+        <ToolsScreen api={api} lang={lang}/>
+        <TabBar active="tools" tabs={['chat','activity','tools','settings'].map(id=>({id,label:id,icon:'box'}))}/>
+      </React.Fragment>);
+    };
+    window.fetch = async (url, options={}) => {
+      window.calls.push(url);
+      return {ok:true,json:async()=>url.endsWith('/tool-library') ? {candidates:[{...window.item,status:'candidate'}],artifacts:[window.item]} :
+        url.endsWith('/export') ? {path:'C:/exports/'+ 'long'.repeat(1000) +'.json'} : {ok:false,error:'Error错误'.repeat(1000)}};
+    };
+  ` },
+  plugins: [{ name: 'isolated-platform', setup(builder) {
+    builder.onResolve({ filter: /(?:cep\/platform\/index\.js|lib\/clipboard)$/ }, args => ({ path: args.path, namespace: 'fixture' }));
+    builder.onLoad({ filter: /.*/, namespace: 'fixture' }, args => ({ contents: args.path.endsWith('clipboard')
+      ? 'export async function copyText(text) { window.copied = text; }'
+      : "export function createPlatformAdapter() { return {paths:{configRoot:'fixture',join:()=>''},fs:{readFileSync:()=> 'fixture-token'}}; }" }));
+  } }],
+});
+const css = await fs.readFile(path.join(panel, '../client/dist/app.css'), 'utf8');
+const browser = await chromium.launch({ headless: true, ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {}) });
+const page = await browser.newPage();
+const ledger = [];
+async function geometry(label) {
+  const data = await page.evaluate(() => {
+    const buttons = [...document.querySelectorAll('button')].filter(el => el.getBoundingClientRect().height && !el.closest('.tools-list'));
+    return { width: innerWidth, height: innerHeight, scroll: [document.documentElement.scrollWidth, document.documentElement.scrollHeight],
+      buttons: buttons.map(el => {
+        const r = el.getBoundingClientRect();
+        const points = [[r.x+2,r.y+2],[r.right-2,r.bottom-2],[r.x+r.width/2,r.y+r.height/2]];
+        return {text:el.textContent || el.title, x:r.x,y:r.y,w:r.width,h:r.height,disabled:el.disabled,
+          hit:points.every(([x,y])=>el.contains(document.elementFromPoint(x,y)))};
+      }), textHeight: document.querySelector('.tools-text-area')?.clientHeight };
+  });
+  assert.ok(data.scroll[0] <= data.width && data.scroll[1] <= data.height, label + ' outer overflow');
+  for (const b of data.buttons) assert.ok(b.x >= 0 && b.y >= 0 && b.x+b.w <= data.width+0.1 && b.y+b.h <= data.height+0.1 && b.hit, label+' '+JSON.stringify(b));
+  assert.ok(data.textHeight >= 20, label + ' usable text area');
+  ledger.push({ label, disposition:'PASS', ...data });
+  return data.buttons;
+}
+async function scrollCheck(label, selector='.tools-text-area') {
+  const before = await geometry(label);
+  const moved = await page.locator(selector).evaluate(el => { el.scrollTop=el.scrollHeight; return el.scrollTop; });
+  assert.ok(moved > 0, label+' text scroll');
+  assert.deepEqual(await geometry(label+' scrolled'), before, label+' fixed controls');
+}
+try {
+  for (const [width,height] of [[280,300],[360,480],[420,480],[800,800]]) for (const lang of ['zh','en']) {
+    await page.setViewportSize({width,height});
+    await page.setContent('<div id="root"></div>');
+    await page.addStyleTag({content:css});
+    await page.addScriptTag({content:fixture.outputFiles[0].text});
+    for (const state of ['candidate','saved','pinned','archived','deprecated','jsx','prompt']) {
+      const skill = ['jsx','prompt'].includes(state);
+      const label = [width,height,lang,state].join('-');
+      await page.evaluate(({lang,state})=>window.reset(lang,state,state,24),{lang,state});
+      if (skill) await page.getByRole('radio',{name:lang==='zh'?'技能':'Skills',exact:true}).click();
+      await page.waitForFunction(()=>document.querySelector('[data-item-id]'));
+      if (width<=560) await page.locator('.tools-selector').selectOption(skill?'skill:'+await page.evaluate(()=>window.item.name):'fixture');
+      else await page.locator('[data-item-id]').first().click();
+      await page.locator('.tools-detail__heading').waitFor({state:'attached'});
+      await scrollCheck(label+' content');
+      await page.getByRole('radio',{name:lang==='zh'?'参数':'Args',exact:true}).click();
+      await scrollCheck(label+' args','.tools-args textarea');
+      const actions = await page.locator('.tools-detail__actions button').allTextContents();
+      const expected = {candidate:['沉淀','删除'],saved:['运行','置顶','归档','导出'],pinned:['运行','取消置顶','归档','导出'],archived:['恢复为已保存','删除'],deprecated:[],jsx:['渲染并复制','运行'],prompt:['渲染并复制']};
+      const expectedEn = {candidate:['Promote','Delete'],saved:['Run','Pin','Archive','Export'],pinned:['Run','Unpin','Archive','Export'],archived:['Restore saved','Delete'],deprecated:[],jsx:['Render & copy','Run'],prompt:['Render & copy']};
+      assert.deepEqual(actions,(lang==='zh'?expected:expectedEn)[state]);
+      if (['saved','pinned','jsx','prompt'].includes(state)) {
+        const run = page.locator('.tools-runner__actions button').first();
+        await run.click();
+        await page.waitForFunction(()=>document.querySelector('.tools-text-area pre')?.textContent.includes('rendered'));
+        await scrollCheck(label+' result');
+        await page.evaluate(()=>{window.fail=true;});
+        await run.click();
+        await page.locator('.tools-result-error').waitFor();
+        await scrollCheck(label+' error');
+        for (const invalid of ['{','{x']) {
+          await page.getByRole('radio',{name:lang==='zh'?'参数':'Args',exact:true}).click();
+          await page.locator('.tools-args textarea').fill(invalid);
+          await run.click();
+          await page.locator('.tools-result-error').waitFor();
+          await geometry(label+' repeated invalid '+invalid);
+        }
+      }
+      if (['saved','pinned'].includes(state)) {
+        await page.getByRole('button',{name:lang==='zh'?'导出':'Export',exact:true}).click();
+        await page.locator('.tools-feedback button').waitFor();
+        await geometry(label+' export feedback');
+      }
+      await page.screenshot({path:path.join(output,label+'.png')});
+    }
+    await page.getByRole('button',{name:lang==='zh'?'导入':'Import',exact:true}).click();
+    await page.locator('.tools-import-view textarea').fill('{'+ 'long json 长文本'.repeat(1000));
+    await page.getByRole('button',{name:lang==='zh'?'导入 JSON':'Import JSON',exact:true}).click();
+    await page.locator('.tools-feedback').waitFor();
+    await scrollCheck([width,height,lang,'import'].join('-'), '.tools-import-view textarea');
+    await page.screenshot({path:path.join(output,[width,height,lang,'import.png'].join('-'))});
+    await page.getByRole('button',{name:lang==='zh'?'取消':'Cancel',exact:true}).click();
+    assert.equal(await page.locator('.tools-import-view').count(),0);
+  }
+} catch (error) {
+  ledger.push({disposition:'FAIL',error:error.message,sideEffects:'isolated browser only'});
+  await page.screenshot({path:path.join(output,'failure.png')});
+  throw error;
+} finally {
+  await fs.writeFile(path.join(output,'geometry.json'),JSON.stringify(ledger,null,2));
+  await browser.close();
+}
+console.log(JSON.stringify({cases:ledger.length,disposition:'PASS',output}));


### PR DESCRIPTION
长工具正文和多参数 JSON 原先会把运行及管理按钮推出可见区。此修改固定工具页导航与操作区，将内容、参数和结果放入可切换的有界文字区；窄屏使用固定条目选择器，导入确认/取消也固定。保持现有状态动作和 280×300 最小尺寸。

Closes #374

范围：2 个实现文件（173 行新增）、1 个可复跑浏览器验收脚本（143 行）、2 个生成 bundle，全部已提交。无 host/native/provider、workflow、配置或版本改动。

验证：448 个真实 Chrome 几何、命中与滚动检查通过；面板 608 PASS / 1 skip，脚本契约 114 PASS / 74 平台 skip，bundle 一致，[三项 CI 全通过](https://github.com/JUNKDOGE-JOE/after-effects-mcp/actions/runs/33940667255)。独立审查两轮，最终 APPROVE，0 阻塞 / 0 随访。

**HDEV: development-verified** — Windows AE 26.3x87 + CEP/host 0.10.6，实际 280×300 / 420×480。面板经公开 ae_toolUse 创建文本层，ae_read 验证 0 → 1，AE 原生 Undo 后再次验证 0；长参数、结果、重复错误、中英文技能渲染与复制、库管理及 JSON 导入通过。29 次公开调用成功，另 1 次 runner 参数错误在分发前被拒绝并纠正。完整机器摘要见 #374 验证记录。

真实管理仅使用验收工件；Clear candidates、候选沉淀和 JSX Skill 状态组合由隔离浏览器矩阵覆盖。唯一临时工程已归档，测试库工件已清理，AE 恢复干净空白工程。

关联 milestone 2 Next release (version TBD)，打包 T5/T6 尚待发布冻结。用户明确批准后已 squash 合并为 fceed08da7d19a3421365ef9015885095f85c213；Issue #374 已关闭。下一项 T4 已获本次明确授权。