### PR TITLE
feat(panel): show tool preview images in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [未发布]
 
+- 面板启动时异步检查 GitHub 稳定 Release，成功结果缓存 24 小时；新版横幅可按版本关闭，“设置 → 关于”可手动检查及打开对应 Release。断网、超时、限流和无法比较的版本显示未知；不下载、安装或重启。
 - Codex 模型目录支持有界分页，并尊重隐藏状态；实际目录包含 GPT-6 Astra 时，新用户默认优先 Astra，推理强度与 Fast 使用 CLI 返回能力。保留每通道显式偏好及 OpenCode 自定义模型；目录失败、旧 CLI 和账号/路由未提供 Astra 分别提示。
 - 设置页显示所选 CLI 的真实路径、当前版和官方稳定版，提供匹配安装来源的可关闭更新提示。重新检测刷新版本与目录，聊天期间禁用重检；不自动安装或升级 CLI，已有进程继续服务当前会话。内置 OpenCode 需使用明确附带新版 runtime 的面板 Release。
 - 移除设置中的“AE 专家防错指导”开关及无效的外部环境变量配置入口。宿主默认防错指引与内置 Skill 保留，旧开关偏好不再影响新建面板会话。
@@ -387,6 +388,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### [Unreleased]
 
+- The panel asynchronously checks stable GitHub releases on startup and caches successful results for 24 hours. Dismiss a version's fixed banner, or manually check and open its release under Settings → About. Offline, timeout, rate-limit and unrecognized versions remain unknown; nothing is downloaded, installed or restarted.
 - Codex discovers all bounded model-list pages and respects hidden entries. When its live catalog includes GPT-6 Astra, new users prefer Astra with the CLI's reasoning and Fast capabilities. Saved channel preferences and custom OpenCode models remain intact; catalog failures, old CLIs and account/route limitations have distinct messages.
 - Settings show the selected CLI path, installed version and official stable version, with dismissible guidance for its installation source. Recheck refreshes versions and catalogs and is disabled during chat. No CLI is installed or upgraded automatically; running sessions keep their existing process. Bundled OpenCode requires a panel release explicitly containing a newer runtime.
 - Removed the expert-guidance switch from Settings and the ineffective external environment toggle. Default host guardrails and bundled skills remain available; the old panel preference no longer affects new panel conversations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [未发布]
 
+- 聊天工具卡片直接显示 Claude、Codex、OpenCode 返回的预览图片，支持查看大图、逐张切换与折叠参数/结果。会话只保存图片引用；本地图片缓存最多 64 MiB / 256 张，生成预览时清理 7 天前的缓存，失效或超限时明确提示。
 - Codex 模型目录支持有界分页，并尊重隐藏状态；实际目录包含 GPT-6 Astra 时，新用户默认优先 Astra，推理强度与 Fast 使用 CLI 返回能力。保留每通道显式偏好及 OpenCode 自定义模型；目录失败、旧 CLI 和账号/路由未提供 Astra 分别提示。
 - 设置页显示所选 CLI 的真实路径、当前版和官方稳定版，提供匹配安装来源的可关闭更新提示。重新检测刷新版本与目录，聊天期间禁用重检；不自动安装或升级 CLI，已有进程继续服务当前会话。内置 OpenCode 需使用明确附带新版 runtime 的面板 Release。
 - 移除设置中的“AE 专家防错指导”开关及无效的外部环境变量配置入口。宿主默认防错指引与内置 Skill 保留，旧开关偏好不再影响新建面板会话。
@@ -387,6 +388,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### [Unreleased]
 
+- Chat tool cards display preview images returned by Claude, Codex, and OpenCode, with a larger image view, image navigation, and collapsed parameters/results. Transcripts store references only; the local cache is capped at 64 MiB / 256 images and removes images older than seven days when capturing previews. Expired or oversized images show an explicit notice.
 - Codex discovers all bounded model-list pages and respects hidden entries. When its live catalog includes GPT-6 Astra, new users prefer Astra with the CLI's reasoning and Fast capabilities. Saved channel preferences and custom OpenCode models remain intact; catalog failures, old CLIs and account/route limitations have distinct messages.
 - Settings show the selected CLI path, installed version and official stable version, with dismissible guidance for its installation source. Recheck refreshes versions and catalogs and is disabled during chat. No CLI is installed or upgraded automatically; running sessions keep their existing process. Bundled OpenCode requires a panel release explicitly containing a newer runtime.
 - Removed the expert-guidance switch from Settings and the ineffective external environment toggle. Default host guardrails and bundled skills remain available; the old panel preference no longer affects new panel conversations.

--- a/plugin/client/dist/app.css
+++ b/plugin/client/dist/app.css
@@ -1210,6 +1210,34 @@ body {
   display: flex;
   flex-direction: column;
 }
+.panel-update-banner {
+  height: 24px;
+  flex: none;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  background: var(--info-bg);
+  border-bottom: 1px solid var(--border-default);
+  font: var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui);
+}
+.panel-update-banner > span {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.panel-update-banner > button {
+  flex: none;
+}
+.panel-update-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-wrap: anywhere;
+}
 .ae-attachment-pond {
   flex: none;
   min-width: 0;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -24940,6 +24940,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   // src/components/chat/ToolCallCard.jsx
   init_cep_runtime_inject();
   var import_react32 = __toESM(require_react(), 1);
+  var import_react_dom = __toESM(require_react_dom(), 1);
   var import_jsx_runtime30 = __toESM(require_jsx_runtime(), 1);
   function StatusGlyph({ status }) {
     if (status === "running") return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Spinner, { size: 12 });
@@ -24986,12 +24987,108 @@ When you are done, remind me of two things: MCP tools load only in a new session
       }
     );
   }
+  function PreviewImage({ image, lang, onOpen, large = false }) {
+    const [failed, setFailed] = import_react32.default.useState(false);
+    const reason = image.unavailable || (failed || !image.src ? "load" : "");
+    const messages = lang === "en" ? {
+      load: "Preview unavailable. The file may have expired or failed to load.",
+      limit: "Preview exceeds the display limit.",
+      format: "This image format cannot be displayed."
+    } : {
+      load: "\u9884\u89C8\u4E0D\u53EF\u7528\uFF0C\u6587\u4EF6\u53EF\u80FD\u5DF2\u5931\u6548\u6216\u52A0\u8F7D\u5931\u8D25\u3002",
+      limit: "\u9884\u89C8\u8D85\u51FA\u663E\u793A\u4E0A\u9650\u3002",
+      format: "\u65E0\u6CD5\u663E\u793A\u6B64\u56FE\u7247\u683C\u5F0F\u3002"
+    };
+    const preview = /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+      "img",
+      {
+        src: image.src,
+        alt: lang === "en" ? "Tool preview" : "\u5DE5\u5177\u9884\u89C8",
+        onError: () => setFailed(true),
+        style: { display: "block", width: "100%", height: large ? "calc(100vh - 112px)" : "min(240px, var(--tool-preview-max-height, 40vh))", objectFit: "contain" }
+      }
+    );
+    return reason ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { role: "status", style: { padding: 8, color: "var(--text-secondary)", fontSize: 12 }, children: messages[reason] || messages.load }) : onOpen ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+      "button",
+      {
+        type: "button",
+        title: lang === "en" ? "View larger image" : "\u67E5\u770B\u5927\u56FE",
+        onClick: onOpen,
+        style: { display: "block", width: "100%", border: 0, padding: 0, background: "transparent", cursor: "zoom-in" },
+        children: preview
+      }
+    ) : preview;
+  }
+  function ToolImages({ images, lang }) {
+    const [index, setIndex] = import_react32.default.useState(0);
+    const [open, setOpen] = import_react32.default.useState(false);
+    const inline = import_react32.default.useRef(null);
+    const dialog = import_react32.default.useRef(null);
+    const close = () => {
+      var _a, _b;
+      setOpen(false);
+      (_b = (_a = inline.current) == null ? void 0 : _a.querySelector("button")) == null ? void 0 : _b.focus();
+    };
+    import_react32.default.useEffect(() => {
+      var _a, _b;
+      if (open) (_b = (_a = dialog.current) == null ? void 0 : _a.querySelector("button")) == null ? void 0 : _b.focus();
+    }, [open]);
+    const dialogKey = (event) => {
+      var _a;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+      if (event.key !== "Tab") return;
+      const buttons = [...dialog.current.querySelectorAll("button:not(:disabled)")];
+      const next = (buttons.indexOf(document.activeElement) + (event.shiftKey ? -1 : 1) + buttons.length) % buttons.length;
+      event.preventDefault();
+      (_a = buttons[next]) == null ? void 0 : _a.focus();
+    };
+    const image = images[index];
+    const navigation = images.length > 1 ? /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("div", { style: { display: "flex", alignItems: "center", justifyContent: "center", gap: 8, padding: 4 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Button, { size: "sm", disabled: index === 0, onClick: () => setIndex(index - 1), title: lang === "en" ? "Previous image" : "\u4E0A\u4E00\u5F20", children: "\u2039" }),
+      /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("span", { style: { fontSize: 12 }, children: [
+        index + 1,
+        " / ",
+        images.length
+      ] }),
+      /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Button, { size: "sm", disabled: index === images.length - 1, onClick: () => setIndex(index + 1), title: lang === "en" ? "Next image" : "\u4E0B\u4E00\u5F20", children: "\u203A" })
+    ] }) : null;
+    return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("div", { ref: inline, "data-tool-images": true, style: { borderTop: "1px solid var(--border-subtle)", minWidth: 0 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+        PreviewImage,
+        {
+          image,
+          lang,
+          onOpen: () => setOpen(true)
+        },
+        `${index}:${image.src || image.unavailable}`
+      ),
+      navigation,
+      open ? (0, import_react_dom.createPortal)(
+        /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { ref: dialog, onKeyDown: dialogKey, style: { position: "fixed", inset: 0, zIndex: 100 }, children: /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(Drawer, { open: true, title: lang === "en" ? "Preview" : "\u9884\u89C8", onClose: close, closeTitle: lang === "en" ? "Close preview" : "\u5173\u95ED\u9884\u89C8", style: { maxHeight: "100%" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(PreviewImage, { image, lang, large: true }, `${index}:${image.src || image.unavailable}`),
+          navigation
+        ] }) }),
+        document.body
+      ) : null
+    ] });
+  }
   function HeaderRow({ status, verb, target, expandable, expanded, onToggle }) {
     const [hover, setHover] = import_react32.default.useState(false);
     return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
       "div",
       {
         role: expandable ? "button" : void 0,
+        tabIndex: expandable ? 0 : void 0,
+        "aria-expanded": expandable ? expanded : void 0,
+        onKeyDown: (event) => {
+          if (expandable && (event.key === "Enter" || event.key === " ")) {
+            event.preventDefault();
+            onToggle();
+          }
+        },
         onClick: expandable ? onToggle : void 0,
         onMouseEnter: () => setHover(true),
         onMouseLeave: () => setHover(false),
@@ -25044,6 +25141,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     errorMessage: errorMessage2,
     hint,
     details,
+    images,
+    lang = "zh",
     detailsLabel = "\u8BE6\u60C5",
     onRetry,
     steps,
@@ -25079,6 +25178,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
               onToggle: () => setExpanded(!expanded)
             }
           ),
+          (images == null ? void 0 : images.length) ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(ToolImages, { images, lang }, JSON.stringify(images)) : null,
           expanded && isGroup ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { style: { borderTop: "1px solid var(--border-subtle)", padding: "var(--space-1) 0" }, children: steps.map((s, i) => /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
             "div",
             {
@@ -27626,6 +27726,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
             target: toolTarget(entry2, t),
             status: statusForTool(entry2.state),
             params: entry2.input,
+            images: entry2.images,
+            lang,
+            details: entry2.text,
             errorMessage: entry2.state === "error" ? entry2.text : null
           }
         ),
@@ -27771,6 +27874,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
         const layout = layoutRef.current;
         const footer = footerRef.current;
         if (!layout || !footer) return;
+        const log = logRef.current;
+        if (log) log.style.setProperty("--tool-preview-max-height", `${Math.max(24, log.clientHeight - 24)}px`);
         const availableHeight = composerAvailableHeight({
           containerHeight: layout.getBoundingClientRect().height,
           footerHeight: footer.getBoundingClientRect().height,
@@ -27782,6 +27887,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       const observer = new ResizeObserver(measureComposerBounds);
       observer.observe(layoutRef.current);
       observer.observe(footerRef.current);
+      if (logRef.current) observer.observe(logRef.current);
       return () => observer.disconnect();
     }, []);
     const sendTurn = (textOverride) => {
@@ -28318,8 +28424,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     }, [port]);
     const load = import_react42.default.useCallback(async () => {
       if (!api) return;
-      const sequence = loadSequence.current + 1;
-      loadSequence.current = sequence;
+      const sequence2 = loadSequence.current + 1;
+      loadSequence.current = sequence2;
       setError("");
       try {
         if (mode === "skills") {
@@ -28329,7 +28435,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             const text = [skill.name, skill.description].join(" ").toLowerCase();
             return !needle || text.includes(needle);
           });
-          if (sequence === loadSequence.current) setItems(skills);
+          if (sequence2 === loadSequence.current) setItems(skills);
           return;
         }
         const toolPromise = query.trim() ? api.search({ query, limit: 100 }) : api.index({ limit: 100 });
@@ -28337,7 +28443,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           toolPromise,
           requestLibrary((libraryApi) => libraryApi.list())
         ]);
-        if (sequence !== loadSequence.current) return;
+        if (sequence2 !== loadSequence.current) return;
         if (toolResult.status === "rejected") throw toolResult.reason;
         const payload = toolResult.value || {};
         const management = libraryResult.status === "fulfilled" ? splitToolLibraryItems(libraryResult.value) : { candidates: [], artifacts: [] };
@@ -28353,7 +28459,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           });
         }
       } catch (cause) {
-        if (sequence === loadSequence.current) setError(cause.message || String(cause));
+        if (sequence2 === loadSequence.current) setError(cause.message || String(cause));
       }
     }, [api, mode, query, requestLibrary]);
     import_react42.default.useEffect(() => {
@@ -28372,20 +28478,20 @@ When you are done, remind me of two things: MCP tools load only in a new session
     };
     const select = async (item) => {
       const id = itemId(mode, item);
-      const sequence = selectSequence.current + 1;
-      selectSequence.current = sequence;
+      const sequence2 = selectSequence.current + 1;
+      selectSequence.current = sequence2;
       setSelectedId(id);
       setResult(null);
       setError("");
       setPane("content");
       try {
         const value = mode === "skills" ? item : (await api.inspect(item.id)).artifact;
-        if (sequence !== selectSequence.current) return;
+        if (sequence2 !== selectSequence.current) return;
         setDetail({ mode, value });
         const schema = mode === "skills" ? value.args_schema : value.argsSchema;
         setArgsText(JSON.stringify(defaultArgs(schema), null, 2));
       } catch (cause) {
-        if (sequence === selectSequence.current) setError(cause.message || String(cause));
+        if (sequence2 === selectSequence.current) setError(cause.message || String(cause));
       }
     };
     const invoke = async (action) => {
@@ -29248,6 +29354,77 @@ When you are done, remind me of two things: MCP tools load only in a new session
       }
       onMessage(message);
     });
+  }
+
+  // src/cep/toolImages.js
+  init_cep_runtime_inject();
+  var TYPES = { "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif" };
+  var CACHE_BYTES = 64 * 1024 * 1024;
+  var RESULT_CHARS = 12 * 1024 * 1024;
+  var CACHE_AGE = 7 * 24 * 60 * 60 * 1e3;
+  var sequence = 0;
+  function toolDisplayText(value) {
+    return String(value || "").replace(/data:image\/[^;\s]+;base64,[A-Za-z0-9+/=]+/g, "[image]").replace(/("base64"\s*:\s*")[^"]*(")/g, "$1[image]$2");
+  }
+  function captureToolImages(content, adapter) {
+    const parts = Array.isArray(content) ? content : [];
+    const candidates = parts.filter((part) => part && (part.type === "image" || part.type === "file" && String(part.mime || part.mimeType || "").startsWith("image/")));
+    if (!candidates.length) return {};
+    const fs = adapter == null ? void 0 : adapter.fs;
+    const now = Date.now();
+    let remaining = RESULT_CHARS;
+    let cache;
+    let files;
+    let bytes = 0;
+    function prepareCache() {
+      if (files) return;
+      cache = adapter.paths.join([adapter.paths.configRoot, "tool-images"]);
+      fs.mkdirSync(cache, { recursive: true });
+      files = fs.readdirSync(cache).filter((name) => /^preview-[a-z0-9-]+\.(png|jpg|webp|gif)$/.test(name)).map((name) => {
+        const path = adapter.paths.join([cache, name]);
+        const stat = fs.statSync(path);
+        return { path, size: stat.size, time: stat.mtimeMs };
+      }).sort((a, b) => a.time - b.time);
+      bytes = files.reduce((total, file) => total + file.size, 0);
+    }
+    const images = candidates.slice(0, 32).map((part) => {
+      const source = part.source || part;
+      const url = part.url || source.url || "";
+      const match = /^data:(image\/[a-z]+);base64,([A-Za-z0-9+/=]+)$/.exec(url);
+      const mimeType = source.media_type || part.mimeType || part.mime || (match == null ? void 0 : match[1]);
+      const data2 = source.data || (match == null ? void 0 : match[2]);
+      if (!TYPES[mimeType]) return { unavailable: "format" };
+      if (!data2 && /^file:\/\//.test(url) && url.length < 4096) return { src: url };
+      if (typeof data2 !== "string" || !data2.length || data2.length % 4 || !/^[A-Za-z0-9+/]+={0,2}$/.test(data2)) return { unavailable: "load" };
+      if (data2.length > 4.5 * 1024 * 1024 || data2.length > remaining) return { unavailable: "limit" };
+      remaining -= data2.length;
+      let path;
+      try {
+        prepareCache();
+        const size = Math.floor(data2.length * 3 / 4);
+        while (files.length && (bytes + size > CACHE_BYTES || files.length >= 256 || files[0].time < now - CACHE_AGE)) {
+          const file = files[0];
+          fs.unlinkSync(file.path);
+          bytes -= file.size;
+          files.shift();
+        }
+        path = adapter.paths.join([cache, `preview-${now.toString(36)}-${Math.random().toString(36).slice(2)}-${++sequence}.${TYPES[mimeType]}`]);
+        fs.writeFileSync(path, data2, { encoding: "base64", flag: "wx" });
+        bytes += size;
+        files.push({ path, size, time: now });
+        return { src: attachmentFileUrl(path, adapter.id) };
+      } catch {
+        if (path) {
+          try {
+            fs.unlinkSync(path);
+          } catch {
+          }
+        }
+        return { unavailable: "load" };
+      }
+    });
+    if (candidates.length > 32) images.push({ unavailable: "limit" });
+    return { images };
   }
 
   // ../shared/tool-approval.mjs
@@ -30225,7 +30402,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           type: "tool-result",
           toolUseId,
           ok: block.is_error !== true,
-          text: toolResultText(block.content),
+          text: toolDisplayText(toolResultText(block.content)),
+          ...captureToolImages(block.content, adapter),
           durationMs: Math.max(0, now() - tool.startedAt)
         });
       }
@@ -31488,6 +31666,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       return true;
     }
     function handleNotification(message) {
+      var _a;
       const params = message.params || {};
       if (message.method === "turn/started") {
         currentTurnId = params.turn && params.turn.id || params.turnId || null;
@@ -31535,7 +31714,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           toolUseId: String(item.id || ""),
           name: mcpToolName(item),
           ok: !item.error && item.status === "completed",
-          text: toolResultText2(item.result),
+          text: toolDisplayText(toolResultText2(item.result)),
+          ...captureToolImages((_a = item.result) == null ? void 0 : _a.content, adapter),
           durationMs: item.durationMs
         });
         return;
@@ -33996,7 +34176,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           toolUseId,
           name,
           ok: status === "completed",
-          text: outputText,
+          text: toolDisplayText(outputText),
+          ...captureToolImages(state.attachments || state.content, adapter),
           durationMs: ms
         });
         return;
@@ -35347,6 +35528,7 @@ ${command}`
             state: evt.ok ? "ok" : "error",
             ok: !!evt.ok,
             text: evt.text || "",
+            ...evt.images ? { images: evt.images } : {},
             durationMs: evt.durationMs
           });
         }
@@ -35355,6 +35537,7 @@ ${command}`
           state: evt.ok ? "ok" : "error",
           ok: !!evt.ok,
           text: evt.text || "",
+          ...evt.images || entry2.images ? { images: evt.images || [] } : {},
           durationMs: evt.durationMs
         }));
       case "tool-denied":
@@ -36836,7 +37019,7 @@ ${command}`
     const listeners = /* @__PURE__ */ new Set();
     const disposeController = new AbortController();
     let classificationTail = Promise.resolve();
-    let sequence = 0;
+    let sequence2 = 0;
     let disposed = false;
     function snapshot() {
       return entries.length ? entries[0].record : null;
@@ -36901,11 +37084,11 @@ ${command}`
     function enqueue(request, context, plan, policy) {
       var _a;
       if (disposed || ((_a = context == null ? void 0 : context.signal) == null ? void 0 : _a.aborted)) return Promise.resolve(cancelResult());
-      sequence += 1;
+      sequence2 += 1;
       const contextView = { ...context };
       delete contextView.signal;
       const record = freezeVisible({
-        id: `elicitation-${sequence}`,
+        id: `elicitation-${sequence2}`,
         request: cloneVisible(request) || {},
         context: cloneVisible(contextView) || {},
         plan,
@@ -37689,14 +37872,14 @@ ${command}`
   function stableEntries(id, entries) {
     const source = clone5(Array.isArray(entries) ? entries : []);
     const used = /* @__PURE__ */ new Set();
-    let sequence = 0;
+    let sequence2 = 0;
     const matcher = new RegExp(`^${String(id).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:(\\d+)$`);
     for (const entry2 of source) {
       const sid = typeof entry2.sid === "string" ? entry2.sid : "";
       const match = sid.match(matcher);
       if (sid && !used.has(sid)) {
         used.add(sid);
-        if (match) sequence = Math.max(sequence, Number(match[1]) || 0);
+        if (match) sequence2 = Math.max(sequence2, Number(match[1]) || 0);
       } else {
         delete entry2.sid;
       }
@@ -37704,9 +37887,9 @@ ${command}`
     for (const entry2 of source) {
       if (entry2.sid) continue;
       do {
-        sequence += 1;
-      } while (used.has(`${id}:${sequence}`));
-      entry2.sid = `${id}:${sequence}`;
+        sequence2 += 1;
+      } while (used.has(`${id}:${sequence2}`));
+      entry2.sid = `${id}:${sequence2}`;
       used.add(entry2.sid);
     }
     return source;

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -19317,12 +19317,12 @@
 
   // src/main.jsx
   init_cep_runtime_inject();
-  var import_react49 = __toESM(require_react(), 1);
+  var import_react50 = __toESM(require_react(), 1);
   var import_client = __toESM(require_client(), 1);
 
   // src/app/App.jsx
   init_cep_runtime_inject();
-  var import_react48 = __toESM(require_react(), 1);
+  var import_react49 = __toESM(require_react(), 1);
 
   // src/app/i18n.jsx
   init_cep_runtime_inject();
@@ -20407,10 +20407,86 @@
 
   // src/screens/SettingsScreen.jsx
   init_cep_runtime_inject();
-  var import_react20 = __toESM(require_react(), 1);
+  var import_react21 = __toESM(require_react(), 1);
 
   // src/lib/cliUpdates.js
   init_cep_runtime_inject();
+
+  // src/lib/versionUpdates.js
+  init_cep_runtime_inject();
+  var UPDATE_CACHE_MS = 864e5;
+  function compareVersions(left, right) {
+    const parse = (value) => /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$/.exec(String(value || "").trim());
+    const a = parse(left), b = parse(right);
+    if (!a || !b || [...a.slice(1), ...b.slice(1)].some((n) => !Number.isSafeInteger(Number(n)))) return null;
+    for (let i = 1; i <= 3; i += 1) {
+      if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
+    }
+    return 0;
+  }
+  function createVersionChecker({
+    requestJson,
+    url,
+    headers,
+    parseRelease,
+    now = Date.now,
+    timeoutMs = 8e3,
+    readCache = () => null,
+    writeCache = () => {
+    },
+    validEntry = () => true
+  }) {
+    let entry2;
+    try {
+      entry2 = readCache();
+    } catch {
+    }
+    const usable = (value) => value && Number.isFinite(value.checkedAt) && now() >= value.checkedAt && now() - value.checkedAt < UPDATE_CACHE_MS && compareVersions(value.latest, value.latest) === 0 && validEntry(value);
+    let pending;
+    async function refresh() {
+      let timer;
+      try {
+        const result = await Promise.race([
+          requestJson({ url, headers, timeoutMs }),
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" })), timeoutMs);
+          })
+        ]);
+        if (!result.ok) return { reason: [403, 429].includes(result.status) ? "limited" : "network" };
+        const release = parseRelease(result.json);
+        if (!release || compareVersions(release.latest, release.latest) !== 0) return { reason: "release" };
+        entry2 = { ...release, checkedAt: now() };
+        try {
+          writeCache(entry2);
+        } catch {
+        }
+        return entry2;
+      } catch (error) {
+        return { reason: (error == null ? void 0 : error.code) === "ETIMEDOUT" ? "timeout" : "network" };
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    return async (current, { force = false } = {}) => {
+      let value = entry2;
+      if (pending || force || !usable(entry2)) {
+        if (!pending) pending = refresh().finally(() => {
+          pending = null;
+        });
+        value = await pending;
+      }
+      if (value.reason) return { status: "unknown", current, reason: value.reason };
+      const comparison = compareVersions(current, value.latest);
+      return {
+        ...value,
+        current,
+        status: comparison === null ? "unknown" : comparison < 0 ? "update" : "current",
+        ...comparison === null ? { reason: "version" } : {}
+      };
+    };
+  }
+
+  // src/lib/cliUpdates.js
   var ASTRA_CLI_BASELINE = "0.153.4";
   var PACKAGES = { codex: "@openai/codex", subscription: "@anthropic-ai/claude-code", opencode: "opencode-ai" };
   var DOCS = {
@@ -20418,15 +20494,6 @@
     subscription: "https://code.claude.com/docs/en/setup",
     opencode: "https://opencode.ai/docs/cli/#upgrade"
   };
-  function compareVersions(left, right) {
-    const parse = (value) => /^(?:v)?(\d+)\.(\d+)\.(\d+)$/.exec(String(value || "").trim());
-    const a = parse(left), b = parse(right);
-    if (!a || !b) return null;
-    for (let i = 1; i <= 3; i += 1) {
-      if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
-    }
-    return 0;
-  }
   function cliIdentity(executable, fs) {
     var _a, _b, _c;
     if (!(executable == null ? void 0 : executable.ok)) return null;
@@ -20478,33 +20545,20 @@
     return { source, command, url, detail };
   }
   function createCliUpdateChecker({ requestJson, now = Date.now, timeoutMs = 8e3 }) {
-    const cache = /* @__PURE__ */ new Map();
-    return async (backend, cli, { force = false } = {}) => {
-      var _a;
+    const checkers = /* @__PURE__ */ new Map();
+    return async (backend, cli, options = {}) => {
       const current = (cli == null ? void 0 : cli.version) || "";
       if (!PACKAGES[backend] || !cli) return { status: "unknown", current };
-      let entry2 = cache.get(backend);
-      if (force || !entry2 || now() - entry2.checkedAt >= 864e5) {
-        let timer;
-        try {
-          const result = await Promise.race([
-            requestJson({ url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`, timeoutMs }),
-            new Promise((_, reject) => {
-              timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
-            })
-          ]);
-          const latest = (_a = result.json) == null ? void 0 : _a.version;
-          if (!result.ok || compareVersions(latest, latest) === null) throw new Error("unknown stable version");
-          entry2 = { latest, checkedAt: now() };
-          cache.set(backend, entry2);
-        } catch {
-          return { status: "unknown", current };
-        } finally {
-          clearTimeout(timer);
-        }
+      if (!checkers.has(backend)) {
+        checkers.set(backend, createVersionChecker({
+          requestJson,
+          now,
+          timeoutMs,
+          url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`,
+          parseRelease: (json) => ({ latest: json == null ? void 0 : json.version })
+        }));
       }
-      const comparison = compareVersions(current, entry2.latest);
-      return { ...entry2, current, status: comparison === null ? "unknown" : comparison < 0 ? "update" : "current" };
+      return checkers.get(backend)(current, options);
     };
   }
   function codexCatalogNotice(probe, lang = "zh") {
@@ -20515,6 +20569,45 @@
     if ((_a = probe.models) == null ? void 0 : _a.some((m) => m.id === "gpt-6-astra" && !m.hidden)) return "";
     if (compareVersions(probe.cliVersion, ASTRA_CLI_BASELINE) === -1) return en ? `Astra is absent from this old CLI catalog. Update Codex to ${ASTRA_CLI_BASELINE} or later, then recheck; other available models remain usable.` : `\u5F53\u524D\u65E7 CLI \u76EE\u5F55\u6CA1\u6709 Astra\u3002\u8BF7\u66F4\u65B0 Codex \u81F3 ${ASTRA_CLI_BASELINE} \u6216\u66F4\u9AD8\u7248\u672C\u540E\u91CD\u65B0\u68C0\u6D4B\uFF1B\u5176\u4ED6\u53EF\u7528\u6A21\u578B\u4ECD\u53EF\u4F7F\u7528\u3002`;
     return en ? "This account or route does not list Astra as available. Choose a listed model." : "\u5F53\u524D\u8D26\u53F7\u6216\u8DEF\u7531\u672A\u5C06 Astra \u5217\u4E3A\u53EF\u7528\u6A21\u578B\uFF0C\u8BF7\u9009\u62E9\u76EE\u5F55\u5185\u7684\u6A21\u578B\u3002";
+  }
+
+  // src/components/shell/PanelUpdate.jsx
+  init_cep_runtime_inject();
+  var import_react12 = __toESM(require_react(), 1);
+  var import_jsx_runtime10 = __toESM(require_jsx_runtime(), 1);
+  function PanelUpdateBanner({ update, lang, onOpen, onDismiss }) {
+    const en = lang === "en";
+    const text = en ? `Panel ${update.current} \u2192 ${update.latest}` : `\u9762\u677F ${update.current} \u2192 ${update.latest}`;
+    return /* @__PURE__ */ (0, import_jsx_runtime10.jsxs)("div", { className: "panel-update-banner", role: "status", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime10.jsx)("span", { title: text, children: text }),
+      /* @__PURE__ */ (0, import_jsx_runtime10.jsx)(Button, { size: "sm", variant: "ghost", onClick: onOpen, children: en ? "View release" : "\u67E5\u770B\u66F4\u65B0" }),
+      /* @__PURE__ */ (0, import_jsx_runtime10.jsx)(IconButton, { icon: "x", title: en ? "Dismiss this version" : "\u5173\u95ED\u6B64\u7248\u672C\u63D0\u9192", onClick: onDismiss })
+    ] });
+  }
+  function PanelUpdateSettings({ update, lang, onCheck, onOpen }) {
+    const en = lang === "en";
+    const reasons = en ? {
+      timeout: "Request timed out.",
+      network: "Network or service unavailable.",
+      limited: "GitHub limited or denied the request.",
+      release: "No comparable stable release.",
+      version: "Panel version cannot be compared."
+    } : {
+      timeout: "\u8BF7\u6C42\u8D85\u65F6\u3002",
+      network: "\u7F51\u7EDC\u6216\u670D\u52A1\u4E0D\u53EF\u7528\u3002",
+      limited: "GitHub \u9650\u6D41\u6216\u62D2\u7EDD\u8BF7\u6C42\u3002",
+      release: "\u672A\u83B7\u5F97\u53EF\u6BD4\u8F83\u7684\u7A33\u5B9A\u7248\u3002",
+      version: "\u9762\u677F\u7248\u672C\u65E0\u6CD5\u6BD4\u8F83\u3002"
+    };
+    const message = (update == null ? void 0 : update.status) === "checking" ? en ? "Checking panel release\u2026" : "\u6B63\u5728\u68C0\u67E5\u9762\u677F Release\u2026" : (update == null ? void 0 : update.status) === "update" ? en ? `Panel update: ${update.latest}` : `\u9762\u677F\u53EF\u66F4\u65B0\uFF1A${update.latest}` : (update == null ? void 0 : update.status) === "current" ? en ? `No newer stable panel release (${update.latest}).` : `\u6CA1\u6709\u66F4\u9AD8\u7684\u9762\u677F\u7A33\u5B9A\u7248\uFF08${update.latest}\uFF09\u3002` : (en ? "Panel update unknown. " : "\u9762\u677F\u66F4\u65B0\u72B6\u6001\u672A\u77E5\u3002") + (reasons[update == null ? void 0 : update.reason] || "");
+    return /* @__PURE__ */ (0, import_jsx_runtime10.jsxs)("div", { className: "panel-update-settings", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime10.jsx)("div", { role: "status", children: message }),
+      (update == null ? void 0 : update.openFailed) ? /* @__PURE__ */ (0, import_jsx_runtime10.jsx)("div", { role: "alert", children: en ? "Could not open the release page. Check your default browser and retry." : "\u65E0\u6CD5\u6253\u5F00 Release \u9875\u9762\uFF0C\u8BF7\u68C0\u67E5\u9ED8\u8BA4\u6D4F\u89C8\u5668\u540E\u91CD\u8BD5\u3002" }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime10.jsxs)("div", { style: { display: "flex", gap: 6, flexWrap: "wrap" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime10.jsx)(Button, { size: "sm", disabled: (update == null ? void 0 : update.status) === "checking", onClick: onCheck, children: en ? "Check panel updates" : "\u68C0\u67E5\u9762\u677F\u66F4\u65B0" }),
+        (update == null ? void 0 : update.status) === "update" ? /* @__PURE__ */ (0, import_jsx_runtime10.jsx)(Button, { size: "sm", onClick: onOpen, children: en ? "View release" : "\u67E5\u770B\u66F4\u65B0" }) : null
+      ] })
+    ] });
   }
 
   // package.json
@@ -20544,8 +20637,8 @@
 
   // src/components/core/Badge.jsx
   init_cep_runtime_inject();
-  var import_react12 = __toESM(require_react(), 1);
-  var import_jsx_runtime10 = __toESM(require_jsx_runtime(), 1);
+  var import_react13 = __toESM(require_react(), 1);
+  var import_jsx_runtime11 = __toESM(require_jsx_runtime(), 1);
   var BADGE_COLORS = {
     ok: { color: "var(--ok)", background: "var(--ok-bg)", borderColor: "var(--ok-border)" },
     warn: { color: "var(--warn)", background: "var(--warn-bg)", borderColor: "var(--warn-border)" },
@@ -20555,7 +20648,7 @@
   };
   function Badge({ status = "neutral", icon, dot = false, children, style }) {
     const c = BADGE_COLORS[status] || BADGE_COLORS.neutral;
-    return /* @__PURE__ */ (0, import_jsx_runtime10.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime11.jsxs)(
       "span",
       {
         style: {
@@ -20573,8 +20666,8 @@
           ...style
         },
         children: [
-          dot ? /* @__PURE__ */ (0, import_jsx_runtime10.jsx)("span", { style: { width: 5, height: 5, borderRadius: "50%", background: "currentColor", flex: "none" } }) : null,
-          icon ? /* @__PURE__ */ (0, import_jsx_runtime10.jsx)(Icon2, { name: icon, size: 10, strokeWidth: 2 }) : null,
+          dot ? /* @__PURE__ */ (0, import_jsx_runtime11.jsx)("span", { style: { width: 5, height: 5, borderRadius: "50%", background: "currentColor", flex: "none" } }) : null,
+          icon ? /* @__PURE__ */ (0, import_jsx_runtime11.jsx)(Icon2, { name: icon, size: 10, strokeWidth: 2 }) : null,
           children
         ]
       }
@@ -20583,11 +20676,11 @@
 
   // src/components/core/Switch.jsx
   init_cep_runtime_inject();
-  var import_react13 = __toESM(require_react(), 1);
-  var import_jsx_runtime11 = __toESM(require_jsx_runtime(), 1);
+  var import_react14 = __toESM(require_react(), 1);
+  var import_jsx_runtime12 = __toESM(require_jsx_runtime(), 1);
   function Switch({ checked = false, onChange, disabled = false, title, style }) {
-    const [hover, setHover] = import_react13.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime11.jsx)(
+    const [hover, setHover] = import_react14.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime12.jsx)(
       "button",
       {
         type: "button",
@@ -20616,7 +20709,7 @@
           transition: "background var(--dur-fast) var(--ease-out)",
           ...style
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime11.jsx)(
+        children: /* @__PURE__ */ (0, import_jsx_runtime12.jsx)(
           "span",
           {
             style: {
@@ -20635,10 +20728,10 @@
 
   // src/components/core/Segmented.jsx
   init_cep_runtime_inject();
-  var import_react14 = __toESM(require_react(), 1);
-  var import_jsx_runtime12 = __toESM(require_jsx_runtime(), 1);
+  var import_react15 = __toESM(require_react(), 1);
+  var import_jsx_runtime13 = __toESM(require_jsx_runtime(), 1);
   function Segmented({ options = [], value, onChange, full = false, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime12.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(
       "div",
       {
         role: "radiogroup",
@@ -20653,14 +20746,14 @@
         },
         children: options.map((opt) => {
           const selected = opt.value === value;
-          return /* @__PURE__ */ (0, import_jsx_runtime12.jsx)(SegmentedOption, { opt, selected, full, onSelect: () => onChange && onChange(opt.value) }, opt.value);
+          return /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(SegmentedOption, { opt, selected, full, onSelect: () => onChange && onChange(opt.value) }, opt.value);
         })
       }
     );
   }
   function SegmentedOption({ opt, selected, full, onSelect }) {
-    const [hover, setHover] = import_react14.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime12.jsxs)(
+    const [hover, setHover] = import_react15.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)(
       "button",
       {
         type: "button",
@@ -20688,7 +20781,7 @@
           transition: "background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out)"
         },
         children: [
-          opt.icon ? /* @__PURE__ */ (0, import_jsx_runtime12.jsx)(Icon2, { name: opt.icon, size: 12 }) : null,
+          opt.icon ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Icon2, { name: opt.icon, size: 12 }) : null,
           opt.label
         ]
       }
@@ -20697,7 +20790,7 @@
 
   // src/components/settings/ChannelCard.jsx
   init_cep_runtime_inject();
-  var import_react15 = __toESM(require_react(), 1);
+  var import_react16 = __toESM(require_react(), 1);
 
   // src/lib/channelCard.js
   init_cep_runtime_inject();
@@ -20756,10 +20849,10 @@
   }
 
   // src/components/settings/ChannelCard.jsx
-  var import_jsx_runtime13 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime14 = __toESM(require_jsx_runtime(), 1);
   var DOT_COLOR = { ok: "var(--ok)", warn: "var(--warn)", neutral: "var(--text-tertiary)" };
   function ChannelDot({ token }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("span", { style: { width: 8, height: 8, flex: "none", borderRadius: "50%", background: DOT_COLOR[token] || DOT_COLOR.neutral } });
+    return /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("span", { style: { width: 8, height: 8, flex: "none", borderRadius: "50%", background: DOT_COLOR[token] || DOT_COLOR.neutral } });
   }
   function ChannelCard({
     lang = "zh",
@@ -20775,10 +20868,10 @@
     readOnly = false,
     renderChannelBody
   }) {
-    const [copied, setCopied] = import_react15.default.useState("");
-    const copyTimerRef = import_react15.default.useRef(null);
-    const mountedRef = import_react15.default.useRef(true);
-    import_react15.default.useEffect(() => {
+    const [copied, setCopied] = import_react16.default.useState("");
+    const copyTimerRef = import_react16.default.useRef(null);
+    const mountedRef = import_react16.default.useRef(true);
+    import_react16.default.useEffect(() => {
       mountedRef.current = true;
       return () => {
         mountedRef.current = false;
@@ -20797,7 +20890,7 @@
       }).catch(() => {
       });
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
+    return /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
       channels.map((probe) => {
         var _a, _b;
         const texts = channelTexts(probe, lang);
@@ -20807,28 +20900,28 @@
         const activeLogin = (loginState == null ? void 0 : loginState.channel) === probe.channel ? loginState : null;
         const loginWaiting = ["launching", "waiting", "verifying"].includes(activeLogin == null ? void 0 : activeLogin.status);
         const loginLabel = loginWaiting ? lang === "en" ? "Waiting for sign-in\u2026" : "\u7B49\u5F85\u767B\u5F55\u2026" : ((_a = loginAction == null ? void 0 : loginAction.label) == null ? void 0 : _a[lang]) || ((_b = loginAction == null ? void 0 : loginAction.label) == null ? void 0 : _b.zh) || "";
-        return /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px 10px", border: `1px solid ${isActive ? "var(--border-strong)" : "var(--border-subtle)"}`, borderRadius: "var(--radius-md)", background: "var(--bg-well)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime13.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(ChannelDot, { token: channelDot(probe) }),
-            /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Badge, { status: channelDot(probe), children: texts.source }),
-            texts.detail ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("span", { title: texts.detail, style: { flex: 1, minWidth: 0, font: "400 10px/1.35 var(--font-mono)", color: "var(--text-secondary)", overflow: "hidden", whiteSpace: "pre-wrap", wordBreak: "break-word", display: "-webkit-box", WebkitBoxOrient: "vertical", WebkitLineClamp: 4 }, children: texts.detail }) : /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("span", { style: { flex: 1 } }),
-            !readOnly && onSelectChannel ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: choice.active ? "secondary" : "ghost", size: "sm", disabled: choice.active, onClick: () => onSelectChannel(probe.channel), children: choice.label }) : null
+        return /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, padding: "8px 10px", border: `1px solid ${isActive ? "var(--border-strong)" : "var(--border-subtle)"}`, borderRadius: "var(--radius-md)", background: "var(--bg-well)" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(ChannelDot, { token: channelDot(probe) }),
+            /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Badge, { status: channelDot(probe), children: texts.source }),
+            texts.detail ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("span", { title: texts.detail, style: { flex: 1, minWidth: 0, font: "400 10px/1.35 var(--font-mono)", color: "var(--text-secondary)", overflow: "hidden", whiteSpace: "pre-wrap", wordBreak: "break-word", display: "-webkit-box", WebkitBoxOrient: "vertical", WebkitLineClamp: 4 }, children: texts.detail }) : /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("span", { style: { flex: 1 } }),
+            !readOnly && onSelectChannel ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Button, { variant: choice.active ? "secondary" : "ghost", size: "sm", disabled: choice.active, onClick: () => onSelectChannel(probe.channel), children: choice.label }) : null
           ] }),
-          texts.fixHint ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-tertiary)", whiteSpace: "pre-wrap" }, children: texts.fixHint }) : null,
-          (activeLogin == null ? void 0 : activeLogin.detail) ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { role: "status", style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-secondary)" }, children: activeLogin.detail }) : null,
-          !readOnly && loginAction && onLogin ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: "primary", size: "sm", disabled: loginWaiting, onClick: () => onLogin(probe, loginAction), children: loginLabel }) }) : null,
-          !readOnly && texts.copyText ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyLoginCommand(probe.channel, texts.copyText), children: copied === probe.channel ? channelCopiedLabel(lang) : texts.copyLabel }) }) : null,
+          texts.fixHint ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("div", { style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-tertiary)", whiteSpace: "pre-wrap" }, children: texts.fixHint }) : null,
+          (activeLogin == null ? void 0 : activeLogin.detail) ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("div", { role: "status", style: { font: "400 10px/1.5 var(--font-ui)", color: "var(--text-secondary)" }, children: activeLogin.detail }) : null,
+          !readOnly && loginAction && onLogin ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Button, { variant: "primary", size: "sm", disabled: loginWaiting, onClick: () => onLogin(probe, loginAction), children: loginLabel }) }) : null,
+          !readOnly && texts.copyText ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyLoginCommand(probe.channel, texts.copyText), children: copied === probe.channel ? channelCopiedLabel(lang) : texts.copyLabel }) }) : null,
           !readOnly && renderChannelBody ? renderChannelBody(probe.channel) : null
         ] }, probe.channel);
       }),
