### PR TITLE
feat(panel): discover Astra and show selected CLI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [未发布]
 
+- Codex 模型目录支持有界分页，并尊重隐藏状态；实际目录包含 GPT-6 Astra 时，新用户默认优先 Astra，推理强度与 Fast 使用 CLI 返回能力。保留每通道显式偏好及 OpenCode 自定义模型；目录失败、旧 CLI 和账号/路由未提供 Astra 分别提示。
+- 设置页显示所选 CLI 的真实路径、当前版和官方稳定版，提供匹配安装来源的可关闭更新提示。重新检测刷新版本与目录，聊天期间禁用重检；不自动安装或升级 CLI，已有进程继续服务当前会话。内置 OpenCode 需使用明确附带新版 runtime 的面板 Release。
 - 移除设置中的“AE 专家防错指导”开关及无效的外部环境变量配置入口。宿主默认防错指引与内置 Skill 保留，旧开关偏好不再影响新建面板会话。
 
 ### [0.10.6] — 2026-09-02
@@ -385,6 +387,8 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### [Unreleased]
 
+- Codex discovers all bounded model-list pages and respects hidden entries. When its live catalog includes GPT-6 Astra, new users prefer Astra with the CLI's reasoning and Fast capabilities. Saved channel preferences and custom OpenCode models remain intact; catalog failures, old CLIs and account/route limitations have distinct messages.
+- Settings show the selected CLI path, installed version and official stable version, with dismissible guidance for its installation source. Recheck refreshes versions and catalogs and is disabled during chat. No CLI is installed or upgraded automatically; running sessions keep their existing process. Bundled OpenCode requires a panel release explicitly containing a newer runtime.
 - Removed the expert-guidance switch from Settings and the ineffective external environment toggle. Default host guardrails and bundled skills remain available; the old panel preference no longer affects new panel conversations.
 
 ### [0.10.6] — 2026-09-02

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20409,6 +20409,114 @@
   init_cep_runtime_inject();
   var import_react20 = __toESM(require_react(), 1);
 
