### PR TITLE
chore(release): prepare Windows v0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [未发布]
 
+### [0.10.7] — 2026-09-05
+
+- 工具面板将长脚本、参数和结果限制在可滚动文字区，常用操作按钮保持可见；覆盖中英文与窄面板。
+
 - 面板启动时异步检查 GitHub 稳定 Release，成功结果缓存 24 小时；新版横幅可按版本关闭，“设置 → 关于”可手动检查及打开对应 Release。断网、超时、限流和无法比较的版本显示未知；不下载、安装或重启。
 - 聊天工具卡片直接显示 Claude、Codex 返回的预览图片，支持查看大图、逐张切换与折叠参数/结果。会话只保存图片引用；本地图片缓存最多 64 MiB / 256 张，生成预览时清理 7 天前的缓存，失效或超限时明确提示。OpenCode 的 preview 调用参数问题尚未解决，本版暂不支持 OpenCode 预览；这不影响已验证的 OpenCode 图片附件输入。
 - 修复 OpenCode 自定义模型因缺少输入模态元数据而误报不支持附件的问题；补全文件 MIME 回退，并区分通道格式限制与模型能力。切换通道保留未发送附件，失败后恢复草稿；结果不确定时保留防重发保护。Codex CLI 在接受回合前明确拒绝音频格式时，提示通道限制并保留可修改草稿；OpenCode 本地媒体拒绝不再附带从日志误判的 HTTP 状态。
@@ -389,6 +393,10 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ## English
 
 ### [Unreleased]
+
+### [0.10.7] — 2026-09-05
+
+- Tool panels keep long scripts, arguments and results in bounded scrolling text areas while preserving visible action buttons, including narrow layouts in both languages.
 
 - The panel asynchronously checks stable GitHub releases on startup and caches successful results for 24 hours. Dismiss a version's fixed banner, or manually check and open its release under Settings → About. Offline, timeout, rate-limit and unrecognized versions remain unknown; nothing is downloaded, installed or restarted.
 - Chat tool cards display preview images returned by Claude and Codex, with a larger image view, image navigation, and collapsed parameters/results. Transcripts store references only; the local cache is capped at 64 MiB / 256 images and removes images older than seven days when capturing previews. Expired or oversized images show an explicit notice. OpenCode preview remains unsupported in this release while its call-argument issue is unresolved; verified OpenCode image attachment input remains supported.

--- a/plugin/CSXS/manifest.xml
+++ b/plugin/CSXS/manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ExtensionManifest Version="7.0" ExtensionBundleId="com.aemcp.panel"
-                   ExtensionBundleVersion="0.10.6"
+                   ExtensionBundleVersion="0.10.7"
                    ExtensionBundleName="ae-mcp Panel"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ExtensionList>
-        <Extension Id="com.aemcp.panel" Version="0.10.6" />
+        <Extension Id="com.aemcp.panel" Version="0.10.7" />
     </ExtensionList>
     <ExecutionEnvironment>
         <HostList>

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -20613,7 +20613,7 @@
   // package.json
   var package_default = {
     name: "ae-mcp-panel",
-    version: "0.10.6",
+    version: "0.10.7",
     private: true,
     type: "module",
     scripts: {
@@ -29135,7 +29135,7 @@ When you are done, remind me of two things: MCP tools load only in a new session
   // src/cep/mcpClient.js
   init_cep_runtime_inject();
   var MCP_PROTOCOL_VERSION = "2025-06-18";
-  var PANEL_VERSION = "0.10.6";
+  var PANEL_VERSION = "0.10.7";
   function defaultFetch() {
     if (globalThis.window && globalThis.window.fetch) {
       return globalThis.window.fetch.bind(globalThis.window);

--- a/plugin/host/native-aegp-client.js
+++ b/plugin/host/native-aegp-client.js
@@ -1076,7 +1076,7 @@ function createNativeAegpClient(options) {
             supportedWireVersions: { minimum: 1, maximum: 1 },
             client: {
                 component: input.component || 'core-broker',
-                version: input.version || '0.10.6',
+                version: input.version || '0.10.7',
                 instanceId: clientInstanceId,
             },
             nonce,

--- a/plugin/host/package-lock.json
+++ b/plugin/host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-host",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "express": "4.22.2"
       }

--- a/plugin/host/package.json
+++ b/plugin/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-host",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "main": "server.js",
   "scripts": {

--- a/plugin/panel/package-lock.json
+++ b/plugin/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.3",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ae-mcp-panel",
-      "version": "0.10.3",
+      "version": "0.10.7",
       "dependencies": {
         "filepond": "4.32.12",
         "filepond-plugin-image-preview": "4.6.12",

--- a/plugin/panel/package.json
+++ b/plugin/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ae-mcp-panel",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin/panel/src/cep/mcpClient.js
+++ b/plugin/panel/src/cep/mcpClient.js
@@ -1,5 +1,5 @@
 const MCP_PROTOCOL_VERSION = '2025-06-18';
-export const PANEL_VERSION = '0.10.6';
+export const PANEL_VERSION = '0.10.7';
 
 function defaultFetch() {
   if (globalThis.window && globalThis.window.fetch) {

--- a/scripts/package-zxp.ps1
+++ b/scripts/package-zxp.ps1
@@ -11,7 +11,7 @@ param(
     [string]$CertPassword = '',
     [string]$CertPath = '',
     [string]$OutputPath = '',
-    [string]$Version = '0.10.6',
+    [string]$Version = '0.10.7',
     [string]$Tsa = 'http://timestamp.digicert.com',
     [switch]$SkipSigning
 )

--- a/scripts/release/test/version-consistency.test.mjs
+++ b/scripts/release/test/version-consistency.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import test from 'node:test';
 
-const VERSION = '0.10.6';
+const VERSION = '0.10.7';
 
 async function text(relative) {
   return fs.readFile(relative, 'utf8');


### PR DESCRIPTION
Prepare the existing Windows ZXP, native AEX and checksum assets for v0.10.7 after the six panel changes merged in #373, #375, #377, #381, #382 and #383. Align product/version constants and lockfile roots, and add bilingual release headings and the bounded Tools layout entry. The npm connector remains 0.10.4.

The release support scope includes Codex/Claude preview and verified OpenCode image attachment input. OpenCode preview remains excluded while its argument issue is unresolved; rejected WAV/MP4 channels are not claimed to understand those formats. The maintainer authorized merge and Windows publication, with macOS assets and hardware acceptance deferred.

Independent review of 0ad28396e824573f0a24ff8b7978538b18d2d522: APPROVE, no blockers. Changes: nine mechanical version files, one changelog and one generated bundle; no new product behavior. Version contracts: 6 PASS; bundle matches source. Required CI and final Windows packaged T5/T6 remain release gates; development results are not release acceptance.