-      !readOnly && onRecheck ? /* @__PURE__ */ (0, import_jsx_runtime13.jsx)("div", { style: { display: "flex", justifyContent: "flex-end" }, children: /* @__PURE__ */ (0, import_jsx_runtime13.jsx)(Button, { variant: "secondary", icon: "rotate-cw", disabled: recheckDisabled, onClick: onRecheck, children: recheckLabel }) }) : null
+      !readOnly && onRecheck ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)("div", { style: { display: "flex", justifyContent: "flex-end" }, children: /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Button, { variant: "secondary", icon: "rotate-cw", disabled: recheckDisabled, onClick: onRecheck, children: recheckLabel }) }) : null
     ] });
   }
 
   // src/components/forms/Input.jsx
   init_cep_runtime_inject();
-  var import_react16 = __toESM(require_react(), 1);
-  var import_jsx_runtime14 = __toESM(require_jsx_runtime(), 1);
+  var import_react17 = __toESM(require_react(), 1);
+  var import_jsx_runtime15 = __toESM(require_jsx_runtime(), 1);
   function Input({
     value,
     onChange,
@@ -20848,10 +20941,10 @@
     autoFocus = false,
     ariaLabel
   }) {
-    const [focus, setFocus] = import_react16.default.useState(false);
-    const [revealed, setRevealed] = import_react16.default.useState(false);
+    const [focus, setFocus] = import_react17.default.useState(false);
+    const [revealed, setRevealed] = import_react17.default.useState(false);
     const h = size === "lg" ? 28 : 24;
-    return /* @__PURE__ */ (0, import_jsx_runtime14.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime15.jsxs)(
       "span",
       {
         style: {
@@ -20869,8 +20962,8 @@
           ...style
         },
         children: [
-          icon ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(Icon2, { name: icon, size: 13, color: "var(--text-tertiary)" }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(
+          icon ? /* @__PURE__ */ (0, import_jsx_runtime15.jsx)(Icon2, { name: icon, size: 13, color: "var(--text-tertiary)" }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime15.jsx)(
             "input",
             {
               type: secret && !revealed ? "password" : type === "password" ? "text" : type,
@@ -20898,7 +20991,7 @@
               }
             }
           ),
-          secret ? /* @__PURE__ */ (0, import_jsx_runtime14.jsx)(
+          secret ? /* @__PURE__ */ (0, import_jsx_runtime15.jsx)(
             IconButton,
             {
               icon: revealed ? "eye-off" : "eye",
@@ -20915,12 +21008,12 @@
 
   // src/components/forms/Select.jsx
   init_cep_runtime_inject();
-  var import_react17 = __toESM(require_react(), 1);
-  var import_jsx_runtime15 = __toESM(require_jsx_runtime(), 1);
+  var import_react18 = __toESM(require_react(), 1);
+  var import_jsx_runtime16 = __toESM(require_jsx_runtime(), 1);
   function Select({ options = [], value, onChange, disabled = false, full = true, size = "md", style }) {
-    const [focus, setFocus] = import_react17.default.useState(false);
+    const [focus, setFocus] = import_react18.default.useState(false);
     const h = size === "lg" ? 28 : 24;
-    return /* @__PURE__ */ (0, import_jsx_runtime15.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)(
       "span",
       {
         style: {
@@ -20937,7 +21030,7 @@
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime15.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(
             "select",
             {
               value,
@@ -20959,10 +21052,10 @@
                 font: `var(--weight-regular) var(--text-body)/1 var(--font-ui)`,
                 cursor: disabled ? "default" : "pointer"
               },
-              children: options.map((opt) => /* @__PURE__ */ (0, import_jsx_runtime15.jsx)("option", { value: opt.value, style: { background: "var(--bg-overlay)", color: "var(--text-primary)" }, children: opt.label }, opt.value))
+              children: options.map((opt) => /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("option", { value: opt.value, style: { background: "var(--bg-overlay)", color: "var(--text-primary)" }, children: opt.label }, opt.value))
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime15.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)(
             Icon2,
             {
               name: "chevron-down",
@@ -20978,25 +21071,25 @@
 
   // src/components/forms/Field.jsx
   init_cep_runtime_inject();
-  var import_react18 = __toESM(require_react(), 1);
-  var import_jsx_runtime16 = __toESM(require_jsx_runtime(), 1);
+  var import_react19 = __toESM(require_react(), 1);
+  var import_jsx_runtime17 = __toESM(require_jsx_runtime(), 1);
   function Field({ label, hint, caption, layout = "stack", children, style }) {
     if (layout === "row") {
-      return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: "var(--hit-min)", ...style }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { flex: 1, minWidth: 0 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: `var(--weight-regular) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: label }),
-          caption ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)", marginTop: 2 }, children: caption }) : null
+      return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: "var(--hit-min)", ...style }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { flex: 1, minWidth: 0 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: `var(--weight-regular) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: label }),
+          caption ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)", marginTop: 2 }, children: caption }) : null
         ] }),
         children
       ] });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-1)", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { style: { display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: "var(--space-2)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("label", { style: { font: `var(--weight-medium) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-secondary)" }, children: label }),
-        hint ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)" }, children: hint }) : null
+    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-1)", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { style: { display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: "var(--space-2)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("label", { style: { font: `var(--weight-medium) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-secondary)" }, children: label }),
+        hint ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)" }, children: hint }) : null
       ] }),
       children,
-      caption ? /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-tertiary)" }, children: caption }) : null
+      caption ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-tertiary)" }, children: caption }) : null
     ] });
   }
 
@@ -22417,8 +22510,8 @@
 
   // src/components/shell/Toast.jsx
   init_cep_runtime_inject();
-  var import_react19 = __toESM(require_react(), 1);
-  var import_jsx_runtime17 = __toESM(require_jsx_runtime(), 1);
+  var import_react20 = __toESM(require_react(), 1);
+  var import_jsx_runtime18 = __toESM(require_jsx_runtime(), 1);
   var TOAST_ICONS = {
     ok: { icon: "check", color: "var(--ok)" },
     error: { icon: "circle-alert", color: "var(--error)" },
@@ -22427,7 +22520,7 @@
   };
   function Toast({ type = "info", message, actionLabel, onAction, onClose, style }) {
     const t = TOAST_ICONS[type] || TOAST_ICONS.info;
-    return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(
       "div",
       {
         role: "status",
@@ -22445,8 +22538,8 @@
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(Icon2, { name: t.icon, size: 13, strokeWidth: 2.25, color: t.color }),
-          /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Icon2, { name: t.icon, size: 13, strokeWidth: 2.25, color: t.color }),
+          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
             "span",
             {
               style: {
@@ -22458,15 +22551,15 @@
               children: message
             }
           ),
-          actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(ToastAction, { label: actionLabel, onClick: onAction }) : null,
-          onClose ? /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(IconButton, { icon: "x", title: "\u5173\u95ED Dismiss", onClick: onClose, style: { width: 20, height: 20 } }) : null
+          actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(ToastAction, { label: actionLabel, onClick: onAction }) : null,
+          onClose ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(IconButton, { icon: "x", title: "\u5173\u95ED Dismiss", onClick: onClose, style: { width: 20, height: 20 } }) : null
         ]
       }
     );
   }
   function ToastAction({ label, onClick }) {
-    const [hover, setHover] = import_react19.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime17.jsx)(
+    const [hover, setHover] = import_react20.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
       "button",
       {
         type: "button",
@@ -22975,7 +23068,7 @@
   }
 
   // src/screens/SettingsScreen.jsx
-  var import_jsx_runtime18 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime19 = __toESM(require_jsx_runtime(), 1);
   var FALLBACK_CLAUDE_DESCRIPTOR = claudeSubDescriptor();
   var FALLBACK_MODEL_OPTIONS = FALLBACK_CLAUDE_DESCRIPTOR.models.map((entry2) => ({
     value: entry2.id,
@@ -23086,8 +23179,8 @@
     }
   };
   function Section({ id, title, children, disabled, caption, expanded, onToggle }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)", opacity: disabled ? 0.45 : 1 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)", opacity: disabled ? 0.45 : 1 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(
         "button",
         {
           type: "button",
@@ -23096,53 +23189,53 @@
           onClick: () => onToggle && onToggle(id),
           style: { display: "flex", alignItems: "center", gap: 6, width: "100%", background: "none", border: "none", padding: "0 0 2px", cursor: "pointer", borderBottom: "1px solid var(--border-subtle)", textAlign: "left" },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Icon2, { name: expanded ? "chevron-down" : "chevron-right", size: 12, strokeWidth: 2, color: "var(--text-tertiary)" }),
-            /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { font: "600 11px/1 var(--font-ui)", letterSpacing: "0.04em", color: "var(--text-tertiary)", textTransform: "uppercase" }, children: title })
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Icon2, { name: expanded ? "chevron-down" : "chevron-right", size: 12, strokeWidth: 2, color: "var(--text-tertiary)" }),
+            /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { font: "600 11px/1 var(--font-ui)", letterSpacing: "0.04em", color: "var(--text-tertiary)", textTransform: "uppercase" }, children: title })
           ]
         }
       ),
-      expanded && caption ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: caption }) : null,
+      expanded && caption ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: caption }) : null,
       expanded ? children : null
     ] });
   }
   function ClientRow({ name, lastActive, blocked, onBlock, blockLabel }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 32, padding: "2px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: blocked ? 0.55 : 1 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: blocked ? "line-through" : "none" }, children: name }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: lastActive })
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 32, padding: "2px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: blocked ? 0.55 : 1 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: blocked ? "line-through" : "none" }, children: name }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: lastActive })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { font: "400 10px/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: blockLabel }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Switch, { checked: blocked, onChange: onBlock })
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { font: "400 10px/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: blockLabel }),
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Switch, { checked: blocked, onChange: onBlock })
     ] });
   }
   function McpSessionRow({ session, t, onBlock }) {
     const info = session.clientInfo || {};
     const name = info.version ? `${info.name} \xB7 ${info.version}` : info.name || session.clientName || "-";
     const source = session.source === "panel" ? t.sessionSourcePanel : t.sessionSourceExternal;
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 42, padding: "4px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: session.blocked ? 0.55 : 1 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: session.blocked ? "line-through" : "none" }, children: name }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: [
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 42, padding: "4px 8px", background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", opacity: session.blocked ? 0.55 : 1 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)", textDecoration: session.blocked ? "line-through" : "none" }, children: name }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: [
           t.sessionId,
           ": ",
           session.sessionId
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("span", { style: { display: "block", font: "400 10px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
           source,
           " \xB7 ",
           formatLastSeen(session.lastActivityAt, t)
         ] })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Switch, { checked: !!session.blocked, onChange: (value) => onBlock && onBlock(info.name, value) })
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Switch, { checked: !!session.blocked, onChange: (value) => onBlock && onBlock(info.name, value) })
     ] });
   }
   function ExternalClientRow({ client, t, configText, copied, onCopy, onOpenExternal, copyDisabled = false }) {
     const isShim = client.kind === "mcp-shim";
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("details", { style: { border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", padding: "7px 8px" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("summary", { style: { cursor: "pointer", listStyle: "none", display: "flex", alignItems: "center", gap: 8 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: client.name }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("details", { style: { border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", padding: "7px 8px" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("summary", { style: { cursor: "pointer", listStyle: "none", display: "flex", alignItems: "center", gap: 8 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { display: "block", font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: client.name }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
             "span",
             {
               style: {
@@ -23154,7 +23247,7 @@
             }
           )
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           Button,
           {
             variant: "secondary",
@@ -23169,10 +23262,10 @@
           }
         )
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
-        client.installHint ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-secondary)" }, children: client.installHint }) : null,
-        client.loginHint ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: client.loginHint }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
+        client.installHint ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-secondary)" }, children: client.installHint }) : null,
+        client.loginHint ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: client.loginHint }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           "pre",
           {
             style: {
@@ -23190,7 +23283,7 @@
             children: configText
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           "div",
           {
             style: {
@@ -23200,8 +23293,8 @@
             children: t.panelOpenNote
           }
         ),
-        client.networkNote ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: client.networkNote }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        client.networkNote ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: client.networkNote }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           "a",
           {
             href: client.docsUrl,
@@ -23217,10 +23310,10 @@
     ] });
   }
   function VersionRow({ label, value, badge }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { flex: 1, font: "400 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { flex: 1, font: "400 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
       badge,
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { font: "400 11px/1 var(--font-mono)", color: "var(--text-secondary)" }, children: value })
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { font: "400 11px/1 var(--font-mono)", color: "var(--text-secondary)" }, children: value })
     ] });
   }
   function maskToken(value) {
@@ -23274,6 +23367,9 @@
     loginState = null,
     recheckDisabled = false,
     cliStatus = {},
+    panelUpdate,
+    onCheckPanelUpdate,
+    onOpenPanelRelease,
     providerManager = null,
     providerInit = { state: "checking", error: "" },
     logLevel = "info",
@@ -23283,18 +23379,18 @@
   }) {
     const t = S[lang] || S.zh;
     const providerInitMessage = t.providerInitializationFailed;
-    const [externalLinkError, setExternalLinkError] = import_react20.default.useState("");
-    const [draftPort, setDraftPort] = import_react20.default.useState(String(port));
-    const [tokenRaw, setTokenRaw] = import_react20.default.useState("");
-    const [copied, setCopied] = import_react20.default.useState("");
-    const [sections, setSections] = import_react20.default.useState(() => loadSectionState(window.localStorage));
+    const [externalLinkError, setExternalLinkError] = import_react21.default.useState("");
+    const [draftPort, setDraftPort] = import_react21.default.useState(String(port));
+    const [tokenRaw, setTokenRaw] = import_react21.default.useState("");
+    const [copied, setCopied] = import_react21.default.useState("");
+    const [sections, setSections] = import_react21.default.useState(() => loadSectionState(window.localStorage));
     const onToggleSection = (id) => setSections((s) => {
       const next = toggleSection(s, id);
       saveSectionState(window.localStorage, next);
       return next;
     });
-    import_react20.default.useEffect(() => setDraftPort(String(port)), [port]);
-    import_react20.default.useEffect(() => setTokenRaw(readTokenValue()), []);
+    import_react21.default.useEffect(() => setDraftPort(String(port)), [port]);
+    import_react21.default.useEffect(() => setTokenRaw(readTokenValue()), []);
     const copy = (label, text) => {
       copyText(text).then(() => {
         setCopied(label);
@@ -23317,15 +23413,15 @@
       setExternalLinkError("");
       return openExternal(url, { onFailure: () => setExternalLinkError(t.externalLinkFailed) });
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-5)" }, children: [
-      externalLinkError ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Toast, { type: "error", message: externalLinkError, onClose: () => setExternalLinkError("") }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(Section, { id: "ai", title: t.ai, expanded: sections.ai, onToggle: onToggleSection, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.backend, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Segmented, { full: true, value: backend, onChange: onBackendChange, options: [
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-5)" }, children: [
+      externalLinkError ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Toast, { type: "error", message: externalLinkError, onClose: () => setExternalLinkError("") }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(Section, { id: "ai", title: t.ai, expanded: sections.ai, onToggle: onToggleSection, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.backend, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Segmented, { full: true, value: backend, onChange: onBackendChange, options: [
           { value: "subscription", label: t.backendSub },
           { value: "codex", label: t.backendCodex },
           { value: "opencode", label: t.backendOpenCode }
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           ChannelCard,
           {
             lang,
@@ -23340,35 +23436,35 @@
             recheckDisabled
           }
         ),
-        providerInit.state === "unavailable" ? /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { role: "alert", style: { padding: "7px 8px", border: "1px solid var(--error-border)", borderRadius: "var(--radius-md)", background: "var(--error-bg)", color: "var(--error)", font: "400 10px/1.5 var(--font-ui)" }, children: [
+        providerInit.state === "unavailable" ? /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { role: "alert", style: { padding: "7px 8px", border: "1px solid var(--error-border)", borderRadius: "var(--radius-md)", background: "var(--error-bg)", color: "var(--error)", font: "400 10px/1.5 var(--font-ui)" }, children: [
           providerInitMessage,
           providerInit.detail || providerInit.error ? ` (${providerInit.detail || providerInit.error})` : ""
         ] }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(CliUpdateStatus, { backend, lang, ...cliStatus, onOpenExternal: handleExternalLink }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(CliUpdateStatus, { backend, lang, ...cliStatus, onOpenExternal: handleExternalLink }),
         providerManager,
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.modelDefault, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Select, { value: model, onChange: onModelChange, options: modelOptions || FALLBACK_MODEL_OPTIONS }) })
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.modelDefault, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Select, { value: model, onChange: onModelChange, options: modelOptions || FALLBACK_MODEL_OPTIONS }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(Section, { id: "conn", title: t.conn, expanded: sections.conn, onToggle: onToggleSection, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.port, hint: t.portHint, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Input, { mono: true, value: draftPort, onChange: setDraftPort, style: { flex: 1 } }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", onClick: () => onApplyPort && onApplyPort(draftPort), children: t.apply })
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(Section, { id: "conn", title: t.conn, expanded: sections.conn, onToggle: onToggleSection, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.port, hint: t.portHint, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Input, { mono: true, value: draftPort, onChange: setDraftPort, style: { flex: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "secondary", onClick: () => onApplyPort && onApplyPort(draftPort), children: t.apply })
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.token, caption: t.tokenCap, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Input, { mono: true, value: tokenDisplay, style: { flex: 1 }, suffix: /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(IconButton, { icon: "copy", title: t.copy, disabled: !tokenRaw, onClick: () => copy("token", tokenRaw), style: { width: 20, height: 20 } }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", icon: "rotate-cw", onClick: regenerate, children: t.regen })
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.token, caption: t.tokenCap, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Input, { mono: true, value: tokenDisplay, style: { flex: 1 }, suffix: /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(IconButton, { icon: "copy", title: t.copy, disabled: !tokenRaw, onClick: () => copy("token", tokenRaw), style: { width: 20, height: 20 } }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "secondary", icon: "rotate-cw", onClick: regenerate, children: t.regen })
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.mcp, caption: copied === "mcp" ? t.copied : null, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("pre", { style: { margin: 0, maxHeight: 160, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-secondary)", font: "400 10px/1.4 var(--font-mono)" }, children: mcpConfig }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", icon: "copy", disabled: !mcpReady, onClick: () => copy("mcp", mcpConfig), children: t.copy })
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.mcp, caption: copied === "mcp" ? t.copied : null, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("pre", { style: { margin: 0, maxHeight: 160, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-secondary)", font: "400 10px/1.4 var(--font-mono)" }, children: mcpConfig }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "secondary", icon: "copy", disabled: !mcpReady, onClick: () => copy("mcp", mcpConfig), children: t.copy })
         ] }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Section, { id: "externalClients", title: t.externalClients, caption: t.externalClientsCap, expanded: sections.externalClients, onToggle: onToggleSection, children: EXTERNAL_CLIENTS.map((externalClient) => {
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Section, { id: "externalClients", title: t.externalClients, caption: t.externalClientsCap, expanded: sections.externalClients, onToggle: onToggleSection, children: EXTERNAL_CLIENTS.map((externalClient) => {
         const configText = mcpReady ? externalClientConfigText({
           client: externalClient,
           port: Number(draftPort) || port || 11488,
           extensionRoot
         }) : "";
-        return /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        return /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           ExternalClientRow,
           {
             client: externalClient,
@@ -23382,9 +23478,9 @@
           externalClient.id
         );
       }) }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(Section, { id: "sec", title: t.sec, expanded: sections.sec, onToggle: onToggleSection, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.mcpSessions }),
-        mcpSessions.map((session) => /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(Section, { id: "sec", title: t.sec, expanded: sections.sec, onToggle: onToggleSection, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.mcpSessions }),
+        mcpSessions.map((session) => /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           McpSessionRow,
           {
             session,
@@ -23393,8 +23489,8 @@
           },
           session.sessionId
         )),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.clients }),
-        clients.map((client) => /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 2 }, children: t.clients }),
+        clients.map((client) => /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
           ClientRow,
           {
             name: client.label,
@@ -23406,29 +23502,30 @@
           client.label
         ))
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(Section, { id: "gen", title: t.gen, expanded: sections.gen, onToggle: onToggleSection, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.language, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.logLevel, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Select, { value: logLevel, onChange: onLogLevel, style: { flex: 1 }, options: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(Section, { id: "gen", title: t.gen, expanded: sections.gen, onToggle: onToggleSection, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.language, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Segmented, { full: true, value: lang, onChange: onLangChange, options: [{ value: "zh", label: "\u4E2D\u6587" }, { value: "en", label: "English" }] }) }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.logLevel, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Select, { value: logLevel, onChange: onLogLevel, style: { flex: 1 }, options: [
             { value: "error", label: "Error" },
             { value: "info", label: "Info" },
             { value: "debug", label: "Debug" }
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", icon: "download", onClick: onExportLogs, children: t.exportLog })
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "secondary", icon: "download", onClick: onExportLogs, children: t.exportLog })
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Field, { label: t.logs, children: /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("details", { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("summary", { style: { cursor: "pointer", color: "var(--text-secondary)", font: "500 11px/1.35 var(--font-ui)" }, children: t.logs }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("pre", { style: { margin: "6px 0 0", maxHeight: 128, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-tertiary)", font: "400 10px/1.4 var(--font-mono)" }, children: logs.join("\n") })
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Field, { label: t.logs, children: /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("details", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("summary", { style: { cursor: "pointer", color: "var(--text-secondary)", font: "500 11px/1.35 var(--font-ui)" }, children: t.logs }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("pre", { style: { margin: "6px 0 0", maxHeight: 128, overflow: "auto", padding: 8, border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)", background: "var(--bg-well)", color: "var(--text-tertiary)", font: "400 10px/1.4 var(--font-mono)" }, children: logs.join("\n") })
         ] }) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)(Section, { id: "about", title: t.about, expanded: sections.about, onToggle: onToggleSection, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(VersionRow, { label: t.verPanel, value: `v${package_default.version}` }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(VersionRow, { label: t.verHost, value: hostVersion, badge: hostVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", icon: "book-open", onClick: () => handleExternalLink(docsUrlForLocale(lang)), children: t.docs }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", icon: "github", onClick: () => handleExternalLink(REPO_URL), children: t.github }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("span", { style: { flex: 1 } }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", icon: "rotate-cw", onClick: onRerunWizard, children: t.rerunWizard })
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)(Section, { id: "about", title: t.about, expanded: sections.about, onToggle: onToggleSection, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(VersionRow, { label: t.verPanel, value: `v${package_default.version}` }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(PanelUpdateSettings, { update: panelUpdate, lang, onCheck: onCheckPanelUpdate, onOpen: onOpenPanelRelease }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(VersionRow, { label: t.verHost, value: hostVersion, badge: hostVersion === "-" ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Badge, { status: "neutral", children: t.pending }) : null }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "ghost", size: "sm", icon: "book-open", onClick: () => handleExternalLink(docsUrlForLocale(lang)), children: t.docs }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "ghost", size: "sm", icon: "github", onClick: () => handleExternalLink(REPO_URL), children: t.github }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("span", { style: { flex: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "ghost", size: "sm", icon: "rotate-cw", onClick: onRerunWizard, children: t.rerunWizard })
         ] })
       ] })
     ] });
@@ -23439,8 +23536,8 @@
     const guide = cliUpdateGuide(backend, cli, lang);
     const key = "ae_mcp_cli_dismiss_" + backend;
     const identity = `${(cli == null ? void 0 : cli.path) || ""}:${(update == null ? void 0 : update.latest) || ""}`;
-    const [dismissed, setDismissed] = import_react20.default.useState("");
-    import_react20.default.useEffect(() => {
+    const [dismissed, setDismissed] = import_react21.default.useState("");
+    import_react21.default.useEffect(() => {
       try {
         setDismissed(window.localStorage.getItem(key) || "");
       } catch {
@@ -23449,25 +23546,25 @@
     const newer = (update == null ? void 0 : update.status) === "update" && dismissed !== identity;
     const running = probe == null ? void 0 : probe.runningCli;
     const changed = running && (running.version !== (cli == null ? void 0 : cli.version) || running.path !== (cli == null ? void 0 : cli.path));
-    return /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { role: "status", style: { font: "400 11px/1.5 var(--font-ui)", color: "var(--text-secondary)", overflowWrap: "anywhere" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { children: [
+    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { role: "status", style: { font: "400 11px/1.5 var(--font-ui)", color: "var(--text-secondary)", overflowWrap: "anywhere" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { children: [
         en ? "Selected CLI" : "\u6240\u9009 CLI",
         ": ",
         (cli == null ? void 0 : cli.version) || (en ? "Unknown" : "\u672A\u77E5"),
         " \xB7 ",
         guide.source
       ] }),
-      (cli == null ? void 0 : cli.path) ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { style: { fontFamily: "var(--font-mono)" }, children: cli.path }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: (update == null ? void 0 : update.status) === "checking" ? en ? "Checking stable version\u2026" : "\u6B63\u5728\u68C0\u67E5\u7A33\u5B9A\u7248\u2026" : (update == null ? void 0 : update.status) === "unknown" || !update ? en ? "Stable version unknown; chat is unaffected." : "\u7A33\u5B9A\u7248\u672A\u77E5\uFF0C\u4E0D\u5F71\u54CD\u804A\u5929\u3002" : `${en ? "Upstream stable" : "\u4E0A\u6E38\u7A33\u5B9A\u7248"}: ${update.latest}` }),
-      changed ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: en ? `This session still runs ${running.version}. Start a new conversation to use the updated CLI.` : `\u5F53\u524D\u4F1A\u8BDD\u4ECD\u8FD0\u884C ${running.version}\uFF1B\u65B0\u5EFA\u5BF9\u8BDD\u540E\u4F7F\u7528\u66F4\u65B0\u7684 CLI\u3002` }) : null,
-      notice ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: notice }) : null,
-      newer ? /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { marginTop: 6 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: en ? `Update available: ${update.current} \u2192 ${update.latest}` : `\u6709\u53EF\u7528\u66F4\u65B0\uFF1A${update.current} \u2192 ${update.latest}` }),
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("div", { children: guide.detail }),
-        guide.command ? /* @__PURE__ */ (0, import_jsx_runtime18.jsx)("code", { children: guide.command }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime18.jsxs)("div", { style: { display: "flex", gap: 6, flexWrap: "wrap", marginTop: 6 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "secondary", size: "sm", onClick: () => onOpenExternal(guide.url), children: en ? "Update guide" : "\u66F4\u65B0\u6307\u5F15" }),
-          /* @__PURE__ */ (0, import_jsx_runtime18.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
+      (cli == null ? void 0 : cli.path) ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { style: { fontFamily: "var(--font-mono)" }, children: cli.path }) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { children: (update == null ? void 0 : update.status) === "checking" ? en ? "Checking stable version\u2026" : "\u6B63\u5728\u68C0\u67E5\u7A33\u5B9A\u7248\u2026" : (update == null ? void 0 : update.status) === "unknown" || !update ? en ? "Stable version unknown; chat is unaffected." : "\u7A33\u5B9A\u7248\u672A\u77E5\uFF0C\u4E0D\u5F71\u54CD\u804A\u5929\u3002" : `${en ? "Upstream stable" : "\u4E0A\u6E38\u7A33\u5B9A\u7248"}: ${update.latest}` }),
+      changed ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { children: en ? `This session still runs ${running.version}. Start a new conversation to use the updated CLI.` : `\u5F53\u524D\u4F1A\u8BDD\u4ECD\u8FD0\u884C ${running.version}\uFF1B\u65B0\u5EFA\u5BF9\u8BDD\u540E\u4F7F\u7528\u66F4\u65B0\u7684 CLI\u3002` }) : null,
+      notice ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { children: notice }) : null,
+      newer ? /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { marginTop: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { children: en ? `Update available: ${update.current} \u2192 ${update.latest}` : `\u6709\u53EF\u7528\u66F4\u65B0\uFF1A${update.current} \u2192 ${update.latest}` }),
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("div", { children: guide.detail }),
+        guide.command ? /* @__PURE__ */ (0, import_jsx_runtime19.jsx)("code", { children: guide.command }) : null,
+        /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: 6, flexWrap: "wrap", marginTop: 6 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "secondary", size: "sm", onClick: () => onOpenExternal(guide.url), children: en ? "Update guide" : "\u66F4\u65B0\u6307\u5F15" }),
+          /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => {
             setDismissed(identity);
             try {
               window.localStorage.setItem(key, identity);
@@ -23481,12 +23578,12 @@
 
   // src/screens/ActivityScreen.jsx
   init_cep_runtime_inject();
-  var import_react23 = __toESM(require_react(), 1);
+  var import_react24 = __toESM(require_react(), 1);
 
   // src/components/activity/FilterBar.jsx
   init_cep_runtime_inject();
-  var import_react21 = __toESM(require_react(), 1);
-  var import_jsx_runtime19 = __toESM(require_jsx_runtime(), 1);
+  var import_react22 = __toESM(require_react(), 1);
+  var import_jsx_runtime20 = __toESM(require_jsx_runtime(), 1);
   function FilterBar({
     query = "",
     onQuery,
@@ -23494,8 +23591,8 @@
     filters = [],
     style
   }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime19.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", padding: "var(--space-2)", borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", padding: "var(--space-2)", borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
         Input,
         {
           value: query,
@@ -23505,14 +23602,14 @@
           suffix: null
         }
       ),
-      filters.map((f, i) => /* @__PURE__ */ (0, import_jsx_runtime19.jsx)(Select, { full: false, value: f.value, onChange: f.onChange, options: f.options, style: { flex: "none", width: f.width || 96 } }, i))
+      filters.map((f, i) => /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(Select, { full: false, value: f.value, onChange: f.onChange, options: f.options, style: { flex: "none", width: f.width || 96 } }, i))
     ] });
   }
 
   // src/components/activity/ActivityRow.jsx
   init_cep_runtime_inject();
-  var import_react22 = __toESM(require_react(), 1);
-  var import_jsx_runtime20 = __toESM(require_jsx_runtime(), 1);
+  var import_react23 = __toESM(require_react(), 1);
+  var import_jsx_runtime21 = __toESM(require_jsx_runtime(), 1);
   var RESULT = {
     success: { icon: "check", color: "var(--ok)" },
     error: { icon: "x", color: "var(--error)" },
@@ -23532,11 +23629,11 @@
     expandable = true,
     style
   }) {
-    const [expanded, setExpanded] = import_react22.default.useState(false);
-    const [hover, setHover] = import_react22.default.useState(false);
+    const [expanded, setExpanded] = import_react23.default.useState(false);
+    const [hover, setHover] = import_react23.default.useState(false);
     const r = RESULT[result] || RESULT.success;
-    return /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)("div", { style: { borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)("div", { style: { borderBottom: "1px solid var(--border-subtle)", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)(
         "div",
         {
           role: expandable ? "button" : void 0,
@@ -23554,11 +23651,11 @@
             transition: "background var(--dur-fast) var(--ease-out)"
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("span", { title: resultTitle, style: { display: "inline-flex", flex: "none" }, children: /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(Icon2, { name: r.icon, size: 12, strokeWidth: 2.5, color: r.color }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("span", { style: { flex: "none", font: `var(--weight-regular) var(--text-micro)/1 var(--font-mono)`, color: "var(--text-tertiary)" }, children: time }),
-            /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(Badge, { status: "neutral", style: { flex: "none", maxWidth: 84, overflow: "hidden" }, children: source }),
-            /* @__PURE__ */ (0, import_jsx_runtime20.jsx)("span", { style: { flex: "none", font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
-            /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime21.jsx)("span", { title: resultTitle, style: { display: "inline-flex", flex: "none" }, children: /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Icon2, { name: r.icon, size: 12, strokeWidth: 2.5, color: r.color }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime21.jsx)("span", { style: { flex: "none", font: `var(--weight-regular) var(--text-micro)/1 var(--font-mono)`, color: "var(--text-tertiary)" }, children: time }),
+            /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Badge, { status: "neutral", style: { flex: "none", maxWidth: 84, overflow: "hidden" }, children: source }),
+            /* @__PURE__ */ (0, import_jsx_runtime21.jsx)("span", { style: { flex: "none", font: `var(--weight-medium) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
+            /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
               "span",
               {
                 style: {
@@ -23573,7 +23670,7 @@
                 children: target
               }
             ),
-            expandable ? /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
+            expandable ? /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
               Icon2,
               {
                 name: "chevron-down",
@@ -23585,8 +23682,8 @@
           ]
         }
       ),
-      expanded ? /* @__PURE__ */ (0, import_jsx_runtime20.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2) 26px", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
-        params != null ? /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(
+      expanded ? /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2) 26px", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+        params != null ? /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
           "pre",
           {
             style: {
@@ -23605,7 +23702,7 @@
             children: typeof params === "string" ? params : JSON.stringify(params, null, 2)
           }
         ) : null,
-        onUndo ? /* @__PURE__ */ (0, import_jsx_runtime20.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: onUndo, style: { alignSelf: "flex-start" }, children: undoLabel }) : null
+        onUndo ? /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: onUndo, style: { alignSelf: "flex-start" }, children: undoLabel }) : null
       ] }) : null
     ] });
   }
@@ -23672,7 +23769,7 @@
   }
 
   // src/screens/ActivityScreen.jsx
-  var import_jsx_runtime21 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime22 = __toESM(require_jsx_runtime(), 1);
   var A = {
     zh: {
       search: "\u641C\u7D22\u64CD\u4F5C\u2026",
@@ -23724,9 +23821,9 @@
     emptyCaption
   }) {
     const t = A[lang] || A.zh;
-    const [q, setQ] = import_react23.default.useState("");
-    const [res, setRes] = import_react23.default.useState("all");
-    const [undoing, setUndoing] = import_react23.default.useState(false);
+    const [q, setQ] = import_react24.default.useState("");
+    const [res, setRes] = import_react24.default.useState("all");
+    const [undoing, setUndoing] = import_react24.default.useState(false);
     const rows = filterEvents(events, { mode: res, query: q });
     const empty = events.length === 0;
     const undoCheckpoint = async () => {
@@ -23738,9 +23835,9 @@
         setUndoing(false);
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime21.jsx)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: empty ? /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)(import_react23.default.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)("div", { style: { display: "flex", borderBottom: "1px solid var(--border-subtle)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: empty ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)(import_react24.default.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { display: "flex", borderBottom: "1px solid var(--border-subtle)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(
           FilterBar,
           {
             query: q,
@@ -23760,12 +23857,12 @@
             ]
           }
         ),
-        onClear ? /* @__PURE__ */ (0, import_jsx_runtime21.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-1)", padding: "var(--space-2) var(--space-2) var(--space-2) 0" }, children: [
-          onUndoCheckpoint ? /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: undoCheckpoint, disabled: undoing, title: t.undoCheckpointTitle, children: undoing ? t.undoingCheckpoint : t.undoCheckpoint }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(Button, { size: "sm", variant: "ghost", icon: "trash-2", onClick: onClear, title: t.clear, children: t.clear })
+        onClear ? /* @__PURE__ */ (0, import_jsx_runtime22.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-1)", padding: "var(--space-2) var(--space-2) var(--space-2) 0" }, children: [
+          onUndoCheckpoint ? /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { size: "sm", variant: "secondary", icon: "undo-2", onClick: undoCheckpoint, disabled: undoing, title: t.undoCheckpointTitle, children: undoing ? t.undoingCheckpoint : t.undoCheckpoint }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(Button, { size: "sm", variant: "ghost", icon: "trash-2", onClick: onClear, title: t.clear, children: t.clear })
         ] }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime21.jsx)("div", { style: { flex: 1, minHeight: 0, overflow: "auto" }, children: rows.length ? rows.map((evt) => /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime22.jsx)("div", { style: { flex: 1, minHeight: 0, overflow: "auto" }, children: rows.length ? rows.map((evt) => /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(
         ActivityRow,
         {
           time: new Date(evt.ts).toLocaleTimeString(),
@@ -23777,20 +23874,20 @@
           params: eventDetails(evt)
         },
         evt.id
-      )) : /* @__PURE__ */ (0, import_jsx_runtime21.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) })
+      )) : /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(EmptyState, { icon: "list", title: emptyTitle || t.empty, caption: emptyCaption || t.emptyCap, style: { flex: 1 } }) })
     ] }) });
   }
 
   // src/screens/WizardScreen.jsx
   init_cep_runtime_inject();
-  var import_react25 = __toESM(require_react(), 1);
+  var import_react26 = __toESM(require_react(), 1);
 
   // src/components/core/Spinner.jsx
   init_cep_runtime_inject();
-  var import_react24 = __toESM(require_react(), 1);
-  var import_jsx_runtime22 = __toESM(require_jsx_runtime(), 1);
+  var import_react25 = __toESM(require_react(), 1);
+  var import_jsx_runtime23 = __toESM(require_jsx_runtime(), 1);
   function Spinner({ size = 12, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime22.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
       "span",
       {
         role: "progressbar",
@@ -23898,7 +23995,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/screens/WizardScreen.jsx
-  var import_jsx_runtime23 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime24 = __toESM(require_jsx_runtime(), 1);
   var W = {
     zh: {
       stepOf: (n) => `\u7B2C ${n} \u6B65 / \u5171 3 \u6B65`,
@@ -23965,7 +24062,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     });
   }
   function CodeBlock({ code, copyLabel, onCopy, wrap = false }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
       "div",
       {
         style: {
@@ -23975,7 +24072,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           borderRadius: "var(--radius-md)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
             "pre",
             {
               style: {
@@ -23991,7 +24088,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
               children: code
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
             IconButton,
             {
               icon: "copy",
@@ -24010,7 +24107,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const busy = status === "checking" || status === "running";
     const problem = status === "missing" || status === "fail";
     const icon = status === "ok" ? "check" : problem ? "triangle-alert" : "circle";
-    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
       "div",
       {
         style: {
@@ -24022,7 +24119,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           background: "var(--bg-panel)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
             "span",
             {
               style: {
@@ -24033,15 +24130,15 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 justifyContent: "center",
                 color: status === "ok" ? "var(--ok)" : problem ? "var(--warn)" : "var(--text-tertiary)"
               },
-              children: busy ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Spinner, { size: 14 }) : /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Icon2, { name: icon, size: 15, strokeWidth: 2 })
+              children: busy ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Spinner, { size: 14 }) : /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Icon2, { name: icon, size: 15, strokeWidth: 2 })
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 5 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 6 }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
-              status === "ok" && state.version ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)" }, children: state.version }) : null,
-              /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1 } }),
-              /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 5 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 6 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { font: "500 12px/1.35 var(--font-ui)", color: "var(--text-primary)" }, children: label }),
+              status === "ok" && state.version ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { font: "400 10px/1.35 var(--font-mono)", color: "var(--text-tertiary)" }, children: state.version }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1 } }),
+              /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                 IconButton,
                 {
                   icon: "rotate-cw",
@@ -24053,10 +24150,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 }
               )
             ] }),
-            hint ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: hint }) : null,
-            problem && state.logTail ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 10px/1.45 var(--font-mono)", color: "var(--text-tertiary)" }, children: state.logTail }) : null,
-            problem && onInstall && commandPreview2 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+            hint ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: hint }) : null,
+            problem && state.logTail ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 10px/1.45 var(--font-mono)", color: "var(--text-tertiary)" }, children: state.logTail }) : null,
+            problem && onInstall && commandPreview2 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                 "code",
                 {
                   style: {
@@ -24069,9 +24166,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
                   children: commandPreview2
                 }
               ),
-              /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "secondary", size: "sm", onClick: onInstall, children: t.install })
+              /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "secondary", size: "sm", onClick: onInstall, children: t.install })
             ] }) : null,
-            pathEntry && onAddToPath ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "secondary", size: "sm", onClick: onAddToPath, children: t.addToPath }) }) : null
+            pathEntry && onAddToPath ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "secondary", size: "sm", onClick: onAddToPath, children: t.addToPath }) }) : null
           ] })
         ]
       }
@@ -24103,7 +24200,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       extensionRoot
     }) : "";
     const mcpUrl = `http://127.0.0.1:${port}/mcp`;
-    return /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
       "div",
       {
         style: {
@@ -24114,8 +24211,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
           padding: "var(--space-6) var(--space-5) var(--space-5)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { display: "flex", gap: 5 }, children: [1, 2, 3].map((number) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { display: "flex", gap: 5 }, children: [1, 2, 3].map((number) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
               "span",
               {
                 style: {
@@ -24127,11 +24224,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
               },
               number
             )) }),
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { font: "400 10px/1 var(--font-mono)", color: "var(--text-tertiary)" }, children: t.stepOf(step) }),
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1 } }),
-            onSkip && step < 3 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "ghost", size: "sm", onClick: onSkip, children: t.skip }) : null
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { font: "400 10px/1 var(--font-mono)", color: "var(--text-tertiary)" }, children: t.stepOf(step) }),
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1 } }),
+            onSkip && step < 3 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "ghost", size: "sm", onClick: onSkip, children: t.skip }) : null
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
             "div",
             {
               style: {
@@ -24144,10 +24241,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 paddingTop: "var(--space-6)"
               },
               children: [
-                step === 1 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t1 }),
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b1 }),
-                  HOST_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                step === 1 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(import_react26.default.Fragment, { children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t1 }),
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b1 }),
+                  HOST_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                     CheckRow,
                     {
                       label: STEP_LABELS[id],
@@ -24162,8 +24259,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     },
                     id
                   )),
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { children: [
-                    /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { children: [
+                    /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                       "div",
                       {
                         style: {
@@ -24174,7 +24271,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                         children: t.langLabel
                       }
                     ),
-                    /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                    /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                       Segmented,
                       {
                         full: true,
@@ -24188,10 +24285,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     )
                   ] })
                 ] }) : null,
-                step === 2 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t2 }),
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b2 }),
-                  CLI_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                step === 2 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(import_react26.default.Fragment, { children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t2 }),
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b2 }),
+                  CLI_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                     CheckRow,
                     {
                       label: STEP_LABELS[id],
@@ -24202,11 +24299,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     id
                   ))
                 ] }) : null,