+  // src/lib/cliUpdates.js
+  init_cep_runtime_inject();
+  var ASTRA_CLI_BASELINE = "0.153.4";
+  var PACKAGES = { codex: "@openai/codex", subscription: "@anthropic-ai/claude-code", opencode: "opencode-ai" };
+  var DOCS = {
+    codex: "https://learn.chatgpt.com/docs/cli",
+    subscription: "https://code.claude.com/docs/en/setup",
+    opencode: "https://opencode.ai/docs/cli/#upgrade"
+  };
+  function compareVersions(left, right) {
+    const parse = (value) => /^(?:v)?(\d+)\.(\d+)\.(\d+)$/.exec(String(value || "").trim());
+    const a = parse(left), b = parse(right);
+    if (!a || !b) return null;
+    for (let i = 1; i <= 3; i += 1) {
+      if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
+    }
+    return 0;
+  }
+  function cliIdentity(executable, fs) {
+    var _a, _b, _c;
+    if (!(executable == null ? void 0 : executable.ok)) return null;
+    const path = executable.displayPath || executable.path;
+    let realPath = ((_a = executable.argsPrefix) == null ? void 0 : _a[0]) || executable.path;
+    try {
+      realPath = ((_b = fs == null ? void 0 : fs.realpathSync) == null ? void 0 : _b.call(fs, realPath)) || realPath;
+    } catch {
+    }
+    return {
+      path,
+      version: executable.version || "",
+      source: executable.source,
+      launchPath: executable.path,
+      realPath,
+      script: ((_c = executable.argsPrefix) == null ? void 0 : _c[0]) || ""
+    };
+  }
+  function cliUpdateGuide(backend, cli, lang = "zh") {
+    const en = lang === "en";
+    const paths = [cli == null ? void 0 : cli.path, cli == null ? void 0 : cli.realPath, cli == null ? void 0 : cli.script].join("/").replace(/\\/g, "/").toLowerCase();
+    let command = "", source = "standalone";
+    let url = DOCS[backend];
+    let detail = en ? "Use the original installation source to update this executable." : "\u8BF7\u6309\u6B64\u53EF\u6267\u884C\u6587\u4EF6\u7684\u539F\u5B89\u88C5\u6765\u6E90\u66F4\u65B0\u3002";
+    if (backend === "opencode" && (cli == null ? void 0 : cli.source) === "runtime") {
+      source = "bundled";
+      url = "https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases";
+      detail = en ? "Choose a panel release whose notes include a newer OpenCode runtime. Reinstalling the same panel version does not upgrade it." : "\u8BF7\u9009\u7528\u53D1\u884C\u8BF4\u660E\u660E\u786E\u9644\u5E26\u65B0\u7248 OpenCode runtime \u7684\u9762\u677F Release\u3002\u91CD\u88C5\u540C\u4E00\u9762\u677F\u7248\u672C\u4E0D\u4F1A\u5347\u7EA7\u5B83\u3002";
+    } else if (/\/openai\/codex\/bin\//.test(paths)) {
+      source = "desktop";
+      detail = en ? "Update the Codex desktop app that owns this executable." : "\u8BF7\u66F4\u65B0\u63D0\u4F9B\u6B64\u53EF\u6267\u884C\u6587\u4EF6\u7684 Codex \u684C\u9762\u5E94\u7528\u3002";
+    } else if (/\/winget\/(packages|links)\//.test(paths)) {
+      source = "winget";
+      if (backend === "subscription") command = "winget upgrade Anthropic.ClaudeCode";
+    } else if (/\/(cellar|caskroom)\/(codex|opencode|claude-code)(?:@latest)?\//.test(paths)) {
+      source = "homebrew";
+      const name = backend === "subscription" ? paths.includes("claude-code@latest") ? "claude-code@latest" : "claude-code" : backend;
+      command = "brew upgrade " + name;
+    } else if (/\/node_modules\//.test(paths)) {
+      source = paths.includes("/pnpm/") || paths.includes("/.pnpm/") ? "pnpm" : paths.includes("/bun/") ? "bun" : "npm";
+      command = source === "npm" ? `npm install -g ${PACKAGES[backend]}@latest` : `${source} add -g ${PACKAGES[backend]}@latest`;
+    } else if (backend === "subscription" && /\/\.local\/(bin\/claude|share\/claude\/)/.test(paths)) {
+      source = "native";
+      command = "claude update";
+    } else if (backend === "opencode" && /\/\.opencode\/bin\//.test(paths)) {
+      source = "native";
+      command = "opencode upgrade";
+    }
+    return { source, command, url, detail };
+  }
+  function createCliUpdateChecker({ requestJson, now = Date.now, timeoutMs = 8e3 }) {
+    const cache = /* @__PURE__ */ new Map();
+    return async (backend, cli, { force = false } = {}) => {
+      var _a;
+      const current = (cli == null ? void 0 : cli.version) || "";
+      if (!PACKAGES[backend] || !cli) return { status: "unknown", current };
+      let entry2 = cache.get(backend);
+      if (force || !entry2 || now() - entry2.checkedAt >= 864e5) {
+        let timer;
+        try {
+          const result = await Promise.race([
+            requestJson({ url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`, timeoutMs }),
+            new Promise((_, reject) => {
+              timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+            })
+          ]);
+          const latest = (_a = result.json) == null ? void 0 : _a.version;
+          if (!result.ok || compareVersions(latest, latest) === null) throw new Error("unknown stable version");
+          entry2 = { latest, checkedAt: now() };
+          cache.set(backend, entry2);
+        } catch {
+          return { status: "unknown", current };
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+      const comparison = compareVersions(current, entry2.latest);
+      return { ...entry2, current, status: comparison === null ? "unknown" : comparison < 0 ? "update" : "current" };
+    };
+  }
+  function codexCatalogNotice(probe, lang = "zh") {
+    var _a;
+    const en = lang === "en";
+    if (!probe) return en ? "Checking model catalog\u2026" : "\u6B63\u5728\u68C0\u67E5\u6A21\u578B\u76EE\u5F55\u2026";
+    if (probe.catalogStatus !== "complete") return en ? "Model catalog check failed; saved choices are retained. Recheck to confirm availability." : "\u6A21\u578B\u76EE\u5F55\u68C0\u67E5\u5931\u8D25\uFF0C\u5DF2\u4FDD\u7559\u539F\u6709\u9009\u62E9\uFF1B\u8BF7\u91CD\u65B0\u68C0\u6D4B\u4EE5\u786E\u8BA4\u53EF\u7528\u6027\u3002";
+    if ((_a = probe.models) == null ? void 0 : _a.some((m) => m.id === "gpt-6-astra" && !m.hidden)) return "";
+    if (compareVersions(probe.cliVersion, ASTRA_CLI_BASELINE) === -1) return en ? `Astra is absent from this old CLI catalog. Update Codex to ${ASTRA_CLI_BASELINE} or later, then recheck; other available models remain usable.` : `\u5F53\u524D\u65E7 CLI \u76EE\u5F55\u6CA1\u6709 Astra\u3002\u8BF7\u66F4\u65B0 Codex \u81F3 ${ASTRA_CLI_BASELINE} \u6216\u66F4\u9AD8\u7248\u672C\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u5176\u4ED6\u53EF\u7528\u6A21\u578B\u4ECD\u53EF\u4F7F\u7528\u3002`;
+    return en ? "This account or route does not list Astra as available. Choose a listed model." : "\u5F53\u524D\u8D26\u53F7\u6216\u8DEF\u7531\u672A\u5C06 Astra \u5217\u4E3A\u53EF\u7528\u6A21\u578B\uFF0C\u8BF7\u9009\u62E9\u76EE\u5F55\u5185\u7684\u6A21\u578B\u3002";
+  }
+
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
@@ -21207,7 +21315,7 @@
   function byteLength(value) {
     return Buffer.byteLength(String(value || ""), "utf8");
   }
-  function compareVersions(actual, minimum) {
+  function compareVersions2(actual, minimum) {
     const left = String(actual || "").match(/\d+(?:\.\d+){0,3}/);
     const right = String(minimum || "").match(/\d+(?:\.\d+){0,3}/);
     if (!left || !right) return null;
@@ -21784,7 +21892,7 @@
       const versionMatch = output.match(/\d+(?:\.\d+){0,3}/);
       const version = versionMatch ? versionMatch[0] : null;
       if (options.minimumVersion) {
-        const compared = compareVersions(version, options.minimumVersion);
+        const compared = compareVersions2(version, options.minimumVersion);
         if (compared === null || compared < 0) {
           attempts.push({ path: candidate.displayPath, source: candidate.source, detail: "version " + (version || "unknown") + " is below " + options.minimumVersion });
           return { failure: "VERSION_TOO_OLD" };
@@ -22731,19 +22839,9 @@
       defaultModelId: "gpt-5.6-sol",
       defaultEffort: "medium",
       supportsFast: (modelId) => CODEX_STATIC_FAST_MODEL_IDS.has(String(modelId || "")),
+      catalogVerified: false,
       approvalModes: APPROVAL_MODES,
       perTurnModelSwitch: true
-    };
-  }
-  function mergeCodexOfficialLoginModels(descriptor) {
-    const models = Array.isArray(descriptor == null ? void 0 : descriptor.models) ? descriptor.models : [];
-    const present = new Set(models.map((model) => model == null ? void 0 : model.id).filter(Boolean));
-    const missing = codexOfficialLogin56Models().filter((model) => !present.has(model.id));
-    const supportsFast = typeof (descriptor == null ? void 0 : descriptor.supportsFast) === "function" ? descriptor.supportsFast : () => false;
-    return {
-      ...descriptor,
-      models: missing.length ? [...models, ...missing] : models,
-      supportsFast: (modelId) => CODEX_OFFICIAL_LOGIN_56_MODEL_IDS.has(String(modelId || "")) || supportsFast(modelId)
     };
   }
   function modelListArray(modelListResult) {
@@ -22753,30 +22851,30 @@
   }
   function codexDescriptorFromModels(modelListResult) {
     var _a;
-    const rawModels = modelListArray(modelListResult).filter((model) => (model == null ? void 0 : model.hidden) !== true);
-    if (!rawModels.length) return codexStaticDescriptor();
+    const rawModels = modelListArray(modelListResult).filter((model) => (model == null ? void 0 : model.id) && model.hidden !== true);
     const fastModels = /* @__PURE__ */ new Set();
     const models = rawModels.map((model) => {
       const id = String(model.id || "");
-      if (Array.isArray(model.additionalSpeedTiers) && model.additionalSpeedTiers.includes("fast")) {
+      if (Array.isArray(model.additionalSpeedTiers) && model.additionalSpeedTiers.includes("fast") || Array.isArray(model.serviceTiers) && model.serviceTiers.some((tier) => (tier == null ? void 0 : tier.id) === "priority")) {
         fastModels.add(id);
       }
       return {
         id,
         label: model.displayName || model.display_name || id,
         effortLevels: Array.isArray(model.supportedReasoningEfforts) ? model.supportedReasoningEfforts.map((effort) => effort == null ? void 0 : effort.reasoningEffort).filter(Boolean) : [],
+        defaultEffort: model.defaultReasoningEffort,
         cost: 2,
         adaptive: false
       };
     }).filter((model) => model.id);
-    if (!models.length) return codexStaticDescriptor();
-    const defaultRaw = rawModels.find((model) => (model == null ? void 0 : model.isDefault) === true) || rawModels[0];
-    const defaultModelId = (defaultRaw == null ? void 0 : defaultRaw.id) ? String(defaultRaw.id) : models[0].id;
+    const defaultRaw = rawModels.find((model) => model.id === "gpt-6-astra") || rawModels.find((model) => model.isDefault === true) || rawModels[0];
+    const defaultModelId = (defaultRaw == null ? void 0 : defaultRaw.id) ? String(defaultRaw.id) : "";
     const defaultEffort = (defaultRaw == null ? void 0 : defaultRaw.defaultReasoningEffort) || ((_a = models.find((model) => model.id === defaultModelId)) == null ? void 0 : _a.effortLevels[0]) || "medium";
     return {
       id: "codex",
       label: "Codex",
       models,
+      catalogVerified: true,
       defaultModelId,
       defaultEffort,
       supportsFast: (modelId) => fastModels.has(String(modelId || "")),
@@ -23175,6 +23273,7 @@
     onLoginChannel,
     loginState = null,
     recheckDisabled = false,
+    cliStatus = {},
     providerManager = null,
     providerInit = { state: "checking", error: "" },
     logLevel = "info",
@@ -23245,6 +23344,7 @@
           providerInitMessage,
           providerInit.detail || providerInit.error ? ` (${providerInit.detail || providerInit.error})` : ""
         ] }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(CliUpdateStatus, { backend, lang, ...cliStatus, onOpenExternal: handleExternalLink }),
         providerManager,
         /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.modelDefault, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Select, { value: model, onChange: onModelChange, options: modelOptions || FALLBACK_MODEL_OPTIONS }) })
       ] }),
@@ -23331,6 +23431,51 @@
           /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", icon: "rotate-cw", onClick: onRerunWizard, children: t.rerunWizard })
         ] })
       ] })
+    ] });
+  }
+  function CliUpdateStatus({ backend, probe, update, notice, lang = "zh", onOpenExternal }) {
+    const en = lang === "en";
+    const cli = probe == null ? void 0 : probe.cli;
+    const guide = cliUpdateGuide(backend, cli, lang);
+    const key = "ae_mcp_cli_dismiss_" + backend;
+    const identity = `${(cli == null ? void 0 : cli.path) || ""}:${(update == null ? void 0 : update.latest) || ""}`;
+    const [dismissed, setDismissed] = import_react20.default.useState("");
+    import_react20.default.useEffect(() => {
+      try {
+        setDismissed(window.localStorage.getItem(key) || "");
+      } catch {
+      }
+    }, [key]);
+    const newer = (update == null ? void 0 : update.status) === "update" && dismissed !== identity;
+    const running = probe == null ? void 0 : probe.runningCli;
+    const changed = running && (running.version !== (cli == null ? void 0 : cli.version) || running.path !== (cli == null ? void 0 : cli.path));
+    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { role: "status", style: { font: "400 11px/1.5 var(--font-ui)", color: "var(--text-secondary)", overflowWrap: "anywhere" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { children: [
+        en ? "Selected CLI" : "\u6240\u9009 CLI",
+        ": ",
+        (cli == null ? void 0 : cli.version) || (en ? "Unknown" : "\u672A\u77E5"),
+        " \xB7 ",
+        guide.source
+      ] }),
+      (cli == null ? void 0 : cli.path) ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { fontFamily: "var(--font-mono)" }, children: cli.path }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: (update == null ? void 0 : update.status) === "checking" ? en ? "Checking stable version\u2026" : "\u6B63\u5728\u68C0\u67E5\u7A33\u5B9A\u7248\u2026" : (update == null ? void 0 : update.status) === "unknown" || !update ? en ? "Stable version unknown; chat is unaffected." : "\u7A33\u5B9A\u7248\u672A\u77E5\uFF0C\u4E0D\u5F71\u54CD\u804A\u5929\u3002" : `${en ? "Upstream stable" : "\u4E0A\u6E38\u7A33\u5B9A\u7248"}: ${update.latest}` }),
+      changed ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: en ? `This session still runs ${running.version}. Start a new conversation to use the updated CLI.` : `\u5F53\u524D\u4F1A\u8BDD\u4ECD\u8FD0\u884C ${running.version}\uFF1B\u65B0\u5EFA\u5BF9\u8BDD\u540E\u4F7F\u7528\u66F4\u65B0\u7684 CLI\u3002` }) : null,
+      notice ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: notice }) : null,
+      newer ? /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { marginTop: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: en ? `Update available: ${update.current} \u2192 ${update.latest}` : `\u6709\u53EF\u7528\u66F4\u65B0\uFF1A${update.current} \u2192 ${update.latest}` }),
+        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: guide.detail }),
+        guide.command ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("code", { children: guide.command }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6, flexWrap: "wrap", marginTop: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", size: "sm", onClick: () => onOpenExternal(guide.url), children: en ? "Update guide" : "\u66F4\u65B0\u6307\u5F15" }),
+          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
+            setDismissed(identity);
+            try {
+              window.localStorage.setItem(key, identity);
+            } catch {
+            }
+          }, children: en ? "Dismiss" : "\u5173\u95ED\u63D0\u9192" })
+        ] })
+      ] }) : null
     ] });
   }
 
@@ -29434,7 +29579,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     if (adapter.id === "windows-x64") return "x64";
     return void 0;
   }
-  function compareVersions2(actual, minimum) {
+  function compareVersions3(actual, minimum) {
     const left = String(actual || "").match(/\d+(?:\.\d+){0,3}/);
     const right = String(minimum || "").match(/\d+(?:\.\d+){0,3}/);
     if (!left || !right) return null;
@@ -30408,7 +30553,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           return false;
         }
         const minimumCliVersion = minimumCliVersionForModel(session.model);
-        const versionComparison = minimumCliVersion ? compareVersions2(resolved.version, minimumCliVersion) : null;
+        const versionComparison = minimumCliVersion ? compareVersions3(resolved.version, minimumCliVersion) : null;
         if (minimumCliVersion && (versionComparison === null || versionComparison < 0)) {
           const classification = classifyErrorCode({ code: "CLI_TOO_OLD" });
           emitAfterText({
@@ -30737,7 +30882,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        resolve(result);
+        resolve({ ...result, cli: cliIdentity(resolved.executable, adapter.fs) });
       }
       const timer = setTimeout(() => {
         if (proc && proc.kill) {
@@ -31983,13 +32128,14 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       const spawnEnv = currentEnv();
       let cliInfo = { ok: false, cliPath: "", version: "" };
       try {
-        cliInfo = lastCliInfo || await resolveCli({ env: spawnEnv, platform: adapter });
-        lastCliInfo = cliInfo;
+        cliInfo = await resolveCli({ env: spawnEnv, platform: adapter });
       } catch (e) {
       }
       const diag = {
         cliPath: cliInfo.cliPath || "",
         cliVersion: cliInfo.version || "",
+        cli: cliIdentity(cliInfo.executable, adapter.fs),
+        runningCli: proc ? cliIdentity(lastCliInfo == null ? void 0 : lastCliInfo.executable, adapter.fs) : null,
         codexHome: codexHomePath(),
         platformId: adapter.id || ""
       };
@@ -32035,9 +32181,31 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         }, PROBE_INITIALIZE_TIMEOUT_MS, "initialize");
         const accountResult = await boundedProbeRequest(probeRpc, "account/read", {}, PROBE_ACCOUNT_READ_TIMEOUT_MS, "account/read");
         let models = null;
+        let catalogStatus = "failed";
         try {
-          const listed = await boundedProbeRequest(probeRpc, "model/list", {}, PROBE_MODEL_LIST_TIMEOUT_MS, "model/list");
-          models = Array.isArray(listed) ? listed : Array.isArray(listed == null ? void 0 : listed.models) ? listed.models : listed == null ? void 0 : listed.data;
+          const all = /* @__PURE__ */ new Map(), cursors = /* @__PURE__ */ new Set();
+          const deadline = Date.now() + PROBE_MODEL_LIST_TIMEOUT_MS;
+          let cursor;
+          for (let page = 0; page < 10; page += 1) {
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) throw new Error("model/list deadline");
+            const listed = await boundedProbeRequest(probeRpc, "model/list", {
+              limit: 100,
+              includeHidden: false,
+              ...cursor ? { cursor } : {}
+            }, remaining, "model/list");
+            const data2 = Array.isArray(listed) ? listed : (listed == null ? void 0 : listed.models) || (listed == null ? void 0 : listed.data);
+            if (!Array.isArray(data2) || data2.some((m) => !m || typeof m.id !== "string" || !m.id)) throw new Error("Invalid model/list");
+            for (const model of data2) all.set(model.id, model);
+            cursor = listed.nextCursor;
+            if (!cursor) {
+              models = [...all.values()];
+              catalogStatus = "complete";
+              break;
+            }
+            if (typeof cursor !== "string" || cursors.has(cursor)) throw new Error("Invalid model/list cursor");
+            cursors.add(cursor);
+          }
         } catch (e) {
           models = null;
         }
@@ -32047,6 +32215,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           runtimeOk: true,
           detail: accountResult && accountResult.requiresOpenaiAuth ? "OpenAI auth required" : void 0,
           models,
+          catalogStatus,
           ...diag
         } : {
           loggedIn: true,
@@ -32054,6 +32223,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           email: account.email,
           planType: account.planType,
           models,
+          catalogStatus,
           ...diag
         };
         if (containsExactSecret(result, probeSecrets())) {
@@ -32821,6 +32991,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     const currentLang = () => (typeof getLang === "function" ? getLang() : lang) || "zh";
     const currentHostGeneration = String(hostGeneration || PANEL_HOST_GENERATION);
     let proc = null;
+    let runningCli = null;
     let port = null;
     let baseUrl = "";
     let configHome = "";
@@ -33576,6 +33747,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         writeInstanceMarker(startHome, spawnedProc, startPort);
         assertCurrentStart();
         proc = spawnedProc;
+        runningCli = cliIdentity(executable, adapter.fs);
         port = startPort;
         baseUrl = startBaseUrl;
         configHome = startHome;
@@ -34268,7 +34440,12 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           })(),
           timeout
         ]);
-        return { loggedIn: true, providers };
+        const requiredArch = adapter.id === "macos-arm64" ? "arm64" : adapter.id === "windows-x64" ? "x64" : void 0;
+        const selected = await adapter.resolveExecutable("opencode", {
+          env: adapter.completeSpawnEnv(currentEnv(), { XDG_CONFIG_HOME: configHome }),
+          ...requiredArch ? { requiredArch } : {}
+        });
+        return { loggedIn: true, providers, cli: cliIdentity(selected, adapter.fs), runningCli };
       } catch (e) {
         if (timedOut) {
           if (!activeRun) reset();
@@ -35475,15 +35652,16 @@ ${command}`
     backendPref = "subscription",
     baseDescriptor,
     codexCachedModels = null,
+    preferredModel = "",
     openCodeProviders = []
   }) {
     if (backendPref === "codex" || effectiveBackend === "codex") {
       if (codexCachedModels) {
-        return mergeCodexOfficialLoginModels(
-          codexDescriptorFromModels({ models: codexCachedModels })
-        );
+        return codexDescriptorFromModels({ models: codexCachedModels });
       }
-      return mergeCodexOfficialLoginModels(baseDescriptor || codexStaticDescriptor());
+      const fallback = baseDescriptor || codexStaticDescriptor();
+      if (!preferredModel || fallback.models.some((m) => m.id === preferredModel)) return fallback;
+      return { ...fallback, models: [...fallback.models, { id: preferredModel, label: preferredModel, effortLevels: [] }] };
     }
     if (backendPref === "opencode" || effectiveBackend === "opencode") {
       const providers = {};
@@ -37798,7 +37976,7 @@ ${command}`
     const resolved = resolveModelPreference({
       channelValue: readPref(key, ""),
       legacyValue,
-      fallback
+      fallback: channel === "codex" ? "" : fallback
     });
     if (resolved.migrateLegacy) writePref(key, resolved.value);
     if (legacyValue) removePref(LEGACY_MODEL_PREF_KEY);
@@ -37991,7 +38169,28 @@ ${command}`
     const [openCodeProbeStale, setOpenCodeProbeStale] = import_react48.default.useState(false);
     const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = import_react48.default.useState(0);
     const openCodeProbeRunRef = import_react48.default.useRef(0);
-    const openCodeAvailableProviders = import_react48.default.useMemo(() => Array.isArray(openCodeProbe == null ? void 0 : openCodeProbe.providers) && openCodeProbe.providers.length ? openCodeProbe.providers : providers, [openCodeProbe, providers]);
+    const openCodeAvailableProviders = import_react48.default.useMemo(() => {
+      var _a;
+      const merged = new Map(providers.map((p) => [p.id, p]));
+      for (const p of (openCodeProbe == null ? void 0 : openCodeProbe.providers) || []) {
+        merged.set(p.id, { ...p, modelIds: [.../* @__PURE__ */ new Set([...((_a = merged.get(p.id)) == null ? void 0 : _a.modelIds) || [], ...p.modelIds])] });
+      }
+      return [...merged.values()];
+    }, [openCodeProbe, providers]);
+    const selectedProbe = backendPref === "codex" ? codexProbe : backendPref === "opencode" ? openCodeProbe : probe;
+    const checkCliUpdate = import_react48.default.useMemo(() => createCliUpdateChecker({ requestJson: platform.requestJson }), [platform]);
+    const [cliUpdate, setCliUpdate] = import_react48.default.useState(null);
+    const [cliRecheck, setCliRecheck] = import_react48.default.useState(0);
+    import_react48.default.useEffect(() => {
+      let alive = true;
+      setCliUpdate({ status: "checking" });
+      if (selectedProbe) checkCliUpdate(backendPref, selectedProbe.cli, { force: cliRecheck > 0 }).then((result) => {
+        if (alive) setCliUpdate(result);
+      });
+      return () => {
+        alive = false;
+      };
+    }, [backendPref, selectedProbe, checkCliUpdate, cliRecheck]);
     const [chatEntries, setChatEntries] = import_react48.default.useState([]);
     const chatEntriesRef = import_react48.default.useRef(chatEntries);
     chatEntriesRef.current = chatEntries;
@@ -38006,12 +38205,19 @@ ${command}`
     );
     const [descriptor, setDescriptor] = import_react48.default.useState(() => baseDescriptor);
     const requestedModel = sessionModel || model;
-    const effectiveModel = descriptor.models.some((m) => m.id === requestedModel) ? requestedModel : descriptor.defaultModelId || descriptor.models[0] && descriptor.models[0].id || requestedModel;
+    const effectiveModel = reconcileModelPref(requestedModel, descriptor) || requestedModel;
+    const catalogEmpty = descriptor.catalogVerified && !descriptor.models.length;
+    const fallbackNotice = requestedModel && requestedModel !== effectiveModel && readPref(modelPreferenceKey(backendPref), "") === requestedModel ? lang === "en" ? `${requestedModel} is absent from this catalog; using ${effectiveModel}. Your saved preference is retained.` : `\u5F53\u524D\u76EE\u5F55\u4E0D\u542B ${requestedModel}\uFF0C\u6682\u7528 ${effectiveModel}\uFF1B\u539F\u6709\u504F\u597D\u5DF2\u4FDD\u7559\u3002` : "";
+    const modelNotice = [
+      backendPref === "codex" ? codexCatalogNotice(codexProbe, lang) : "",
+      fallbackNotice,
+      catalogEmpty ? lang === "en" ? "No visible models are available. Recheck in Settings." : "\u76EE\u5F55\u4E2D\u6CA1\u6709\u53EF\u89C1\u6A21\u578B\uFF0C\u8BF7\u5728\u8BBE\u7F6E\u4E2D\u91CD\u65B0\u68C0\u6D4B\u3002" : ""
+    ].filter(Boolean).join(" ");
     const modelMeta = descriptor.models.find((m) => m.id === effectiveModel) || descriptor.models[0] || {};
     const effectiveEffort = resolveEffectiveEffort({
       requested: sessionEffort,
       model: modelMeta,
-      defaultEffort: descriptor.defaultEffort
+      defaultEffort: modelMeta.defaultEffort || descriptor.defaultEffort
     });
     const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
     const providerManager = /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
@@ -38438,17 +38644,11 @@ ${draft.baseUrl}`)) return;
         backendPref,
         baseDescriptor,
         codexCachedModels: codexModels,
+        preferredModel: requestedModel,
         openCodeProviders: openCodeAvailableProviders
       };
       const nextDescriptor = selectDescriptor(facts);
       setDescriptor(nextDescriptor);
-      const reconciled = reconcileModelPref(model, nextDescriptor, {
-        providerFactsPending: backendPref === "codex" ? codexProbe === null || codexModels === null : backendPref === "opencode" && (providerInit.state !== "ready" || openCodeProbe === null)
-      });
-      if (reconciled !== model) {
-        setModel(reconciled);
-        writePref(modelPreferenceKey(backendPref), reconciled);
-      }
     }, [
       effective.backend,
       effective.channel,
@@ -38459,6 +38659,7 @@ ${draft.baseUrl}`)) return;
       openCodeAvailableProviders,
       openCodeProbe,
       model,
+      requestedModel,
       providerInit.state
     ]);
     const lastRealBackendRef = import_react48.default.useRef(null);
@@ -38490,7 +38691,6 @@ ${draft.baseUrl}`)) return;
     const runCodexProbe = import_react48.default.useCallback(() => {
       let alive = true;
       setCodexProbe(null);
-      setCodexModels(null);
       codexBackend.probeAccount().then((result) => {
         if (!alive) return;
         if (containsExactSecret(result, ["aemcp-secret://"])) {
@@ -38504,7 +38704,6 @@ ${draft.baseUrl}`)) return;
         }
       }).catch((e) => {
         if (alive) {
-          setCodexModels(null);
           setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
         }
       });
@@ -38703,7 +38902,7 @@ ${draft.baseUrl}`)) return;
     ]);
     const sendChat = (input) => {
       var _a;
-      if (pendingTurnRef.current) return;
+      if (pendingTurnRef.current || catalogEmpty) return;
       let turn;
       try {
         turn = normalizeTurnInput(input);
@@ -39083,7 +39282,7 @@ ${draft.baseUrl}`)) return;
       { id: "settings", icon: "settings", label: t.settings }
     ];
     const backendDisabledHint = effective.fixHint && (effective.fixHint[lang] || effective.fixHint.zh) || (effective.reason && effective.reason.endsWith("-probing") ? lang === "zh" ? "\u6B63\u5728\u68C0\u6D4B\u51ED\u636E\u901A\u9053\u2026" : "Checking credential channels\u2026" : "");
-    const composerDisabled = paused || effective.backend === "none" || Boolean(hostConversationError);
+    const composerDisabled = paused || effective.backend === "none" || Boolean(hostConversationError) || catalogEmpty;
     const modelOptions = descriptor.models.map((m) => ({ value: m.id, label: `${m.label} ${costBadge(m.cost)}` }));
     const activeSessionMeta = sessionSnapshot.sessions.find(
       (meta) => meta.id === sessionSnapshot.activeId
@@ -39121,7 +39320,7 @@ ${draft.baseUrl}`)) return;
             sessionTitle,
             onOpenSessions: () => setSessionsOpen(true),
             composerDisabled,
-            disabledHint: hostConversationError ? t.approvalSyncError : paused ? t.pausedHint : composerDisabled ? backendDisabledHint : "",
+            disabledHint: hostConversationError ? t.approvalSyncError : paused ? t.pausedHint : catalogEmpty ? modelNotice : composerDisabled ? backendDisabledHint : fallbackNotice,
             noticeActionLabel: paused ? t.resume : t.goSettings,
             onNoticeAction: () => paused ? togglePause() : setTab("settings"),
             onSend: sendChat,
@@ -39225,6 +39424,8 @@ ${draft.baseUrl}`)) return;
             onLoginChannel,
             loginState,
             onRecheckBackend: () => {
+              if (chatStreaming || pendingTurnRef.current) return;
+              setCliRecheck((value) => value + 1);
               if (backendPref === "codex") runCodexProbe();
               else if (backendPref === "opencode") {
                 if (openCodeProbe === null && openCodeProbeStale && !chatStreaming) {
@@ -39233,7 +39434,8 @@ ${draft.baseUrl}`)) return;
                 runOpenCodeProbe();
               } else runClaudeProbe();
             },