-                step === 3 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t3 }),
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b3 }),
-                  promptText ? /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)(import_react25.default.Fragment, { children: [
-                    /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                step === 3 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(import_react26.default.Fragment, { children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "600 20px/1.35 var(--font-ui)" }, children: t.t3 }),
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)" }, children: t.b3 }),
+                  promptText ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(import_react26.default.Fragment, { children: [
+                    /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                       CodeBlock,
                       {
                         wrap: true,
@@ -24215,8 +24312,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                         onCopy: () => onCopy ? onCopy(promptText) : copyText2(promptText)
                       }
                     ),
-                    /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.directUrl }),
-                    /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                    /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.directUrl }),
+                    /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                       CodeBlock,
                       {
                         code: mcpUrl,
@@ -24225,8 +24322,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                       }
                     )
                   ] }) : null,
-                  /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.panelOpenNote }),
-                  OPTIONAL_CLIENT_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(
+                  /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("div", { style: { font: "400 10px/1.45 var(--font-ui)", color: "var(--text-tertiary)" }, children: t.panelOpenNote }),
+                  OPTIONAL_CLIENT_STEPS.map((id) => /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
                     CheckRow,
                     {
                       label: t.optionalNode,
@@ -24245,10 +24342,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
               ]
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime23.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", paddingTop: "var(--space-3)" }, children: [
-            step > 1 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "ghost", size: "lg", onClick: onBack, children: t.back }) : null,
-            /* @__PURE__ */ (0, import_jsx_runtime23.jsx)("span", { style: { flex: 1 } }),
-            step < 3 ? /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "primary", size: "lg", onClick: onNext, children: t.next }) : /* @__PURE__ */ (0, import_jsx_runtime23.jsx)(Button, { variant: "primary", size: "lg", onClick: onDone, children: t.start })
+          /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)", paddingTop: "var(--space-3)" }, children: [
+            step > 1 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "ghost", size: "lg", onClick: onBack, children: t.back }) : null,
+            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1 } }),
+            step < 3 ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "primary", size: "lg", onClick: onNext, children: t.next }) : /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { variant: "primary", size: "lg", onClick: onDone, children: t.start })
           ] })
         ]
       }
@@ -24257,12 +24354,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/screens/ConnectionDrawer.jsx
   init_cep_runtime_inject();
-  var import_react28 = __toESM(require_react(), 1);
+  var import_react29 = __toESM(require_react(), 1);
 
   // src/components/shell/DiagnosticItem.jsx
   init_cep_runtime_inject();
-  var import_react26 = __toESM(require_react(), 1);
-  var import_jsx_runtime24 = __toESM(require_jsx_runtime(), 1);
+  var import_react27 = __toESM(require_react(), 1);
+  var import_jsx_runtime25 = __toESM(require_jsx_runtime(), 1);
   var GLYPHS = {
     pass: { icon: "check", color: "var(--ok)" },
     fail: { icon: "x", color: "var(--error)" },
@@ -24270,10 +24367,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
   };
   function DiagnosticItem({ label, status = "pending", detail, actionLabel, onAction, style }) {
     const g = GLYPHS[status];
-    return /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { padding: "var(--space-1) 0", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: 22 }, children: [
-        status === "running" ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Spinner, { size: 12 }) : /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Icon2, { name: g.icon, size: 12, strokeWidth: 2.5, color: g.color }),
-        /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { padding: "var(--space-1) 0", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-2)", minHeight: 22 }, children: [
+        status === "running" ? /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Spinner, { size: 12 }) : /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Icon2, { name: g.icon, size: 12, strokeWidth: 2.5, color: g.color }),
+        /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(
           "span",
           {
             style: {
@@ -24286,7 +24383,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           }
         )
       ] }),
-      status === "fail" && detail ? /* @__PURE__ */ (0, import_jsx_runtime24.jsxs)(
+      status === "fail" && detail ? /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(
         "div",
         {
           style: {
@@ -24300,8 +24397,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
             borderRadius: "var(--radius-sm)"
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime24.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: detail }),
-            actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime24.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, style: { flex: "none" }, children: actionLabel }) : null
+            /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: detail }),
+            actionLabel ? /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, style: { flex: "none" }, children: actionLabel }) : null
           ]
         }
       ) : null
@@ -24310,19 +24407,19 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/shell/Drawer.jsx
   init_cep_runtime_inject();
-  var import_react27 = __toESM(require_react(), 1);
-  var import_jsx_runtime25 = __toESM(require_jsx_runtime(), 1);
+  var import_react28 = __toESM(require_react(), 1);
+  var import_jsx_runtime26 = __toESM(require_jsx_runtime(), 1);
   function Drawer({ open = false, title, onClose, children, closeTitle = "\u5173\u95ED Close", style }) {
     if (!open) return null;
-    return /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)("div", { style: { position: "absolute", inset: 0, zIndex: 30 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { position: "absolute", inset: 0, zIndex: 30 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
         "div",
         {
           onClick: onClose,
           style: { position: "absolute", inset: 0, background: "var(--scrim)", animation: "ds-fade var(--dur-slow) var(--ease-out)" }
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(
+      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(
         "div",
         {
           role: "dialog",
@@ -24343,7 +24440,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             ...style
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime25.jsxs)(
+            /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(
               "div",
               {
                 style: {
@@ -24354,12 +24451,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
                   borderBottom: "1px solid var(--border-subtle)"
                 },
                 children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-semibold) var(--text-heading)/1 var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
-                  /* @__PURE__ */ (0, import_jsx_runtime25.jsx)(IconButton, { icon: "x", title: closeTitle, onClick: onClose })
+                  /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { flex: 1, minWidth: 0, font: `var(--weight-semibold) var(--text-heading)/1 var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+                  /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(IconButton, { icon: "x", title: closeTitle, onClick: onClose })
                 ]
               }
             ),
-            /* @__PURE__ */ (0, import_jsx_runtime25.jsx)("div", { style: { overflow: "auto", padding: "var(--space-3)" }, children })
+            /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { overflow: "auto", padding: "var(--space-3)" }, children })
           ]
         }
       )
@@ -24367,7 +24464,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/screens/ConnectionDrawer.jsx
-  var import_jsx_runtime26 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
   var D = {
     zh: {
       title: "\u8FDE\u63A5",
@@ -24425,9 +24522,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     }
   };
   function KV({ k, children }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { width: 72, flex: "none", font: "400 11px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: k }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.35 var(--font-mono)", color: "var(--text-primary)" }, children })
+    return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, minHeight: 24 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { width: 72, flex: "none", font: "400 11px/1.35 var(--font-ui)", color: "var(--text-tertiary)" }, children: k }),
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.35 var(--font-mono)", color: "var(--text-primary)" }, children })
     ] });
   }
   function formatTime(ts) {
@@ -24452,40 +24549,40 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const hostVersion = info.hostVersion || "-";
     const mismatch = info.hostVersion && info.hostVersion !== panelVersion;
     const recent = info.lastClientSeenAt ? [{ time: formatTime(info.lastClientSeenAt), text: lang === "zh" ? "\u5916\u90E8 MCP \u5BA2\u6237\u7AEF" : "External MCP client" }] : [];
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.status, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(StatusDot, { status: connected ? "connected" : "waiting", size: 7 }),
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { fontFamily: "var(--font-ui)" }, children: statusLabel2 || (connected ? t.connected : t.waiting) })
+    return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(KV, { k: t.status, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(StatusDot, { status: connected ? "connected" : "waiting", size: 7 }),
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { fontFamily: "var(--font-ui)" }, children: statusLabel2 || (connected ? t.connected : t.waiting) })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.port, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(KV, { k: t.port, children: [
         info.port || "-",
         " ",
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(IconButton, { icon: "copy", title: t.copyConfig, disabled: !copyReady, onClick: () => callCopy(onCopyConfig), style: { width: 20, height: 20 } })
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(IconButton, { icon: "copy", title: t.copyConfig, disabled: !copyReady, onClick: () => callCopy(onCopyConfig), style: { width: 20, height: 20 } })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(KV, { k: t.token, children: info.tokenLabel || t.tokenLocal }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(KV, { k: t.ver, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(KV, { k: t.token, children: info.tokenLabel || t.tokenLocal }),
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(KV, { k: t.ver, children: [
         "v",
         panelVersion,
         " \xB7 host ",
         hostVersion,
-        mismatch ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Badge, { status: "warn", children: t.mismatch }) : null
+        mismatch ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Badge, { status: "warn", children: t.mismatch }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 4 }, children: t.recent }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", padding: "2px 8px" }, children: (recent.length ? recent : [{ time: "-", text: t.noRecent }]).map((r, i) => /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", gap: 8, alignItems: "center", minHeight: 22, font: "400 10px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { fontFamily: "var(--font-mono)", color: "var(--text-tertiary)" }, children: r.time }),
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("span", { style: { flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: r.text })
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { font: "500 11px/1.35 var(--font-ui)", color: "var(--text-secondary)", marginTop: 4 }, children: t.recent }),
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { background: "var(--bg-well)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", padding: "2px 8px" }, children: (recent.length ? recent : [{ time: "-", text: t.noRecent }]).map((r, i) => /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", gap: 8, alignItems: "center", minHeight: 22, font: "400 10px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { fontFamily: "var(--font-mono)", color: "var(--text-tertiary)" }, children: r.time }),
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { flex: 1, minWidth: 0, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: r.text })
       ] }, i)) }),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", gap: 6, marginTop: 4, flexWrap: "wrap" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", disabled: !copyReady, onClick: () => callCopy(onCopyConfig), children: t.copyConfig }),
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRestart, children: t.restart }),
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "stethoscope", onClick: onDiagnose, children: t.diagnose })
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", gap: 6, marginTop: 4, flexWrap: "wrap" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", disabled: !copyReady, onClick: () => callCopy(onCopyConfig), children: t.copyConfig }),
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRestart, children: t.restart }),
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "secondary", size: "sm", icon: "stethoscope", onClick: onDiagnose, children: t.diagnose })
       ] })
     ] });
   }
   function DiagnosticsBody({ lang = "zh", diagnostics = [], onRerun }) {
     const t = D[lang] || D.zh;
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", flexDirection: "column" }, children: [
-      diagnostics.map((c) => /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", flexDirection: "column" }, children: [
+      diagnostics.map((c) => /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
         DiagnosticItem,
         {
           label: t.checks[c.id] || c.id,
@@ -24494,10 +24591,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
         },
         c.id
       )),
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 6, paddingTop: "var(--space-2)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyText(JSON.stringify(diagnostics, null, 2)).catch(() => {
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 6, paddingTop: "var(--space-2)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "secondary", size: "sm", icon: "copy", onClick: () => copyText(JSON.stringify(diagnostics, null, 2)).catch(() => {
         }), children: t.copyReport }),
-        /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRerun, children: t.rerun })
+        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "secondary", size: "sm", icon: "rotate-cw", onClick: onRerun, children: t.rerun })
       ] })
     ] });
   }
@@ -24505,8 +24602,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const diagList = Array.isArray(diagnostics) ? diagnostics : [];
     const t = D[lang] || D.zh;
     const panelVersion = info.panelVersion || package_default.version;
-    return /* @__PURE__ */ (0, import_jsx_runtime26.jsxs)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
         ConnectionDrawerBody,
         {
           lang,
@@ -24518,13 +24615,13 @@ When you are done, remind me of two things: MCP tools load only in a new session
           onDiagnose
         }
       ),
-      diagList.length ? /* @__PURE__ */ (0, import_jsx_runtime26.jsx)("div", { style: { marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime26.jsx)(DiagnosticsBody, { lang, diagnostics: diagList, onRerun: onDiagnose }) }) : null
+      diagList.length ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(DiagnosticsBody, { lang, diagnostics: diagList, onRerun: onDiagnose }) }) : null
     ] });
   }
 
   // src/screens/SessionDrawer.jsx
   init_cep_runtime_inject();
-  var import_react29 = __toESM(require_react(), 1);
+  var import_react30 = __toESM(require_react(), 1);
 
   // src/lib/sessionList.js
   init_cep_runtime_inject();
@@ -24594,7 +24691,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/screens/SessionDrawer.jsx
-  var import_jsx_runtime27 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime28 = __toESM(require_jsx_runtime(), 1);
   var C = {
     zh: {
       title: "\u4F1A\u8BDD\u5386\u53F2",
@@ -24645,11 +24742,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onDelete
   }) {
     const t = C[lang] || C.zh;
-    const [search, setSearch] = import_react29.default.useState("");
-    const [view, setView] = import_react29.default.useState("active");
-    const [editingId, setEditingId] = import_react29.default.useState(null);
-    const [editingTitle, setEditingTitle] = import_react29.default.useState("");
-    const [confirmId, setConfirmId] = import_react29.default.useState(null);
+    const [search, setSearch] = import_react30.default.useState("");
+    const [view, setView] = import_react30.default.useState("active");
+    const [editingId, setEditingId] = import_react30.default.useState(null);
+    const [editingTitle, setEditingTitle] = import_react30.default.useState("");
+    const [confirmId, setConfirmId] = import_react30.default.useState(null);
     const now = Date.now();
     const archived = view === "archived";
     const visible = sortSessions(filterSessions(sessions, { archived, search }));
@@ -24658,9 +24755,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       setEditingId(null);
       setEditingTitle("");
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)", flexWrap: "wrap" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Drawer, { open, title: t.title, onClose, closeTitle: t.close, children: /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-2)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)", flexWrap: "wrap" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
           Input,
           {
             value: search,
@@ -24671,7 +24768,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             style: { flex: "1 1 150px" }
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
           Button,
           {
             variant: "primary",
@@ -24685,7 +24782,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           }
         )
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
         Segmented,
         {
           full: true,
@@ -24701,11 +24798,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ]
         }
       ),
-      visible.length ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { display: "flex", flexDirection: "column", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", overflow: "hidden" }, children: visible.map((meta) => {
+      visible.length ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("div", { style: { display: "flex", flexDirection: "column", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-md)", overflow: "hidden" }, children: visible.map((meta) => {
         const current = meta.id === activeId;
         const editing = editingId === meta.id;
         const confirming = confirmId === meta.id;
-        return /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(
+        return /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
           "div",
           {
             style: {
@@ -24718,8 +24815,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
               borderBottom: "1px solid var(--border-subtle)"
             },
             children: [
-              /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { flex: 1, minWidth: 0 }, children: [
-                editing ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { flex: 1, minWidth: 0 }, children: [
+                editing ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
                   Input,
                   {
                     value: editingTitle,
@@ -24731,7 +24828,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                       if (event.key === "Escape") setEditingId(null);
                     }
                   }
-                ) : /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)(
+                ) : /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)(
                   "button",
                   {
                     type: "button",
@@ -24754,26 +24851,26 @@ When you are done, remind me of two things: MCP tools load only in a new session
                       cursor: "pointer"
                     },
                     children: [
-                      /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", font: "var(--weight-medium) var(--text-body)/var(--leading-tight) var(--font-ui)" }, children: displayTitle(meta, lang) }),
-                      current ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Badge, { status: "accent", children: t.current }) : null
+                      /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", font: "var(--weight-medium) var(--text-body)/var(--leading-tight) var(--font-ui)" }, children: displayTitle(meta, lang) }),
+                      current ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Badge, { status: "accent", children: t.current }) : null
                     ]
                   }
                 ),
-                !editing ? /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, minWidth: 0, marginTop: 3 }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Badge, { status: "neutral", children: backendLabel(meta.backend, lang) }),
-                  meta.model ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Badge, { status: "neutral", children: meta.model }) : null,
-                  /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { minWidth: 0, color: "var(--text-tertiary)", font: "var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: relativeTime(meta.updatedAt, now, lang) })
+                !editing ? /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, minWidth: 0, marginTop: 3 }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Badge, { status: "neutral", children: backendLabel(meta.backend, lang) }),
+                  meta.model ? /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Badge, { status: "neutral", children: meta.model }) : null,
+                  /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { minWidth: 0, color: "var(--text-tertiary)", font: "var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }, children: relativeTime(meta.updatedAt, now, lang) })
                 ] }) : null
               ] }),
-              confirming ? /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flex: "none" }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("span", { style: { color: "var(--error)", font: "var(--weight-medium) var(--text-caption)/1 var(--font-ui)" }, children: t.confirmRemove }),
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "danger", size: "sm", onClick: () => {
+              confirming ? /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flex: "none" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("span", { style: { color: "var(--error)", font: "var(--weight-medium) var(--text-caption)/1 var(--font-ui)" }, children: t.confirmRemove }),
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Button, { variant: "danger", size: "sm", onClick: () => {
                   setConfirmId(null);
                   if (onDelete) onDelete(meta.id);
                 }, children: t.remove }),
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => setConfirmId(null), children: t.cancel })
-              ] }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { style: { display: "flex", alignItems: "center", flex: "none" }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Button, { variant: "ghost", size: "sm", onClick: () => setConfirmId(null), children: t.cancel })
+              ] }) : /* @__PURE__ */ (0, import_jsx_runtime28.jsxs)("div", { style: { display: "flex", alignItems: "center", flex: "none" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
                   IconButton,
                   {
                     icon: "pencil",
@@ -24785,7 +24882,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     }
                   }
                 ),
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
                   IconButton,
                   {
                     icon: meta.archived ? "archive-restore" : "archive",
@@ -24793,7 +24890,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     onClick: () => meta.archived ? onUnarchive == null ? void 0 : onUnarchive(meta.id) : onArchive == null ? void 0 : onArchive(meta.id)
                   }
                 ),
-                /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(IconButton, { icon: "trash-2", danger: true, title: t.remove, onClick: () => {
+                /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(IconButton, { icon: "trash-2", danger: true, title: t.remove, onClick: () => {
                   setConfirmId(meta.id);
                   setEditingId(null);
                 } })
@@ -24802,24 +24899,24 @@ When you are done, remind me of two things: MCP tools load only in a new session
           },
           meta.id
         );
-      }) }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { style: { padding: "var(--space-5) var(--space-2)", textAlign: "center", color: "var(--text-tertiary)", font: "var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)" }, children: archived ? t.emptyArchived : t.emptyActive })
+      }) }) : /* @__PURE__ */ (0, import_jsx_runtime28.jsx)("div", { style: { padding: "var(--space-5) var(--space-2)", textAlign: "center", color: "var(--text-tertiary)", font: "var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui)" }, children: archived ? t.emptyArchived : t.emptyActive })
     ] }) });
   }
 
   // src/screens/ChatScreen.jsx
   init_cep_runtime_inject();
-  var import_react40 = __toESM(require_react(), 1);
+  var import_react41 = __toESM(require_react(), 1);
 
   // src/components/chat/ChatBubble.jsx
   init_cep_runtime_inject();
-  var import_react31 = __toESM(require_react(), 1);
+  var import_react32 = __toESM(require_react(), 1);
 
   // src/components/chat/AIAvatar.jsx
   init_cep_runtime_inject();
-  var import_react30 = __toESM(require_react(), 1);
-  var import_jsx_runtime28 = __toESM(require_jsx_runtime(), 1);
+  var import_react31 = __toESM(require_react(), 1);
+  var import_jsx_runtime29 = __toESM(require_jsx_runtime(), 1);
   function AIAvatar({ size = 20, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(
       "span",
       {
         "aria-label": "AI",
@@ -24835,13 +24932,13 @@ When you are done, remind me of two things: MCP tools load only in a new session
           borderRadius: "var(--radius-md)",
           ...style
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Icon2, { name: "sparkles", size: Math.round(size * 0.6), color: "var(--accent)", strokeWidth: 2 })
+        children: /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Icon2, { name: "sparkles", size: Math.round(size * 0.6), color: "var(--accent)", strokeWidth: 2 })
       }
     );
   }
 
   // src/components/chat/ChatBubble.jsx
-  var import_jsx_runtime29 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime30 = __toESM(require_jsx_runtime(), 1);
   function formatAttachmentBytes(value) {
     const bytes = Number(value) || 0;
     if (bytes < 1024) return bytes + " B";
@@ -24862,7 +24959,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }) {
     const children = normalizeBreaks(rawChildren);
     if (role === "user") {
-      return /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { style: { display: "flex", justifyContent: "flex-end", ...style }, children: /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+      return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { style: { display: "flex", justifyContent: "flex-end", ...style }, children: /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
         "div",
         {
           style: {
@@ -24878,8 +24975,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
             whiteSpace: "pre-wrap"
           },
           children: [
-            children ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { children }) : null,
-            attachments.length ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 3, marginTop: children ? 5 : 0 }, children: attachments.map((attachment) => /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+            children ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { children }) : null,
+            attachments.length ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { style: { display: "flex", flexDirection: "column", gap: 3, marginTop: children ? 5 : 0 }, children: attachments.map((attachment) => /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
               "div",
               {
                 style: {
@@ -24891,8 +24988,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                   font: "var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)"
                 },
                 children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: attachment.name }),
-                  /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("span", { style: { flex: "none", color: "var(--text-tertiary)" }, children: formatAttachmentBytes(attachment.size) })
+                  /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: attachment.name }),
+                  /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { flex: "none", color: "var(--text-tertiary)" }, children: formatAttachmentBytes(attachment.size) })
                 ]
               },
               attachment.id
@@ -24901,9 +24998,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
         }
       ) });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)("div", { style: { display: "flex", gap: "var(--space-2)", alignItems: "flex-start", ...style }, children: [
-      avatar ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(AIAvatar, { style: { marginTop: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime29.jsx)("span", { style: { width: 20, flex: "none" } }),
-      /* @__PURE__ */ (0, import_jsx_runtime29.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("div", { style: { display: "flex", gap: "var(--space-2)", alignItems: "flex-start", ...style }, children: [
+      avatar ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(AIAvatar, { style: { marginTop: 1 } }) : /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { width: 20, flex: "none" } }),
+      /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
         "div",
         {
           style: {
@@ -24916,7 +25013,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           },
           children: [
             children,
-            streaming ? /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(
+            streaming ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
               "span",
               {
                 style: {
@@ -24939,15 +25036,15 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/chat/ToolCallCard.jsx
   init_cep_runtime_inject();
-  var import_react32 = __toESM(require_react(), 1);
-  var import_jsx_runtime30 = __toESM(require_jsx_runtime(), 1);
+  var import_react33 = __toESM(require_react(), 1);
+  var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
   function StatusGlyph({ status }) {
-    if (status === "running") return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Spinner, { size: 12 });
-    if (status === "error") return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Icon2, { name: "x", size: 12, strokeWidth: 2.5, color: "var(--error)" });
-    return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.5, color: "var(--ok)" });
+    if (status === "running") return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Spinner, { size: 12 });
+    if (status === "error") return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: "x", size: 12, strokeWidth: 2.5, color: "var(--error)" });
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.5, color: "var(--ok)" });
   }
   function ParamsBlock({ params }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
       "pre",
       {
         style: {
@@ -24967,7 +25064,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function DetailsBlock({ details }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
       "pre",
       {
         style: {
@@ -24987,8 +25084,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function HeaderRow({ status, verb, target, expandable, expanded, onToggle }) {
-    const [hover, setHover] = import_react32.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
+    const [hover, setHover] = import_react33.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
       "div",
       {
         role: expandable ? "button" : void 0,
@@ -25006,9 +25103,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
           transition: "background var(--dur-fast) var(--ease-out)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(StatusGlyph, { status }),
-          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { font: `var(--weight-medium) var(--text-body)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
-          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(StatusGlyph, { status }),
+          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { style: { font: `var(--weight-medium) var(--text-body)/1 var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "nowrap" }, children: verb }),
+          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
             "span",
             {
               style: {
@@ -25023,7 +25120,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
               children: target
             }
           ),
-          expandable ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+          expandable ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
             Icon2,
             {
               name: "chevron-down",
@@ -25052,11 +25149,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
     retryLabel = "\u91CD\u8BD5",
     style
   }) {
-    const [expanded, setExpanded] = import_react32.default.useState(defaultExpanded);
+    const [expanded, setExpanded] = import_react33.default.useState(defaultExpanded);
     const isGroup = Array.isArray(steps) && steps.length > 0;
     const hasDetails = details !== void 0 && details !== null && details !== "";
     const expandable = isGroup || params != null || hasDetails;
-    return /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
       "div",
       {
         style: {
@@ -25068,7 +25165,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
             HeaderRow,
             {
               status,
@@ -25079,14 +25176,14 @@ When you are done, remind me of two things: MCP tools load only in a new session
               onToggle: () => setExpanded(!expanded)
             }
           ),
-          expanded && isGroup ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("div", { style: { borderTop: "1px solid var(--border-subtle)", padding: "var(--space-1) 0" }, children: steps.map((s, i) => /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
+          expanded && isGroup ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { borderTop: "1px solid var(--border-subtle)", padding: "var(--space-1) 0" }, children: steps.map((s, i) => /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
             "div",
             {
               style: { display: "flex", alignItems: "center", gap: "var(--space-15)", minHeight: 22, padding: "0 var(--space-2) 0 var(--space-5)" },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(StatusGlyph, { status: s.status || "success" }),
-                /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-secondary)", whiteSpace: "nowrap" }, children: s.verb }),
-                /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(StatusGlyph, { status: s.status || "success" }),
+                /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)`, color: "var(--text-secondary)", whiteSpace: "nowrap" }, children: s.verb }),
+                /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
                   "span",
                   {
                     style: {
@@ -25105,9 +25202,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
             },
             i
           )) }) : null,
-          expanded && !isGroup && params != null ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(ParamsBlock, { params }) : null,
-          expanded && !isGroup && hasDetails ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(DetailsBlock, { details }) : null,
-          status === "error" && errorMessage2 ? /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)(
+          expanded && !isGroup && params != null ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(ParamsBlock, { params }) : null,
+          expanded && !isGroup && hasDetails ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(DetailsBlock, { details }) : null,
+          status === "error" && errorMessage2 ? /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
             "div",
             {
               style: {
@@ -25119,10 +25216,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 background: "var(--error-bg)"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime30.jsxs)("div", { style: { flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 3 }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--error)" }, children: errorMessage2 }),
-                  hint ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)("span", { style: { font: `var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui)`, color: "var(--text-secondary)" }, children: hint }) : null,
-                  hasDetails ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 3 }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--error)" }, children: errorMessage2 }),
+                  hint ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("span", { style: { font: `var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui)`, color: "var(--text-secondary)" }, children: hint }) : null,
+                  hasDetails ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
                     "button",
                     {
                       type: "button",
@@ -25132,7 +25229,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     }
                   ) : null
                 ] }),
-                onRetry ? /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Button, { size: "sm", variant: "secondary", icon: "rotate-cw", onClick: onRetry, children: retryLabel }) : null
+                onRetry ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Button, { size: "sm", variant: "secondary", icon: "rotate-cw", onClick: onRetry, children: retryLabel }) : null
               ]
             }
           ) : null
@@ -25143,8 +25240,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/chat/ApprovalCard.jsx
   init_cep_runtime_inject();
-  var import_react33 = __toESM(require_react(), 1);
-  var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
+  var import_react34 = __toESM(require_react(), 1);
+  var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
   var L = {
     zh: {
       needs: "\u9700\u8981\u6279\u51C6",
@@ -25179,10 +25276,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onAllowSession,
     style
   }) {
-    const [expanded, setExpanded] = import_react33.default.useState(false);
+    const [expanded, setExpanded] = import_react34.default.useState(false);
     const t = L[lang] || L.zh;
     const high = risk === "high";
-    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
       "div",
       {
         style: {
@@ -25194,19 +25291,19 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { padding: "var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)" }, children: high ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Badge, { status: "error", icon: "shield-alert", children: t.high }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Badge, { status: "warn", icon: "shield", children: t.needs }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { font: `var(--weight-semibold) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
-            description ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: description }) : null,
-            params != null ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(ApprovalParams, { t, expanded, onToggle: () => setExpanded(!expanded), params }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { padding: "var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)" }, children: high ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Badge, { status: "error", icon: "shield-alert", children: t.high }) : /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Badge, { status: "warn", icon: "shield", children: t.needs }) }),
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: `var(--weight-semibold) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+            description ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)" }, children: description }) : null,
+            params != null ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(ApprovalParams, { t, expanded, onToggle: () => setExpanded(!expanded), params }) : null
           ] }),
-          state === "pending" ? /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Button, { variant: high ? "danger" : "primary", full: true, onClick: onAllow, children: t.allow }),
-              /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Button, { variant: "secondary", full: true, onClick: onDeny, children: t.deny })
+          state === "pending" ? /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", gap: "var(--space-15)" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { variant: high ? "danger" : "primary", full: true, onClick: onAllow, children: t.allow }),
+              /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { variant: "secondary", full: true, onClick: onDeny, children: t.deny })
             ] }),
-            onAllowSession && !high ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Button, { variant: "ghost", size: "sm", onClick: onAllowSession, style: { alignSelf: "flex-start", color: "var(--text-tertiary)" }, children: t.session }) : null
-          ] }) : /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+            onAllowSession && !high ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { variant: "ghost", size: "sm", onClick: onAllowSession, style: { alignSelf: "flex-start", color: "var(--text-tertiary)" }, children: t.session }) : null
+          ] }) : /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
             "div",
             {
               style: {
@@ -25219,7 +25316,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 color: state === "allowed" ? "var(--ok)" : "var(--text-tertiary)"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: state === "allowed" ? "check" : "x", size: 12, strokeWidth: 2.5 }),
+                /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: state === "allowed" ? "check" : "x", size: 12, strokeWidth: 2.5 }),
                 state === "allowed" ? t.allowed : t.denied
               ]
             }
@@ -25229,9 +25326,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function ApprovalParams({ t, expanded, onToggle, params }) {
-    const [hover, setHover] = import_react33.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)("div", { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime31.jsxs)(
+    const [hover, setHover] = import_react34.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
         "button",
         {
           type: "button",
@@ -25252,12 +25349,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
             color: hover ? "var(--text-secondary)" : "var(--text-tertiary)"
           },
           children: [
-            /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Icon2, { name: "chevron-right", size: 11, style: { transform: expanded ? "rotate(90deg)" : "none", transition: "transform var(--dur-base) var(--ease-out)" } }),
+            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: "chevron-right", size: 11, style: { transform: expanded ? "rotate(90deg)" : "none", transition: "transform var(--dur-base) var(--ease-out)" } }),
             t.params
           ]
         }
       ),
-      expanded ? /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(
+      expanded ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
         "pre",
         {
           style: {
@@ -25281,7 +25378,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/chat/QuestionCard.jsx
   init_cep_runtime_inject();
-  var import_react34 = __toESM(require_react(), 1);
+  var import_react35 = __toESM(require_react(), 1);
 
   // src/lib/questionForm.js
   init_cep_runtime_inject();
@@ -25466,7 +25563,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/components/chat/QuestionCard.jsx
-  var import_jsx_runtime32 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
   var L2 = {
     zh: {
       needs: "\u9700\u8981\u56DE\u7B54",
@@ -25497,8 +25594,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
   };
   var OTHER_KEY = "__ae_mcp_other__";
   function OptionRow({ selected, multiSelect, label, description, onToggle }) {
-    const [hover, setHover] = import_react34.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+    const [hover, setHover] = import_react35.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
       "button",
       {
         type: "button",
@@ -25523,7 +25620,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           font: `var(--weight-regular) var(--text-body)/var(--leading-tight) var(--font-ui)`
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
             "span",
             {
               "aria-hidden": true,
@@ -25540,12 +25637,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 background: selected ? "var(--accent)" : "transparent",
                 color: "var(--text-on-solid)"
               },
-              children: selected ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: "check", size: 9, strokeWidth: 3 }) : null
+              children: selected ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: "check", size: 9, strokeWidth: 3 }) : null
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("span", { style: { minWidth: 0 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { display: "block", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: label }),
-            description ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("span", { style: { minWidth: 0 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { display: "block", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: label }),
+            description ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
               "span",
               {
                 style: {
@@ -25581,12 +25678,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const selected = Array.isArray(selection) ? selection : selection ? [selection] : [];
     const customActive = selected.includes(OTHER_KEY);
     const freeText = !question.options.length;
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { font: `var(--weight-semibold) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: [
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 4 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { font: `var(--weight-semibold) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: [
         question.prompt || question.header || question.key,
-        question.multiSelect ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("span", { style: { marginLeft: 6, color: "var(--text-tertiary)", font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)` }, children: t.multiHint }) : null
+        question.multiSelect ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { marginLeft: 6, color: "var(--text-tertiary)", font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)` }, children: t.multiHint }) : null
       ] }),
-      freeText ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+      freeText ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
         "textarea",
         {
           rows: 2,
@@ -25596,8 +25693,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
           onChange: (event) => onCustomText(event.target.value),
           style: textInputStyle(Boolean(error))
         }
-      ) : /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 3 }, role: question.multiSelect ? "group" : "radiogroup", children: [
-        question.options.map((option2) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+      ) : /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 3 }, role: question.multiSelect ? "group" : "radiogroup", children: [
+        question.options.map((option2) => /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
           OptionRow,
           {
             multiSelect: question.multiSelect,
@@ -25608,7 +25705,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           },
           option2.label
         )),
-        question.allowCustom ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+        question.allowCustom ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
           OptionRow,
           {
             multiSelect: question.multiSelect,
@@ -25618,7 +25715,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             onToggle: () => onSelect(OTHER_KEY)
           }
         ) : null,
-        question.allowCustom && customActive ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+        question.allowCustom && customActive ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
           "textarea",
           {
             rows: 1,
@@ -25630,7 +25727,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           }
         ) : null
       ] }),
-      error ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { color: "var(--error)", font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)` }, children: error === "invalid-option" ? t.invalidOption : t.required }) : null
+      error ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("div", { style: { color: "var(--error)", font: `var(--weight-regular) var(--text-caption)/1 var(--font-ui)` }, children: error === "invalid-option" ? t.invalidOption : t.required }) : null
     ] });
   }
   function collectQuestionValues(questions, selections, customTexts) {
@@ -25660,9 +25757,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     style
   }) {
     const t = L2[lang] || L2.zh;
-    const [selections, setSelections] = import_react34.default.useState({});
-    const [customTexts, setCustomTexts] = import_react34.default.useState({});
-    const [errors, setErrors] = import_react34.default.useState({});
+    const [selections, setSelections] = import_react35.default.useState({});
+    const [customTexts, setCustomTexts] = import_react35.default.useState({});
+    const [errors, setErrors] = import_react35.default.useState({});
     const select = (question, label) => {
       setSelections((current) => {
         const previous = current[question.id];
@@ -25688,7 +25785,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       }
       if (onSubmit) onSubmit(values);
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
       "div",
       {
         style: {
@@ -25700,10 +25797,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { padding: "var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)" }, children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Badge, { status: "warn", icon: "message-square", children: t.needs }) }),
-            title ? /* @__PURE__ */ (0, import_jsx_runtime32.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: title }) : null,
-            state === "pending" ? questions.map((question) => /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { padding: "var(--space-2)", display: "flex", flexDirection: "column", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("div", { style: { display: "flex", alignItems: "center", gap: "var(--space-15)" }, children: /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Badge, { status: "warn", icon: "message-square", children: t.needs }) }),
+            title ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("div", { style: { font: `var(--weight-regular) var(--text-caption)/var(--leading-normal) var(--font-ui)`, color: "var(--text-secondary)", whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: title }) : null,
+            state === "pending" ? questions.map((question) => /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(
               QuestionField,
               {
                 question,
@@ -25717,10 +25814,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
               question.id
             )) : null
           ] }),
-          state === "pending" ? /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2)", display: "flex", gap: "var(--space-15)" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { variant: "primary", full: true, onClick: submit, children: t.submit }),
-            /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Button, { variant: "secondary", full: true, onClick: onCancel, children: t.cancel })
-          ] }) : /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)(
+          state === "pending" ? /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("div", { style: { padding: "0 var(--space-2) var(--space-2)", display: "flex", gap: "var(--space-15)" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Button, { variant: "primary", full: true, onClick: submit, children: t.submit }),
+            /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Button, { variant: "secondary", full: true, onClick: onCancel, children: t.cancel })
+          ] }) : /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
             "div",
             {
               style: {
@@ -25733,8 +25830,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 color: state === "answered" ? "var(--ok)" : "var(--text-tertiary)"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Icon2, { name: state === "answered" ? "check" : "x", size: 12, strokeWidth: 2.5, style: { marginTop: 1 } }),
-                /* @__PURE__ */ (0, import_jsx_runtime32.jsxs)("span", { style: { minWidth: 0, whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: state === "answered" ? "check" : "x", size: 12, strokeWidth: 2.5, style: { marginTop: 1 } }),
+                /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("span", { style: { minWidth: 0, whiteSpace: "pre-wrap", overflowWrap: "break-word" }, children: [
                   state === "answered" ? t.answered : t.cancelled,
                   state === "answered" && answers && Object.keys(answers).length ? ": " + Object.values(answers).join(" \xB7 ") : ""
                 ] })
@@ -25748,11 +25845,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/chat/PromptCard.jsx
   init_cep_runtime_inject();
-  var import_react35 = __toESM(require_react(), 1);
-  var import_jsx_runtime33 = __toESM(require_jsx_runtime(), 1);
+  var import_react36 = __toESM(require_react(), 1);
+  var import_jsx_runtime34 = __toESM(require_jsx_runtime(), 1);
   function PromptCard({ icon = "wand-2", title, caption, onClick, style }) {
-    const [hover, setHover] = import_react35.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)(
+    const [hover, setHover] = import_react36.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)(
       "button",
       {
         type: "button",
@@ -25775,10 +25872,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ...style
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Icon2, { name: icon, size: 14, color: "var(--text-tertiary)", style: { marginTop: 1 } }),
-          /* @__PURE__ */ (0, import_jsx_runtime33.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { display: "block", font: `var(--weight-medium) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
-            caption ? /* @__PURE__ */ (0, import_jsx_runtime33.jsx)("span", { style: { display: "block", marginTop: 2, font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)" }, children: caption }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: icon, size: 14, color: "var(--text-tertiary)", style: { marginTop: 1 } }),
+          /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("span", { style: { flex: 1, minWidth: 0 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { style: { display: "block", font: `var(--weight-medium) var(--text-body)/var(--leading-tight) var(--font-ui)`, color: "var(--text-primary)" }, children: title }),
+            caption ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { style: { display: "block", marginTop: 2, font: `var(--weight-regular) var(--text-caption)/var(--leading-tight) var(--font-ui)`, color: "var(--text-tertiary)" }, children: caption }) : null
           ] })
         ]
       }
@@ -25787,11 +25884,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/chat/Composer.jsx
   init_cep_runtime_inject();
-  var import_react37 = __toESM(require_react(), 1);
+  var import_react38 = __toESM(require_react(), 1);
 
   // src/components/chat/AttachmentPond.jsx
   init_cep_runtime_inject();
-  var import_react36 = __toESM(require_react(), 1);
+  var import_react37 = __toESM(require_react(), 1);
   var import_react_filepond = __toESM(require_react_filepond(), 1);
   var import_filepond_plugin_image_preview = __toESM(require_filepond_plugin_image_preview(), 1);
 
@@ -25904,7 +26001,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/components/chat/AttachmentPond.jsx
-  var import_jsx_runtime34 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime35 = __toESM(require_jsx_runtime(), 1);
   (0, import_react_filepond.registerPlugin)(import_filepond_plugin_image_preview.default);
   var DEFAULT_LABELS = {
     add: "\u6DFB\u52A0\u6587\u4EF6 Add files",
@@ -25924,7 +26021,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   function findItem(items, fileItem) {
     return items.find((item) => item.pondId === (fileItem == null ? void 0 : fileItem.id) || item.file === (fileItem == null ? void 0 : fileItem.file));
   }
-  var AttachmentPond = import_react36.default.forwardRef(function AttachmentPond2({
+  var AttachmentPond = import_react37.default.forwardRef(function AttachmentPond2({
     items = [],
     disabled = false,
     labels: suppliedLabels,
@@ -25932,11 +26029,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onRemoveAttachment,
     onRetryAttachment
   }, forwardedRef) {
-    const pondRef = import_react36.default.useRef(null);
+    const pondRef = import_react37.default.useRef(null);
     const labels = { ...DEFAULT_LABELS, ...suppliedLabels || {} };
     const pondFiles = items.map((item) => item.file).filter(Boolean);
     const labelIdle = labels.drop + ' <span class="filepond--label-action">' + labels.add + "</span>";
-    import_react36.default.useImperativeHandle(forwardedRef, () => ({
+    import_react37.default.useImperativeHandle(forwardedRef, () => ({
       addFiles(files) {
         var _a;
         return (_a = pondRef.current) == null ? void 0 : _a.addFiles(Array.from(files || []));
@@ -25951,8 +26048,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
       const item = findItem(items, fileItem);
       if (item) onRemoveAttachment == null ? void 0 : onRemoveAttachment(item);
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)("div", { className: "ae-attachment-pond", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { className: "ae-attachment-pond", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
         import_react_filepond.FilePond,
         {
           ref: pondRef,
@@ -25971,19 +26068,19 @@ When you are done, remind me of two things: MCP tools load only in a new session
           onremovefile: handleRemove
         }
       ),
-      items.length ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("div", { className: "ae-attachment-status-list", "aria-live": "polite", children: items.map((item) => {
+      items.length ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { className: "ae-attachment-status-list", "aria-live": "polite", children: items.map((item) => {
         var _a, _b, _c, _d, _e, _f;
-        return /* @__PURE__ */ (0, import_jsx_runtime34.jsxs)(
+        return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(
           "div",
           {
             className: `ae-attachment-status ae-attachment-status--${item.status}`,
             children: [
-              /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Icon2, { name: "paperclip", size: 12 }),
-              /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { className: "ae-attachment-status__name", children: ((_a = item.file) == null ? void 0 : _a.name) || ((_b = item.ref) == null ? void 0 : _b.name) }),
-              /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { className: "ae-attachment-status__size", children: formatBytes((_e = (_c = item.file) == null ? void 0 : _c.size) != null ? _e : (_d = item.ref) == null ? void 0 : _d.size) }),
-              /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("span", { className: "ae-attachment-status__state", children: item.status === "staging" ? labels.staging : item.status === "error" ? ((_f = item.error) == null ? void 0 : _f.message) || labels.retry : labels.ready }),
-              item.status === "error" ? /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("button", { type: "button", onClick: () => onRetryAttachment == null ? void 0 : onRetryAttachment(item), children: labels.retry }) : null,
-              /* @__PURE__ */ (0, import_jsx_runtime34.jsx)("button", { type: "button", onClick: () => onRemoveAttachment == null ? void 0 : onRemoveAttachment(item), children: labels.remove })
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Icon2, { name: "paperclip", size: 12 }),
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { className: "ae-attachment-status__name", children: ((_a = item.file) == null ? void 0 : _a.name) || ((_b = item.ref) == null ? void 0 : _b.name) }),
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { className: "ae-attachment-status__size", children: formatBytes((_e = (_c = item.file) == null ? void 0 : _c.size) != null ? _e : (_d = item.ref) == null ? void 0 : _d.size) }),
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("span", { className: "ae-attachment-status__state", children: item.status === "staging" ? labels.staging : item.status === "error" ? ((_f = item.error) == null ? void 0 : _f.message) || labels.retry : labels.ready }),
+              item.status === "error" ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("button", { type: "button", onClick: () => onRetryAttachment == null ? void 0 : onRetryAttachment(item), children: labels.retry }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("button", { type: "button", onClick: () => onRemoveAttachment == null ? void 0 : onRemoveAttachment(item), children: labels.remove })
             ]
           },
           item.pondId
@@ -26269,7 +26366,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/components/chat/Composer.jsx
-  var import_jsx_runtime35 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime36 = __toESM(require_jsx_runtime(), 1);
   function ComposerResizeHandle({
     height,
     minHeight,
@@ -26277,10 +26374,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onHeightChange,
     onHeightReset
   }) {
-    const [hover, setHover] = import_react37.default.useState(false);
-    const [dragging, setDragging] = import_react37.default.useState(false);
-    const [focused, setFocused] = import_react37.default.useState(false);
-    const dragRef = import_react37.default.useRef(null);
+    const [hover, setHover] = import_react38.default.useState(false);
+    const [dragging, setDragging] = import_react38.default.useState(false);
+    const [focused, setFocused] = import_react38.default.useState(false);
+    const dragRef = import_react38.default.useRef(null);
     const clearDrag = (updateState = true) => {
       const active = dragRef.current;
       if (!active) return;
@@ -26290,7 +26387,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       dragRef.current = null;
       if (updateState) setDragging(false);
     };
-    import_react37.default.useEffect(() => () => clearDrag(false), []);
+    import_react38.default.useEffect(() => () => clearDrag(false), []);
     const handleMouseDown = (event) => {
       if (event.button !== 0) return;
       event.currentTarget.focus();
@@ -26322,7 +26419,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
       event.preventDefault();
       onHeightChange == null ? void 0 : onHeightChange(nextHeight);
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(
       "div",
       {
         style: {
@@ -26339,7 +26436,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           boxShadow: focused ? "0 0 0 1px var(--focus-ring)" : "none"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
             "input",
             {
               type: "text",
@@ -26373,7 +26470,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
               }
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
             "span",
             {
               role: "separator",
@@ -26414,8 +26511,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onRetryAttachment,
     attachmentLabels
   }) {
-    const [focus, setFocus] = import_react37.default.useState(false);
-    const attachmentPondRef = import_react37.default.useRef(null);
+    const [focus, setFocus] = import_react38.default.useState(false);
+    const attachmentPondRef = import_react38.default.useRef(null);
     const readyAttachmentCount = readyAttachments(attachmentDraft).length;
     const attachmentsBusy = draftIsBusy(attachmentDraft) || attachmentDraft.items.some((item) => item.status === "error");
     const canSend = !disabled && !streaming && !attachmentsBusy && (value.trim().length > 0 || readyAttachmentCount > 0);
@@ -26440,9 +26537,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       event.stopPropagation();
       (_a = attachmentPondRef.current) == null ? void 0 : _a.addFiles(files);
     };
-    const dropStateRef = import_react37.default.useRef(null);
+    const dropStateRef = import_react38.default.useRef(null);
     dropStateRef.current = { disabled, streaming, pendingTurnId: attachmentDraft.pendingTurnId };
-    import_react37.default.useEffect(() => {
+    import_react38.default.useEffect(() => {
       const guard = createPanelFileDropGuard({
         target: window,
         canAttach: () => {
@@ -26456,10 +26553,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
       });
       return guard.dispose;
     }, []);
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-15)", ...style }, children: [
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: "var(--space-15)", ...style }, children: [
       notice,
-      /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { display: "flex", flexDirection: "column", minHeight: 0 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { style: { display: "flex", flexDirection: "column", minHeight: 0 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
           ComposerResizeHandle,
           {
             height,
@@ -26469,7 +26566,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             onHeightReset
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(
+        /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(
           "div",
           {
             style: {
@@ -26491,7 +26588,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             onDragOverCapture: handleFileDrag,
             onDropCapture: handleFileDrop,
             children: [
-              /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
                 AttachmentPond,
                 {
                   ref: attachmentPondRef,
@@ -26503,8 +26600,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
                   onRetryAttachment
                 }
               ),
-              /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { flex: 1, minWidth: 0, minHeight: 0, display: "flex", alignItems: "stretch", gap: "var(--space-15)" }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { style: { flex: 1, minWidth: 0, minHeight: 0, display: "flex", alignItems: "stretch", gap: "var(--space-15)" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
                   "textarea",
                   {
                     rows: 1,
@@ -26530,11 +26627,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
                     }
                   }
                 ),
-                !options ? streaming ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 }) : null
+                !options ? streaming ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 }) : null
               ] }),
-              options ? /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)("div", { style: { flex: "none", display: "flex", alignItems: "center", gap: 2, minWidth: 0, overflow: "visible" }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime35.jsx)("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 2 }, children: options }),
-                streaming ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
+              options ? /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)("div", { style: { flex: "none", display: "flex", alignItems: "center", gap: 2, minWidth: 0, overflow: "visible" }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: 2 }, children: options }),
+                streaming ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(SendButton, { icon: "square", title: "\u505C\u6B62 Stop", kind: "stop", onClick: onStop }) : /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(SendButton, { icon: "arrow-up", title: "\u53D1\u9001 Send", kind: "send", disabled: !canSend, onClick: canSend ? onSend : void 0 })
               ] }) : null
             ]
           }
@@ -26543,9 +26640,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     ] });
   }
   function SendButton({ icon, title, kind, disabled = false, onClick }) {
-    const [hover, setHover] = import_react37.default.useState(false);
+    const [hover, setHover] = import_react38.default.useState(false);
     const active = kind === "send" && !disabled;
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
       "button",
       {
         type: "button",
@@ -26572,21 +26669,21 @@ When you are done, remind me of two things: MCP tools load only in a new session
           cursor: disabled ? "default" : "pointer",
           transition: "background var(--dur-fast) var(--ease-out)"
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Icon2, { name: icon, size: 13, strokeWidth: 2.25 })
+        children: /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Icon2, { name: icon, size: 13, strokeWidth: 2.25 })
       }
     );
   }
 
   // src/components/chat/ComposerChip.jsx
   init_cep_runtime_inject();
-  var import_react39 = __toESM(require_react(), 1);
+  var import_react40 = __toESM(require_react(), 1);
 
   // src/components/core/Menu.jsx
   init_cep_runtime_inject();
-  var import_react38 = __toESM(require_react(), 1);
-  var import_jsx_runtime36 = __toESM(require_jsx_runtime(), 1);
+  var import_react39 = __toESM(require_react(), 1);
+  var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
   function Keycap({ children }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
       "span",
       {
         style: {
@@ -26607,9 +26704,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function MenuRow({ item, onClose }) {
-    const [hover, setHover] = import_react38.default.useState(false);
+    const [hover, setHover] = import_react39.default.useState(false);
     const disabled = !!item.disabled;
-    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
       "button",
       {
         type: "button",
@@ -26638,15 +26735,15 @@ When you are done, remind me of two things: MCP tools load only in a new session
           transition: "background var(--dur-fast) var(--ease-out)"
         },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("span", { style: { flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.label }),
-          item.checked ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.25, color: "var(--text-primary)" }) : null,
-          item.hint ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("span", { style: { flex: "none", font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: item.hint }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { style: { flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.label }),
+          item.checked ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Icon2, { name: "check", size: 12, strokeWidth: 2.25, color: "var(--text-primary)" }) : null,
+          item.hint ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { style: { flex: "none", font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: item.hint }) : null
         ]
       }
     );
   }
   function Menu({ header, items = [], footer, onClose, minWidth = 184, style }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
       "div",
       {
         role: "menu",
@@ -26660,7 +26757,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           ...style
         },
         children: [
-          header ? /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(
+          header ? /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
             "div",
             {
               style: {
@@ -26673,15 +26770,15 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 marginBottom: "var(--space-1)"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("span", { style: { font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: header.label }),
-                header.keys && header.keys.length ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("span", { style: { display: "inline-flex", gap: 3 }, children: header.keys.map((k, i) => /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(Keycap, { children: k }, i)) }) : null
+                /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { style: { font: "400 var(--text-caption)/1 var(--font-ui)", color: "var(--text-tertiary)" }, children: header.label }),
+                header.keys && header.keys.length ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { style: { display: "inline-flex", gap: 3 }, children: header.keys.map((k, i) => /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Keycap, { children: k }, i)) }) : null
               ]
             }
           ) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("div", { style: { display: "flex", flexDirection: "column" }, children: items.map(
-            (item, i) => item.divider ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("div", { style: { height: 1, background: "var(--border-subtle)", margin: "4px 0" } }, i) : /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(MenuRow, { item, onClose }, i)
+          /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("div", { style: { display: "flex", flexDirection: "column" }, children: items.map(
+            (item, i) => item.divider ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("div", { style: { height: 1, background: "var(--border-subtle)", margin: "4px 0" } }, i) : /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(MenuRow, { item, onClose }, i)
           ) }),
-          footer ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(
+          footer ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
             "div",
             {
               style: {
@@ -26700,7 +26797,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/components/chat/ComposerChip.jsx
-  var import_jsx_runtime37 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime38 = __toESM(require_jsx_runtime(), 1);
   function ComposerChip({
     icon,
     label,
@@ -26714,11 +26811,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
     title,
     style
   }) {
-    const [hover, setHover] = import_react39.default.useState(false);
-    const [open, setOpen] = import_react39.default.useState(false);
-    const rootRef = import_react39.default.useRef(null);
+    const [hover, setHover] = import_react40.default.useState(false);
+    const [open, setOpen] = import_react40.default.useState(false);
+    const rootRef = import_react40.default.useRef(null);
     const isMenu = Array.isArray(items) && items.length > 0;
-    import_react39.default.useEffect(() => {
+    import_react40.default.useEffect(() => {
       if (!open) return void 0;
       const onDoc = (e) => {
         if (rootRef.current && !rootRef.current.contains(e.target)) setOpen(false);
@@ -26734,8 +26831,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
       };
     }, [open]);
     const lit = active || open;
-    return /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)("div", { ref: rootRef, style: { position: "relative", flex: "none", ...style }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime37.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { ref: rootRef, style: { position: "relative", flex: "none", ...style }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(
         "button",
         {
           type: "button",
@@ -26768,14 +26865,14 @@ When you are done, remind me of two things: MCP tools load only in a new session
             whiteSpace: "nowrap"
           },
           children: [
-            icon ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Icon2, { name: icon, size: 12 }) : null,
-            label ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", { style: { overflow: "hidden", textOverflow: "ellipsis", maxWidth: 96 }, children: label }) : null,
-            !isMenu && onToggle && active ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Icon2, { name: "check", size: 10, strokeWidth: 2.5 }) : null,
-            isMenu ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Icon2, { name: "chevron-down", size: 10, strokeWidth: 2, style: { opacity: 0.7 } }) : null
+            icon ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Icon2, { name: icon, size: 12 }) : null,
+            label ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { style: { overflow: "hidden", textOverflow: "ellipsis", maxWidth: 96 }, children: label }) : null,
+            !isMenu && onToggle && active ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Icon2, { name: "check", size: 10, strokeWidth: 2.5 }) : null,
+            isMenu ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Icon2, { name: "chevron-down", size: 10, strokeWidth: 2, style: { opacity: 0.7 } }) : null
           ]
         }
       ),
-      isMenu && open ? /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(
+      isMenu && open ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
         "div",
         {
           style: {
@@ -26785,7 +26882,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             zIndex: 30,
             animation: "ds-fade-up var(--dur-base) var(--ease-out)"
           },
-          children: /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(Menu, { header: menuHeader, items, footer: menuFooter, onClose: () => setOpen(false) })
+          children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Menu, { header: menuHeader, items, footer: menuFooter, onClose: () => setOpen(false) })
         }
       ) : null
     ] });
@@ -27495,7 +27592,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/screens/ChatScreen.jsx
-  var import_jsx_runtime38 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime39 = __toESM(require_jsx_runtime(), 1);
   var C2 = {
     zh: {
       hello: "\u4F60\u597D\uFF01\u6211\u53EF\u4EE5\u76F4\u63A5\u64CD\u4F5C\u5F53\u524D\u6253\u5F00\u7684 AE \u5DE5\u7A0B\u3002\u8BD5\u8BD5\u8FD9\u4E9B\uFF1A",
@@ -27573,10 +27670,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
     ]
   };
   function Notice({ text, actionLabel, onAction }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, padding: "5px 8px", background: "var(--bg-well)", border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Icon2, { name: "plug", size: 12, color: "var(--text-tertiary)" }),
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { style: { flex: 1, minWidth: 0, font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: text }),
-      onAction ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, children: actionLabel }) : null
+    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, padding: "5px 8px", background: "var(--bg-well)", border: "1px solid var(--border-default)", borderRadius: "var(--radius-md)" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Icon2, { name: "plug", size: 12, color: "var(--text-tertiary)" }),
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { style: { flex: 1, minWidth: 0, font: "400 11px/1.35 var(--font-ui)", color: "var(--text-secondary)" }, children: text }),
+      onAction ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { size: "sm", variant: "secondary", onClick: onAction, children: actionLabel }) : null
     ] });
   }
   function statusForTool(state) {
@@ -27597,13 +27694,13 @@ When you are done, remind me of two things: MCP tools load only in a new session
   function Entry({ entry: entry2, lang, onApprove, onAnswerQuestion }) {
     const t = C2[lang] || C2.zh;
     if (entry2.type === "user-text") {
-      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(ChatBubble, { role: "user", attachments: entry2.attachments, children: entry2.text });
+      return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(ChatBubble, { role: "user", attachments: entry2.attachments, children: entry2.text });
     }
     if (entry2.type === "ai-text") {
-      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(ChatBubble, { role: "ai", children: entry2.text });
+      return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(ChatBubble, { role: "ai", children: entry2.text });
     }
     if (entry2.type === "question") {
-      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         QuestionCard,
         {
           lang,
@@ -27618,8 +27715,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     }
     if (entry2.type === "tool-call") {
       const highRisk = entry2.risk === "destructive" || entry2.risk === "external";
-      return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", gap: 6 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", gap: 6 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
           ToolCallCard,
           {
             verb: titleForTool(entry2, lang),
@@ -27629,7 +27726,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             errorMessage: entry2.state === "error" ? entry2.text : null
           }
         ),
-        entry2.state === "awaiting-approval" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+        entry2.state === "awaiting-approval" ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
           ApprovalCard,
           {
             risk: highRisk ? "high" : "normal",
@@ -27646,7 +27743,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     }
     if (entry2.type === "error") {
       const details = formatErrorDetail(entry2.detail);
-      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { paddingLeft: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ToolCallCard,
         {
           verb: entry2.kind === "model" ? t.modelErrorTitle : t.errorTitle,
@@ -27705,21 +27802,21 @@ When you are done, remind me of two things: MCP tools load only in a new session
     onRetryAttachment
   }) {
     const t = C2[lang] || C2.zh;
-    const logRef = import_react40.default.useRef(null);
-    const layoutRef = import_react40.default.useRef(null);
-    const footerRef = import_react40.default.useRef(null);
-    const [composerSize, dispatchComposerSize] = import_react40.default.useReducer(
+    const logRef = import_react41.default.useRef(null);
+    const layoutRef = import_react41.default.useRef(null);
+    const footerRef = import_react41.default.useRef(null);
+    const [composerSize, dispatchComposerSize] = import_react41.default.useReducer(
       reduceComposerHeight,
       void 0,
       () => createComposerHeightState()
     );
-    const composerHeightRef = import_react40.default.useRef(composerSize.height);
+    const composerHeightRef = import_react41.default.useRef(composerSize.height);
     composerHeightRef.current = composerSize.height;
     const hasEntries = entries.length > 0;
     const prompts = promptCards || DEFAULT_PROMPTS[lang] || DEFAULT_PROMPTS.zh;
     const chips = chipState && chipState.descriptor ? buildComposerChips({ ...chipState, lang }) : null;
-    const composerOptions = chips ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
-      chips.model ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+    const composerOptions = chips ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_react41.default.Fragment, { children: [
+      chips.model ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ComposerChip,
         {
           icon: "box",
@@ -27729,7 +27826,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           items: menuItems(chips.model.items, chipState.modelId, onChipModel)
         }
       ) : null,
-      chips.effort ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      chips.effort ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ComposerChip,
         {
           icon: "brain",
@@ -27739,7 +27836,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           items: menuItems(chips.effort.items, chipState.effort, onChipEffort)
         }
       ) : null,
-      chips.fast ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      chips.fast ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ComposerChip,
         {
           icon: "zap",
@@ -27749,7 +27846,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           onToggle: (next) => onChipFast && onChipFast(next)
         }
       ) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         ComposerChip,
         {
           icon: "shield",
@@ -27760,11 +27857,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
         }
       )
     ] }) : null;
-    import_react40.default.useEffect(() => {
+    import_react41.default.useEffect(() => {
       const el = logRef.current;
       if (el) el.scrollTop = el.scrollHeight;
     }, [entries, streaming, thinking, turnStage, turnProgress]);
-    import_react40.default.useEffect(() => {
+    import_react41.default.useEffect(() => {
       if (typeof ResizeObserver !== "function") return void 0;
       if (!layoutRef.current || !footerRef.current) return void 0;
       const measureComposerBounds = () => {
@@ -27810,9 +27907,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
       retry: t.attachmentRetry,
       remove: t.attachmentRemove
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { ref: layoutRef, style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
-      sessionTitle ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { flex: "none", height: 28, display: "flex", alignItems: "center", gap: "var(--space-1)", padding: "0 var(--space-2)", borderBottom: "1px solid var(--border-subtle)" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { minWidth: 0, flex: 1 }, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { ref: layoutRef, style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }, children: [
+      sessionTitle ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { flex: "none", height: 28, display: "flex", alignItems: "center", gap: "var(--space-1)", padding: "0 var(--space-2)", borderBottom: "1px solid var(--border-subtle)" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { minWidth: 0, flex: 1 }, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
           Button,
           {
             variant: "ghost",
@@ -27821,23 +27918,23 @@ When you are done, remind me of two things: MCP tools load only in a new session
             title: sessionTitle,
             onClick: onOpenSessions,
             style: { maxWidth: "100%", minWidth: 0 },
-            children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: sessionTitle })
+            children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { style: { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: sessionTitle })
           }
         ) }),
-        /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Button, { variant: "ghost", size: "sm", icon: "plus", onClick: () => onNewSession(), children: t.newSession })
+        /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Button, { variant: "ghost", size: "sm", icon: "plus", onClick: () => onNewSession(), children: t.newSession })
       ] }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
-        !hasEntries && composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(import_react40.default.Fragment, { children: /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(AIAvatar, { size: 32 }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { font: "600 12px/1.35 var(--font-ui)", color: "var(--text-primary)", maxWidth: 240 }, children: disabledHint || t.keyTitle }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { font: "400 11px/1.45 var(--font-ui)", color: "var(--text-tertiary)", maxWidth: 250 }, children: t.keyCaption })
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { ref: logRef, style: { flex: 1, minHeight: 0, overflow: "auto", padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }, children: [
+        !hasEntries && composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(import_react41.default.Fragment, { children: /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(AIAvatar, { size: 32 }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { font: "600 12px/1.35 var(--font-ui)", color: "var(--text-primary)", maxWidth: 240 }, children: disabledHint || t.keyTitle }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { font: "400 11px/1.45 var(--font-ui)", color: "var(--text-tertiary)", maxWidth: 250 }, children: t.keyCaption })
         ] }) }) : null,
-        !hasEntries && !composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_react40.default.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(AIAvatar, { size: 32 }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.hello })
+        !hasEntries && !composerDisabled ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_react41.default.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "var(--space-5) 0 var(--space-2)", textAlign: "center" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(AIAvatar, { size: 32 }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { style: { font: "400 12px/1.55 var(--font-ui)", color: "var(--text-secondary)", maxWidth: 240 }, children: t.hello })
           ] }),