-            recheckDisabled: backendPref === "codex" ? codexProbe === null : backendPref === "opencode" ? openCodeProbe === null && !openCodeProbeStale : probe === null,
+            cliStatus: { probe: selectedProbe, update: cliUpdate, notice: modelNotice },
+            recheckDisabled: chatStreaming || (backendPref === "codex" ? codexProbe === null : backendPref === "opencode" ? openCodeProbe === null && !openCodeProbeStale : probe === null),
             providers,
             providerManager,
             providerInit,

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -25,6 +25,7 @@ import { firstErrorDetailLine, serializeErrorDetail } from '../lib/errorDetail.j
 import { createMcpClient } from '../cep/mcpClient';
 import { createToolsApi } from '../cep/toolsApi';
 import { probeClaudeLogin } from '../cep/claudeAuth';
+import { createCliUpdateChecker, codexCatalogNotice } from '../lib/cliUpdates.js';
 import { startCodexLogin } from '../cep/codexHeadlessLogin.js';
 import { createClaudeAgentBackend } from '../cep/claudeAgentBackend';
 import { createCodexBackend } from '../cep/codexBackend';
@@ -159,7 +160,7 @@ function loadModelPref(channel, fallback) {
   const resolved = resolveModelPreference({
     channelValue: readPref(key, ''),
     legacyValue,
-    fallback,
+    fallback: channel === 'codex' ? '' : fallback,
   });
   if (resolved.migrateLegacy) writePref(key, resolved.value);
   if (legacyValue) removePref(LEGACY_MODEL_PREF_KEY);
@@ -366,11 +367,25 @@ function Shell({ cs }) {
   const [openCodeProbeStale, setOpenCodeProbeStale] = React.useState(false);
   const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = React.useState(0);
   const openCodeProbeRunRef = React.useRef(0);
-  const openCodeAvailableProviders = React.useMemo(() => (
-    Array.isArray(openCodeProbe?.providers) && openCodeProbe.providers.length
-      ? openCodeProbe.providers
-      : providers
-  ), [openCodeProbe, providers]);
+  const openCodeAvailableProviders = React.useMemo(() => {
+    const merged = new Map(providers.map((p) => [p.id, p]));
+    for (const p of openCodeProbe?.providers || []) {
+      merged.set(p.id, { ...p, modelIds: [...new Set([...(merged.get(p.id)?.modelIds || []), ...p.modelIds])] });
+    }
+    return [...merged.values()];
+  }, [openCodeProbe, providers]);
+  const selectedProbe = backendPref === 'codex' ? codexProbe : backendPref === 'opencode' ? openCodeProbe : probe;
+  const checkCliUpdate = React.useMemo(() => createCliUpdateChecker({ requestJson: platform.requestJson }), [platform]);
+  const [cliUpdate, setCliUpdate] = React.useState(null);
+  const [cliRecheck, setCliRecheck] = React.useState(0);
+  React.useEffect(() => {
+    let alive = true;
+    setCliUpdate({ status: 'checking' });
+    if (selectedProbe) checkCliUpdate(backendPref, selectedProbe.cli, { force: cliRecheck > 0 }).then((result) => {
+      if (alive) setCliUpdate(result);
+    });
+    return () => { alive = false; };
+  }, [backendPref, selectedProbe, checkCliUpdate, cliRecheck]);
   const [chatEntries, setChatEntries] = React.useState([]);
   const chatEntriesRef = React.useRef(chatEntries);
   chatEntriesRef.current = chatEntries;
@@ -385,9 +400,14 @@ function Shell({ cs }) {
   );
   const [descriptor, setDescriptor] = React.useState(() => baseDescriptor);
   const requestedModel = sessionModel || model;
-  const effectiveModel = descriptor.models.some((m) => m.id === requestedModel)
-    ? requestedModel
-    : (descriptor.defaultModelId || (descriptor.models[0] && descriptor.models[0].id) || requestedModel);
+  const effectiveModel = reconcileModelPref(requestedModel, descriptor) || requestedModel;
+  const catalogEmpty = descriptor.catalogVerified && !descriptor.models.length;
+  const fallbackNotice = requestedModel && requestedModel !== effectiveModel
+    && readPref(modelPreferenceKey(backendPref), '') === requestedModel
+    ? (lang === 'en' ? `${requestedModel} is absent from this catalog; using ${effectiveModel}. Your saved preference is retained.`
+      : `当前目录不含 ${requestedModel}，暂用 ${effectiveModel}；原有偏好已保留。`) : '';
+  const modelNotice = [backendPref === 'codex' ? codexCatalogNotice(codexProbe, lang) : '', fallbackNotice,
+    catalogEmpty ? (lang === 'en' ? 'No visible models are available. Recheck in Settings.' : '目录中没有可见模型，请在设置中重新检测。') : ''].filter(Boolean).join(' ');
   const modelMeta = descriptor.models.find((m) => m.id === effectiveModel) || descriptor.models[0] || {};
   // Reconcile against the SELECTED model, not just the backend: a session
   // effort chosen for one model must not survive a switch to a model with a
@@ -396,7 +416,7 @@ function Shell({ cs }) {
   const effectiveEffort = resolveEffectiveEffort({
     requested: sessionEffort,
     model: modelMeta,
-    defaultEffort: descriptor.defaultEffort,
+    defaultEffort: modelMeta.defaultEffort || descriptor.defaultEffort,
   });
   const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
   const providerManager = (
@@ -820,25 +840,11 @@ function Shell({ cs }) {
       backendPref,
       baseDescriptor,
       codexCachedModels: codexModels,
+      preferredModel: requestedModel,
       openCodeProviders: openCodeAvailableProviders,
     };
     const nextDescriptor = selectDescriptor(facts);
     setDescriptor(nextDescriptor);
-    // A persisted model id can outlive its backend or model catalog. Reset it
-    // when the current model isn't in the new descriptor's model list — but
-    // never while the OpenCode provider registry is still loading: the static
-    // fallback descriptor would clobber a valid provider-model pref at boot
-    // (live-seen: pref reset to the first relay model on every restart).
-    const reconciled = reconcileModelPref(model, nextDescriptor, {
-      providerFactsPending: backendPref === 'codex'
-        ? codexProbe === null || codexModels === null
-        : backendPref === 'opencode'
-          && (providerInit.state !== 'ready' || openCodeProbe === null),
-    });
-    if (reconciled !== model) {
-      setModel(reconciled);
-      writePref(modelPreferenceKey(backendPref), reconciled);
-    }
   }, [
     effective.backend,
     effective.channel,
@@ -849,6 +855,7 @@ function Shell({ cs }) {
     openCodeAvailableProviders,
     openCodeProbe,
     model,
+    requestedModel,
     providerInit.state,
   ]);
   const lastRealBackendRef = React.useRef(null);
@@ -881,7 +888,6 @@ function Shell({ cs }) {
   const runCodexProbe = React.useCallback(() => {
     let alive = true;
     setCodexProbe(null);
-    setCodexModels(null);
     codexBackend.probeAccount().then((result) => {
       if (!alive) return;
       if (containsExactSecret(result, ['aemcp-secret://'])) {
@@ -895,7 +901,6 @@ function Shell({ cs }) {
       }
     }).catch((e) => {
       if (alive) {
-        setCodexModels(null);
         setCodexProbe({ loggedIn: false, detail: e && e.message ? e.message : String(e) });
       }
     });
@@ -1117,7 +1122,7 @@ function Shell({ cs }) {
   ]);
 
   const sendChat = (input) => {
-    if (pendingTurnRef.current) return;
+    if (pendingTurnRef.current || catalogEmpty) return;
     let turn;
     try {
       turn = normalizeTurnInput(input);
@@ -1530,7 +1535,7 @@ function Shell({ cs }) {
     || (effective.reason && effective.reason.endsWith('-probing')
       ? (lang === 'zh' ? '正在检测凭据通道…' : 'Checking credential channels…')
       : '');
-  const composerDisabled = paused || effective.backend === 'none' || Boolean(hostConversationError);
+  const composerDisabled = paused || effective.backend === 'none' || Boolean(hostConversationError) || catalogEmpty;
   const modelOptions = descriptor.models.map((m) => ({ value: m.id, label: `${m.label} ${costBadge(m.cost)}` }));
   const activeSessionMeta = sessionSnapshot.sessions.find(
     (meta) => meta.id === sessionSnapshot.activeId,
@@ -1568,7 +1573,7 @@ function Shell({ cs }) {
             composerDisabled={composerDisabled}
             disabledHint={hostConversationError
               ? t.approvalSyncError
-              : paused ? t.pausedHint : composerDisabled ? backendDisabledHint : ''}
+              : paused ? t.pausedHint : catalogEmpty ? modelNotice : composerDisabled ? backendDisabledHint : fallbackNotice}
             noticeActionLabel={paused ? t.resume : t.goSettings}
             onNoticeAction={() => (paused ? togglePause() : setTab('settings'))}
             onSend={sendChat}
@@ -1669,6 +1674,8 @@ function Shell({ cs }) {
             onLoginChannel={onLoginChannel}
             loginState={loginState}
             onRecheckBackend={() => {
+              if (chatStreaming || pendingTurnRef.current) return;
+              setCliRecheck((value) => value + 1);
               if (backendPref === 'codex') runCodexProbe();
               else if (backendPref === 'opencode') {
                 if (openCodeProbe === null && openCodeProbeStale && !chatStreaming) {
@@ -1678,9 +1685,10 @@ function Shell({ cs }) {
               }
               else runClaudeProbe();
             }}
-            recheckDisabled={backendPref === 'codex'
+            cliStatus={{ probe: selectedProbe, update: cliUpdate, notice: modelNotice }}
+            recheckDisabled={chatStreaming || (backendPref === 'codex'
               ? codexProbe === null : backendPref === 'opencode'
-                ? openCodeProbe === null && !openCodeProbeStale : probe === null}
+                ? openCodeProbe === null && !openCodeProbeStale : probe === null)}
             providers={providers}
             providerManager={providerManager}
             providerInit={providerInit}

--- a/plugin/panel/src/cep/claudeAuth.js
+++ b/plugin/panel/src/cep/claudeAuth.js
@@ -1,6 +1,7 @@
 import { claudeChannelEnv } from '../lib/claudeChannel.js';
 import { createPlatformAdapter } from './platform/index.js';
 import { resolveClaudeCli } from './claudeAgentBackend.js';
+import { cliIdentity } from '../lib/cliUpdates.js';
 
 export async function probeClaudeLogin({
   platform,
@@ -34,7 +35,7 @@ export async function probeClaudeLogin({
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(result);
+      resolve({ ...result, cli: cliIdentity(resolved.executable, adapter.fs) });
     }
 
     const timer = setTimeout(() => {

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -1,4 +1,5 @@
 import { createNdjsonReader } from '../lib/ndjson.js';
+import { cliIdentity } from '../lib/cliUpdates.js';
 import {
   containsExactSecret,
   createDeltaRedactor,
@@ -1141,12 +1142,13 @@ export function createCodexBackend({
     const spawnEnv = currentEnv();
     let cliInfo = { ok: false, cliPath: '', version: '' };
     try {
-      cliInfo = lastCliInfo || await resolveCli({ env: spawnEnv, platform: adapter });
-      lastCliInfo = cliInfo;
+      cliInfo = await resolveCli({ env: spawnEnv, platform: adapter });
     } catch (e) { /* diagnostics only, never blocks the probe */ }
     const diag = {
       cliPath: cliInfo.cliPath || '',
       cliVersion: cliInfo.version || '',
+      cli: cliIdentity(cliInfo.executable, adapter.fs),
+      runningCli: proc ? cliIdentity(lastCliInfo?.executable, adapter.fs) : null,
       codexHome: codexHomePath(),
       platformId: adapter.id || '',
     };
@@ -1188,11 +1190,25 @@ export function createCodexBackend({
       }, PROBE_INITIALIZE_TIMEOUT_MS, 'initialize');
       const accountResult = await boundedProbeRequest(probeRpc, 'account/read', {}, PROBE_ACCOUNT_READ_TIMEOUT_MS, 'account/read');
       let models = null;
+      let catalogStatus = 'failed';
       try {
-        const listed = await boundedProbeRequest(probeRpc, 'model/list', {}, PROBE_MODEL_LIST_TIMEOUT_MS, 'model/list');
-        models = Array.isArray(listed)
-          ? listed
-          : (Array.isArray(listed?.models) ? listed.models : listed?.data);
+        const all = new Map(), cursors = new Set();
+        const deadline = Date.now() + PROBE_MODEL_LIST_TIMEOUT_MS;
+        let cursor;
+        for (let page = 0; page < 10; page += 1) {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) throw new Error('model/list deadline');
+          const listed = await boundedProbeRequest(probeRpc, 'model/list', {
+            limit: 100, includeHidden: false, ...(cursor ? { cursor } : {}),
+          }, remaining, 'model/list');
+          const data = Array.isArray(listed) ? listed : listed?.models || listed?.data;
+          if (!Array.isArray(data) || data.some((m) => !m || typeof m.id !== 'string' || !m.id)) throw new Error('Invalid model/list');
+          for (const model of data) all.set(model.id, model);
+          cursor = listed.nextCursor;
+          if (!cursor) { models = [...all.values()]; catalogStatus = 'complete'; break; }
+          if (typeof cursor !== 'string' || cursors.has(cursor)) throw new Error('Invalid model/list cursor');
+          cursors.add(cursor);
+        }
       } catch (e) {
         // Non-fatal: a stuck/slow model/list (e.g. a relay whose upstream
         // stream disconnects) must not fail the whole probe.
@@ -1204,6 +1220,7 @@ export function createCodexBackend({
         runtimeOk: true,
         detail: accountResult && accountResult.requiresOpenaiAuth ? 'OpenAI auth required' : undefined,
         models,
+        catalogStatus,
         ...diag,
       } : {
         loggedIn: true,
@@ -1211,6 +1228,7 @@ export function createCodexBackend({
         email: account.email,
         planType: account.planType,
         models,
+        catalogStatus,
         ...diag,
       };
       if (containsExactSecret(result, probeSecrets())) {

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -1,4 +1,5 @@
 import { createSseParser } from '../lib/sse.js';
+import { cliIdentity } from '../lib/cliUpdates.js';
 import { openCodeCatalogId } from '../lib/openCodeCatalogId.js';
 import { createPlatformAdapter } from './platform/index.js';
 import { createDeltaRedactor, redactValue } from '../lib/exactSecretRedaction.js';
@@ -384,6 +385,7 @@ export function createOpenCodeBackend({
   const currentLang = () => (typeof getLang === 'function' ? getLang() : lang) || 'zh';
   const currentHostGeneration = String(hostGeneration || PANEL_HOST_GENERATION);
   let proc = null;
+  let runningCli = null;
   let port = null;
   let baseUrl = '';
   let configHome = '';
@@ -1184,6 +1186,7 @@ export function createOpenCodeBackend({
       writeInstanceMarker(startHome, spawnedProc, startPort);
       assertCurrentStart();
       proc = spawnedProc;
+      runningCli = cliIdentity(executable, adapter.fs);
       port = startPort;
       baseUrl = startBaseUrl;
       configHome = startHome;
@@ -1932,7 +1935,11 @@ export function createOpenCodeBackend({
         })(),
         timeout,
       ]);
-      return { loggedIn: true, providers };
+      const requiredArch = adapter.id === 'macos-arm64' ? 'arm64' : (adapter.id === 'windows-x64' ? 'x64' : undefined);
+      const selected = await adapter.resolveExecutable('opencode', {
+        env: adapter.completeSpawnEnv(currentEnv(), { XDG_CONFIG_HOME: configHome }), ...(requiredArch ? { requiredArch } : {}),
+      });
+      return { loggedIn: true, providers, cli: cliIdentity(selected, adapter.fs), runningCli };
     } catch (e) {
       if (timedOut) {
         if (!activeRun) reset();

--- a/plugin/panel/src/lib/backendCapabilities.js
+++ b/plugin/panel/src/lib/backendCapabilities.js
@@ -2,8 +2,7 @@
 // these, with no hardcoded model ids or tier names elsewhere.
 //
 // Claude ids are the API aliases (no date suffixes); the CLI passes them
-// through unchanged. The default stays on Opus 5, which every current CLI
-// accepts.
+// through unchanged. Account access is still decided by the selected CLI.
 export const CLAUDE_PRICE_USD_PER_MTOK = {
   'claude-fable-5-1': { input: 10, output: 50 },
   'claude-opus-5': { input: 5, output: 25 },
@@ -146,23 +145,9 @@ export function codexStaticDescriptor() {
     defaultModelId: 'gpt-5.6-sol',
     defaultEffort: 'medium',
     supportsFast: (modelId) => CODEX_STATIC_FAST_MODEL_IDS.has(String(modelId || '')),
+    catalogVerified: false,
     approvalModes: APPROVAL_MODES,
     perTurnModelSwitch: true,
-  };
-}
-
-export function mergeCodexOfficialLoginModels(descriptor) {
-  const models = Array.isArray(descriptor?.models) ? descriptor.models : [];
-  const present = new Set(models.map((model) => model?.id).filter(Boolean));
-  const missing = codexOfficialLogin56Models().filter((model) => !present.has(model.id));
-  const supportsFast = typeof descriptor?.supportsFast === 'function'
-    ? descriptor.supportsFast
-    : () => false;
-  return {
-    ...descriptor,
-    models: missing.length ? [...models, ...missing] : models,
-    supportsFast: (modelId) => CODEX_OFFICIAL_LOGIN_56_MODEL_IDS.has(String(modelId || ''))
-      || supportsFast(modelId),
   };
 }
 
@@ -174,14 +159,13 @@ function modelListArray(modelListResult) {
 }
 
 export function codexDescriptorFromModels(modelListResult) {
-  const rawModels = modelListArray(modelListResult).filter((model) => model?.hidden !== true);
-  if (!rawModels.length) return codexStaticDescriptor();
+  const rawModels = modelListArray(modelListResult).filter((model) => model?.id && model.hidden !== true);
 
   const fastModels = new Set();
   const models = rawModels.map((model) => {
     const id = String(model.id || '');
-    if (Array.isArray(model.additionalSpeedTiers)
-        && model.additionalSpeedTiers.includes('fast')) {
+    if ((Array.isArray(model.additionalSpeedTiers) && model.additionalSpeedTiers.includes('fast'))
+        || (Array.isArray(model.serviceTiers) && model.serviceTiers.some((tier) => tier?.id === 'priority'))) {
       fastModels.add(id);
     }
     return {
@@ -191,14 +175,15 @@ export function codexDescriptorFromModels(modelListResult) {
         ? model.supportedReasoningEfforts.map((effort) => effort?.reasoningEffort)
           .filter(Boolean)
         : [],
+      defaultEffort: model.defaultReasoningEffort,
       cost: 2,
       adaptive: false,
     };
   }).filter((model) => model.id);
 
-  if (!models.length) return codexStaticDescriptor();
-  const defaultRaw = rawModels.find((model) => model?.isDefault === true) || rawModels[0];
-  const defaultModelId = defaultRaw?.id ? String(defaultRaw.id) : models[0].id;
+  const defaultRaw = rawModels.find((model) => model.id === 'gpt-6-astra')
+    || rawModels.find((model) => model.isDefault === true) || rawModels[0];
+  const defaultModelId = defaultRaw?.id ? String(defaultRaw.id) : '';
   const defaultEffort = defaultRaw?.defaultReasoningEffort
     || models.find((model) => model.id === defaultModelId)?.effortLevels[0]
     || 'medium';
@@ -206,6 +191,7 @@ export function codexDescriptorFromModels(modelListResult) {
     id: 'codex',
     label: 'Codex',
     models,
+    catalogVerified: true,
     defaultModelId,
     defaultEffort,
     supportsFast: (modelId) => fastModels.has(String(modelId || '')),

--- a/plugin/panel/src/lib/cliUpdates.js
+++ b/plugin/panel/src/lib/cliUpdates.js
@@ -1,0 +1,98 @@
+export const ASTRA_CLI_BASELINE = '0.153.4';
+const PACKAGES = { codex: '@openai/codex', subscription: '@anthropic-ai/claude-code', opencode: 'opencode-ai' };
+const DOCS = {
+  codex: 'https://learn.chatgpt.com/docs/cli',
+  subscription: 'https://code.claude.com/docs/en/setup',
+  opencode: 'https://opencode.ai/docs/cli/#upgrade',
+};
+
+export function compareVersions(left, right) {
+  const parse = (value) => /^(?:v)?(\d+)\.(\d+)\.(\d+)$/.exec(String(value || '').trim());
+  const a = parse(left), b = parse(right);
+  if (!a || !b) return null;
+  for (let i = 1; i <= 3; i += 1) {
+    if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
+  }
+  return 0;
+}
+
+export function cliIdentity(executable, fs) {
+  if (!executable?.ok) return null;
+  const path = executable.displayPath || executable.path;
+  let realPath = executable.argsPrefix?.[0] || executable.path;
+  try { realPath = fs?.realpathSync?.(realPath) || realPath; } catch {}
+  return { path, version: executable.version || '', source: executable.source,
+    launchPath: executable.path, realPath, script: executable.argsPrefix?.[0] || '' };
+}
+
+export function cliUpdateGuide(backend, cli, lang = 'zh') {
+  const en = lang === 'en';
+  const paths = [cli?.path, cli?.realPath, cli?.script].join('/').replace(/\\/g, '/').toLowerCase();
+  let command = '', source = 'standalone';
+  let url = DOCS[backend];
+  let detail = en ? 'Use the original installation source to update this executable.' : '请按此可执行文件的原安装来源更新。';
+  if (backend === 'opencode' && cli?.source === 'runtime') {
+    source = 'bundled';
+    url = 'https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases';
+    detail = en ? 'Choose a panel release whose notes include a newer OpenCode runtime. Reinstalling the same panel version does not upgrade it.'
+      : '请选用发行说明明确附带新版 OpenCode runtime 的面板 Release。重装同一面板版本不会升级它。';
+  } else if (/\/openai\/codex\/bin\//.test(paths)) {
+    source = 'desktop';
+    detail = en ? 'Update the Codex desktop app that owns this executable.' : '请更新提供此可执行文件的 Codex 桌面应用。';
+  } else if (/\/winget\/(packages|links)\//.test(paths)) {
+    source = 'winget';
+    if (backend === 'subscription') command = 'winget upgrade Anthropic.ClaudeCode';
+  } else if (/\/(cellar|caskroom)\/(codex|opencode|claude-code)(?:@latest)?\//.test(paths)) {
+    source = 'homebrew';
+    const name = backend === 'subscription' ? (paths.includes('claude-code@latest') ? 'claude-code@latest' : 'claude-code') : backend;
+    command = 'brew upgrade ' + name;
+  } else if (/\/node_modules\//.test(paths)) {
+    source = paths.includes('/pnpm/') || paths.includes('/.pnpm/') ? 'pnpm' : paths.includes('/bun/') ? 'bun' : 'npm';
+    command = source === 'npm' ? `npm install -g ${PACKAGES[backend]}@latest` : `${source} add -g ${PACKAGES[backend]}@latest`;
+  } else if (backend === 'subscription' && /\/\.local\/(bin\/claude|share\/claude\/)/.test(paths)) {
+    source = 'native'; command = 'claude update';
+  } else if (backend === 'opencode' && /\/\.opencode\/bin\//.test(paths)) {
+    source = 'native'; command = 'opencode upgrade';
+  }
+  return { source, command, url, detail };
+}
+
+export function createCliUpdateChecker({ requestJson, now = Date.now, timeoutMs = 8000 }) {
+  const cache = new Map();
+  return async (backend, cli, { force = false } = {}) => {
+    const current = cli?.version || '';
+    if (!PACKAGES[backend] || !cli) return { status: 'unknown', current };
+    let entry = cache.get(backend);
+    if (force || !entry || now() - entry.checkedAt >= 86400000) {
+      let timer;
+      try {
+        const result = await Promise.race([
+          requestJson({ url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`, timeoutMs }),
+          new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('timeout')), timeoutMs); }),
+        ]);
+        const latest = result.json?.version;
+        if (!result.ok || compareVersions(latest, latest) === null) throw new Error('unknown stable version');
+        entry = { latest, checkedAt: now() };
+        cache.set(backend, entry);
+      } catch {
+        return { status: 'unknown', current };
+      } finally { clearTimeout(timer); }
+    }
+    const comparison = compareVersions(current, entry.latest);
+    return { ...entry, current, status: comparison === null ? 'unknown' : comparison < 0 ? 'update' : 'current' };
+  };
+}
+
+export function codexCatalogNotice(probe, lang = 'zh') {
+  const en = lang === 'en';
+  if (!probe) return en ? 'Checking model catalog…' : '正在检查模型目录…';
+  if (probe.catalogStatus !== 'complete') return en
+    ? 'Model catalog check failed; saved choices are retained. Recheck to confirm availability.'
+    : '模型目录检查失败，已保留原有选择；请重新检测以确认可用性。';
+  if (probe.models?.some((m) => m.id === 'gpt-6-astra' && !m.hidden)) return '';
+  if (compareVersions(probe.cliVersion, ASTRA_CLI_BASELINE) === -1) return en
+    ? `Astra is absent from this old CLI catalog. Update Codex to ${ASTRA_CLI_BASELINE} or later, then recheck; other available models remain usable.`
+    : `当前旧 CLI 目录没有 Astra。请更新 Codex 至 ${ASTRA_CLI_BASELINE} 或更高版本后重新检测；其他可用模型仍可使用。`;
+  return en ? 'This account or route does not list Astra as available. Choose a listed model.'
+    : '当前账号或路由未将 Astra 列为可用模型，请选择目录内的模型。';
+}

--- a/plugin/panel/src/lib/descriptorSelect.js
+++ b/plugin/panel/src/lib/descriptorSelect.js
@@ -3,7 +3,6 @@
 import {
   codexStaticDescriptor,
   codexDescriptorFromModels,
-  mergeCodexOfficialLoginModels,
   openCodeDescriptorFromModels,
 } from './backendCapabilities.js';
 
@@ -12,15 +11,16 @@ export function selectDescriptor({
   backendPref = 'subscription',
   baseDescriptor,
   codexCachedModels = null,
+  preferredModel = '',
   openCodeProviders = [],
 }) {
   if (backendPref === 'codex' || effectiveBackend === 'codex') {
     if (codexCachedModels) {
-      return mergeCodexOfficialLoginModels(
-        codexDescriptorFromModels({ models: codexCachedModels }),
-      );
+      return codexDescriptorFromModels({ models: codexCachedModels });
     }
-    return mergeCodexOfficialLoginModels(baseDescriptor || codexStaticDescriptor());
+    const fallback = baseDescriptor || codexStaticDescriptor();
+    if (!preferredModel || fallback.models.some((m) => m.id === preferredModel)) return fallback;
+    return { ...fallback, models: [...fallback.models, { id: preferredModel, label: preferredModel, effortLevels: [] }] };
   }
   if (backendPref === 'opencode' || effectiveBackend === 'opencode') {
     const providers = {};

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cliUpdateGuide } from '../lib/cliUpdates.js';
 import pkg from '../../package.json';
 import { Badge } from '../components/core/Badge';
 import { Button } from '../components/core/Button';
@@ -316,6 +317,7 @@ export function SettingsScreen({
   onLoginChannel,
   loginState = null,
   recheckDisabled = false,
+  cliStatus = {},
   providerManager = null,
   providerInit = { state: 'checking', error: '' },
   logLevel = 'info',
@@ -389,6 +391,7 @@ export function SettingsScreen({
             {providerInitMessage}{providerInit.detail || providerInit.error ? ` (${providerInit.detail || providerInit.error})` : ''}
           </div>
         ) : null}
+        <CliUpdateStatus backend={backend} lang={lang} {...cliStatus} onOpenExternal={handleExternalLink} />
         {providerManager}
         <Field label={t.modelDefault}>
           <Select value={model} onChange={onModelChange} options={modelOptions || FALLBACK_MODEL_OPTIONS} />
@@ -493,6 +496,45 @@ export function SettingsScreen({
           <Button variant="ghost" size="sm" icon="rotate-cw" onClick={onRerunWizard}>{t.rerunWizard}</Button>
         </div>
       </Section>
+    </div>
+  );
+}
+
+export function CliUpdateStatus({ backend, probe, update, notice, lang = 'zh', onOpenExternal }) {
+  const en = lang === 'en';
+  const cli = probe?.cli;
+  const guide = cliUpdateGuide(backend, cli, lang);
+  const key = 'ae_mcp_cli_dismiss_' + backend;
+  const identity = `${cli?.path || ''}:${update?.latest || ''}`;
+  const [dismissed, setDismissed] = React.useState('');
+  React.useEffect(() => {
+    try { setDismissed(window.localStorage.getItem(key) || ''); } catch {}
+  }, [key]);
+  const newer = update?.status === 'update' && dismissed !== identity;
+  const running = probe?.runningCli;
+  const changed = running && (running.version !== cli?.version || running.path !== cli?.path);
+  return (
+    <div role="status" style={{ font: '400 11px/1.5 var(--font-ui)', color: 'var(--text-secondary)', overflowWrap: 'anywhere' }}>
+      <div>{en ? 'Selected CLI' : '所选 CLI'}: {cli?.version || (en ? 'Unknown' : '未知')} · {guide.source}</div>
+      {cli?.path ? <div style={{ fontFamily: 'var(--font-mono)' }}>{cli.path}</div> : null}
+      <div>{update?.status === 'checking' ? (en ? 'Checking stable version…' : '正在检查稳定版…')
+        : update?.status === 'unknown' || !update ? (en ? 'Stable version unknown; chat is unaffected.' : '稳定版未知，不影响聊天。')
+          : `${en ? 'Upstream stable' : '上游稳定版'}: ${update.latest}`}</div>
+      {changed ? <div>{en ? `This session still runs ${running.version}. Start a new conversation to use the updated CLI.`
+        : `当前会话仍运行 ${running.version}；新建对话后使用更新的 CLI。`}</div> : null}
+      {notice ? <div>{notice}</div> : null}
+      {newer ? <div style={{ marginTop: 6 }}>
+        <div>{en ? `Update available: ${update.current} → ${update.latest}` : `有可用更新：${update.current} → ${update.latest}`}</div>
+        <div>{guide.detail}</div>
+        {guide.command ? <code>{guide.command}</code> : null}
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
+          <Button variant="secondary" size="sm" onClick={() => onOpenExternal(guide.url)}>{en ? 'Update guide' : '更新指引'}</Button>
+          <Button variant="ghost" size="sm" onClick={() => {
+            setDismissed(identity);
+            try { window.localStorage.setItem(key, identity); } catch {}
+          }}>{en ? 'Dismiss' : '关闭提醒'}</Button>
+        </div>
+      </div> : null}
     </div>
   );
 }

--- a/plugin/panel/test/backendCapabilities.test.js
+++ b/plugin/panel/test/backendCapabilities.test.js
@@ -8,7 +8,6 @@ import {
   codexDescriptorFromModels,
   codexStaticDescriptor,
   costTier,
-  mergeCodexOfficialLoginModels,
   openCodeDescriptorFromModels,
   resolveEffectiveEffort,
 } from '../src/lib/backendCapabilities.js';
@@ -59,9 +58,7 @@ test('Codex static fallback mirrors the official login inventory', () => {
   assert.equal(descriptor.supportsFast('gpt-5.5'), true);
   assert.equal(descriptor.supportsFast('gpt-5.4-mini'), false);
   assert.equal(descriptor.supportsFast('gpt-5.3-codex-spark'), false);
-  // Merging the official models into the static list must not duplicate them.
-  const merged = mergeCodexOfficialLoginModels(descriptor);
-  assert.equal(merged.models.length, descriptor.models.length);
+  assert.equal(descriptor.catalogVerified, false);
 });
 
 test('Codex model-list data preserves capability metadata', () => {
@@ -101,10 +98,22 @@ test('Codex model-list accepts the app-server data envelope', () => {
   assert.equal(descriptor.supportsFast('gpt-5.6-luna'), true);
 });
 
-test('Codex login descriptor fills the official 5.6 models', () => {
-  const merged = mergeCodexOfficialLoginModels(codexStaticDescriptor());
-  assert.ok(merged.models.some((model) => model.id === 'gpt-5.6-terra'));
-  assert.equal(merged.supportsFast('gpt-5.6-terra'), true);
+test('Astra is preferred only when visible, with reasoning and Fast from the CLI', () => {
+  const astra = { id: 'gpt-6-astra', displayName: 'GPT-6 Astra', defaultReasoningEffort: 'high',
+    supportedReasoningEfforts: ['low', 'high', 'ultra'].map((reasoningEffort) => ({ reasoningEffort })),
+    serviceTiers: [{ id: 'priority' }] };
+  const d = codexDescriptorFromModels([{ id: 'gpt-5.6-sol', isDefault: true }, astra]);
+  assert.equal(d.defaultModelId, astra.id);
+  assert.equal(d.defaultEffort, 'high');
+  assert.equal(d.models[1].label, 'GPT-6 Astra');
+  assert.deepEqual(d.models[1].effortLevels, ['low', 'high', 'ultra']);
+  assert.equal(d.supportsFast(astra.id), true);
+  assert.equal(codexDescriptorFromModels([{ ...astra, serviceTiers: [] }]).supportsFast(astra.id), false);
+  const hidden = codexDescriptorFromModels([{ ...astra, hidden: true }]);
+  assert.deepEqual(hidden.models, []);
+  assert.equal(hidden.defaultModelId, '');
+  assert.equal(hidden.catalogVerified, true);
+  assert.deepEqual(codexDescriptorFromModels([]).models, []);
 });
 
 test('OpenCode descriptor qualifies third-party models with their provider id', () => {
@@ -133,4 +142,83 @@ test('effective effort stays compatible with the selected model', () => {
     'medium',
   );
   assert.equal(resolveEffectiveEffort({ requested: 'high', model: { effortLevels: [] } }), null);
+});
+
+import { cliIdentity, cliUpdateGuide, compareVersions, createCliUpdateChecker, codexCatalogNotice } from '../src/lib/cliUpdates.js';
+
+test('stable versions compare numerically and unknown or prerelease stays unknown', () => {
+  assert.equal(compareVersions('0.99.9', '0.153.4'), -1);
+  assert.equal(compareVersions('v1.2.3', '1.2.3'), 0);
+  assert.equal(compareVersions('1.2.4', '1.2.3'), 1);
+  for (const value of ['', 'unknown', '1.2.3-beta.1', '1.2', 'codex 1.2.3']) {
+    assert.equal(compareVersions(value, '1.2.3'), null);
+  }
+});
+
+test('update checks cache only successful stable results and recheck bypasses cache', async () => {
+  let calls = 0, version = '0.153.4', now = 100;
+  const check = createCliUpdateChecker({ now: () => now, requestJson: async (request) => {
+    calls += 1;
+    assert.equal(request.url, 'https://registry.npmjs.org/@openai/codex/latest');
+    return { ok: true, json: { version } };
+  } });
+  assert.equal((await check('codex', { version: '0.144.1' })).status, 'update');
+  assert.equal((await check('codex', { version: '0.153.4' })).status, 'current');
+  assert.equal(calls, 1);
+  version = '0.154.0';
+  assert.equal((await check('codex', { version: '0.153.4' }, { force: true })).latest, version);
+  assert.equal(calls, 2);
+  now += 86400000;
+  assert.equal((await check('codex', { version: '0.155.0' })).status, 'current');
+  assert.equal(calls, 3);
+  assert.equal((await check('codex', { version: '' })).status, 'unknown');
+});
+
+test('offline, rate limits, malformed versions and hung requests cannot claim current', async () => {
+  for (const requestJson of [
+    async () => { throw new Error('offline'); },
+    async () => ({ ok: false, status: 429 }),
+    async () => ({ ok: true, json: { version: '0.154.0-beta.1' } }),
+    () => new Promise(() => {}),
+  ]) {
+    const check = createCliUpdateChecker({ requestJson, timeoutMs: 10 });
+    assert.equal((await check('codex', { version: '0.144.1' })).status, 'unknown');
+  }
+});
+
+test('update guidance follows the launched executable, including materialized npm shims', () => {
+  const cli = cliIdentity({ ok: true, path: 'C:/node.exe', displayPath: 'C:/npm/codex.cmd',
+    version: '0.144.1', argsPrefix: ['C:/npm/node_modules/@openai/codex/bin/codex.js'] });
+  assert.equal(cli.path, 'C:/npm/codex.cmd');
+  assert.equal(cli.launchPath, 'C:/node.exe');
+  assert.equal(cliUpdateGuide('codex', cli).command, 'npm install -g @openai/codex@latest');
+  const mac = cliIdentity({ ok: true, path: '/opt/homebrew/bin/node', argsPrefix: ['/opt/homebrew/bin/codex'] }, {
+    realpathSync: (path) => path.endsWith('/codex') ? '/opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js'
+      : '/opt/homebrew/Cellar/node/24.6.0/bin/node',
+  });
+  assert.equal(cliUpdateGuide('codex', mac).command, 'npm install -g @openai/codex@latest');
+  const cases = [
+    ['subscription', '/opt/homebrew/Caskroom/claude-code/2.1.1/claude', 'homebrew', 'brew upgrade claude-code'],
+    ['subscription', 'C:/Microsoft/WinGet/Packages/Anthropic.ClaudeCode/claude.exe', 'winget', 'winget upgrade Anthropic.ClaudeCode'],
+    ['subscription', '/home/test/.local/share/claude/versions/2.1.1', 'native', 'claude update'],
+    ['codex', 'C:/OpenAI/Codex/bin/123/codex.exe', 'desktop', ''],
+    ['opencode', '/home/test/.opencode/bin/opencode', 'native', 'opencode upgrade'],
+    ['codex', '/custom/tools/codex', 'standalone', ''],
+  ];
+  for (const [backend, path, source, command] of cases) {
+    const result = cliUpdateGuide(backend, { path });
+    assert.equal(result.source, source);
+    assert.equal(result.command, command);
+  }
+  const bundled = cliUpdateGuide('opencode', { source: 'runtime', path: '/panel/runtime/opencode' }, 'en');
+  assert.equal(bundled.command, '');
+  assert.match(bundled.detail, /same panel version does not upgrade/);
+  assert.match(bundled.url, /after-effects-mcp\/releases$/);
+});
+
+test('Astra absence distinguishes old CLI, account/route and failed catalog', () => {
+  assert.match(codexCatalogNotice({ catalogStatus: 'failed', cliVersion: '0.144.1' }, 'en'), /check failed/);
+  assert.match(codexCatalogNotice({ catalogStatus: 'complete', models: [], cliVersion: '0.144.1' }, 'en'), /old CLI/);
+  assert.match(codexCatalogNotice({ catalogStatus: 'complete', models: [], cliVersion: '0.153.4' }, 'en'), /account or route/);
+  assert.equal(codexCatalogNotice({ catalogStatus: 'complete', models: [{ id: 'gpt-6-astra' }] }), '');
 });

--- a/plugin/panel/test/claudeAuth.test.js
+++ b/plugin/panel/test/claudeAuth.test.js
@@ -66,6 +66,8 @@ test('probeClaudeLogin uses claude auth status and strips provider env', async (
 
   assert.deepEqual(await resultPromise, {
     loggedIn: true,
+    cli: { path: 'C:\\npm\\claude.cmd', version: '2.1.227', source: 'path', script: '',
+      launchPath: resolvedClaude().cliPath, realPath: resolvedClaude().cliPath },
     cliOk: true,
     cliVersion: '2.1.227',
     cliPath: 'C:\\npm\\claude.cmd',
@@ -93,6 +95,8 @@ test('probeClaudeLogin reports a valid CLI that is not logged in', async () => {
 
   assert.deepEqual(await resultPromise, {
     loggedIn: false,
+    cli: { path: 'C:\\npm\\claude.cmd', version: '2.1.227', source: 'path', script: '',
+      launchPath: resolvedClaude().cliPath, realPath: resolvedClaude().cliPath },
     cliOk: true,
     cliVersion: '2.1.227',
     cliPath: 'C:\\npm\\claude.cmd',

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -349,6 +349,62 @@ test('Codex account probes retain the real model/list data envelope', async () =
   assert.deepEqual(result.models, [{ id: 'gpt-5.6-luna' }]);
 });
 
+async function probePages(h, pages) {
+  const pending = h.backend.probeAccount();
+  await flush();
+  const proc = h.spawned.at(-1).proc;
+  proc.emit({ id: parseWrites(proc).at(-1).id, result: {} });
+  await flush();
+  proc.emit({ id: parseWrites(proc).at(-1).id, result: { account: { planType: 'pro' } } });
+  for (const page of pages) {
+    await flush();
+    const request = parseWrites(proc).at(-1);
+    assert.equal(request.method, 'model/list');
+    assert.equal(request.params.includeHidden, false);
+    proc.emit({ id: request.id, ...page });
+  }
+  return { result: await pending, proc };
+}
+
+test('Codex pagination retains Astra, de-duplicates and respects hidden metadata', async () => {
+  const h = makeBackend();
+  const { result, proc } = await probePages(h, [
+    { result: { data: [{ id: 'gpt-5.6-sol' }], nextCursor: 'page2' } },
+    { result: { data: [{ id: 'gpt-6-astra' }, { id: 'gpt-5.6-sol', hidden: true }], nextCursor: null } },
+  ]);
+  assert.equal(result.catalogStatus, 'complete');
+  assert.deepEqual(result.models, [{ id: 'gpt-5.6-sol', hidden: true }, { id: 'gpt-6-astra' }]);
+  assert.equal(parseWrites(proc).at(-1).params.cursor, 'page2');
+  assert.equal(proc.killCount, 1);
+});
+
+test('Codex partial failure, malformed page, cursor cycles and page limit fail the catalog only', async () => {
+  for (const pages of [
+    [{ result: { data: [], nextCursor: 'next' } }, { error: { code: -1, message: 'offline' } }],
+    [{ result: { unexpected: [] } }],
+    [{ result: { data: [], nextCursor: 'same' } }, { result: { data: [], nextCursor: 'same' } }],
+    Array.from({ length: 10 }, (_, i) => ({ result: { data: [{ id: 'gpt-5.6-sol' }], nextCursor: `page${i}` } })),
+  ]) {
+    const { result, proc } = await probePages(makeBackend(), pages);
+    assert.equal(result.catalogStatus, 'failed');
+    assert.equal(result.models, null);
+    assert.equal(result.loggedIn, true);
+    assert.equal(proc.killCount, 1);
+  }
+});
+
+test('Codex recheck resolves the updated executable without resetting the conversation', async () => {
+  let version = '0.144.1';
+  const h = makeBackend({ resolveExecutable: async () => ({ ok: true, path: 'C:/codex.exe', version }) });
+  const first = await probePages(h, [{ result: { data: [{ id: 'gpt-5.6-sol' }] } }]);
+  assert.equal(first.result.cli.version, version);
+  version = '0.153.4';
+  const second = await probePages(h, [{ result: { data: [{ id: 'gpt-6-astra' }] } }]);
+  assert.equal(second.result.cli.version, version);
+  assert.equal(second.result.models[0].id, 'gpt-6-astra');
+  assert.equal(h.spawned.length, 2);
+});
+
 test('Codex account probes return isolated-home diagnostics when login is required', async () => {
   const { backend, spawned } = makeBackend();
   const pending = backend.probeAccount();

--- a/plugin/panel/test/descriptorSelect.test.js
+++ b/plugin/panel/test/descriptorSelect.test.js
@@ -20,7 +20,29 @@ test('Codex uses its CLI model inventory when it is available', () => {
     codexCachedModels: [{ id: 'gpt-live', isDefault: true }],
   });
   assert.equal(descriptor.defaultModelId, 'gpt-live');
-  assert.ok(descriptor.models.some((model) => model.id === 'gpt-5.6-terra'));
+  assert.deepEqual(descriptor.models.map((m) => m.id), ['gpt-live']);
+});
+
+test('saved Codex choice survives missing facts and falls back only on a complete catalog', () => {
+  const input = { backendPref: 'codex', preferredModel: 'gpt-6-astra', baseDescriptor: codexStaticDescriptor() };
+  const unverified = selectDescriptor(input);
+  assert.equal(reconcileModelPref(input.preferredModel, unverified), 'gpt-6-astra');
+  assert.equal(unverified.supportsFast(input.preferredModel), false);
+  const complete = selectDescriptor({ ...input, codexCachedModels: [{ id: 'gpt-5.6-sol' }] });
+  assert.equal(reconcileModelPref(input.preferredModel, complete), 'gpt-5.6-sol');
+  const upgraded = selectDescriptor({ ...input, codexCachedModels: [{ id: 'gpt-5.6-sol' }, { id: 'gpt-6-astra' }] });
+  assert.equal(reconcileModelPref('', upgraded), 'gpt-6-astra');
+  assert.equal(reconcileModelPref('gpt-5.6-sol', upgraded), 'gpt-5.6-sol');
+});
+
+test('an empty Codex preference uses the offline Codex default then visible Astra', () => {
+  const pref = resolveModelPreference({ channelValue: null, legacyValue: null, fallback: '' });
+  const input = { backendPref: 'codex', preferredModel: pref.value, baseDescriptor: codexStaticDescriptor() };
+  const offline = selectDescriptor(input);
+  assert.equal(reconcileModelPref(pref.value, offline), 'gpt-5.6-sol');
+  assert.equal(offline.models.some((m) => m.id.startsWith('claude-')), false);
+  const live = selectDescriptor({ ...input, codexCachedModels: [{ id: 'gpt-6-astra' }] });
+  assert.equal(reconcileModelPref(pref.value, live), 'gpt-6-astra');
 });
 
 test('OpenCode derives models from the Provider Manager registry', () => {

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -229,8 +229,11 @@ const TOOL_META = {
   },
 };
 
+const OPEN_CODE_CLI = { path: 'C:\\Tools\\opencode.exe', launchPath: 'C:\\Tools\\opencode.exe',
+  realPath: 'C:\\Tools\\opencode.exe', source: 'path', script: '', version: '1.0.0' };
 const OPEN_CODE_PROBE = {
   loggedIn: true,
+  cli: OPEN_CODE_CLI, runningCli: OPEN_CODE_CLI,
   providers: [{ id: 'opencode', modelIds: ['hy3-free'], needsApiKey: false }],
 };
 
@@ -360,6 +363,21 @@ test('OpenCode decodes both child-process streams as UTF-8', async () => {
     ['stderr', 'utf8'],
   ]);
   h.backend.reset();
+});
+
+test('OpenCode recheck uses the same architecture and config environment as startup', async () => {
+  const resolutions = [];
+  const h = makeBackend({ resolveExecutable: async (_id, options) => {
+    resolutions.push(options);
+    return { ok: true, path: options.requiredArch === 'x64' ? 'C:/runtime/opencode.exe' : 'C:/arm64/opencode.exe',
+      source: 'runtime', version: '1.2.0' };
+  } });
+  try {
+    const result = await h.backend.probeAccount();
+    assert.equal(result.cli.path, 'C:/runtime/opencode.exe');
+    assert.deepEqual(result.cli, result.runningCli);
+    assert.deepEqual(resolutions[1], resolutions[0]);
+  } finally { h.backend.reset(); }
 });
 
 test('OpenCode does not terminate a stable marker owned by another live panel in the same host generation', async () => {

--- a/plugin/panel/test/sessionWiring.test.js
+++ b/plugin/panel/test/sessionWiring.test.js
@@ -57,9 +57,11 @@ test('OpenCode pending probes become retryable and stale rechecks reset idle run
   assert.match(APP, /openCodeProbe === null && !openCodeProbeStale/);
 });
 
-test('model preferences are channel-scoped and Codex waits for live model facts', () => {
+test('model preferences are channel-scoped and catalog fallbacks do not overwrite them', () => {
   assert.doesNotMatch(APP, /['"]ae_mcp_model['"]/);
-  assert.match(APP, /providerFactsPending:[\s\S]*backendPref === 'codex'[\s\S]*codexProbe === null[\s\S]*codexModels === null/);
+  assert.match(APP, /fallback: channel === 'codex' \? '' : fallback/);
+  assert.match(APP, /reconcileModelPref\(requestedModel, descriptor\)/);
+  assert.doesNotMatch(APP, /writePref\(modelPreferenceKey\(backendPref\), reconciled\)/);
 });
 
 test('model chips persist the selected model as the current channel default', () => {


### PR DESCRIPTION
When the selected Codex CLI lists Astra, the panel now prefers it for an unset or unavailable model selection and uses the live catalog's effort/Fast capabilities. Catalog failures retain explicit saved choices; successful live catalogs no longer receive static models that imply account access.

The selected Claude, Codex, or OpenCode route reports its actual executable/version and an asynchronous stable-version check with installation-specific update guidance, dismissal and manual recheck. It never installs software or restarts an active turn.

Refs #376; milestone 2. **development-verified on 4ca88a3a18fc11e0757a5fffd941bb7cd6f45d0c. User-authorized squash merge completed as 191eab3635c27c4a31e1cafc6a08932c9359468a.** No parent Epic was specified.

Validation:
- Independent review APPROVE. Three focused rounds: the first two found reproduced executable-identity and empty-Codex-preference blockers; the third verified the final fix.
- One committed-source T3: 1,046 passed / 93 platform or environment skips / 0 failed. Production bundle verified. One CI run: all 3 jobs passed, including real Node 15 and macOS packaging contracts.
- Chinese/English update UI: 280×300 and 420×480, 16 checks passed with production CSS (guide, dismiss persistence, new-version reappearance, overflow).
- One HDEV session: actual panel, existing Codex 0.153.3, two gpt-6-astra / medium turns in the same thread. Recheck disabled during execution and available afterward; idle recheck preserved the running thread.

| Public tool | Calls | Result | Observable evidence |
| --- | ---: | --- | --- |
| ae_status | 1 | PASS | Real AE 26.3x87; MCP 2025-06-18 |
| ae_read | 3 | PASS | Before 0 / after 1 / after Undo 0 |
| ae_skillUse | 1 | PASS | Execution guidance read |
| ae_exec | 1 | PASS | 0 → 1 text layer; native Undo; public readback 0 |
| ae_previewFrame | 1 | PASS | 640×360 PNG, 4,219 bytes received by Astra |

AE state, model transcript, received PNG and host MCP audit agree. Undo was executed through the native AE Edit menu, then independently read and verified by a second Astra ae_read call. Host/panel 0.10.6, CEP Node 17.7.2, AE 26.3x87, MCP 2025-06-18. This is the ExtendScript plane; no AEGP primitive was changed.

Selected-install checks: Codex 0.144.1 → stable 0.153.4 (npm, Astra absent); existing desktop Codex 0.153.3 exposed Astra while retaining saved Sol; Claude 2.1.257 → 2.1.261 and OpenCode 1.17.4 → 1.18.29 showed npm guidance. No CLI was installed or upgraded. The temporary desktop override was removed; the original Claude/Sonnet, Codex Sol and Chinese preferences were restored. The default system Codex remains 0.144.1 and requires a manual update to expose Astra.

Cleanup: 1 ephemeral .aep created and archived, 0 active/unclassified/canonical/evidence snapshots; 60,273 logical bytes moved by a same-volume metadata move (0 physical payload bytes copied or released). Test conversation archived and the single test-generated candidate removed. AE returned to an unmodified empty project.

Footprint: 16 committed files, 434 handwritten additions / 80 deletions: implementation 8 files (229/69), tests 6 (201/11), documentation 1 (4/0), generated app.js 1. No infrastructure, schema/configuration, version bump or release banner changes. Working tree clean.

Limits: actual chat used medium with Fast off; Fast/other effort options were verified from the live catalog and UI. Packaged T5/T6 remain pending; this is not release-accepted. Merged on 2026-09-05T04:16:32Z. No release was published; packaged T5/T6 remain pending.