-          prompts.map((card) => /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+          prompts.map((card) => /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
             PromptCard,
             {
               icon: card.icon,
@@ -27851,27 +27948,27 @@ When you are done, remind me of two things: MCP tools load only in a new session
             card.id || card.title
           ))
         ] }) : null,
-        entries.map((entry2) => /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Entry, { entry: entry2, lang, onApprove, onAnswerQuestion }, entry2.sid || entry2.id)),
-        streaming && thinking && !turnProgress ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { paddingLeft: 28, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Spinner, { size: 12 }),
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: t.thinking })
-        ] }) : turnStage || turnProgress ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 4, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 6 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Spinner, { size: 12 }),
-            /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { children: turnProgressText((turnProgress == null ? void 0 : turnProgress.stage) || turnStage, turnBackend, lang) }),
-            (turnProgress == null ? void 0 : turnProgress.estimatedTokens) !== void 0 ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { children: [
+        entries.map((entry2) => /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Entry, { entry: entry2, lang, onApprove, onAnswerQuestion }, entry2.sid || entry2.id)),
+        streaming && thinking && !turnProgress ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { paddingLeft: 28, display: "flex", alignItems: "center", gap: 6, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Spinner, { size: 12 }),
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: t.thinking })
+        ] }) : turnStage || turnProgress ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { paddingLeft: 28, display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 4, font: "400 11px/1.4 var(--font-ui)", color: "var(--text-tertiary)" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 6 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Spinner, { size: 12 }),
+            /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { children: turnProgressText((turnProgress == null ? void 0 : turnProgress.stage) || turnStage, turnBackend, lang) }),
+            (turnProgress == null ? void 0 : turnProgress.estimatedTokens) !== void 0 ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("span", { children: [
               "\xB7 ",
               t.progressTokens(turnProgress.estimatedTokens)
             ] }) : null,
-            (turnProgress == null ? void 0 : turnProgress.elapsedMs) !== void 0 ? /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)("span", { children: [
+            (turnProgress == null ? void 0 : turnProgress.elapsedMs) !== void 0 ? /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)("span", { children: [
               "\xB7 ",
               t.progressElapsed(progressSeconds(turnProgress.elapsedMs))
             ] }) : null
           ] }),
-          (turnProgress == null ? void 0 : turnProgress.warning) ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", { style: { color: "var(--warning, var(--text-secondary))" }, children: t.progressWarning }) : null
+          (turnProgress == null ? void 0 : turnProgress.warning) ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", { style: { color: "var(--warning, var(--text-secondary))" }, children: t.progressWarning }) : null
         ] }) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("div", { ref: footerRef, style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("div", { ref: footerRef, style: { flex: "none", padding: "var(--space-2) var(--space-3) var(--space-3)", borderTop: "1px solid var(--border-subtle)" }, children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
         Composer,
         {
           value: attachmentDraft.text,
@@ -27882,7 +27979,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           disabled: composerDisabled,
           placeholder: t.placeholder,
           options: composerOptions,
-          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || (() => onNewSession()) }) : sendError ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(
+          notice: disabledHint ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(Notice, { text: disabledHint, actionLabel: noticeActionLabel || t.noticeAction, onAction: onNoticeAction || (() => onNewSession()) }) : sendError ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
             Notice,
             {
               text: attachmentDraft.dispatchState === "uncertain" ? t.uncertainTurn : sendError.message,
@@ -27907,12 +28004,12 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/screens/ToolsScreen.jsx
   init_cep_runtime_inject();
-  var import_react42 = __toESM(require_react(), 1);
+  var import_react43 = __toESM(require_react(), 1);
 
   // src/components/forms/Textarea.jsx
   init_cep_runtime_inject();
-  var import_react41 = __toESM(require_react(), 1);
-  var import_jsx_runtime39 = __toESM(require_jsx_runtime(), 1);
+  var import_react42 = __toESM(require_react(), 1);
+  var import_jsx_runtime40 = __toESM(require_jsx_runtime(), 1);
   function Textarea({
     value,
     onChange,
@@ -27923,8 +28020,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
     rows = 5,
     style
   }) {
-    const [focused, setFocused] = import_react41.default.useState(false);
-    return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(
+    const [focused, setFocused] = import_react42.default.useState(false);
+    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
       "textarea",
       {
         className: "ds-focusable",
@@ -28075,7 +28172,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
 
   // src/screens/ToolsScreen.jsx
-  var import_jsx_runtime40 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime41 = __toESM(require_jsx_runtime(), 1);
   var TEXT = {
     zh: {
       title: "\u5DE5\u5177\u5E93",
@@ -28209,7 +28306,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const id = itemId(mode, item);
     const status = mode === "tools" ? item.status : "";
     const archived = status === "archived" || status === "deprecated";
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(
       "button",
       {
         type: "button",
@@ -28229,8 +28326,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
         },
         "data-item-id": id,
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("span", { style: { display: "flex", alignItems: "center", gap: 6, minWidth: 0 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("span", { style: { display: "flex", alignItems: "center", gap: 6, minWidth: 0 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
               "span",
               {
                 style: {
@@ -28244,9 +28341,9 @@ When you are done, remind me of two things: MCP tools load only in a new session
                 children: item.name || item.id
               }
             ),
-            status ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: statusBadgeStatus(status), children: statusLabel(t, status) }) : null
+            status ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: statusBadgeStatus(status), children: statusLabel(t, status) }) : null
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
             "span",
             {
               style: {
@@ -28266,7 +28363,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
     );
   }
   function LibraryActionButtons({ artifact, t, onAction, disabled }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-library-actions", children: toolLibraryActions(artifact.status).map((action) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-library-actions", children: toolLibraryActions(artifact.status).map((action) => /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
       Button,
       {
         variant: action === "delete" ? "danger" : "secondary",
@@ -28280,43 +28377,43 @@ When you are done, remind me of two things: MCP tools load only in a new session
   }
   function Feedback({ feedback, t, onCopy }) {
     if (!feedback) return null;
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(
       "div",
       {
         role: feedback.type === "error" ? "alert" : "status",
         className: "tools-feedback",
         style: { color: feedback.type === "error" ? "var(--error)" : "var(--text-secondary)" },
         children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("span", { children: feedback.message }),
-          feedback.path ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: onCopy, children: t.copyPath }) : null
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { children: feedback.message }),
+          feedback.path ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "ghost", onClick: onCopy, children: t.copyPath }) : null
         ]
       }
     );
   }
   function ToolsScreen({ api, lang = "zh", port = 11488 }) {
     const t = TEXT[lang] || TEXT.zh;
-    const [mode, setMode] = import_react42.default.useState("tools");
-    const [query, setQuery] = import_react42.default.useState("");
-    const [items, setItems] = import_react42.default.useState([]);
-    const [libraryRows, setLibraryRows] = import_react42.default.useState({ candidates: [], artifacts: [] });
-    const [selectedId, setSelectedId] = import_react42.default.useState("");
-    const [detail, setDetail] = import_react42.default.useState(null);
-    const [argsText, setArgsText] = import_react42.default.useState("{}");
-    const [result, setResult] = import_react42.default.useState(null);
-    const [busy, setBusy] = import_react42.default.useState(false);
-    const [error, setError] = import_react42.default.useState("");
-    const [feedback, setFeedback] = import_react42.default.useState(null);
-    const [showImport, setShowImport] = import_react42.default.useState(false);
-    const [importText, setImportText] = import_react42.default.useState("");
-    const [pane, setPane] = import_react42.default.useState("content");
-    const loadSequence = import_react42.default.useRef(0);
-    const selectSequence = import_react42.default.useRef(0);
-    const fileInputRef = import_react42.default.useRef(null);
-    const requestLibrary = import_react42.default.useCallback(async (operation) => {
+    const [mode, setMode] = import_react43.default.useState("tools");
+    const [query, setQuery] = import_react43.default.useState("");
+    const [items, setItems] = import_react43.default.useState([]);
+    const [libraryRows, setLibraryRows] = import_react43.default.useState({ candidates: [], artifacts: [] });
+    const [selectedId, setSelectedId] = import_react43.default.useState("");
+    const [detail, setDetail] = import_react43.default.useState(null);
+    const [argsText, setArgsText] = import_react43.default.useState("{}");
+    const [result, setResult] = import_react43.default.useState(null);
+    const [busy, setBusy] = import_react43.default.useState(false);
+    const [error, setError] = import_react43.default.useState("");
+    const [feedback, setFeedback] = import_react43.default.useState(null);
+    const [showImport, setShowImport] = import_react43.default.useState(false);
+    const [importText, setImportText] = import_react43.default.useState("");
+    const [pane, setPane] = import_react43.default.useState("content");
+    const loadSequence = import_react43.default.useRef(0);
+    const selectSequence = import_react43.default.useRef(0);
+    const fileInputRef = import_react43.default.useRef(null);
+    const requestLibrary = import_react43.default.useCallback(async (operation) => {
       const libraryApi = createToolLibraryApi({ port });
       return operation(libraryApi);
     }, [port]);
-    const load = import_react42.default.useCallback(async () => {
+    const load = import_react43.default.useCallback(async () => {
       if (!api) return;
       const sequence = loadSequence.current + 1;
       loadSequence.current = sequence;
@@ -28356,11 +28453,11 @@ When you are done, remind me of two things: MCP tools load only in a new session
         if (sequence === loadSequence.current) setError(cause.message || String(cause));
       }
     }, [api, mode, query, requestLibrary]);
-    import_react42.default.useEffect(() => {
+    import_react43.default.useEffect(() => {
       const timer = setTimeout(load, 120);
       return () => clearTimeout(timer);
     }, [load]);
-    import_react42.default.useEffect(() => {
+    import_react43.default.useEffect(() => {
       if (result || error) setPane("result");
     }, [result, error]);
     const changeMode = (next) => {
@@ -28494,17 +28591,17 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const canExecuteSkill = detail && detail.mode === "skills" && selected.template_type === "jsx";
     const canExecuteTool = detail && detail.mode === "tools" && !["candidate", "archived", "deprecated"].includes(selected.status);
     const groups = mode === "tools" ? groupToolLibraryItems(items) : [];
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-screen", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("header", { className: "tools-header", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-header__title", title: t.title, children: t.title }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-header__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: load, disabled: busy, children: t.refresh }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setShowImport(!showImport), disabled: busy, children: t.import }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "danger", onClick: clearCandidates, disabled: busy || !libraryRows.candidates.length, children: t.clearCandidates })
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-screen", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("header", { className: "tools-header", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-header__title", title: t.title, children: t.title }),
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-header__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "ghost", onClick: load, disabled: busy, children: t.refresh }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "ghost", onClick: () => setShowImport(!showImport), disabled: busy, children: t.import }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "danger", onClick: clearCandidates, disabled: busy || !libraryRows.candidates.length, children: t.clearCandidates })
         ] })
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-filters", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-filters", children: [
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
           Segmented,
           {
             value: mode,
@@ -28515,7 +28612,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
             ]
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
           Input,
           {
             value: query,
@@ -28524,7 +28621,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
           }
         )
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
         Feedback,
         {
           feedback,
@@ -28535,23 +28632,23 @@ When you are done, remind me of two things: MCP tools load only in a new session
           )
         }
       ),
-      error && !selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-error", role: "alert", children: error }) : null,
-      showImport ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("section", { className: "tools-import-view", "aria-label": t.import, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-text-area", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("p", { children: t.importHint }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { children: [
+      error && !selected ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-error", role: "alert", children: error }) : null,
+      showImport ? /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("section", { className: "tools-import-view", "aria-label": t.import, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-text-area", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("p", { children: t.importHint }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("label", { children: [
             t.importJson,
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Textarea, { mono: true, value: importText, onChange: setImportText, rows: 4 })
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Textarea, { mono: true, value: importText, onChange: setImportText, rows: 4 })
           ] })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-import__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("input", { ref: fileInputRef, type: "file", accept: "application/json,.json", onChange: chooseFile, style: { display: "none" } }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy, onClick: () => fileInputRef.current && fileInputRef.current.click(), children: t.selectFile }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy || !importText.trim(), onClick: importArtifact, children: t.importJson }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", disabled: busy, onClick: () => setShowImport(false), children: t.cancel })
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-import__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("input", { ref: fileInputRef, type: "file", accept: "application/json,.json", onChange: chooseFile, style: { display: "none" } }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", disabled: busy, onClick: () => fileInputRef.current && fileInputRef.current.click(), children: t.selectFile }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", disabled: busy || !importText.trim(), onClick: importArtifact, children: t.importJson }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", disabled: busy, onClick: () => setShowImport(false), children: t.cancel })
         ] })
-      ] }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(
+      ] }) : /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react43.default.Fragment, { children: [
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(
           "select",
           {
             className: "tools-selector ds-focusable",
@@ -28562,19 +28659,19 @@ When you are done, remind me of two things: MCP tools load only in a new session
               if (item) select(item);
             },
             children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("option", { value: "", disabled: true, children: t.select }),
-              selectedId && !items.some((item) => itemId(mode, item) === selectedId) ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("option", { value: selectedId, children: (selected == null ? void 0 : selected.name) || selectedId }) : null,
-              items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("option", { value: itemId(mode, item), children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("option", { value: "", disabled: true, children: t.select }),
+              selectedId && !items.some((item) => itemId(mode, item) === selectedId) ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("option", { value: selectedId, children: (selected == null ? void 0 : selected.name) || selectedId }) : null,
+              items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("option", { value: itemId(mode, item), children: [
                 mode === "tools" ? statusLabel(t, item.status) + " \xB7 " : "",
                 item.name || item.id
               ] }, itemId(mode, item)))
             ]
           }
         ),
-        /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-split", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-list", "aria-label": mode === "skills" ? t.skills : t.tools, children: mode === "tools" && groups.length ? groups.map((group) => /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { style: { margin: "4px 2px 2px", color: "var(--text-tertiary)", font: "600 10px/1.35 var(--font-ui)", textTransform: "uppercase" }, children: statusLabel(t, group.status) }),
-            group.items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-split", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("section", { className: "tools-list", "aria-label": mode === "skills" ? t.skills : t.tools, children: mode === "tools" && groups.length ? groups.map((group) => /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react43.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { style: { margin: "4px 2px 2px", color: "var(--text-tertiary)", font: "600 10px/1.35 var(--font-ui)", textTransform: "uppercase" }, children: statusLabel(t, group.status) }),
+            group.items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
               ItemRow,
               {
                 mode,
@@ -28585,7 +28682,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
               },
               itemId(mode, item)
             ))
-          ] }, group.status)) : mode === "skills" && items.length ? items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+          ] }, group.status)) : mode === "skills" && items.length ? items.map((item) => /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
             ItemRow,
             {
               mode,
@@ -28595,24 +28692,24 @@ When you are done, remind me of two things: MCP tools load only in a new session
               t
             },
             itemId(mode, item)
-          )) : /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.empty, compact: true }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-detail", children: !selected ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-detail__heading", children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h2", { title: selected.name, children: selected.name }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Badge, { status: detail.mode === "tools" ? statusBadgeStatus(selected.status) : selected.verified ? "ok" : "neutral", children: detail.mode === "tools" ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt })
+          )) : /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(EmptyState, { icon: "box", title: t.empty, compact: true }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("section", { className: "tools-detail", children: !selected ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(EmptyState, { icon: "box", title: t.select, caption: t.selectCap }) : /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react43.default.Fragment, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-detail__heading", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("h2", { title: selected.name, children: selected.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: detail.mode === "tools" ? statusBadgeStatus(selected.status) : selected.verified ? "ok" : "neutral", children: detail.mode === "tools" ? statusLabel(t, selected.status) : selected.verified ? t.signed : t.prompt })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-detail__tabs", children: /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Segmented, { value: pane, onChange: setPane, options: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-detail__tabs", children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Segmented, { value: pane, onChange: setPane, options: [
               { value: "content", label: t.content },
               { value: "args", label: t.argsTab },
               { value: "result", label: t.result }
             ] }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("section", { className: "tools-text-area", "aria-label": t[pane], children: pane === "content" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("h3", { children: selected.name }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("p", { children: selected.description }),
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: selectedContent || "\u2014" })
-            ] }) : pane === "args" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("label", { className: "tools-args", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("section", { className: "tools-text-area", "aria-label": t[pane], children: pane === "content" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react43.default.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("h3", { children: selected.name }),
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("p", { children: selected.description }),
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("pre", { className: "tools-content", children: selectedContent || "\u2014" })
+            ] }) : pane === "args" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("label", { className: "tools-args", children: [
               t.args,
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(
                 Textarea,
                 {
                   mono: true,
@@ -28623,16 +28720,16 @@ When you are done, remind me of two things: MCP tools load only in a new session
                   disabled: detail.mode === "tools" && !canExecuteTool
                 }
               )
-            ] }) : /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)(import_react42.default.Fragment, { children: [
-              error ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("div", { className: "tools-result-error", role: "alert", children: error }) : null,
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsx)("pre", { className: "tools-content", children: result ? JSON.stringify(result, null, 2) : "\u2014" })
+            ] }) : /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)(import_react43.default.Fragment, { children: [
+              error ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-result-error", role: "alert", children: error }) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("pre", { className: "tools-content", children: result ? JSON.stringify(result, null, 2) : "\u2014" })
             ] }) }),
-            /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("footer", { className: "tools-detail__actions", children: [
-              /* @__PURE__ */ (0, import_jsx_runtime40.jsxs)("div", { className: "tools-runner__actions", children: [
-                detail.mode === "skills" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => invoke("render"), disabled: busy, children: t.render }) : null,
-                canExecuteTool || canExecuteSkill ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(Button, { size: "sm", variant: "primary", onClick: () => invoke("execute"), disabled: busy, children: t.run }) : null
+            /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("footer", { className: "tools-detail__actions", children: [
+              /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-runner__actions", children: [
+                detail.mode === "skills" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "secondary", onClick: () => invoke("render"), disabled: busy, children: t.render }) : null,
+                canExecuteTool || canExecuteSkill ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { size: "sm", variant: "primary", onClick: () => invoke("execute"), disabled: busy, children: t.run }) : null
               ] }),
-              detail.mode === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(LibraryActionButtons, { artifact: selected, t, onAction: runLibraryAction, disabled: busy }) : null
+              detail.mode === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(LibraryActionButtons, { artifact: selected, t, onAction: runLibraryAction, disabled: busy }) : null
             ] })
           ] }) })
         ] })
@@ -28642,8 +28739,8 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/tools/ToolApprovalDialog.jsx
   init_cep_runtime_inject();
-  var import_react43 = __toESM(require_react(), 1);
-  var import_jsx_runtime41 = __toESM(require_jsx_runtime(), 1);
+  var import_react44 = __toESM(require_react(), 1);
+  var import_jsx_runtime42 = __toESM(require_jsx_runtime(), 1);
   var L3 = {
     zh: {
       title: "\u6279\u51C6\u5DE5\u5177\u6267\u884C\uFF1F",
@@ -28673,29 +28770,29 @@ When you are done, remind me of two things: MCP tools load only in a new session
     const t = L3[lang] || L3.zh;
     const plan = record.plan || {};
     const resolve = (decision) => onResolve && onResolve({ id: record.id, decision });
-    return /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve("deny") }),
-      /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-approval", role: "alertdialog", "aria-label": t.title, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-approval__heading", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("span", { children: t.title }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Badge, { status: plan.risk === "destructive" || plan.risk === "external" ? "error" : "warn", children: plan.risk })
+    return /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve("deny") }),
+      /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { className: "tools-approval", role: "alertdialog", "aria-label": t.title, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { className: "tools-approval__heading", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("span", { children: t.title }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Badge, { status: plan.risk === "destructive" || plan.risk === "external" ? "error" : "warn", children: plan.risk })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("dl", { className: "tools-kv", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dt", { children: t.artifact }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dd", { children: plan.artifactId || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dt", { children: t.operation }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dd", { children: plan.operation || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dt", { children: t.risk }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dd", { children: plan.risk || "-" }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dt", { children: t.args }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("pre", { children: JSON.stringify(plan.normalizedArgs || {}, null, 2) }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dt", { children: t.target }),
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime41.jsx)("pre", { children: JSON.stringify(plan.target || {}, null, 2) }) })
+        /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("dl", { className: "tools-kv", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dt", { children: t.artifact }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dd", { children: plan.artifactId || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dt", { children: t.operation }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dd", { children: plan.operation || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dt", { children: t.risk }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dd", { children: plan.risk || "-" }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dt", { children: t.args }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("pre", { children: JSON.stringify(plan.normalizedArgs || {}, null, 2) }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dt", { children: t.target }),
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("dd", { children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("pre", { children: JSON.stringify(plan.target || {}, null, 2) }) })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime41.jsxs)("div", { className: "tools-approval__actions", children: [
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "ghost", onClick: () => resolve("deny"), children: t.deny }),
-          record.policy && record.policy.allowSession ? /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "secondary", onClick: () => resolve("session"), children: t.session }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(Button, { variant: "primary", onClick: () => resolve("once"), children: t.once })
+        /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { className: "tools-approval__actions", children: [
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Button, { variant: "ghost", onClick: () => resolve("deny"), children: t.deny }),
+          record.policy && record.policy.allowSession ? /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Button, { variant: "secondary", onClick: () => resolve("session"), children: t.session }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(Button, { variant: "primary", onClick: () => resolve("once"), children: t.once })
         ] })
       ] })
     ] });
@@ -28703,17 +28800,17 @@ When you are done, remind me of two things: MCP tools load only in a new session
 
   // src/components/tools/QuestionFormDialog.jsx
   init_cep_runtime_inject();
-  var import_react44 = __toESM(require_react(), 1);
-  var import_jsx_runtime42 = __toESM(require_jsx_runtime(), 1);
+  var import_react45 = __toESM(require_react(), 1);
+  var import_jsx_runtime43 = __toESM(require_jsx_runtime(), 1);
   function QuestionFormDialog({ record, lang = "zh", onResolve }) {
     if (!record) return null;
     const presentation = record.presentation;
     if (!presentation || presentation.kind !== "question-form") return null;
     const questions = Array.isArray(presentation.questions) ? presentation.questions : [];
     const resolve = (result) => onResolve && onResolve({ id: record.id, ...result });
-    return /* @__PURE__ */ (0, import_jsx_runtime42.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
-      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve({ action: "cancel", content: {} }) }),
-      /* @__PURE__ */ (0, import_jsx_runtime42.jsx)("div", { className: "tools-approval", role: "dialog", "aria-label": presentation.title || "", children: /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { className: "tools-modal", role: "presentation", children: [
+      /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { className: "tools-modal__scrim", onClick: () => resolve({ action: "cancel", content: {} }) }),
+      /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { className: "tools-approval", role: "dialog", "aria-label": presentation.title || "", children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
         QuestionCard,
         {
           lang,
@@ -30981,6 +31078,27 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         });
       }
     });
+  }
+
+  // src/lib/panelUpdates.js
+  init_cep_runtime_inject();
+  var PANEL_UPDATE_CACHE = "ae-mcp.panel-release-cache";
+  var PANEL_UPDATE_DISMISSED = "ae-mcp.panel-release-dismissed";
+  var PANEL_RELEASE_API = "https://api.github.com/repos/JUNKDOGE-JOE/after-effects-mcp/releases/latest";
+  var releasePage = (tag) => `${REPO_URL}/releases/tag/${encodeURIComponent(tag)}`;
+  function createPanelUpdateChecker({ readPref: readPref2, writePref: writePref2, ...options }) {
+    return createVersionChecker({
+      ...options,
+      url: PANEL_RELEASE_API,
+      headers: { Accept: "application/vnd.github+json", "User-Agent": "ae-mcp-panel" },
+      readCache: () => JSON.parse(readPref2(PANEL_UPDATE_CACHE, "null")),
+      writeCache: (value) => writePref2(PANEL_UPDATE_CACHE, JSON.stringify(value)),
+      validEntry: (value) => value.url === releasePage(value.latest),
+      parseRelease: (release) => (release == null ? void 0 : release.draft) === false && (release == null ? void 0 : release.prerelease) === false ? { latest: release.tag_name, url: releasePage(release.tag_name) } : null
+    });
+  }
+  function showPanelUpdate(update, dismissed) {
+    return (update == null ? void 0 : update.status) === "update" && compareVersions(update.latest, dismissed) !== 0;
   }
 
   // src/cep/codexHeadlessLogin.js
@@ -34716,7 +34834,7 @@ ${command}`
 
   // src/components/settings/ProviderManagerSection.jsx
   init_cep_runtime_inject();
-  var import_react45 = __toESM(require_react(), 1);
+  var import_react46 = __toESM(require_react(), 1);
 
   // src/lib/providerManagerState.js
   init_cep_runtime_inject();
@@ -34801,7 +34919,7 @@ ${command}`
   }
 
   // src/components/settings/ProviderManagerSection.jsx
-  var import_jsx_runtime43 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime44 = __toESM(require_jsx_runtime(), 1);
   var L4 = {
     zh: {
       title: "Provider \u7BA1\u7406",
@@ -34863,7 +34981,7 @@ ${command}`
     }
   };
   function SecretInput({ name, disabled = false }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
       "input",
       {
         name,
@@ -34896,12 +35014,12 @@ ${command}`
     disabled = false
   }) {
     const t = L4[lang] || L4.zh;
-    const [draft, setDraft] = import_react45.default.useState(null);
-    const [error, setError] = import_react45.default.useState("");
-    const [note, setNote] = import_react45.default.useState("");
-    const [probing, setProbing] = import_react45.default.useState(false);
-    const probeRunRef = import_react45.default.useRef(0);
-    const invalidateProbe = import_react45.default.useCallback(() => {
+    const [draft, setDraft] = import_react46.default.useState(null);
+    const [error, setError] = import_react46.default.useState("");
+    const [note, setNote] = import_react46.default.useState("");
+    const [probing, setProbing] = import_react46.default.useState(false);
+    const probeRunRef = import_react46.default.useRef(0);
+    const invalidateProbe = import_react46.default.useCallback(() => {
       probeRunRef.current += 1;
       setProbing(false);
     }, []);
@@ -34931,25 +35049,25 @@ ${command}`
         (_b = (_a = event.currentTarget) == null ? void 0 : _a.reset) == null ? void 0 : _b.call(_a);
       }
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("details", { style: {
+    return /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("details", { style: {
       border: "1px solid var(--border-subtle)",
       borderRadius: "var(--radius-md)",
       background: "var(--bg-well)",
       padding: "7px 8px"
     }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("summary", { style: {
+      /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("summary", { style: {
         cursor: "pointer",
         listStyle: "none",
         display: "flex",
         alignItems: "center",
         gap: 8
       }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("span", { style: {
+        /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("span", { style: {
           flex: 1,
           font: "500 12px/1.35 var(--font-ui)",
           color: "var(--text-primary)"
         }, children: t.title }),
-        /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
           Button,
           {
             variant: "secondary",
@@ -34967,11 +35085,11 @@ ${command}`
           }
         )
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }, children: [
         providers.map((provider) => {
           const modelCount = Array.isArray(provider == null ? void 0 : provider.modelIds) ? provider.modelIds.length : 0;
           const selected = provider.id === activeProviderId;
-          return /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { "data-provider-id": provider.id, style: {
+          return /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { "data-provider-id": provider.id, style: {
             display: "flex",
             flexDirection: "column",
             gap: 4,
@@ -34980,8 +35098,8 @@ ${command}`
             borderRadius: "var(--radius-sm)",
             background: "var(--bg-panel)"
           }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("span", { style: {
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("span", { style: {
                 flex: 1,
                 minWidth: 120,
                 font: "500 12px/1.35 var(--font-ui)",
@@ -34990,19 +35108,19 @@ ${command}`
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap"
               }, children: provider.name }),
-              selected ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Badge, { status: "accent", children: t.selected }) : null,
-              provider.needsApiKey ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Badge, { status: "warn", children: t.needsApiKey }) : null,
-              modelCount ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Badge, { status: "ok", children: t.models(modelCount) }) : null
+              selected ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Badge, { status: "accent", children: t.selected }) : null,
+              provider.needsApiKey ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Badge, { status: "warn", children: t.needsApiKey }) : null,
+              modelCount ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Badge, { status: "ok", children: t.models(modelCount) }) : null
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { style: {
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("div", { style: {
               font: "400 10px/1.35 var(--font-mono)",
               color: "var(--text-tertiary)",
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap"
             }, children: provider.baseUrl }),
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, flexWrap: "wrap" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
                 Button,
                 {
                   variant: "ghost",
@@ -35017,7 +35135,7 @@ ${command}`
                   children: t.edit
                 }
               ),
-              /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
                 Button,
                 {
                   variant: "ghost",
@@ -35033,7 +35151,7 @@ ${command}`
             ] })
           ] }, provider.id);
         }),
-        draft ? /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("form", { onSubmit: save, style: {
+        draft ? /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("form", { onSubmit: save, style: {
           display: "flex",
           flexDirection: "column",
           gap: 6,
@@ -35042,7 +35160,7 @@ ${command}`
           borderRadius: "var(--radius-sm)",
           background: "var(--bg-panel)"
         }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.name, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.name, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
             Input,
             {
               disabled,
@@ -35050,7 +35168,7 @@ ${command}`
               onChange: (value) => setDraft({ ...draft, name: value })
             }
           ) }),
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.baseUrl, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.baseUrl, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
             Input,
             {
               mono: true,
@@ -35063,7 +35181,7 @@ ${command}`
               placeholder: "https://api.example.com/v1"
             }
           ) }),
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.dialect, caption: t.dialectCap, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.dialect, caption: t.dialectCap, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
             Select,
             {
               disabled,
@@ -35078,13 +35196,13 @@ ${command}`
               ]
             }
           ) }),
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("label", { style: {
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("label", { style: {
             display: "flex",
             gap: 6,
             alignItems: "center",
             font: "400 11px/1.35 var(--font-ui)"
           }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
               "input",
               {
                 type: "checkbox",
@@ -35101,9 +35219,9 @@ ${command}`
             ),
             t.insecure
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.apiKey, caption: t.openCodeKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) }),
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: { display: "flex", gap: 6, alignItems: "center" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.apiKey, caption: t.openCodeKeyCap, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(SecretInput, { name: "modelAuthSecret", disabled }) }),
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.model, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { display: "flex", gap: 6, alignItems: "center" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
               Input,
               {
                 mono: true,
@@ -35116,7 +35234,7 @@ ${command}`
                 placeholder: "claude-sonnet-5"
               }
             ),
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
               Button,
               {
                 type: "button",
@@ -35171,7 +35289,7 @@ ${command}`
               }
             )
           ] }) }),
-          draftModelIds.length ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(Field, { label: t.contextWindow, caption: t.contextCap, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { style: {
+          draftModelIds.length ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Field, { label: t.contextWindow, caption: t.contextCap, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("div", { style: {
             display: "flex",
             flexDirection: "column",
             gap: 5,
@@ -35184,20 +35302,20 @@ ${command}`
               modelId
             ) ? draft.modelContexts[modelId] : OPEN_CODE_DEFAULT_CONTEXT_WINDOW;
             const choice = openCodeContextPresetValue(contextValue);
-            return /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: {
+            return /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: {
               display: "grid",
               gridTemplateColumns: "minmax(90px, 1fr) 105px",
               gap: 6,
               alignItems: "center"
             }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("span", { title: modelId, style: {
+              /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("span", { title: modelId, style: {
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap",
                 font: "400 10px/1.35 var(--font-mono)",
                 color: "var(--text-secondary)"
               }, children: modelId }),
-              /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+              /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
                 Select,
                 {
                   disabled,
@@ -35215,7 +35333,7 @@ ${command}`
                   ]
                 }
               ),
-              choice === "custom" ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { style: { gridColumn: "1 / -1", display: "flex", gap: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+              choice === "custom" ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("div", { style: { gridColumn: "1 / -1", display: "flex", gap: 6 }, children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
                 Input,
                 {
                   mono: true,
@@ -35223,7 +35341,7 @@ ${command}`
                   disabled,
                   value: String(contextValue),
                   onChange: (value) => setModelContext(modelId, value),
-                  suffix: /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("span", { style: {
+                  suffix: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("span", { style: {
                     paddingRight: 5,
                     font: "400 9px/1 var(--font-ui)",
                     color: "var(--text-tertiary)"
@@ -35232,16 +35350,16 @@ ${command}`
               ) }) : null
             ] }, modelId);
           }) }) }) : null,
-          error ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { style: {
+          error ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("div", { style: {
             font: "400 10px/1.4 var(--font-ui)",
             color: "var(--warn)"
           }, children: error }) : null,
-          note ? /* @__PURE__ */ (0, import_jsx_runtime43.jsx)("div", { style: {
+          note ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)("div", { style: {
             font: "400 10px/1.4 var(--font-ui)",
             color: "var(--text-tertiary)"
           }, children: note }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime43.jsxs)("div", { style: { display: "flex", gap: 6, justifyContent: "flex-end" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { display: "flex", gap: 6, justifyContent: "flex-end" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
               Button,
               {
                 variant: "ghost",
@@ -35255,7 +35373,7 @@ ${command}`
                 children: t.cancel
               }
             ),
-            /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
               Button,
               {
                 variant: "primary",
@@ -35714,10 +35832,10 @@ ${command}`
 
   // src/cep/useActivity.js
   init_cep_runtime_inject();
-  var import_react46 = __toESM(require_react(), 1);
+  var import_react47 = __toESM(require_react(), 1);
   function useActivity(getHost) {
-    const [events, setEvents] = import_react46.default.useState([]);
-    import_react46.default.useEffect(() => {
+    const [events, setEvents] = import_react47.default.useState([]);
+    import_react47.default.useEffect(() => {
       let unsub = null;
       let retry = null;
       let disposed = false;
@@ -35739,7 +35857,7 @@ ${command}`
         if (retry) clearTimeout(retry);
       };
     }, [getHost]);
-    const clear = import_react46.default.useCallback(() => setEvents([]), []);
+    const clear = import_react47.default.useCallback(() => setEvents([]), []);
     return { events, clear };
   }
 
@@ -35768,7 +35886,7 @@ ${command}`
 
   // src/app/wizardWiring.js
   init_cep_runtime_inject();
-  var import_react47 = __toESM(require_react(), 1);
+  var import_react48 = __toESM(require_react(), 1);
 
   // src/cep/wizardActions.js
   init_cep_runtime_inject();
@@ -35896,17 +36014,17 @@ ${command}`
     fetchImpl,
     platform
   } = {}) {
-    const [stepStates, dispatch] = import_react47.default.useReducer(stepReducer, null, initialStepStates);
-    const [pathOffers, setPathOffers] = import_react47.default.useState({});
-    const commands = import_react47.default.useMemo(
+    const [stepStates, dispatch] = import_react48.default.useReducer(stepReducer, null, initialStepStates);
+    const [pathOffers, setPathOffers] = import_react48.default.useState({});
+    const commands = import_react48.default.useMemo(
       () => buildInstallCommands({ platform }),
       [platform]
     );
-    const commandPreviews = import_react47.default.useMemo(() => ({
+    const commandPreviews = import_react48.default.useMemo(() => ({
       node: commandPreview(commands.node),
       claude: commandPreview(commands.claude)
     }), [commands]);
-    const updatePathOffer = import_react47.default.useCallback(async (id, result) => {
+    const updatePathOffer = import_react48.default.useCallback(async (id, result) => {
       var _a;
       if (!(platform == null ? void 0 : platform.canManageUserPath) || !result.ok || !result.path) {
         setPathOffers((current) => {
@@ -35935,7 +36053,7 @@ ${command}`
         });
       }
     }, [platform]);
-    const detect = import_react47.default.useCallback(async (id) => {
+    const detect = import_react48.default.useCallback(async (id) => {
       dispatch({ type: "detect-start", id });
       const result = await detectTool(id, {
         platform,
@@ -35954,7 +36072,7 @@ ${command}`
       await updatePathOffer(id, result);
       return result;
     }, [fetchImpl, platform, port, updatePathOffer]);
-    const install = import_react47.default.useCallback(async (id) => {
+    const install = import_react48.default.useCallback(async (id) => {
       const command = commands[id];
       if (!command) return { ok: false, output: "No install command configured for " + id };
       dispatch({ type: "run-start", id });
@@ -35967,7 +36085,7 @@ ${command}`
       await detect(id);
       return result;
     }, [commands, detect, platform]);
-    const addToPath = import_react47.default.useCallback(async (id) => {
+    const addToPath = import_react48.default.useCallback(async (id) => {
       const offer = pathOffers[id];
       if (!offer) return { changed: false };
       const result = await platform.addUserPathEntry(offer.directory);
@@ -35981,8 +36099,8 @@ ${command}`
       }
       return result;
     }, [detect, pathOffers, platform]);
-    const bootDetectRef = import_react47.default.useRef(false);
-    import_react47.default.useEffect(() => {
+    const bootDetectRef = import_react48.default.useRef(false);
+    import_react48.default.useEffect(() => {
       if (bootDetectRef.current) return;
       bootDetectRef.current = true;
       [...HOST_STEPS, ...CLI_STEPS, ...OPTIONAL_CLIENT_STEPS].forEach((id) => {
@@ -37889,7 +38007,7 @@ ${command}`
   }
 
   // src/app/App.jsx
-  var import_jsx_runtime44 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime45 = __toESM(require_jsx_runtime(), 1);
   var T = {
     zh: {
       connected: "\u670D\u52A1\u8FD0\u884C\u4E2D",
@@ -38006,23 +38124,23 @@ ${command}`
   }
   function Shell({ cs: cs2 }) {
     const { lang, setLang } = useLang();
-    const langRef = import_react48.default.useRef(lang);
+    const langRef = import_react49.default.useRef(lang);
     langRef.current = lang;
     const t = T[lang];
-    const [tab, setTab] = import_react48.default.useState("chat");
-    const [status, setStatus] = import_react48.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
-    const statusRef = import_react48.default.useRef(status);
+    const [tab, setTab] = import_react49.default.useState("chat");
+    const [status, setStatus] = import_react49.default.useState({ state: "starting", port: DEFAULT_PORT, error: null });
+    const statusRef = import_react49.default.useRef(status);
     statusRef.current = status;
-    const [paused, setPaused] = import_react48.default.useState(false);
-    const [logs, setLogs] = import_react48.default.useState([]);
-    const backendErrorsRef = import_react48.default.useRef([]);
-    const panelLogRef = import_react48.default.useRef(null);
-    const ctrl = import_react48.default.useRef(null);
-    const getHost = import_react48.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
-    const hostConversation = import_react48.default.useMemo(() => createHostConversation({ getHost }), [getHost]);
-    const hostApprovalBridge = import_react48.default.useMemo(() => createHostApprovalBridge(), []);
-    const [hostConversationError, setHostConversationError] = import_react48.default.useState("");
-    const runHostConversationSync = import_react48.default.useCallback((operation) => {
+    const [paused, setPaused] = import_react49.default.useState(false);
+    const [logs, setLogs] = import_react49.default.useState([]);
+    const backendErrorsRef = import_react49.default.useRef([]);
+    const panelLogRef = import_react49.default.useRef(null);
+    const ctrl = import_react49.default.useRef(null);
+    const getHost = import_react49.default.useCallback(() => ctrl.current ? ctrl.current.getHost() : null, []);
+    const hostConversation = import_react49.default.useMemo(() => createHostConversation({ getHost }), [getHost]);
+    const hostApprovalBridge = import_react49.default.useMemo(() => createHostApprovalBridge(), []);
+    const [hostConversationError, setHostConversationError] = import_react49.default.useState("");
+    const runHostConversationSync = import_react49.default.useCallback((operation) => {
       var _a;
       try {
         const value = operation();
@@ -38035,54 +38153,54 @@ ${command}`
         return null;
       }
     }, []);
-    const [wizardDone, setWizardDone] = import_react48.default.useState(() => isWizardDone(window.localStorage));
-    const [wizStep, setWizStep] = import_react48.default.useState(1);
-    const [drawerOpen, setDrawerOpen] = import_react48.default.useState(false);
-    const [sessionsOpen, setSessionsOpen] = import_react48.default.useState(false);
-    const [connInfo, setConnInfo] = import_react48.default.useState(null);
-    const [diagnostics, setDiagnostics] = import_react48.default.useState(null);
+    const [wizardDone, setWizardDone] = import_react49.default.useState(() => isWizardDone(window.localStorage));
+    const [wizStep, setWizStep] = import_react49.default.useState(1);
+    const [drawerOpen, setDrawerOpen] = import_react49.default.useState(false);
+    const [sessionsOpen, setSessionsOpen] = import_react49.default.useState(false);
+    const [connInfo, setConnInfo] = import_react49.default.useState(null);
+    const [diagnostics, setDiagnostics] = import_react49.default.useState(null);
     const { events, clear } = useActivity(getHost);
-    const [clients, setClients] = import_react48.default.useState([]);
-    const [mcpSessions, setMcpSessions] = import_react48.default.useState([]);
-    const [confirmRegen, setConfirmRegen] = import_react48.default.useState(false);
-    const [confirmChatNavigation, setConfirmChatNavigation] = import_react48.default.useState(null);
-    const [tokenEpoch, setTokenEpoch] = import_react48.default.useState(0);
-    const platform = import_react48.default.useMemo(() => createPlatformAdapter(), []);
-    const sessionStore = import_react48.default.useMemo(() => createSessionStore({
+    const [clients, setClients] = import_react49.default.useState([]);
+    const [mcpSessions, setMcpSessions] = import_react49.default.useState([]);
+    const [confirmRegen, setConfirmRegen] = import_react49.default.useState(false);
+    const [confirmChatNavigation, setConfirmChatNavigation] = import_react49.default.useState(null);
+    const [tokenEpoch, setTokenEpoch] = import_react49.default.useState(0);
+    const platform = import_react49.default.useMemo(() => createPlatformAdapter(), []);
+    const sessionStore = import_react49.default.useMemo(() => createSessionStore({
       platform,
       log: (message) => {
         var _a;
         return (_a = panelLogRef.current) == null ? void 0 : _a.call(panelLogRef, message);
       }
     }), [platform]);
-    const attachmentStore = import_react48.default.useMemo(() => createAttachmentStore({
+    const attachmentStore = import_react49.default.useMemo(() => createAttachmentStore({
       platform,
       randomUUID: randomProviderCredentialId
     }), [platform]);
-    const [attachmentDraft, dispatchAttachmentDraft] = import_react48.default.useReducer(
+    const [attachmentDraft, dispatchAttachmentDraft] = import_react49.default.useReducer(
       reduceAttachmentDraft,
       void 0,
       createAttachmentDraftState
     );
-    const [chatSessionId, setChatSessionId] = import_react48.default.useState("chat-0");
-    const chatSessionIdRef = import_react48.default.useRef(chatSessionId);
+    const [chatSessionId, setChatSessionId] = import_react49.default.useState("chat-0");
+    const chatSessionIdRef = import_react49.default.useRef(chatSessionId);
     chatSessionIdRef.current = chatSessionId;
-    const attachmentOperationsRef = import_react48.default.useRef(/* @__PURE__ */ new Map());
-    const pendingTurnRef = import_react48.default.useRef(null);
-    const acceptedTurnRef = import_react48.default.useRef(null);
-    import_react48.default.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
-    const backendMigration = import_react48.default.useMemo(() => migrateBackendPref(window.localStorage), []);
-    const [model, setModel] = import_react48.default.useState(() => loadModelPref(backendMigration.pref, DEFAULT_MODEL));
-    const [logLevel, setLogLevel] = import_react48.default.useState(() => readPref("ae_mcp_log_level", "info"));
-    const logLevelRef = import_react48.default.useRef(logLevel);
+    const attachmentOperationsRef = import_react49.default.useRef(/* @__PURE__ */ new Map());
+    const pendingTurnRef = import_react49.default.useRef(null);
+    const acceptedTurnRef = import_react49.default.useRef(null);
+    import_react49.default.useEffect(() => () => attachmentStore.dispose(), [attachmentStore]);
+    const backendMigration = import_react49.default.useMemo(() => migrateBackendPref(window.localStorage), []);
+    const [model, setModel] = import_react49.default.useState(() => loadModelPref(backendMigration.pref, DEFAULT_MODEL));
+    const [logLevel, setLogLevel] = import_react49.default.useState(() => readPref("ae_mcp_log_level", "info"));
+    const logLevelRef = import_react49.default.useRef(logLevel);
     logLevelRef.current = logLevel;
-    const [sessionModel, setSessionModel] = import_react48.default.useState(null);
-    const [sessionEffort, setSessionEffort] = import_react48.default.useState(null);
-    const [sessionFast, setSessionFast] = import_react48.default.useState(null);
-    const [permissionMode, setPermissionMode] = import_react48.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
-    const permissionModeRef = import_react48.default.useRef(permissionMode);
+    const [sessionModel, setSessionModel] = import_react49.default.useState(null);
+    const [sessionEffort, setSessionEffort] = import_react49.default.useState(null);
+    const [sessionFast, setSessionFast] = import_react49.default.useState(null);
+    const [permissionMode, setPermissionMode] = import_react49.default.useState(() => readPref("ae_mcp_perm_mode", "manual"));
+    const permissionModeRef = import_react49.default.useRef(permissionMode);
     permissionModeRef.current = permissionMode;
-    const elicitationCoordinator = import_react48.default.useMemo(() => createElicitationCoordinator({
+    const elicitationCoordinator = import_react49.default.useMemo(() => createElicitationCoordinator({
       resolveApproval: (_request, { plan }) => decideToolPlan({
         tier: permissionModeRef.current,
         plan
@@ -38103,42 +38221,42 @@ ${command}`
         };
       }
     }), []);
-    const [toolApproval, setToolApproval] = import_react48.default.useState(() => elicitationCoordinator.snapshot());
-    import_react48.default.useEffect(() => elicitationCoordinator.subscribe(setToolApproval), [elicitationCoordinator]);
-    import_react48.default.useEffect(() => {
+    const [toolApproval, setToolApproval] = import_react49.default.useState(() => elicitationCoordinator.snapshot());
+    import_react49.default.useEffect(() => elicitationCoordinator.subscribe(setToolApproval), [elicitationCoordinator]);
+    import_react49.default.useEffect(() => {
       runHostConversationSync(() => hostConversation.updatePolicy({ approvalTier: permissionMode }));
     }, [hostConversation, permissionMode, runHostConversationSync]);
-    import_react48.default.useEffect(() => () => {
+    import_react49.default.useEffect(() => () => {
       elicitationCoordinator.dispose();
     }, [elicitationCoordinator]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       const guard = createPanelFileDropGuard({ target: window });
       return guard.dispose;
     }, []);
-    const [backendPref, setBackendPref] = import_react48.default.useState(() => backendMigration.pref);
-    const [channelChoices, setChannelChoices] = import_react48.default.useState(() => backendMigration.channelChoices);
-    const openCodeProviderStore = import_react48.default.useMemo(() => createOpenCodeProviderStore({ platform }), [platform]);
-    const [providerInit, setProviderInit] = import_react48.default.useState({ state: "checking", error: "" });
-    const [providers, setProviders] = import_react48.default.useState([]);
-    const providersRef = import_react48.default.useRef(providers);
+    const [backendPref, setBackendPref] = import_react49.default.useState(() => backendMigration.pref);
+    const [channelChoices, setChannelChoices] = import_react49.default.useState(() => backendMigration.channelChoices);
+    const openCodeProviderStore = import_react49.default.useMemo(() => createOpenCodeProviderStore({ platform }), [platform]);
+    const [providerInit, setProviderInit] = import_react49.default.useState({ state: "checking", error: "" });
+    const [providers, setProviders] = import_react49.default.useState([]);
+    const providersRef = import_react49.default.useRef(providers);
     providersRef.current = providers;
-    const providerSensitiveValues = import_react48.default.useMemo(() => providers.map((provider) => {
+    const providerSensitiveValues = import_react49.default.useMemo(() => providers.map((provider) => {
       try {
         return openCodeProviderStore.readApiKey(provider.id);
       } catch {
         return "";
       }
     }).filter(Boolean), [openCodeProviderStore, providers]);
-    const providerSensitiveValuesRef = import_react48.default.useRef(providerSensitiveValues);
+    const providerSensitiveValuesRef = import_react49.default.useRef(providerSensitiveValues);
     providerSensitiveValuesRef.current = providerSensitiveValues;
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (status.state !== "ok") return;
       runHostConversationSync(() => hostConversation.ensureConversation({
         label: chatSessionIdRef.current,
         approvalTier: permissionModeRef.current
       }));
     }, [hostConversation, runHostConversationSync, status.state]);
-    const resolveHostConversationContext = import_react48.default.useCallback((conversationId) => {
+    const resolveHostConversationContext = import_react49.default.useCallback((conversationId) => {
       const current = hostConversation.currentConversation();
       if (!current || current.id !== conversationId) return null;
       return {
@@ -38146,7 +38264,7 @@ ${command}`
         conversationLabel: current.label || chatSessionIdRef.current
       };
     }, [hostConversation]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (status.state !== "ok") {
         hostApprovalBridge.detach();
         return void 0;
@@ -38160,16 +38278,16 @@ ${command}`
       });
       return () => hostApprovalBridge.detach();
     }, [elicitationCoordinator, getHost, hostApprovalBridge, resolveHostConversationContext, status.state]);
-    const [probe, setProbe] = import_react48.default.useState(null);
-    const [codexProbe, setCodexProbe] = import_react48.default.useState(null);
-    const [codexModels, setCodexModels] = import_react48.default.useState(null);
-    const [loginState, setLoginState] = import_react48.default.useState({ channel: "", status: "idle", detail: "" });
-    const codexLoginRef = import_react48.default.useRef(null);
-    const [openCodeProbe, setOpenCodeProbe] = import_react48.default.useState(null);
-    const [openCodeProbeStale, setOpenCodeProbeStale] = import_react48.default.useState(false);
-    const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = import_react48.default.useState(0);
-    const openCodeProbeRunRef = import_react48.default.useRef(0);
-    const openCodeAvailableProviders = import_react48.default.useMemo(() => {
+    const [probe, setProbe] = import_react49.default.useState(null);
+    const [codexProbe, setCodexProbe] = import_react49.default.useState(null);
+    const [codexModels, setCodexModels] = import_react49.default.useState(null);
+    const [loginState, setLoginState] = import_react49.default.useState({ channel: "", status: "idle", detail: "" });
+    const codexLoginRef = import_react49.default.useRef(null);
+    const [openCodeProbe, setOpenCodeProbe] = import_react49.default.useState(null);
+    const [openCodeProbeStale, setOpenCodeProbeStale] = import_react49.default.useState(false);
+    const [openCodeProbeAttempt, setOpenCodeProbeAttempt] = import_react49.default.useState(0);
+    const openCodeProbeRunRef = import_react49.default.useRef(0);
+    const openCodeAvailableProviders = import_react49.default.useMemo(() => {
       var _a;
       const merged = new Map(providers.map((p) => [p.id, p]));
       for (const p of (openCodeProbe == null ? void 0 : openCodeProbe.providers) || []) {
@@ -38178,10 +38296,28 @@ ${command}`
       return [...merged.values()];
     }, [openCodeProbe, providers]);
     const selectedProbe = backendPref === "codex" ? codexProbe : backendPref === "opencode" ? openCodeProbe : probe;
-    const checkCliUpdate = import_react48.default.useMemo(() => createCliUpdateChecker({ requestJson: platform.requestJson }), [platform]);
-    const [cliUpdate, setCliUpdate] = import_react48.default.useState(null);
-    const [cliRecheck, setCliRecheck] = import_react48.default.useState(0);
-    import_react48.default.useEffect(() => {
+    const checkCliUpdate = import_react49.default.useMemo(() => createCliUpdateChecker({ requestJson: platform.requestJson }), [platform]);
+    const [cliUpdate, setCliUpdate] = import_react49.default.useState(null);
+    const [cliRecheck, setCliRecheck] = import_react49.default.useState(0);
+    const checkPanelUpdate = import_react49.default.useMemo(() => createPanelUpdateChecker({ requestJson: platform.requestJson, readPref, writePref }), [platform]);
+    const [panelUpdate, setPanelUpdate] = import_react49.default.useState({ status: "checking" });
+    const [panelRecheck, setPanelRecheck] = import_react49.default.useState(0);
+    const [dismissedRelease, setDismissedRelease] = import_react49.default.useState(() => readPref(PANEL_UPDATE_DISMISSED, ""));
+    import_react49.default.useEffect(() => {
+      let alive = true;
+      setPanelUpdate({ status: "checking" });
+      checkPanelUpdate(pkgVersion, { force: panelRecheck > 0 }).then((result) => {
+        if (alive) setPanelUpdate(result);
+      });
+      return () => {
+        alive = false;
+      };
+    }, [checkPanelUpdate, panelRecheck]);
+    const openPanelRelease = () => openExternal(panelUpdate.url, { onFailure: () => {
+      setTab("settings");
+      setPanelUpdate((value) => ({ ...value, openFailed: true }));
+    } });
+    import_react49.default.useEffect(() => {
       let alive = true;
       setCliUpdate({ status: "checking" });
       if (selectedProbe) checkCliUpdate(backendPref, selectedProbe.cli, { force: cliRecheck > 0 }).then((result) => {
@@ -38191,19 +38327,19 @@ ${command}`
         alive = false;
       };
     }, [backendPref, selectedProbe, checkCliUpdate, cliRecheck]);
-    const [chatEntries, setChatEntries] = import_react48.default.useState([]);
-    const chatEntriesRef = import_react48.default.useRef(chatEntries);
+    const [chatEntries, setChatEntries] = import_react49.default.useState([]);
+    const chatEntriesRef = import_react49.default.useRef(chatEntries);
     chatEntriesRef.current = chatEntries;
-    const sessionControllerRef = import_react48.default.useRef(null);
-    const [chatStreaming, setChatStreaming] = import_react48.default.useState(false);
-    const [thinkingActive, setThinkingActive] = import_react48.default.useState(false);
-    const [turnStage, setTurnStage] = import_react48.default.useState(null);
-    const [turnProgress, setTurnProgress] = import_react48.default.useState(null);
-    const baseDescriptor = import_react48.default.useMemo(
+    const sessionControllerRef = import_react49.default.useRef(null);
+    const [chatStreaming, setChatStreaming] = import_react49.default.useState(false);
+    const [thinkingActive, setThinkingActive] = import_react49.default.useState(false);
+    const [turnStage, setTurnStage] = import_react49.default.useState(null);
+    const [turnProgress, setTurnProgress] = import_react49.default.useState(null);
+    const baseDescriptor = import_react49.default.useMemo(
       () => baseDescriptorFor(backendPref),
       [backendPref]
     );
-    const [descriptor, setDescriptor] = import_react48.default.useState(() => baseDescriptor);
+    const [descriptor, setDescriptor] = import_react49.default.useState(() => baseDescriptor);
     const requestedModel = sessionModel || model;
     const effectiveModel = reconcileModelPref(requestedModel, descriptor) || requestedModel;
     const catalogEmpty = descriptor.catalogVerified && !descriptor.models.length;
@@ -38220,7 +38356,7 @@ ${command}`
       defaultEffort: modelMeta.defaultEffort || descriptor.defaultEffort
     });
     const effectiveFast = Boolean(sessionFast && descriptor.supportsFast(effectiveModel));
-    const providerManager = /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+    const providerManager = /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
       ProviderManagerSection,
       {
         lang,
@@ -38269,7 +38405,7 @@ ${draft.baseUrl}`)) return;
         }
       }
     );
-    const channels = import_react48.default.useMemo(() => ({
+    const channels = import_react49.default.useMemo(() => ({
       claude: claudeChannels({
         probe,
         canOpenLoginTerminal: typeof platform.openLoginTerminal === "function"
@@ -38292,27 +38428,27 @@ ${draft.baseUrl}`)) return;
       platform
     ]);
     const effective = pickBackend({ pref: backendPref, channels, channelChoices });
-    const effectiveBackendRef = import_react48.default.useRef(effective.backend);
+    const effectiveBackendRef = import_react49.default.useRef(effective.backend);
     effectiveBackendRef.current = effective.backend;
-    const effectiveChannelRef = import_react48.default.useRef(effective.channel);
+    const effectiveChannelRef = import_react49.default.useRef(effective.channel);
     effectiveChannelRef.current = effective.channel;
-    const runtimeRef = import_react48.default.useRef({
+    const runtimeRef = import_react49.default.useRef({
       model: effectiveModel,
       permissionMode,
       effort: effectiveEffort,
       thinking: null,
       fast: effectiveFast
     });
-    const extRoot = import_react48.default.useMemo(() => readCepSystemPath({ cs: cs2, platform }), [cs2, platform]);
-    const hostPortRef = import_react48.default.useRef(status.port);
+    const extRoot = import_react49.default.useMemo(() => readCepSystemPath({ cs: cs2, platform }), [cs2, platform]);
+    const hostPortRef = import_react49.default.useRef(status.port);
     hostPortRef.current = status.port;
-    const getMcpSpec2 = import_react48.default.useCallback(() => getMcpSpec({
+    const getMcpSpec2 = import_react49.default.useCallback(() => getMcpSpec({
       port: hostPortRef.current,
       label: chatSessionIdRef.current,
       approvalTier: permissionModeRef.current,
       hostConversation
     }), [hostConversation]);
-    const mcp = import_react48.default.useMemo(() => createMcpClient({
+    const mcp = import_react49.default.useMemo(() => createMcpClient({
       extRoot,
       getHost,
       getPort: () => hostPortRef.current,
@@ -38321,14 +38457,14 @@ ${draft.baseUrl}`)) return;
         approvalTier: permissionModeRef.current
       })
     }), [extRoot, getHost, hostConversation]);
-    const toolsApi = import_react48.default.useMemo(() => createToolsApi(mcp), [mcp]);
-    import_react48.default.useEffect(() => () => mcp.stop(), [mcp]);
-    const releaseTurnAttachments = import_react48.default.useCallback((turn) => {
+    const toolsApi = import_react49.default.useMemo(() => createToolsApi(mcp), [mcp]);
+    import_react49.default.useEffect(() => () => mcp.stop(), [mcp]);
+    const releaseTurnAttachments = import_react49.default.useCallback((turn) => {
       for (const attachment of (turn == null ? void 0 : turn.attachments) || []) {
         attachmentStore.release(attachment.id);
       }
     }, [attachmentStore]);
-    const resetAttachmentDraftSession = import_react48.default.useCallback((nextSessionId = null) => {
+    const resetAttachmentDraftSession = import_react49.default.useCallback((nextSessionId = null) => {
       attachmentStore.releaseSession(chatSessionIdRef.current);
       attachmentOperationsRef.current.clear();
       pendingTurnRef.current = null;
@@ -38339,7 +38475,7 @@ ${draft.baseUrl}`)) return;
         setChatSessionId(nextSessionId);
       }
     }, [attachmentStore]);
-    const addAttachment = import_react48.default.useCallback(async ({ pondId, file }) => {
+    const addAttachment = import_react49.default.useCallback(async ({ pondId, file }) => {
       const operation = {};
       const sessionId = chatSessionId;
       attachmentOperationsRef.current.set(pondId, operation);
@@ -38365,15 +38501,15 @@ ${draft.baseUrl}`)) return;
         });
       }
     }, [attachmentStore, chatSessionId]);
-    const removeAttachment = import_react48.default.useCallback((item) => {
+    const removeAttachment = import_react49.default.useCallback((item) => {
       attachmentOperationsRef.current.delete(item.pondId);
       if (item.ref) attachmentStore.release(item.ref.id);
       dispatchAttachmentDraft({ type: "remove", pondId: item.pondId });
     }, [attachmentStore]);
-    const retryAttachment = import_react48.default.useCallback((item) => {
+    const retryAttachment = import_react49.default.useCallback((item) => {
       addAttachment({ pondId: item.pondId, file: item.file });
     }, [addAttachment]);
-    const commitChatEntries = import_react48.default.useCallback((updater, event) => {
+    const commitChatEntries = import_react49.default.useCallback((updater, event) => {
       var _a;
       const current = chatEntriesRef.current;
       const next = typeof updater === "function" ? updater(current) : updater;
@@ -38381,7 +38517,7 @@ ${draft.baseUrl}`)) return;
       setChatEntries(chatEntriesRef.current);
       (_a = sessionControllerRef.current) == null ? void 0 : _a.recordEntries(chatEntriesRef.current, event);
     }, []);
-    const handleChatEvent = import_react48.default.useCallback((evt) => {
+    const handleChatEvent = import_react49.default.useCallback((evt) => {
       var _a;
       const pending = pendingTurnRef.current;
       setTurnStage((current) => reduceTurnStage(current, evt, {
@@ -38484,7 +38620,7 @@ ${draft.baseUrl}`)) return;
       }
       commitChatEntries((entries) => reduceEvent(entries, evt), evt);
     }, [commitChatEntries, releaseTurnAttachments]);
-    const claudeBackend = import_react48.default.useMemo(() => createClaudeAgentBackend({
+    const claudeBackend = import_react49.default.useMemo(() => createClaudeAgentBackend({
       platform,
       getMcpSpec: getMcpSpec2,
       getToolMeta: async () => deriveToolMeta(await mcp.listTools()),
@@ -38501,7 +38637,7 @@ ${draft.baseUrl}`)) return;
       handleChatEvent,
       platform
     ]);
-    const codexBackend = import_react48.default.useMemo(() => createCodexBackend({
+    const codexBackend = import_react49.default.useMemo(() => createCodexBackend({
       platform,
       getMcpSpec: getMcpSpec2,
       getModel: () => runtimeRef.current.model,
@@ -38514,7 +38650,7 @@ ${draft.baseUrl}`)) return;
       env: { AE_MCP_PANEL_EXT_ROOT: extRoot },
       onEvent: handleChatEvent
     }), [extRoot, getMcpSpec2, mcp, handleChatEvent, platform]);
-    const openCodeBackend = import_react48.default.useMemo(() => createOpenCodeBackend({
+    const openCodeBackend = import_react49.default.useMemo(() => createOpenCodeBackend({
       platform,
       getMcpSpec: getMcpSpec2,
       getModel: () => runtimeRef.current.model,
@@ -38547,13 +38683,13 @@ ${draft.baseUrl}`)) return;
         `Unknown backend id "${effective.backend}". Known backend ids: ${knownBackendIds}`
       );
     })();
-    const backendInstancesRef = import_react48.default.useRef(backendInstances);
+    const backendInstancesRef = import_react49.default.useRef(backendInstances);
     backendInstancesRef.current = backendInstances;
-    const activeBackendInstanceRef = import_react48.default.useRef(activeBackend);
+    const activeBackendInstanceRef = import_react49.default.useRef(activeBackend);
     activeBackendInstanceRef.current = activeBackend;
-    const pendingSessionLoadRef = import_react48.default.useRef(null);
-    const [sessionSnapshot, setSessionSnapshot] = import_react48.default.useState({ sessions: [], activeId: null });
-    const sessionController = import_react48.default.useMemo(() => createSessionController({
+    const pendingSessionLoadRef = import_react49.default.useRef(null);
+    const [sessionSnapshot, setSessionSnapshot] = import_react49.default.useState({ sessions: [], activeId: null });
+    const sessionController = import_react49.default.useMemo(() => createSessionController({
       store: sessionStore,
       now: () => Date.now(),
       uuid: randomProviderCredentialId,
@@ -38616,9 +38752,9 @@ ${draft.baseUrl}`)) return;
       sessionStore
     ]);
     sessionControllerRef.current = sessionController;
-    import_react48.default.useEffect(() => sessionController.subscribe(setSessionSnapshot), [sessionController]);
-    const sessionBootStartedRef = import_react48.default.useRef(false);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => sessionController.subscribe(setSessionSnapshot), [sessionController]);
+    const sessionBootStartedRef = import_react49.default.useRef(false);
+    import_react49.default.useEffect(() => {
       if (status.state !== "ok" || effective.backend === "none" || sessionBootStartedRef.current) return;
       sessionBootStartedRef.current = true;
       sessionController.boot().catch((error) => {
@@ -38629,7 +38765,7 @@ ${draft.baseUrl}`)) return;
         );
       });
     }, [effective.backend, sessionController, status.state]);
-    import_react48.default.useEffect(
+    import_react49.default.useEffect(
       () => installBeforeUnloadReset(
         window,
         [codexBackend, openCodeBackend, claudeBackend],
@@ -38637,7 +38773,7 @@ ${draft.baseUrl}`)) return;
       ),
       [claudeBackend, codexBackend, openCodeBackend, sessionController]
     );
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       const facts = {
         effectiveBackend: effective.backend,
         effectiveChannel: effective.channel,
@@ -38662,8 +38798,8 @@ ${draft.baseUrl}`)) return;
       requestedModel,
       providerInit.state
     ]);
-    const lastRealBackendRef = import_react48.default.useRef(null);
-    const runClaudeProbe = import_react48.default.useCallback(() => {
+    const lastRealBackendRef = import_react49.default.useRef(null);
+    const runClaudeProbe = import_react49.default.useCallback(() => {
       let alive = true;
       setProbe(null);
       probeClaudeLogin({
@@ -38684,11 +38820,11 @@ ${draft.baseUrl}`)) return;
         alive = false;
       };
     }, [platform]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (backendPref !== "subscription") return void 0;
       return runClaudeProbe();
     }, [backendPref, runClaudeProbe]);
-    const runCodexProbe = import_react48.default.useCallback(() => {
+    const runCodexProbe = import_react49.default.useCallback(() => {
       let alive = true;
       setCodexProbe(null);
       codexBackend.probeAccount().then((result) => {
@@ -38711,11 +38847,11 @@ ${draft.baseUrl}`)) return;
         alive = false;
       };
     }, [codexBackend]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (backendPref !== "codex") return void 0;
       return runCodexProbe();
     }, [backendPref, runCodexProbe]);
-    const onLoginChannel = import_react48.default.useCallback((_channel, action) => {
+    const onLoginChannel = import_react49.default.useCallback((_channel, action) => {
       if ((action == null ? void 0 : action.kind) === "terminal") {
         setLoginState({
           channel: "subscription",
@@ -38775,7 +38911,7 @@ ${draft.baseUrl}`)) return;
         (_a = panelLogRef.current) == null ? void 0 : _a.call(panelLogRef, `Codex login failed: ${(error == null ? void 0 : error.message) || String(error)}`);
       });
     }, [codexBackend, codexProbe == null ? void 0 : codexProbe.codexHome, platform, runCodexProbe]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (loginState.channel !== "subscription" || loginState.status !== "waiting") return void 0;
       if (tab !== "settings" || backendPref !== "subscription") return void 0;
       let alive = true;
@@ -38808,7 +38944,7 @@ ${draft.baseUrl}`)) return;
         if (timer) clearTimeout(timer);
       };
     }, [backendPref, loginState.channel, loginState.status, platform, tab]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (loginState.channel !== "cli" || loginState.status !== "verifying" || codexProbe === null) return;
       setLoginState(codexProbe.loggedIn ? { channel: "", status: "idle", detail: "" } : {
         channel: "cli",
@@ -38816,7 +38952,7 @@ ${draft.baseUrl}`)) return;
         detail: langRef.current === "en" ? "Codex sign-in could not be verified. Retry or use the copy-command fallback below." : "\u672A\u80FD\u9A8C\u8BC1 Codex \u767B\u5F55\u72B6\u6001\u3002\u8BF7\u91CD\u8BD5\uFF0C\u6216\u4F7F\u7528\u4E0B\u65B9\u7684\u590D\u5236\u547D\u4EE4\u5907\u7528\u64CD\u4F5C\u3002"
       });
     }, [codexProbe, loginState.channel, loginState.status]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       const loginBackend = loginState.channel === "cli" ? "codex" : "subscription";
       if (loginState.status === "idle" || tab === "settings" && backendPref === loginBackend) return;
       const current = codexLoginRef.current;
@@ -38824,12 +38960,12 @@ ${draft.baseUrl}`)) return;
       if (current) current.cancel();
       setLoginState({ channel: "", status: "idle", detail: "" });
     }, [backendPref, loginState.channel, loginState.status, tab]);
-    import_react48.default.useEffect(() => () => {
+    import_react49.default.useEffect(() => () => {
       const current = codexLoginRef.current;
       codexLoginRef.current = null;
       if (current) current.cancel();
     }, []);
-    const runOpenCodeProbe = import_react48.default.useCallback(() => {
+    const runOpenCodeProbe = import_react49.default.useCallback(() => {
       let alive = true;
       const runId = openCodeProbeRunRef.current + 1;
       openCodeProbeRunRef.current = runId;
@@ -38852,7 +38988,7 @@ ${draft.baseUrl}`)) return;
         alive = false;
       };
     }, [openCodeBackend]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (backendPref !== "opencode" || openCodeProbe !== null) {
         setOpenCodeProbeStale(false);
         return void 0;
@@ -38860,12 +38996,12 @@ ${draft.baseUrl}`)) return;
       const timer = setTimeout(() => setOpenCodeProbeStale(true), PROBE_PENDING_GRACE_MS);
       return () => clearTimeout(timer);
     }, [backendPref, openCodeProbe, openCodeProbeAttempt]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (backendPref !== "opencode") return void 0;
       if (status.state !== "ok" || providerInit.state !== "ready") return void 0;
       return runOpenCodeProbe();
     }, [backendPref, status.state, providerInit.state, runOpenCodeProbe]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       const pendingSessionLoad = pendingSessionLoadRef.current;
       const decision = decideBackendReset({
         lastReal: lastRealBackendRef.current,
@@ -38965,7 +39101,7 @@ ${draft.baseUrl}`)) return;
       setTurnStage(null);
       setTurnProgress(null);
     };
-    const pushLog = import_react48.default.useCallback((m) => {
+    const pushLog = import_react49.default.useCallback((m) => {
       const message = String(m != null ? m : "");
       const host = getHost();
       try {
@@ -38979,7 +39115,7 @@ ${draft.baseUrl}`)) return;
       setLogs((xs) => [...xs.slice(-199), `[${(/* @__PURE__ */ new Date()).toLocaleTimeString()}] ${message}`]);
     }, [getHost]);
     panelLogRef.current = pushLog;
-    const switchChatSession = import_react48.default.useCallback(async (id) => {
+    const switchChatSession = import_react49.default.useCallback(async (id) => {
       if (id === sessionController.snapshot().activeId) return;
       if (pendingTurnRef.current || chatStreaming) {
         setConfirmChatNavigation({ kind: "switch", id });
@@ -38987,7 +39123,7 @@ ${draft.baseUrl}`)) return;
       }
       await switchChatSessionNow(id);
     }, [chatStreaming, sessionController]);
-    const switchChatSessionNow = import_react48.default.useCallback(async (id) => {
+    const switchChatSessionNow = import_react49.default.useCallback(async (id) => {
       const target = sessionController.snapshot().sessions.find((meta) => meta.id === id);
       pendingSessionLoadRef.current = target ? { id, backend: target.backend } : { id, backend: null };
       if (target) {
@@ -39009,7 +39145,7 @@ ${draft.baseUrl}`)) return;
         }
       }
     }, [pushLog, sessionController]);
-    const confirmChatNavigationNow = import_react48.default.useCallback(async () => {
+    const confirmChatNavigationNow = import_react49.default.useCallback(async () => {
       const request = confirmChatNavigation;
       setConfirmChatNavigation(null);
       if (!request) return;
@@ -39017,7 +39153,7 @@ ${draft.baseUrl}`)) return;
       if (request.kind === "new") await newChatSession(true);
       else await switchChatSessionNow(request.id);
     }, [activeBackend, chatStreaming, confirmChatNavigation, newChatSession, switchChatSessionNow]);
-    const deleteChatSession = import_react48.default.useCallback(async (id) => {
+    const deleteChatSession = import_react49.default.useCallback(async (id) => {
       var _a;
       const target = sessionController.snapshot().sessions.find((meta) => meta.id === id);
       try {
@@ -39030,7 +39166,7 @@ ${draft.baseUrl}`)) return;
         pushLog("Session delete failed: " + ((error == null ? void 0 : error.message) || String(error)));
       }
     }, [pushLog, sessionController]);
-    const exportLogs = import_react48.default.useCallback(async () => {
+    const exportLogs = import_react49.default.useCallback(async () => {
       var _a;
       try {
         const exactSecrets = [];
@@ -39138,7 +39274,7 @@ ${draft.baseUrl}`)) return;
       status.port,
       cs2
     ]);
-    const undoToPreviousCheckpoint = import_react48.default.useCallback(async () => {
+    const undoToPreviousCheckpoint = import_react49.default.useCallback(async () => {
       try {
         await revertToPreviousCheckpoint(mcp);
         pushLog("Reverted to previous checkpoint");
@@ -39146,7 +39282,7 @@ ${draft.baseUrl}`)) return;
         pushLog("Checkpoint revert failed: " + (e && e.message ? e.message : String(e)));
       }
     }, [mcp, pushLog]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       const port = loadSavedPort(window.localStorage) || DEFAULT_PORT;
       ctrl.current = createHostController({
         cs: cs2,
@@ -39164,7 +39300,7 @@ ${draft.baseUrl}`)) return;
       });
       ctrl.current.start(port);
     }, [cs2, extRoot, platform, pushLog]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (status.state !== "ok") return void 0;
       let alive = true;
       setProviderInit({ state: "checking", error: "" });
@@ -39185,7 +39321,7 @@ ${draft.baseUrl}`)) return;
         alive = false;
       };
     }, [openCodeProviderStore, status.state]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (!drawerOpen) return void 0;
       const update = () => {
         const h = getHost();
@@ -39195,7 +39331,7 @@ ${draft.baseUrl}`)) return;
       const i = setInterval(update, 3e3);
       return () => clearInterval(i);
     }, [drawerOpen, getHost]);
-    import_react48.default.useEffect(() => {
+    import_react49.default.useEffect(() => {
       if (tab !== "settings") return void 0;
       const update = () => {
         const h = getHost();
@@ -39207,7 +39343,7 @@ ${draft.baseUrl}`)) return;
       const i = setInterval(update, 4e3);
       return () => clearInterval(i);
     }, [tab, getHost]);
-    const runDiag = import_react48.default.useCallback(async () => {
+    const runDiag = import_react49.default.useCallback(async () => {
       setDiagnostics("running");
       try {
         const items = await runDiagnostics({
@@ -39256,7 +39392,7 @@ ${draft.baseUrl}`)) return;
       fetchImpl: window.fetch.bind(window)
     });
     if (!wizardDone) {
-      return /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         WizardScreen,
         {
           step: wizStep,
@@ -39288,8 +39424,8 @@ ${draft.baseUrl}`)) return;
       (meta) => meta.id === sessionSnapshot.activeId
     ) || null;
     const sessionTitle = displayTitle(activeSessionMeta, lang);
-    return /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)(import_react48.default.Fragment, { children: [
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime45.jsxs)(import_react49.default.Fragment, { children: [
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         StatusBar,
         {
           status: statusForBar,
@@ -39306,8 +39442,20 @@ ${draft.baseUrl}`)) return;
           settingsTitle: t.settings
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
-        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      showPanelUpdate(panelUpdate, dismissedRelease) ? /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
+        PanelUpdateBanner,
+        {
+          update: panelUpdate,
+          lang,
+          onOpen: openPanelRelease,
+          onDismiss: () => {
+            writePref(PANEL_UPDATE_DISMISSED, panelUpdate.latest);
+            setDismissedRelease(panelUpdate.latest);
+          }
+        }
+      ) : null,
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsxs)("div", { style: { flex: 1, minHeight: 0, display: "flex", flexDirection: "column", position: "relative" }, children: [
+        tab === "chat" ? /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
           ChatScreen,
           {
             lang,
@@ -39354,7 +39502,7 @@ ${draft.baseUrl}`)) return;
             onRetryAttachment: retryAttachment
           }
         ) : null,
-        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+        tab === "activity" ? /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
           ActivityScreen,
           {
             events,
@@ -39365,7 +39513,7 @@ ${draft.baseUrl}`)) return;
             emptyCaption: t.actEmptyB
           }
         ) : null,
-        tab === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+        tab === "tools" ? /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
           ToolsScreen,
           {
             api: toolsApi,
@@ -39373,7 +39521,7 @@ ${draft.baseUrl}`)) return;
             port: status.port
           }
         ) : null,
-        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+        tab === "settings" ? /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
           SettingsScreen,
           {
             lang,
@@ -39435,6 +39583,9 @@ ${draft.baseUrl}`)) return;
               } else runClaudeProbe();
             },
             cliStatus: { probe: selectedProbe, update: cliUpdate, notice: modelNotice },
+            panelUpdate,
+            onCheckPanelUpdate: () => setPanelRecheck((value) => value + 1),
+            onOpenPanelRelease: openPanelRelease,
             recheckDisabled: chatStreaming || (backendPref === "codex" ? codexProbe === null : backendPref === "opencode" ? openCodeProbe === null && !openCodeProbeStale : probe === null),
             providers,
             providerManager,
@@ -39468,8 +39619,8 @@ ${draft.baseUrl}`)) return;
           tokenEpoch
         ) : null
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(TabBar, { tabs, active: tab, onChange: setTab }),
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         ConnectionDrawer,
         {
           open: drawerOpen,
@@ -39483,7 +39634,7 @@ ${draft.baseUrl}`)) return;
           onRestart: () => applyPort(status.port)
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         SessionDrawer,
         {
           open: sessionsOpen,
@@ -39499,7 +39650,7 @@ ${draft.baseUrl}`)) return;
           onDelete: deleteChatSession
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         ConfirmDialog,
         {
           open: confirmRegen,
@@ -39521,7 +39672,7 @@ ${draft.baseUrl}`)) return;
           }
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         ConfirmDialog,
         {
           open: Boolean(confirmChatNavigation),
@@ -39534,7 +39685,7 @@ ${draft.baseUrl}`)) return;
           onConfirm: confirmChatNavigationNow
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         ToolApprovalDialog,
         {
           record: toolApproval && toolApproval.plan ? toolApproval : null,
@@ -39542,7 +39693,7 @@ ${draft.baseUrl}`)) return;
           onResolve: (result) => elicitationCoordinator.resolveVisible(result)
         }
       ),
-      /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(
         QuestionFormDialog,
         {
           record: toolApproval && !toolApproval.plan ? toolApproval : null,
@@ -39553,13 +39704,13 @@ ${draft.baseUrl}`)) return;
     ] });
   }
   function App({ cs: cs2 }) {
-    return /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(Shell, { cs: cs2 }) });
+    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(LangProvider, { children: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Shell, { cs: cs2 }) });
   }
 
   // src/main.jsx
-  var import_jsx_runtime45 = __toESM(require_jsx_runtime(), 1);
+  var import_jsx_runtime46 = __toESM(require_jsx_runtime(), 1);
   var cs = new window.CSInterface();
-  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime45.jsx)(App, { cs }));
+  (0, import_client.createRoot)(document.getElementById("root")).render(/* @__PURE__ */ (0, import_jsx_runtime46.jsx)(App, { cs }));
 })();
 /*! Bundled license information:
 

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -26,6 +26,9 @@ import { createMcpClient } from '../cep/mcpClient';
 import { createToolsApi } from '../cep/toolsApi';
 import { probeClaudeLogin } from '../cep/claudeAuth';
 import { createCliUpdateChecker, codexCatalogNotice } from '../lib/cliUpdates.js';
+import { createPanelUpdateChecker, PANEL_UPDATE_DISMISSED, showPanelUpdate } from '../lib/panelUpdates.js';
+import { PanelUpdateBanner } from '../components/shell/PanelUpdate';
+import { openExternal } from '../lib/externalLinks.js';
 import { startCodexLogin } from '../cep/codexHeadlessLogin.js';
 import { createClaudeAgentBackend } from '../cep/claudeAgentBackend';
 import { createCodexBackend } from '../cep/codexBackend';
@@ -378,6 +381,20 @@ function Shell({ cs }) {
   const checkCliUpdate = React.useMemo(() => createCliUpdateChecker({ requestJson: platform.requestJson }), [platform]);
   const [cliUpdate, setCliUpdate] = React.useState(null);
   const [cliRecheck, setCliRecheck] = React.useState(0);
+  const checkPanelUpdate = React.useMemo(() => createPanelUpdateChecker({ requestJson: platform.requestJson, readPref, writePref }), [platform]);
+  const [panelUpdate, setPanelUpdate] = React.useState({ status: 'checking' });
+  const [panelRecheck, setPanelRecheck] = React.useState(0);
+  const [dismissedRelease, setDismissedRelease] = React.useState(() => readPref(PANEL_UPDATE_DISMISSED, ''));
+  React.useEffect(() => {
+    let alive = true;
+    setPanelUpdate({ status: 'checking' });
+    checkPanelUpdate(pkgVersion, { force: panelRecheck > 0 }).then((result) => { if (alive) setPanelUpdate(result); });
+    return () => { alive = false; };
+  }, [checkPanelUpdate, panelRecheck]);
+  const openPanelRelease = () => openExternal(panelUpdate.url, { onFailure: () => {
+    setTab('settings');
+    setPanelUpdate((value) => ({ ...value, openFailed: true }));
+  } });
   React.useEffect(() => {
     let alive = true;
     setCliUpdate({ status: 'checking' });
@@ -1558,6 +1575,11 @@ function Shell({ cs }) {
         sessionsTitle={t.sessions}
         settingsTitle={t.settings}
       />
+      {showPanelUpdate(panelUpdate, dismissedRelease) ? <PanelUpdateBanner update={panelUpdate} lang={lang}
+        onOpen={openPanelRelease} onDismiss={() => {
+          writePref(PANEL_UPDATE_DISMISSED, panelUpdate.latest);
+          setDismissedRelease(panelUpdate.latest);
+        }} /> : null}
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', position: 'relative' }}>
         {tab === 'chat' ? (
           <ChatScreen
@@ -1686,6 +1708,9 @@ function Shell({ cs }) {
               else runClaudeProbe();
             }}
             cliStatus={{ probe: selectedProbe, update: cliUpdate, notice: modelNotice }}
+            panelUpdate={panelUpdate}
+            onCheckPanelUpdate={() => setPanelRecheck((value) => value + 1)}
+            onOpenPanelRelease={openPanelRelease}
             recheckDisabled={chatStreaming || (backendPref === 'codex'
               ? codexProbe === null : backendPref === 'opencode'
                 ? openCodeProbe === null && !openCodeProbeStale : probe === null)}

--- a/plugin/panel/src/cep/claudeAgentBackend.js
+++ b/plugin/panel/src/cep/claudeAgentBackend.js
@@ -12,6 +12,7 @@ import {
   trimStderrTail,
 } from '../lib/errorCodes.js';
 import { createPlatformAdapter } from './platform/index.js';
+import { captureToolImages, toolDisplayText } from './toolImages.js';
 import {
   normalizeTurnInput,
   withAttachmentManifest,
@@ -814,7 +815,8 @@ export function createClaudeAgentBackend({
         type: 'tool-result',
         toolUseId,
         ok: block.is_error !== true,
-        text: toolResultText(block.content),
+        text: toolDisplayText(toolResultText(block.content)),
+        ...captureToolImages(block.content, adapter),
         durationMs: Math.max(0, now() - tool.startedAt),
       });
     }

--- a/plugin/panel/src/cep/codexBackend.js
+++ b/plugin/panel/src/cep/codexBackend.js
@@ -1,4 +1,5 @@
 import { createNdjsonReader } from '../lib/ndjson.js';
+import { captureToolImages, toolDisplayText } from './toolImages.js';
 import { cliIdentity } from '../lib/cliUpdates.js';
 import {
   containsExactSecret,
@@ -507,7 +508,8 @@ export function createCodexBackend({
         toolUseId: String(item.id || ''),
         name: mcpToolName(item),
         ok: !item.error && item.status === 'completed',
-        text: toolResultText(item.result),
+        text: toolDisplayText(toolResultText(item.result)),
+        ...captureToolImages(item.result?.content, adapter),
         durationMs: item.durationMs,
       });
       return;

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -1,4 +1,5 @@
 import { createSseParser } from '../lib/sse.js';
+import { captureToolImages, toolDisplayText } from './toolImages.js';
 import { cliIdentity } from '../lib/cliUpdates.js';
 import { openCodeCatalogId } from '../lib/openCodeCatalogId.js';
 import { createPlatformAdapter } from './platform/index.js';
@@ -1455,7 +1456,8 @@ export function createOpenCodeBackend({
         toolUseId,
         name,
         ok: status === 'completed',
-        text: outputText,
+        text: toolDisplayText(outputText),
+        ...captureToolImages(state.attachments || state.content, adapter),
         durationMs: ms,
       });
       return;

--- a/plugin/panel/src/cep/toolImages.js
+++ b/plugin/panel/src/cep/toolImages.js
@@ -1,0 +1,71 @@
+import { attachmentFileUrl } from '../../../shared/chat-attachments.mjs';
+
+const TYPES = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/webp': 'webp', 'image/gif': 'gif' };
+const CACHE_BYTES = 64 * 1024 * 1024;
+const RESULT_CHARS = 12 * 1024 * 1024;
+const CACHE_AGE = 7 * 24 * 60 * 60 * 1000;
+let sequence = 0;
+
+export function toolDisplayText(value) {
+  return String(value || '').replace(/data:image\/[^;\s]+;base64,[A-Za-z0-9+/=]+/g, '[image]')
+    .replace(/("base64"\s*:\s*")[^"]*(")/g, '$1[image]$2');
+}
+
+export function captureToolImages(content, adapter) {
+  const parts = Array.isArray(content) ? content : [];
+  const candidates = parts.filter((part) => part && (part.type === 'image'
+    || (part.type === 'file' && String(part.mime || part.mimeType || '').startsWith('image/'))));
+  if (!candidates.length) return {};
+  const fs = adapter?.fs;
+  const now = Date.now();
+  let remaining = RESULT_CHARS;
+  let cache;
+  let files;
+  let bytes = 0;
+  function prepareCache() {
+    if (files) return;
+    cache = adapter.paths.join([adapter.paths.configRoot, 'tool-images']);
+    fs.mkdirSync(cache, { recursive: true });
+    files = fs.readdirSync(cache).filter((name) => /^preview-[a-z0-9-]+\.(png|jpg|webp|gif)$/.test(name))
+      .map((name) => {
+        const path = adapter.paths.join([cache, name]);
+        const stat = fs.statSync(path);
+        return { path, size: stat.size, time: stat.mtimeMs };
+      }).sort((a, b) => a.time - b.time);
+    bytes = files.reduce((total, file) => total + file.size, 0);
+  }
+  const images = candidates.slice(0, 32).map((part) => {
+    const source = part.source || part;
+    const url = part.url || source.url || '';
+    const match = /^data:(image\/[a-z]+);base64,([A-Za-z0-9+/=]+)$/.exec(url);
+    const mimeType = source.media_type || part.mimeType || part.mime || match?.[1];
+    const data = source.data || match?.[2];
+    if (!TYPES[mimeType]) return { unavailable: 'format' };
+    if (!data && /^file:\/\//.test(url) && url.length < 4096) return { src: url };
+    if (typeof data !== 'string' || !data.length || data.length % 4
+      || !/^[A-Za-z0-9+/]+={0,2}$/.test(data)) return { unavailable: 'load' };
+    if (data.length > 4.5 * 1024 * 1024 || data.length > remaining) return { unavailable: 'limit' };
+    remaining -= data.length;
+    let path;
+    try {
+      prepareCache();
+      const size = Math.floor(data.length * 3 / 4);
+      while (files.length && (bytes + size > CACHE_BYTES || files.length >= 256 || files[0].time < now - CACHE_AGE)) {
+        const file = files[0];
+        fs.unlinkSync(file.path);
+        bytes -= file.size;
+        files.shift();
+      }
+      path = adapter.paths.join([cache, `preview-${now.toString(36)}-${Math.random().toString(36).slice(2)}-${++sequence}.${TYPES[mimeType]}`]);
+      fs.writeFileSync(path, data, { encoding: 'base64', flag: 'wx' });
+      bytes += size;
+      files.push({ path, size, time: now });
+      return { src: attachmentFileUrl(path, adapter.id) };
+    } catch {
+      if (path) { try { fs.unlinkSync(path); } catch {} }
+      return { unavailable: 'load' };
+    }
+  });
+  if (candidates.length > 32) images.push({ unavailable: 'limit' });
+  return { images };
+}

--- a/plugin/panel/src/components/chat/ToolCallCard.jsx
+++ b/plugin/panel/src/components/chat/ToolCallCard.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { Icon } from '../core/Icon';
 import { Spinner } from '../core/Spinner';
 import { Button } from '../core/Button';
+import { Drawer } from '../shell/Drawer';
 
 function StatusGlyph({ status }) {
   if (status === 'running') return <Spinner size={12} />;
@@ -51,11 +53,77 @@ function DetailsBlock({ details }) {
   );
 }
 
+function PreviewImage({ image, lang, onOpen, large = false }) {
+  const [failed, setFailed] = React.useState(false);
+  const reason = image.unavailable || (failed || !image.src ? 'load' : '');
+  const messages = lang === 'en' ? {
+    load: 'Preview unavailable. The file may have expired or failed to load.',
+    limit: 'Preview exceeds the display limit.',
+    format: 'This image format cannot be displayed.',
+  } : {
+    load: '预览不可用，文件可能已失效或加载失败。',
+    limit: '预览超出显示上限。',
+    format: '无法显示此图片格式。',
+  };
+  const preview = <img src={image.src} alt={lang === 'en' ? 'Tool preview' : '工具预览'} onError={() => setFailed(true)}
+    style={{ display: 'block', width: '100%', height: large ? 'calc(100vh - 112px)' : 'min(240px, var(--tool-preview-max-height, 40vh))', objectFit: 'contain' }} />;
+  return reason ? (
+    <div role="status" style={{ padding: 8, color: 'var(--text-secondary)', fontSize: 12 }}>{messages[reason] || messages.load}</div>
+  ) : onOpen ? <button type="button" title={lang === 'en' ? 'View larger image' : '查看大图'} onClick={onOpen}
+    style={{ display: 'block', width: '100%', border: 0, padding: 0, background: 'transparent', cursor: 'zoom-in' }}>{preview}</button> : preview;
+}
+
+function ToolImages({ images, lang }) {
+  const [index, setIndex] = React.useState(0);
+  const [open, setOpen] = React.useState(false);
+  const inline = React.useRef(null);
+  const dialog = React.useRef(null);
+  const close = () => { setOpen(false); inline.current?.querySelector('button')?.focus(); };
+  React.useEffect(() => {
+    if (open) dialog.current?.querySelector('button')?.focus();
+  }, [open]);
+  const dialogKey = (event) => {
+    if (event.key === 'Escape') { event.preventDefault(); close(); }
+    if (event.key !== 'Tab') return;
+    const buttons = [...dialog.current.querySelectorAll('button:not(:disabled)')];
+    const next = (buttons.indexOf(document.activeElement) + (event.shiftKey ? -1 : 1) + buttons.length) % buttons.length;
+    event.preventDefault(); buttons[next]?.focus();
+  };
+  const image = images[index];
+  const navigation = images.length > 1 ? (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, padding: 4 }}>
+          <Button size="sm" disabled={index === 0} onClick={() => setIndex(index - 1)} title={lang === 'en' ? 'Previous image' : '上一张'}>‹</Button>
+          <span style={{ fontSize: 12 }}>{index + 1} / {images.length}</span>
+          <Button size="sm" disabled={index === images.length - 1} onClick={() => setIndex(index + 1)} title={lang === 'en' ? 'Next image' : '下一张'}>›</Button>
+        </div>
+      ) : null;
+  return (
+    <div ref={inline} data-tool-images style={{ borderTop: '1px solid var(--border-subtle)', minWidth: 0 }}>
+      <PreviewImage key={`${index}:${image.src || image.unavailable}`} image={image} lang={lang}
+        onOpen={() => setOpen(true)} />
+      {navigation}
+      {open ? createPortal(
+        <div ref={dialog} onKeyDown={dialogKey} style={{ position: 'fixed', inset: 0, zIndex: 100 }}>
+          <Drawer open title={lang === 'en' ? 'Preview' : '预览'} onClose={close} closeTitle={lang === 'en' ? 'Close preview' : '关闭预览'} style={{ maxHeight: '100%' }}>
+            <PreviewImage key={`${index}:${image.src || image.unavailable}`} image={image} lang={lang} large />
+            {navigation}
+          </Drawer>
+        </div>, document.body,
+      ) : null}
+    </div>
+  );
+}
+
 function HeaderRow({ status, verb, target, expandable, expanded, onToggle }) {
   const [hover, setHover] = React.useState(false);
   return (
     <div
       role={expandable ? 'button' : undefined}
+      tabIndex={expandable ? 0 : undefined}
+      aria-expanded={expandable ? expanded : undefined}
+      onKeyDown={(event) => {
+        if (expandable && (event.key === 'Enter' || event.key === ' ')) { event.preventDefault(); onToggle(); }
+      }}
       onClick={expandable ? onToggle : undefined}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
@@ -105,6 +173,8 @@ export function ToolCallCard({
   errorMessage,
   hint,
   details,
+  images,
+  lang = 'zh',
   detailsLabel = '详情',
   onRetry,
   steps,
@@ -136,6 +206,7 @@ export function ToolCallCard({
         expanded={expanded}
         onToggle={() => setExpanded(!expanded)}
       />
+      {images?.length ? <ToolImages key={JSON.stringify(images)} images={images} lang={lang} /> : null}
       {expanded && isGroup ? (
         <div style={{ borderTop: '1px solid var(--border-subtle)', padding: 'var(--space-1) 0' }}>
           {steps.map((s, i) => (

--- a/plugin/panel/src/components/shell/PanelUpdate.jsx
+++ b/plugin/panel/src/components/shell/PanelUpdate.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Button } from '../core/Button';
+import { IconButton } from '../core/IconButton';
+
+export function PanelUpdateBanner({ update, lang, onOpen, onDismiss }) {
+  const en = lang === 'en';
+  const text = en ? `Panel ${update.current} → ${update.latest}` : `面板 ${update.current} → ${update.latest}`;
+  return <div className="panel-update-banner" role="status">
+    <span title={text}>{text}</span>
+    <Button size="sm" variant="ghost" onClick={onOpen}>{en ? 'View release' : '查看更新'}</Button>
+    <IconButton icon="x" title={en ? 'Dismiss this version' : '关闭此版本提醒'} onClick={onDismiss} />
+  </div>;
+}
+
+export function PanelUpdateSettings({ update, lang, onCheck, onOpen }) {
+  const en = lang === 'en';
+  const reasons = en ? { timeout: 'Request timed out.', network: 'Network or service unavailable.',
+    limited: 'GitHub limited or denied the request.', release: 'No comparable stable release.', version: 'Panel version cannot be compared.' }
+    : { timeout: '请求超时。', network: '网络或服务不可用。', limited: 'GitHub 限流或拒绝请求。',
+      release: '未获得可比较的稳定版。', version: '面板版本无法比较。' };
+  const message = update?.status === 'checking' ? (en ? 'Checking panel release…' : '正在检查面板 Release…')
+    : update?.status === 'update' ? (en ? `Panel update: ${update.latest}` : `面板可更新：${update.latest}`)
+    : update?.status === 'current' ? (en ? `No newer stable panel release (${update.latest}).` : `没有更高的面板稳定版（${update.latest}）。`)
+    : (en ? 'Panel update unknown. ' : '面板更新状态未知。') + (reasons[update?.reason] || '');
+  return <div className="panel-update-settings">
+    <div role="status">{message}</div>
+    {update?.openFailed ? <div role="alert">{en ? 'Could not open the release page. Check your default browser and retry.' : '无法打开 Release 页面，请检查默认浏览器后重试。'}</div> : null}
+    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+      <Button size="sm" disabled={update?.status === 'checking'} onClick={onCheck}>{en ? 'Check panel updates' : '检查面板更新'}</Button>
+      {update?.status === 'update' ? <Button size="sm" onClick={onOpen}>{en ? 'View release' : '查看更新'}</Button> : null}
+    </div>
+  </div>;
+}

--- a/plugin/panel/src/lib/chatEntries.js
+++ b/plugin/panel/src/lib/chatEntries.js
@@ -79,6 +79,7 @@ export function reduceEvent(entries, evt) {
           state: evt.ok ? 'ok' : 'error',
           ok: !!evt.ok,
           text: evt.text || '',
+          ...(evt.images ? { images: evt.images } : {}),
           durationMs: evt.durationMs,
         });
       }
@@ -87,6 +88,7 @@ export function reduceEvent(entries, evt) {
         state: evt.ok ? 'ok' : 'error',
         ok: !!evt.ok,
         text: evt.text || '',
+        ...(evt.images || entry.images ? { images: evt.images || [] } : {}),
         durationMs: evt.durationMs,
       }));
 

--- a/plugin/panel/src/lib/cliUpdates.js
+++ b/plugin/panel/src/lib/cliUpdates.js
@@ -1,3 +1,5 @@
+import { compareVersions, createVersionChecker } from './versionUpdates.js';
+export { compareVersions } from './versionUpdates.js';
 export const ASTRA_CLI_BASELINE = '0.153.4';
 const PACKAGES = { codex: '@openai/codex', subscription: '@anthropic-ai/claude-code', opencode: 'opencode-ai' };
 const DOCS = {
@@ -5,16 +7,6 @@ const DOCS = {
   subscription: 'https://code.claude.com/docs/en/setup',
   opencode: 'https://opencode.ai/docs/cli/#upgrade',
 };
-
-export function compareVersions(left, right) {
-  const parse = (value) => /^(?:v)?(\d+)\.(\d+)\.(\d+)$/.exec(String(value || '').trim());
-  const a = parse(left), b = parse(right);
-  if (!a || !b) return null;
-  for (let i = 1; i <= 3; i += 1) {
-    if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
-  }
-  return 0;
-}
 
 export function cliIdentity(executable, fs) {
   if (!executable?.ok) return null;
@@ -58,28 +50,15 @@ export function cliUpdateGuide(backend, cli, lang = 'zh') {
 }
 
 export function createCliUpdateChecker({ requestJson, now = Date.now, timeoutMs = 8000 }) {
-  const cache = new Map();
-  return async (backend, cli, { force = false } = {}) => {
+  const checkers = new Map();
+  return async (backend, cli, options = {}) => {
     const current = cli?.version || '';
     if (!PACKAGES[backend] || !cli) return { status: 'unknown', current };
-    let entry = cache.get(backend);
-    if (force || !entry || now() - entry.checkedAt >= 86400000) {
-      let timer;
-      try {
-        const result = await Promise.race([
-          requestJson({ url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`, timeoutMs }),
-          new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('timeout')), timeoutMs); }),
-        ]);
-        const latest = result.json?.version;
-        if (!result.ok || compareVersions(latest, latest) === null) throw new Error('unknown stable version');
-        entry = { latest, checkedAt: now() };
-        cache.set(backend, entry);
-      } catch {
-        return { status: 'unknown', current };
-      } finally { clearTimeout(timer); }
+    if (!checkers.has(backend)) {
+      checkers.set(backend, createVersionChecker({ requestJson, now, timeoutMs,
+        url: `https://registry.npmjs.org/${PACKAGES[backend]}/latest`, parseRelease: (json) => ({ latest: json?.version }) }));
     }
-    const comparison = compareVersions(current, entry.latest);
-    return { ...entry, current, status: comparison === null ? 'unknown' : comparison < 0 ? 'update' : 'current' };
+    return checkers.get(backend)(current, options);
   };
 }
 

--- a/plugin/panel/src/lib/panelUpdates.js
+++ b/plugin/panel/src/lib/panelUpdates.js
@@ -1,0 +1,23 @@
+import { compareVersions, createVersionChecker } from './versionUpdates.js';
+import { REPO_URL } from './externalLinks.js';
+
+export const PANEL_UPDATE_CACHE = 'ae-mcp.panel-release-cache';
+export const PANEL_UPDATE_DISMISSED = 'ae-mcp.panel-release-dismissed';
+export const PANEL_RELEASE_API = 'https://api.github.com/repos/JUNKDOGE-JOE/after-effects-mcp/releases/latest';
+const releasePage = (tag) => `${REPO_URL}/releases/tag/${encodeURIComponent(tag)}`;
+
+export function createPanelUpdateChecker({ readPref, writePref, ...options }) {
+  return createVersionChecker({
+    ...options, url: PANEL_RELEASE_API,
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'ae-mcp-panel' },
+    readCache: () => JSON.parse(readPref(PANEL_UPDATE_CACHE, 'null')),
+    writeCache: (value) => writePref(PANEL_UPDATE_CACHE, JSON.stringify(value)),
+    validEntry: (value) => value.url === releasePage(value.latest),
+    parseRelease: (release) => release?.draft === false && release?.prerelease === false
+      ? { latest: release.tag_name, url: releasePage(release.tag_name) } : null,
+  });
+}
+
+export function showPanelUpdate(update, dismissed) {
+  return update?.status === 'update' && compareVersions(update.latest, dismissed) !== 0;
+}

--- a/plugin/panel/src/lib/versionUpdates.js
+++ b/plugin/panel/src/lib/versionUpdates.js
@@ -1,0 +1,48 @@
+export const UPDATE_CACHE_MS = 86400000;
+
+export function compareVersions(left, right) {
+  const parse = (value) => /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$/.exec(String(value || '').trim());
+  const a = parse(left), b = parse(right);
+  if (!a || !b || [...a.slice(1), ...b.slice(1)].some((n) => !Number.isSafeInteger(Number(n)))) return null;
+  for (let i = 1; i <= 3; i += 1) {
+    if (Number(a[i]) !== Number(b[i])) return Math.sign(Number(a[i]) - Number(b[i]));
+  }
+  return 0;
+}
+
+export function createVersionChecker({ requestJson, url, headers, parseRelease, now = Date.now, timeoutMs = 8000,
+  readCache = () => null, writeCache = () => {}, validEntry = () => true }) {
+  let entry;
+  try { entry = readCache(); } catch {}
+  const usable = (value) => value && Number.isFinite(value.checkedAt) && now() >= value.checkedAt
+    && now() - value.checkedAt < UPDATE_CACHE_MS && compareVersions(value.latest, value.latest) === 0 && validEntry(value);
+  let pending;
+  async function refresh() {
+    let timer;
+    try {
+      const result = await Promise.race([
+        requestJson({ url, headers, timeoutMs }),
+        new Promise((_, reject) => { timer = setTimeout(() => reject(Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' })), timeoutMs); }),
+      ]);
+      if (!result.ok) return { reason: [403, 429].includes(result.status) ? 'limited' : 'network' };
+      const release = parseRelease(result.json);
+      if (!release || compareVersions(release.latest, release.latest) !== 0) return { reason: 'release' };
+      entry = { ...release, checkedAt: now() };
+      try { writeCache(entry); } catch {}
+      return entry;
+    } catch (error) {
+      return { reason: error?.code === 'ETIMEDOUT' ? 'timeout' : 'network' };
+    } finally { clearTimeout(timer); }
+  }
+  return async (current, { force = false } = {}) => {
+    let value = entry;
+    if (pending || force || !usable(entry)) {
+      if (!pending) pending = refresh().finally(() => { pending = null; });
+      value = await pending;
+    }
+    if (value.reason) return { status: 'unknown', current, reason: value.reason };
+    const comparison = compareVersions(current, value.latest);
+    return { ...value, current, status: comparison === null ? 'unknown' : comparison < 0 ? 'update' : 'current',
+      ...(comparison === null ? { reason: 'version' } : {}) };
+  };
+}

--- a/plugin/panel/src/screens/ChatScreen.jsx
+++ b/plugin/panel/src/screens/ChatScreen.jsx
@@ -167,6 +167,9 @@ function Entry({ entry, lang, onApprove, onAnswerQuestion }) {
           target={toolTarget(entry, t)}
           status={statusForTool(entry.state)}
           params={entry.input}
+          images={entry.images}
+          lang={lang}
+          details={entry.text}
           errorMessage={entry.state === 'error' ? entry.text : null}
         />
         {entry.state === 'awaiting-approval' ? (
@@ -315,6 +318,8 @@ export function ChatScreen({
       const layout = layoutRef.current;
       const footer = footerRef.current;
       if (!layout || !footer) return;
+      const log = logRef.current;
+      if (log) log.style.setProperty('--tool-preview-max-height', `${Math.max(24, log.clientHeight - 24)}px`);
       const availableHeight = composerAvailableHeight({
         containerHeight: layout.getBoundingClientRect().height,
         footerHeight: footer.getBoundingClientRect().height,
@@ -327,6 +332,7 @@ export function ChatScreen({
     const observer = new ResizeObserver(measureComposerBounds);
     observer.observe(layoutRef.current);
     observer.observe(footerRef.current);
+    if (logRef.current) observer.observe(logRef.current);
     return () => observer.disconnect();
   }, []);
 

--- a/plugin/panel/src/screens/SettingsScreen.jsx
+++ b/plugin/panel/src/screens/SettingsScreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { cliUpdateGuide } from '../lib/cliUpdates.js';
+import { PanelUpdateSettings } from '../components/shell/PanelUpdate';
 import pkg from '../../package.json';
 import { Badge } from '../components/core/Badge';
 import { Button } from '../components/core/Button';
@@ -318,6 +319,9 @@ export function SettingsScreen({
   loginState = null,
   recheckDisabled = false,
   cliStatus = {},
+  panelUpdate,
+  onCheckPanelUpdate,
+  onOpenPanelRelease,
   providerManager = null,
   providerInit = { state: 'checking', error: '' },
   logLevel = 'info',
@@ -488,6 +492,7 @@ export function SettingsScreen({
 
       <Section id="about" title={t.about} expanded={sections.about} onToggle={onToggleSection}>
         <VersionRow label={t.verPanel} value={`v${pkg.version}`} />
+        <PanelUpdateSettings update={panelUpdate} lang={lang} onCheck={onCheckPanelUpdate} onOpen={onOpenPanelRelease} />
         <VersionRow label={t.verHost} value={hostVersion} badge={hostVersion === '-' ? <Badge status="neutral">{t.pending}</Badge> : null} />
         <div style={{ display: 'flex', gap: 6 }}>
           <Button variant="ghost" size="sm" icon="book-open" onClick={() => handleExternalLink(docsUrlForLocale(lang))}>{t.docs}</Button>

--- a/plugin/panel/src/styles/index.css
+++ b/plugin/panel/src/styles/index.css
@@ -9,6 +9,15 @@ html, body { margin: 0; height: 100%; }
 body { background: var(--bg-panel); color: var(--text-primary); font: var(--weight-regular) var(--text-body)/var(--leading-normal) var(--font-ui); }
 #root { height: 100%; display: flex; flex-direction: column; }
 
+.panel-update-banner {
+  height: 24px; flex: none; min-width: 0; display: flex; align-items: center; gap: 2px;
+  padding: 0 4px; background: var(--info-bg); border-bottom: 1px solid var(--border-default);
+  font: var(--weight-regular) var(--text-micro)/var(--leading-tight) var(--font-ui);
+}
+.panel-update-banner > span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.panel-update-banner > button { flex: none; }
+.panel-update-settings { display: flex; flex-direction: column; gap: 6px; overflow-wrap: anywhere; }
+
 .ae-attachment-pond {
   flex: none;
   min-width: 0;

--- a/plugin/panel/test/claudeAgentBackend.test.js
+++ b/plugin/panel/test/claudeAgentBackend.test.js
@@ -548,6 +548,26 @@ test('real assistant and user wire map AE tool start and result events', async (
   });
 });
 
+test('Claude tool_result image sources retain their tool_use_id', async () => {
+  const h = makeHarness();
+  const run = h.backend.sendUser('preview');
+  await flush();
+  emitWire(h.processes[0], wire('B', 3));
+  const assistant = wire('B', 57);
+  assistant.message.content[0].name = 'mcp__ae__ae_previewFrame';
+  emitWire(h.processes[0], assistant);
+  const user = wire('B', 59);
+  user.message.content[0].content = [{ type: 'image', source: {
+    type: 'url', url: 'file:///tmp/claude.png', media_type: 'image/png',
+  } }];
+  emitWire(h.processes[0], user);
+  finishTurn(h.processes[0]);
+  await run;
+  const result = h.events.find((event) => event.type === 'tool-result');
+  assert.equal(result.toolUseId, user.message.content[0].tool_use_id);
+  assert.deepEqual(result.images, [{ src: 'file:///tmp/claude.png' }]);
+});
+
 test('Claude flushes redacted assistant text before tool_use events', async () => {
   const selected = 'C:\\' + 's'.repeat(61);
   assert.equal(selected.length, 64);

--- a/plugin/panel/test/codexBackend.test.js
+++ b/plugin/panel/test/codexBackend.test.js
@@ -131,6 +131,22 @@ async function startTurn(
   return { pending, proc, thread, turn };
 }
 
+test('Codex completed MCP image results retain their call id and omit data from display text', async () => {
+  const h = makeBackend();
+  try {
+    const { proc } = await startTurn(h.backend, h.spawned);
+    proc.emit({ method: 'item/completed', params: { item: { type: 'mcpToolCall', id: 'preview-1',
+      tool: 'ae_previewFrame', status: 'completed', result: { content: [
+        { type: 'text', text: '{"base64":"AAAA"}' },
+        { type: 'image', mimeType: 'image/png', url: 'file:///tmp/frame.png' },
+      ] } } } });
+    const result = h.events.find((event) => event.type === 'tool-result');
+    assert.equal(result.toolUseId, 'preview-1');
+    assert.deepEqual(result.images, [{ src: 'file:///tmp/frame.png' }]);
+    assert.equal(result.text, '{"base64":"[image]"}');
+  } finally { h.backend.reset(); }
+});
+
 test('resolveCodexCli exposes the CLI shim for diagnostics', async () => {
   const result = await resolveCodexCli({
     env: { AE_MCP_CODEX_CLI: 'C:\\Custom\\codex.cmd' },

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -1202,6 +1202,26 @@ test('OpenCode prefixes only ae server tool names', async () => {
   );
 });
 
+test('OpenCode completed tool attachments retain their callID separately from output text', async () => {
+  const { backend, events, fetched } = makeBackend();
+  const pending = backend.sendUser('preview');
+  await flush();
+  fetched.sse.push({ type: 'message.part.updated', properties: { sessionID: 'session_1', part: {
+    type: 'tool', tool: 'ae_ae_previewFrame', callID: 'oc-preview', state: {
+      status: 'completed', output: '{"frames":2}', attachments: [
+        { type: 'file', mime: 'image/png', url: 'file:///tmp/oc1.png' },
+        { type: 'file', mime: 'image/png', url: 'file:///tmp/oc2.png' },
+      ],
+    },
+  } } });
+  completeTurn(fetched);
+  await pending;
+  const result = events.find((event) => event.type === 'tool-result');
+  assert.equal(result.toolUseId, 'oc-preview');
+  assert.deepEqual(result.images.map((image) => image.src), ['file:///tmp/oc1.png', 'file:///tmp/oc2.png']);
+  assert.equal(result.text, '{"frames":2}');
+});
+
 test('OpenCode flushes redacted assistant text before built-in question events', async () => {
   const providerSecret = 'p'.repeat(64);
   assert.equal(providerSecret.length, 64);

--- a/plugin/panel/test/panelUpdates.test.js
+++ b/plugin/panel/test/panelUpdates.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPanelUpdateChecker, PANEL_RELEASE_API, PANEL_UPDATE_CACHE, showPanelUpdate } from '../src/lib/panelUpdates.js';
+import { compareVersions, UPDATE_CACHE_MS } from '../src/lib/versionUpdates.js';
+
+function fixture(options = {}) {
+  const prefs = new Map();
+  let calls = 0, time = 100, response = { ok: true, json: { tag_name: 'v0.11.0', draft: false, prerelease: false } };
+  const make = () => createPanelUpdateChecker({ now: () => time, timeoutMs: 10,
+    readPref: (key, fallback) => prefs.get(key) || fallback, writePref: (key, value) => prefs.set(key, value),
+    requestJson: async (request) => {
+      calls += 1;
+      assert.equal(request.url, PANEL_RELEASE_API);
+      assert.equal(request.headers['User-Agent'], 'ae-mcp-panel');
+      if (response instanceof Error) throw response;
+      return response;
+    }, ...options });
+  return { make, prefs, get calls() { return calls; }, set response(value) { response = value; }, advance: (ms) => { time += ms; } };
+}
+
+test('running panel versions compare numerically, never offer downgrades, reject ambiguous tags', async () => {
+  const check = fixture().make();
+  for (const [version, status] of [['0.9.9', 'update'], ['v0.11.0', 'current'], ['0.12.0', 'current'],
+    ['0.11.0+dev.1', 'current'], ['', 'unknown'], ['development', 'unknown'], ['0.11.0-beta.1', 'unknown']]) {
+    assert.equal((await check(version)).status, status, version);
+  }
+  for (const version of ['01.2.3', '1.2', '1.2.3-', '9007199254740992.0.0']) assert.equal(compareVersions(version, '1.2.3'), null);
+});
+
+test('drafts, prereleases and malformed release data are ignored and never cached', async () => {
+  for (const json of [{ tag_name: 'v0.11.0', draft: true, prerelease: false },
+    { tag_name: 'v0.11.0', draft: false, prerelease: true },
+    { tag_name: 'v0.11.0-beta.1', draft: false, prerelease: false },
+    { tag_name: 'latest', draft: false, prerelease: false }, {}, null]) {
+    const f = fixture(); f.response = { ok: true, json };
+    assert.equal((await f.make()('0.10.6')).reason, 'release');
+    assert.equal(f.prefs.size, 0);
+  }
+});
+
+test('successful checks persist for 24 hours, manual refresh bypasses cache, dismissal follows version', async () => {
+  const f = fixture(); const check = f.make();
+  const first = await check('0.10.6');
+  assert.equal(first.url, 'https://github.com/JUNKDOGE-JOE/after-effects-mcp/releases/tag/v0.11.0');
+  assert.equal(showPanelUpdate(first, ''), true);
+  assert.equal(showPanelUpdate(await f.make()('0.10.6'), '0.11.0'), false);
+  assert.equal(f.calls, 1);
+  f.response = { ok: true, json: { tag_name: 'v0.12.0', draft: false, prerelease: false } };
+  assert.equal(showPanelUpdate(await check('0.10.6', { force: true }), 'v0.11.0'), true);
+  assert.equal(f.calls, 2);
+  f.advance(UPDATE_CACHE_MS - 1); await f.make()('0.10.6'); assert.equal(f.calls, 2);
+  f.advance(1); await f.make()('0.10.6'); assert.equal(f.calls, 3);
+});
+
+test('offline, rate limited and timed-out checks are unknown, retryable, and cannot claim current', async () => {
+  for (const [response, reason] of [[new Error('offline'), 'network'], [{ ok: false, status: 429 }, 'limited'],
+    [{ ok: false, status: 403 }, 'limited'], [{ ok: false, status: 500 }, 'network'],
+    [Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }), 'timeout']]) {
+    const f = fixture(); f.response = response; const check = f.make();
+    const result = await check('0.10.6');
+    assert.equal(result.status, 'unknown'); assert.equal(result.reason, reason);
+    assert.equal(showPanelUpdate(result, ''), false); assert.equal(f.prefs.size, 0);
+    await check('0.10.6'); assert.equal(f.calls, 2);
+  }
+  const check = fixture({ requestJson: () => new Promise(() => {}) }).make();
+  assert.equal((await check('0.10.6')).reason, 'timeout');
+});
+
+test('failed forced refresh does not report the cached version as a successful check', async () => {
+  const f = fixture(), check = f.make(); await check('0.11.0');
+  f.response = new Error('offline');
+  assert.equal((await check('0.11.0', { force: true })).status, 'unknown');
+});
+
+test('invalid/future cache and unavailable storage do not prevent checking', async () => {
+  for (const cached of ['broken', JSON.stringify({ latest: 'v0.11.0', checkedAt: 9999999999999 }),
+    JSON.stringify({ latest: 'v0.11.0', checkedAt: 100, url: 'https://example.com/' })]) {
+    const f = fixture(); f.prefs.set(PANEL_UPDATE_CACHE, cached);
+    assert.equal((await f.make()('0.10.6')).status, 'update'); assert.equal(f.calls, 1);
+  }
+  const f = fixture({ readPref: () => { throw new Error('storage'); }, writePref: () => { throw new Error('storage'); } });
+  assert.equal((await f.make()('0.10.6')).status, 'update');
+});
+
+test('overlapping checks share one request and compare each caller version', async () => {
+  const f = fixture(), check = f.make();
+  const results = await Promise.all([check('0.10.6'), check('0.11.0', { force: true })]);
+  assert.deepEqual(results.map((r) => r.status), ['update', 'current']); assert.equal(f.calls, 1);
+});

--- a/plugin/panel/test/toolImages.test.js
+++ b/plugin/panel/test/toolImages.test.js
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { captureToolImages, toolDisplayText } from '../src/cep/toolImages.js';
+import { reduceEvent } from '../src/lib/chatEntries.js';
+import { createSessionStore } from '../src/cep/sessionStore.js';
+
+const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLbtAAAAABJRU5ErkJggg==';
+const mcp = { type: 'image', mimeType: 'image/png', data: png };
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tool-images-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { id: process.platform === 'win32' ? 'windows-x64' : 'macos-arm64', fs,
+    paths: { configRoot: root, join: (parts) => path.join(...parts) } };
+}
+
+test('MCP, Claude source and OpenCode file payloads preserve identical pixels without mutating model results', (t) => {
+  const adapter = fixture(t);
+  const content = [mcp, { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+    { type: 'file', mime: 'image/png', url: `data:image/png;base64,${png}` }];
+  const original = JSON.stringify(content);
+  const { images } = captureToolImages(content, adapter);
+  assert.equal(images.length, 3);
+  assert.equal(new Set(images.map((image) => image.src)).size, 3);
+  for (const image of images) assert.equal(fs.readFileSync(fileURLToPath(image.src)).toString('base64'), png);
+  assert.equal(JSON.stringify(content), original);
+  assert.equal(JSON.stringify(images).includes(png), false);
+});
+
+test('out-of-order results stay with their call and historical transcripts contain only image references', (t) => {
+  const adapter = fixture(t);
+  let entries = reduceEvent([], { type: 'tool-start', toolUseId: 'a' });
+  entries = reduceEvent(entries, { type: 'tool-start', toolUseId: 'b' });
+  const a = captureToolImages([mcp], adapter);
+  const b = captureToolImages([mcp, mcp], adapter);
+  entries = reduceEvent(entries, { type: 'tool-result', toolUseId: 'b', ok: true, ...b });
+  entries = reduceEvent(entries, { type: 'tool-result', toolUseId: 'a', ok: true, ...a });
+  assert.deepEqual(entries.map((entry) => entry.images), [a.images, b.images]);
+  const store = createSessionStore({ platform: adapter });
+  store.saveTranscript('chat-test', entries);
+  const restored = store.loadTranscript('chat-test');
+  assert.equal(JSON.stringify(restored).includes(png), false);
+  assert.ok(JSON.stringify(restored).length < 2000);
+  assert.ok(fs.existsSync(fileURLToPath(restored.entries[0].images[0].src)));
+  fs.unlinkSync(fileURLToPath(a.images[0].src));
+  assert.deepEqual(store.loadTranscript('chat-test'), restored);
+  assert.ok(!fs.existsSync(fileURLToPath(restored.entries[0].images[0].src)));
+  assert.deepEqual(reduceEvent(entries, { type: 'tool-result', toolUseId: 'a', ok: false })[0].images, []);
+  assert.equal(reduceEvent([], { type: 'tool-result', toolUseId: 'c', ok: true, ...b })[0].images.length, 2);
+});
+
+test('cache evicts only owned old files and enforces a byte budget', (t) => {
+  const adapter = fixture(t);
+  const cache = path.join(adapter.paths.configRoot, 'tool-images');
+  fs.mkdirSync(cache);
+  const old = path.join(cache, 'preview-old.png');
+  fs.writeFileSync(old, 'old');
+  fs.utimesSync(old, new Date(0), new Date(0));
+  fs.writeFileSync(path.join(cache, 'keep.txt'), 'unrelated');
+  const large = path.join(cache, 'preview-large.png');
+  fs.writeFileSync(large, '');
+  fs.truncateSync(large, 64 * 1024 * 1024);
+  const { images } = captureToolImages([mcp], adapter);
+  assert.ok(images[0].src);
+  assert.ok(!fs.existsSync(old));
+  assert.ok(!fs.existsSync(large));
+  assert.equal(fs.readFileSync(path.join(cache, 'keep.txt'), 'utf8'), 'unrelated');
+});
+
+test('invalid, unavailable and excessive images remain explicit without throwing or exposing base64', (t) => {
+  const adapter = fixture(t);
+  assert.deepEqual(captureToolImages([{ ...mcp, data: '?' }], adapter).images, [{ unavailable: 'load' }]);
+  assert.deepEqual(captureToolImages([{ ...mcp, mimeType: 'image/svg+xml' }], adapter).images, [{ unavailable: 'format' }]);
+  assert.deepEqual(captureToolImages([{ ...mcp, data: 'AAAA'.repeat(1200000) }], adapter).images, [{ unavailable: 'limit' }]);
+  assert.deepEqual(captureToolImages([mcp], {}).images, [{ unavailable: 'load' }]);
+  assert.equal(captureToolImages(Array(34).fill(mcp), adapter).images.at(-1).unavailable, 'limit');
+  assert.equal(toolDisplayText(`{"base64":"${png}"} data:image/png;base64,${png}`), '{"base64":"[image]"} [image]');
+});

--- a/plugin/panel/validation/tool-images.mjs
+++ b/plugin/panel/validation/tool-images.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const require = createRequire(import.meta.url);
+const { chromium } = require(process.env.PLAYWRIGHT_MODULE || 'playwright');
+const panel = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const output = path.resolve(process.argv[2]);
+await fs.mkdir(output, { recursive: true });
+const fixture = await build({
+  absWorkingDir: panel, bundle: true, write: false, format: 'iife', jsx: 'automatic',
+  define: { 'process.env.NODE_ENV': '"production"' },
+  stdin: { resolveDir: panel, loader: 'jsx', contents: `
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { ChatScreen } from './src/screens/ChatScreen.jsx';
+    import { StatusBar } from './src/components/shell/StatusBar.jsx';
+    import { TabBar } from './src/components/shell/TabBar.jsx';
+    const root = createRoot(document.getElementById('root'));
+    const canvas = document.createElement('canvas'); canvas.width=1600; canvas.height=900;
+    const ctx=canvas.getContext('2d');
+    window.images=['#c54d37','#276f60'].map((color,i)=>{ctx.fillStyle=color;ctx.fillRect(0,0,1600,900);
+      ctx.fillStyle='#ffffff';ctx.fillRect(100,100,400,700);ctx.font='160px sans-serif';ctx.fillText('FRAME '+(i+1),550,480);
+      return {src:canvas.toDataURL()};});
+    window.reset = (lang, images=window.images) => {
+      root.render(<React.Fragment>
+        <StatusBar label="Connected"/><div style={{height:32,flex:'none'}}>Update available · 有新版本</div>
+        <ChatScreen lang={lang} sessionTitle="Preview" onNewSession={()=>{}} attachmentDraft={{items:[],text:'continue'}}
+          createTurnId={()=>'continue'} onSend={()=>{window.sent=true;}} entries={[{
+          id:'preview',type:'tool-call',toolUseId:'preview',name:'ae_previewFrame',state:'ok',images,
+          input:{times:[0,1]},text:JSON.stringify({frames:2,detail:'long content'.repeat(1000)})
+        }]}/><TabBar active="chat" tabs={['chat','activity','tools','settings'].map(id=>({id,label:id,icon:'box'}))}/>
+      </React.Fragment>);
+    };
+  ` },
+});
+const css = await fs.readFile(path.join(panel, '../client/dist/app.css'), 'utf8');
+const browser = await chromium.launch({ headless: true, ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {}) });
+const page = await browser.newPage();
+const ledger = [];
+async function geometry(label) {
+  const data = await page.evaluate(() => {
+    const input=document.querySelector('textarea');
+    const r=input.getBoundingClientRect();
+    const image=document.querySelector('[data-tool-images] img');
+    const ir=image?.getBoundingClientRect();
+    return {width:innerWidth,height:innerHeight,scroll:[document.documentElement.scrollWidth,document.documentElement.scrollHeight],
+      input:[r.x,r.y,r.width,r.height],inputHit:input.contains(document.elementFromPoint(r.x+r.width/2,r.y+r.height/2)),
+      image:ir && {width:ir.width,height:ir.height,naturalWidth:image.naturalWidth,fit:getComputedStyle(image).objectFit}};
+  });
+  assert.ok(data.scroll[0]<=data.width && data.scroll[1]<=data.height, label+' outer overflow');
+  assert.ok(data.inputHit && data.input[1]>=0 && data.input[1]+data.input[3]<=data.height, label+' input accessible');
+  if(data.image) assert.ok(data.image.width<=data.width && data.image.height<=241 && data.image.fit==='contain');
+  ledger.push({label,disposition:'PASS',...data});
+  return data.input;
+}
+try {
+  for (const [width,height] of [[280,300],[420,480]]) for (const lang of ['zh','en']) {
+    const label=[width,height,lang].join('-');
+    await page.setViewportSize({width,height});
+    await page.setContent('<div id="root"></div>');
+    await page.addStyleTag({content:css});
+    await page.addScriptTag({content:fixture.outputFiles[0].text});
+    await page.evaluate(lang=>window.reset(lang),lang);
+    await page.waitForFunction(()=>document.querySelector('[data-tool-images] img')?.naturalWidth===1600);
+    assert.equal(await page.locator('pre').count(),0);
+    const before=await geometry(label+' initial');
+    const first=await page.locator('[data-tool-images] img').getAttribute('src');
+    await page.getByTitle(lang==='zh'?'下一张':'Next image',{exact:true}).click();
+    assert.notEqual(await page.locator('[data-tool-images] img').getAttribute('src'),first);
+    assert.deepEqual(await geometry(label+' next'),before);
+    await page.locator('[aria-expanded="false"]').click();
+    assert.equal(await page.locator('pre').count(),2);
+    assert.deepEqual(await geometry(label+' details'),before);
+    await page.locator('[aria-expanded="true"]').press('Enter');
+    await page.locator('[data-tool-images] img').scrollIntoViewIfNeeded();
+    const visible = await page.locator('[data-tool-images] img').evaluate(el => {
+      const r=el.getBoundingClientRect();
+      return [0.1,0.5,0.9].every(v=>el.contains(document.elementFromPoint(r.x+r.width/2,r.y+r.height*v)));
+    });
+    assert.ok(visible,label+' entire preview is visible inside the transcript');
+    await page.screenshot({path:path.join(output,label+'.png')});
+    await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).click();
+    const dialog=page.getByRole('dialog');
+    await dialog.waitFor();
+    const large=await dialog.locator('img').boundingBox();
+    assert.ok(large.width>=250 && large.height>=180,label+' readable enlarged preview');
+    await dialog.getByTitle(lang==='zh'?'上一张':'Previous image',{exact:true}).click();
+    assert.equal(await dialog.locator('img').getAttribute('src'),first);
+    await page.screenshot({path:path.join(output,label+'-large.png')});
+    await dialog.getByTitle(lang==='zh'?'关闭预览':'Close preview',{exact:true}).press('Escape');
+    assert.equal(await page.getByRole('dialog').count(),0);
+    assert.ok(await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).evaluate(el=>el===document.activeElement));
+    await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).click();
+    await page.getByTitle(lang==='zh'?'关闭预览':'Close preview',{exact:true}).click();
+    assert.deepEqual(await geometry(label+' close large'),before);
+    await page.locator('textarea').focus();
+    assert.ok(await page.locator('textarea').evaluate(el=>el===document.activeElement));
+    await page.getByTitle('发送 Send',{exact:true}).click();
+    assert.equal(await page.evaluate(()=>window.sent),true);
+    await page.evaluate(lang=>window.reset(lang,[{src:'file:///missing-preview.png'}]),lang);
+    await page.getByRole('status').waitFor();
+    assert.match(await page.getByRole('status').textContent(),lang==='zh'?/失效|失败/:/expired|failed/);
+    await geometry(label+' expired');
+    await page.evaluate(lang=>window.reset(lang,[window.images[0]]),lang);
+    await page.waitForFunction(()=>document.querySelector('[data-tool-images] img')?.naturalWidth===1600);
+    assert.equal(await page.getByRole('status').count(),0);
+    assert.equal(await page.locator('[data-tool-images] img').getAttribute('src'),first);
+    await geometry(label+' restored');
+  }
+  await fs.writeFile(path.join(output,'summary.json'),JSON.stringify({validationProfile:'offline',cases:ledger},null,2));
+  console.log(JSON.stringify({passed:ledger.length}));
+} finally { await browser.close(); }

--- a/plugin/panel/validation/tools-layout.mjs
+++ b/plugin/panel/validation/tools-layout.mjs
@@ -20,6 +20,7 @@ const fixture = await build({
     import { ToolsScreen } from './src/screens/ToolsScreen.jsx';
     import { StatusBar } from './src/components/shell/StatusBar.jsx';
     import { TabBar } from './src/components/shell/TabBar.jsx';
+    import { PanelUpdateBanner } from './src/components/shell/PanelUpdate.jsx';
     const root = createRoot(document.getElementById('root'));
     window.reset = (lang, kind, status, notice) => {
       const long = 'VeryLongName超长名称'.repeat(120);
@@ -32,7 +33,8 @@ const fixture = await build({
         inspect:async()=>({artifact:window.item}),listSkills:async()=>({skills:[window.item]}),
         executeTool:async()=>output(),executeSkill:async()=>output(),renderSkill:async()=>output()};
       root.render(<React.Fragment key={Math.random()}>
-        <StatusBar label="Connected"/><div style={{height:notice,flex:'none'}}>Notice 提示</div>
+        <StatusBar label="Connected"/>{notice ? <PanelUpdateBanner lang={lang}
+          update={{current:'0.10.6',latest:'v0.11.0'}} onOpen={()=>{window.releaseOpened=true;}} onDismiss={()=>{window.releaseDismissed=true;}}/> : null}
         <ToolsScreen api={api} lang={lang}/>
         <TabBar active="tools" tabs={['chat','activity','tools','settings'].map(id=>({id,label:id,icon:'box'}))}/>
       </React.Fragment>);
@@ -93,6 +95,9 @@ try {
       else await page.locator('[data-item-id]').first().click();
       await page.locator('.tools-detail__heading').waitFor({state:'attached'});
       await scrollCheck(label+' content');
+      await page.locator('.panel-update-banner button').first().click();
+      await page.locator('.panel-update-banner button').last().click();
+      assert.equal(await page.evaluate(()=>window.releaseOpened && window.releaseDismissed), true);
       await page.getByRole('radio',{name:lang==='zh'?'参数':'Args',exact:true}).click();
       await scrollCheck(label+' args','.tools-args textarea');
       const actions = await page.locator('.tools-detail__actions button').allTextContents();


### PR DESCRIPTION
When `ae_previewFrame` returns images, its chat card displays the real pixels, supports multi-frame navigation and a larger view, and keeps parameters/JSON collapsed. Existing Claude, Codex, and OpenCode result events associate images with their tool call without changing model delivery or making another AE call. Transcripts store bounded file references, with explicit feedback for missing or oversized images.

Refs #378. **Verified support for this release: Codex and Claude preview images. OpenCode preview is temporarily outside the supported scope for this release.** Its current calls fail before producing images; whether the model or argument/schema conversion introduces the conflicting fields remains unresolved. The maintainer accepted this known limitation while preparing merge and release. OpenCode image-file input was independently verified in #383 and remains supported. This PR remains a draft pending merge preparation; packaged release acceptance has not run.

Validation on unchanged source `81790f73d39de948df7170fbe53d18c10aea5d31`:

- Independent review APPROVE. 153 focused tests, 24 isolated rendering checks, and the standard regression passed: panel 626 / 1 skipped, host 299 / 18, other suites 129 / 74. Bundle verification and [all three required CI checks](https://github.com/JUNKDOGE-JOE/after-effects-mcp/actions/runs/33945336188) passed.
- Prior real-AE Codex and Claude double-frame calls passed: cached PNG hashes matched the public results, cards displayed both frames, and models described them correctly. Sixteen real CEP checks passed across Chinese/English, minimum/default viewports, large-view navigation, history reload, and missing-cache recovery. The update-banner layout check used a synthetic height placeholder; integration with the separate release-notice branch remains untested.
- After the route was restored, a focused OpenCode supplement reached the tool twice. Both persisted tool calls supplied mutually exclusive `time`, `times`, and `range` fields, so public MCP rejected them before producing images. One retry explicitly requested omission of the conflicting fields. The live public schema has no top-level required list. Original upstream arguments were not captured, so responsibility between the model and argument/schema conversion remains unresolved.
- A separate direct public MCP call with the correct parameters returned real FRAME A/B PNGs. This diagnostic does not substitute for OpenCode acceptance: actual image attachments, card rendering, and model image understanding remain BLOCKED. No source changes or full test/CI reruns were made during the supplement.
- Both development sessions were cleaned up, temporary projects archived, and each session's captured user configuration restored. No unresolved AE write remains. These are development results, not packaged T5/T6 evidence.

Scope: 14 committed files, 414 handwritten additions / 3 deletions; implementation 7, tests/validation 5, documentation 1, generated bundle 1. No native, input-provider, public schema, workflow, or version changes. Worktree clean.

