### PR TITLE
fix(panel): resolve Windows release acceptance blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [0.10.7] — 2026-09-05
 
+- 修复 Windows CEP 文件 URL 路径识别，确保自动选择包内 OpenCode；预览大图打开时接收 Escape，关闭后释放按键。
+- OpenCode 明确拒绝附件格式后，修改草稿重试会保留失败消息之前的对话，排除已拒绝附件，并继续使用所选模型；无法核实恢复时停止发送，保留原历史和草稿。
+
 - 工具面板将长脚本、参数和结果限制在可滚动文字区，常用操作按钮保持可见；覆盖中英文与窄面板。
 
 - 面板启动时异步检查 GitHub 稳定 Release，成功结果缓存 24 小时；新版横幅可按版本关闭，“设置 → 关于”可手动检查及打开对应 Release。断网、超时、限流和无法比较的版本显示未知；不下载、安装或重启。
@@ -395,6 +398,9 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 ### [Unreleased]
 
 ### [0.10.7] — 2026-09-05
+
+- Normalize Windows CEP file URLs so the bundled OpenCode is discovered automatically. Enlarged previews receive Escape while open and release the key when closed.
+- After an explicit OpenCode media-format rejection, a user-edited retry preserves the preceding conversation, excludes the rejected attachments, and uses the selected model. Unverified recovery stops the send and retains history and draft.
 
 - Tool panels keep long scripts, arguments and results in bounded scrolling text areas while preserving visible action buttons, including narrow layouts in both languages.
 

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -22463,7 +22463,7 @@
     var _a, _b, _c;
     try {
       const root = (_c = (_b = (_a = globalThis.window) == null ? void 0 : _a.__adobe_cep__) == null ? void 0 : _b.getSystemPath) == null ? void 0 : _c.call(_b, "extension");
-      if (typeof root === "string" && root.trim()) return root;
+      if (typeof root === "string" && root.trim()) return normalizeCepSystemPath(root);
     } catch {
     }
     try {
@@ -25038,6 +25038,37 @@ When you are done, remind me of two things: MCP tools load only in a new session
   init_cep_runtime_inject();
   var import_react33 = __toESM(require_react(), 1);
   var import_react_dom = __toESM(require_react_dom(), 1);
+
+  // src/cep/platform/previewKeyboard.js
+  init_cep_runtime_inject();
+  function registerPreviewEscape(page = globalThis.window) {
+    var _a, _b, _c, _d;
+    const platform = ((_b = (_a = page == null ? void 0 : page.cep_node) == null ? void 0 : _a.process) == null ? void 0 : _b.platform) || ((_c = globalThis.process) == null ? void 0 : _c.platform);
+    const cep = page == null ? void 0 : page.__adobe_cep__;
+    if (platform !== "win32" || typeof (cep == null ? void 0 : cep.registerKeyEventsInterest) !== "function") return void 0;
+    try {
+      cep.registerKeyEventsInterest(JSON.stringify([
+        { keyCode: 27, ctrlKey: false, altKey: false, shiftKey: false }
+      ]));
+    } catch {
+      return void 0;
+    }
+    let active = true;
+    const release = () => {
+      var _a2;
+      if (!active) return;
+      active = false;
+      (_a2 = page.removeEventListener) == null ? void 0 : _a2.call(page, "beforeunload", release);
+      try {
+        cep.registerKeyEventsInterest("");
+      } catch {
+      }
+    };
+    (_d = page.addEventListener) == null ? void 0 : _d.call(page, "beforeunload", release);
+    return release;
+  }
+
+  // src/components/chat/ToolCallCard.jsx
   var import_jsx_runtime31 = __toESM(require_jsx_runtime(), 1);
   function StatusGlyph({ status }) {
     if (status === "running") return /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Spinner, { size: 12 });
@@ -25128,7 +25159,10 @@ When you are done, remind me of two things: MCP tools load only in a new session
     };
     import_react33.default.useEffect(() => {
       var _a, _b;
-      if (open) (_b = (_a = dialog.current) == null ? void 0 : _a.querySelector("button")) == null ? void 0 : _b.focus();
+      if (!open) return void 0;
+      const release = registerPreviewEscape();
+      (_b = (_a = dialog.current) == null ? void 0 : _a.querySelector("button")) == null ? void 0 : _b.focus();
+      return release;
     }, [open]);
     const dialogKey = (event) => {
       var _a;
@@ -33373,6 +33407,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     let stderrRedactor = createDeltaRedactor([], () => {
     });
     let activeTurn = null;
+    let activeUserMessageId = null;
+    let lastMessageRequest = null;
+    let rejectedMediaTurn = null;
+    let copiedMessageIds = /* @__PURE__ */ new Set();
     let activeTurnAccepted = false;
     let messageDispatched = false;
     let turnStarted = false;
@@ -33410,6 +33448,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       adoptedSessionId = null;
       sessionWasAdopted = false;
       sessionPromise = null;
+      rejectedMediaTurn = null;
+      copiedMessageIds.clear();
       sessionAllowedTools.clear();
       return Boolean(invalidated);
     }
@@ -34264,6 +34304,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (liveGeneration !== generation) throw cancelledStartError2();
         sessionId = String(result && (result.id || result.sessionID || result.sessionId) || "");
         if (!sessionId) throw taggedError2(new Error("OpenCode did not return a session id."), "fallbackCode", "SESSION_START_FAILED");
+        copiedMessageIds.clear();
         adoptedSessionId = sessionId;
         sessionWasAdopted = false;
         emit({ type: "session-ref", ref: { kind: "opencode-session", id: sessionId } });
@@ -34365,12 +34406,21 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       emitAfterText({ type: "tool-start", toolUseId, name, input: state.input || {} });
     }
     function handleOpenCodeEvent(evt) {
-      var _a;
+      var _a, _b, _c, _d;
       const type = eventType(evt);
       if (!type) return;
       const p = evt && evt.properties || {};
       if (p.sessionID && (!sessionId || p.sessionID !== sessionId)) return;
+      if (type.startsWith("message.") && copiedMessageIds.has(((_a = p.info) == null ? void 0 : _a.id) || ((_b = p.part) == null ? void 0 : _b.messageID) || p.messageID)) return;
+      if (rejectedMediaTurn && !messageDispatched) return;
       touchStallWatchdog();
+      if (type === "message.updated") {
+        const info = p.info;
+        if (activeTurn && messageDispatched && (info == null ? void 0 : info.role) === "user" && info.sessionID === sessionId) {
+          activeUserMessageId = info.id;
+        }
+        return;
+      }
       if (type === "session.status") {
         const st = p.status && p.status.type || "";
         if (st === "busy") {
@@ -34467,7 +34517,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         const causeChain = boundedCauseChain(error);
         const processTail = trimStderrTail(stderrTail);
         const combined = [detail, ...causeChain, processTail].filter(Boolean).join("\n");
-        const httpStatus = extractHttpStatus(error == null ? void 0 : error.statusCode) || extractHttpStatus((_a = error == null ? void 0 : error.data) == null ? void 0 : _a.statusCode) || extractHttpStatus(combined);
+        const httpStatus = extractHttpStatus(error == null ? void 0 : error.statusCode) || extractHttpStatus((_c = error == null ? void 0 : error.data) == null ? void 0 : _c.statusCode) || extractHttpStatus(combined);
         const classified = classifyErrorCode({
           error: { message: combined },
           httpStatus,
@@ -34478,6 +34528,14 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         if (isAeMcpTransportFailure(error, combined)) {
           void recoverAeMcpTransport();
           return;
+        }
+        if (mediaRejected) {
+          rejectedMediaTurn = {
+            sessionId,
+            messageId: activeUserMessageId,
+            request: lastMessageRequest,
+            mediaType: (_d = detail.match(/(?:file part media type |media type: )([^']+)/)) == null ? void 0 : _d[1]
+          };
         }
         settleFailedTurnInteractions();
         emitAfterText({
@@ -34530,19 +34588,89 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         }))
       ];
     }
+    async function recoverRejectedMedia(rejected, turn) {
+      var _a;
+      const ownerGeneration = generation;
+      const assertOwner = () => {
+        if (generation !== ownerGeneration || activeTurn !== turn || sessionId !== rejected.sessionId) {
+          throw cancelledStartError2();
+        }
+      };
+      const controller = new AbortController();
+      messageAbortController = controller;
+      const timer = setTimeoutImpl(() => controller.abort(), 1e4);
+      const interrupted = new Promise((_, reject) => {
+        controller.signal.addEventListener("abort", () => reject(cancelledStartError2()), { once: true });
+      });
+      const historyPath = "/session/" + encodeURIComponent(rejected.sessionId);
+      const comparable = (messages) => {
+        const positions = new Map(messages.map((message, index) => [message.info.id, index]));
+        return JSON.stringify(messages.map((message) => ({
+          role: message.info.role,
+          parts: message.parts.map(({ id, sessionID, messageID, ...part }) => part.type === "compaction" && positions.has(part.tail_start_id) ? { ...part, tail_start_id: { messageIndex: positions.get(part.tail_start_id) } } : part)
+        })));
+      };
+      try {
+        await Promise.race([rejected.request, interrupted]);
+        assertOwner();
+        const statuses = await requestJson("/session/status", { signal: controller.signal });
+        if (((_a = statuses == null ? void 0 : statuses[rejected.sessionId]) == null ? void 0 : _a.type) === "busy") throw new Error("Rejected turn is still busy");
+        const messages = await requestJson(historyPath + "/message", { signal: controller.signal });
+        assertOwner();
+        const boundary = Array.isArray(messages) ? messages.findIndex((message) => {
+          var _a2, _b;
+          return ((_a2 = message.info) == null ? void 0 : _a2.id) === rejected.messageId && message.info.role === "user" && message.info.sessionID === rejected.sessionId && ((_b = message.parts) == null ? void 0 : _b.some((part) => part.type === "file" && part.mime === rejected.mediaType));
+        }) : -1;
+        if (boundary < 0) throw new Error("Rejected user message could not be verified");
+        const unsafeSuffix = messages.slice(boundary + 1).some((message) => {
+          var _a2;
+          return ((_a2 = message.info) == null ? void 0 : _a2.role) !== "assistant" || message.info.parentID !== rejected.messageId || !Array.isArray(message.parts) || message.parts.some((part) => ["tool", "patch", "file"].includes(part.type) || ["text", "reasoning"].includes(part.type) && String(part.text || "").trim());
+        });
+        if (unsafeSuffix) throw new Error("Rejected turn has subsequent activity");
+        const prefix = comparable(messages.slice(0, boundary));
+        const fork = await postJson(historyPath + "/fork", { messageID: rejected.messageId }, controller.signal);
+        assertOwner();
+        if (!(fork == null ? void 0 : fork.id) || fork.id === rejected.sessionId) throw new Error("Invalid recovery session");
+        const restored = await requestJson("/session/" + encodeURIComponent(fork.id) + "/message", { signal: controller.signal });
+        assertOwner();
+        if (!Array.isArray(restored) || comparable(restored) !== prefix) throw new Error("Recovery context differs");
+        copiedMessageIds = new Set(restored.map((message) => message.info.id));
+        sessionId = fork.id;
+        adoptedSessionId = fork.id;
+        sessionWasAdopted = false;
+        rejectedMediaTurn = null;
+        emit({ type: "session-ref", ref: { kind: "opencode-session", id: sessionId } });
+        return sessionId;
+      } finally {
+        clearTimeoutImpl(timer);
+        if (messageAbortController === controller) messageAbortController = null;
+      }
+    }
     async function prepareTurnSession() {
       if (!proc || !baseUrl || sseClosed) emitTurnProgress("spawn");
       else if (!sessionId) emitTurnProgress("session");
-      return ensureSession();
+      const id = await ensureSession();
+      if (!rejectedMediaTurn) return id;
+      if (rejectedMediaTurn.sessionId !== id) {
+        rejectedMediaTurn = null;
+        return id;
+      }
+      return recoverRejectedMedia(rejectedMediaTurn, activeTurn);
     }
     async function dispatchTurnMessage(id, turn) {
-      const messageBody = { parts: openCodeParts(turn) };
+      const model = parseModel(getModel ? getModel() : DEFAULT_MODEL_ID);
+      const messageBody = {
+        parts: openCodeParts(turn),
+        model: { providerID: model.providerID, modelID: model.id }
+      };
       try {
         messageDispatched = true;
         armStallWatchdog();
         const controller = new AbortController();
         messageAbortController = controller;
         const messageRequest = postJson("/session/" + encodeURIComponent(id) + "/message", messageBody, controller.signal);
+        lastMessageRequest = messageRequest.catch(() => {
+        });
         emitTurnProgress("dispatch");
         await messageRequest;
       } catch (error) {
@@ -34558,6 +34686,8 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
           messageBody,
           controller.signal
         );
+        lastMessageRequest = replacementRequest.catch(() => {
+        });
         emitTurnProgress("dispatch");
         await replacementRequest;
       }
@@ -34581,6 +34711,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       }
       activeAssistantText = "";
       activeTurn = turn;
+      activeUserMessageId = null;
       activeTurnAccepted = false;
       messageDispatched = false;
       aeMcpRecoveryAttempts = 0;
@@ -34593,6 +34724,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
       activeRun = new Promise((resolve) => {
         activeResolve = resolve;
       });
+      const turnRun = activeRun;
       try {
         const id = await prepareTurnSession();
         const userText = turn.text;
@@ -34603,7 +34735,19 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         }
         await dispatchTurnMessage(id, turn);
       } catch (e) {
-        if (stopRequested || !activeRun) return;
+        if (stopRequested || activeTurn !== turn) return;
+        if (rejectedMediaTurn && !messageDispatched) {
+          emitAfterText({
+            type: "error",
+            kind: "attachment",
+            code: "ATTACHMENT_RETRY_BLOCKED",
+            message: currentLang() === "zh" ? "\u65E0\u6CD5\u786E\u8BA4\u5931\u8D25\u9644\u4EF6\u4E4B\u524D\u7684\u5BF9\u8BDD\u5DF2\u6062\u590D\uFF0C\u672C\u6B21\u6D88\u606F\u672A\u53D1\u9001\u3002\u539F\u6709\u5386\u53F2\u548C\u8349\u7A3F\u5DF2\u4FDD\u7559\uFF0C\u8BF7\u65B0\u5EFA\u4F1A\u8BDD\u540E\u91CD\u8BD5\u3002" : "The conversation before the rejected attachment could not be restored. This message was not sent. History and draft are retained; start a new conversation to retry.",
+            ...activeTurnFailureFields(),
+            dispatchState: "not-started"
+          });
+          finishActive();
+          return;
+        }
         if (aeMcpRecoveryStarted) {
           if (aeMcpRecoveryPromise) await aeMcpRecoveryPromise;
           return activeRun;
@@ -34646,7 +34790,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         });
         finishActive();
       }
-      return activeRun;
+      return turnRun;
     }
     async function approve(toolUseId, decision) {
       const id = String(toolUseId);
@@ -34733,6 +34877,10 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
         finishActive();
       }
       generation += 1;
+      rejectedMediaTurn = null;
+      copiedMessageIds.clear();
+      activeUserMessageId = null;
+      lastMessageRequest = null;
       const stoppedProc = proc;
       const stoppedHome = configHome;
       stopping = true;
@@ -34830,6 +34978,7 @@ ${ATTACHMENT_READ_RULE}` : SYSTEM_PROMPTS[lang];
     }
     function adoptSessionRef(ref) {
       settlePendingQuestions();
+      copiedMessageIds.clear();
       partTypes.clear();
       sessionId = null;
       adoptedSessionId = ref && ref.kind === "opencode-session" && ref.id ? String(ref.id) : null;

--- a/plugin/panel/src/cep/openCodeBackend.js
+++ b/plugin/panel/src/cep/openCodeBackend.js
@@ -408,6 +408,10 @@ export function createOpenCodeBackend({
   let assistantDeltaRedactor = createDeltaRedactor([], () => {});
   let stderrRedactor = createDeltaRedactor([], () => {});
   let activeTurn = null;
+  let activeUserMessageId = null;
+  let lastMessageRequest = null;
+  let rejectedMediaTurn = null;
+  let copiedMessageIds = new Set();
   let activeTurnAccepted = false;
   let messageDispatched = false;
   let turnStarted = false;
@@ -446,6 +450,8 @@ export function createOpenCodeBackend({
     adoptedSessionId = null;
     sessionWasAdopted = false;
     sessionPromise = null;
+    rejectedMediaTurn = null;
+    copiedMessageIds.clear();
     sessionAllowedTools.clear();
     return Boolean(invalidated);
   }
@@ -1352,6 +1358,7 @@ export function createOpenCodeBackend({
       if (liveGeneration !== generation) throw cancelledStartError();
       sessionId = String((result && (result.id || result.sessionID || result.sessionId)) || '');
       if (!sessionId) throw taggedError(new Error('OpenCode did not return a session id.'), 'fallbackCode', 'SESSION_START_FAILED');
+      copiedMessageIds.clear();
       adoptedSessionId = sessionId;
       sessionWasAdopted = false;
       emit({ type: 'session-ref', ref: { kind: 'opencode-session', id: sessionId } });
@@ -1476,7 +1483,17 @@ export function createOpenCodeBackend({
     if (!type) return;
     const p = (evt && evt.properties) || {};
     if (p.sessionID && (!sessionId || p.sessionID !== sessionId)) return;
+    if (type.startsWith('message.') && copiedMessageIds.has(p.info?.id || p.part?.messageID || p.messageID)) return;
+    if (rejectedMediaTurn && !messageDispatched) return;
     touchStallWatchdog();
+
+    if (type === 'message.updated') {
+      const info = p.info;
+      if (activeTurn && messageDispatched && info?.role === 'user' && info.sessionID === sessionId) {
+        activeUserMessageId = info.id;
+      }
+      return;
+    }
 
     if (type === 'session.status') {
       const st = (p.status && p.status.type) || '';
@@ -1590,10 +1607,14 @@ export function createOpenCodeBackend({
         void recoverAeMcpTransport();
         return;
       }
-      // A provider failure does not invalidate OpenCode's local conversation.
-      // Keep the session so a user retry preserves context; only settle
-      // interactions that belonged to the failed turn. Local 404/process/SSE
-      // failures still invalidate the session through their dedicated paths.
+      // OpenCode persists rejected file parts before model dispatch. Isolate
+      // that message before a user retry; ordinary provider errors keep context.
+      if (mediaRejected) {
+        rejectedMediaTurn = {
+          sessionId, messageId: activeUserMessageId, request: lastMessageRequest,
+          mediaType: detail.match(/(?:file part media type |media type: )([^']+)/)?.[1],
+        };
+      }
       settleFailedTurnInteractions();
       emitAfterText({
         type: 'error',
@@ -1658,20 +1679,98 @@ export function createOpenCodeBackend({
     ];
   }
 
+  async function recoverRejectedMedia(rejected, turn) {
+    const ownerGeneration = generation;
+    const assertOwner = () => {
+      if (generation !== ownerGeneration || activeTurn !== turn || sessionId !== rejected.sessionId) {
+        throw cancelledStartError();
+      }
+    };
+    const controller = new AbortController();
+    messageAbortController = controller;
+    const timer = setTimeoutImpl(() => controller.abort(), 10000);
+    const interrupted = new Promise((_, reject) => {
+      controller.signal.addEventListener('abort', () => reject(cancelledStartError()), { once: true });
+    });
+    const historyPath = '/session/' + encodeURIComponent(rejected.sessionId);
+    const comparable = (messages) => {
+      const positions = new Map(messages.map((message, index) => [message.info.id, index]));
+      return JSON.stringify(messages.map((message) => ({
+        role: message.info.role,
+        parts: message.parts.map(({ id, sessionID, messageID, ...part }) => (
+          part.type === 'compaction' && positions.has(part.tail_start_id)
+            ? { ...part, tail_start_id: { messageIndex: positions.get(part.tail_start_id) } }
+            : part
+        )),
+      })));
+    };
+    try {
+      await Promise.race([rejected.request, interrupted]);
+      assertOwner();
+      const statuses = await requestJson('/session/status', { signal: controller.signal });
+      if (statuses?.[rejected.sessionId]?.type === 'busy') throw new Error('Rejected turn is still busy');
+      const messages = await requestJson(historyPath + '/message', { signal: controller.signal });
+      assertOwner();
+      const boundary = Array.isArray(messages) ? messages.findIndex((message) => (
+        message.info?.id === rejected.messageId && message.info.role === 'user'
+        && message.info.sessionID === rejected.sessionId
+        && message.parts?.some((part) => part.type === 'file' && part.mime === rejected.mediaType)
+      )) : -1;
+      if (boundary < 0) throw new Error('Rejected user message could not be verified');
+      const unsafeSuffix = messages.slice(boundary + 1).some((message) => (
+        message.info?.role !== 'assistant' || message.info.parentID !== rejected.messageId
+        || !Array.isArray(message.parts) || message.parts.some((part) => (
+          ['tool', 'patch', 'file'].includes(part.type)
+          || (['text', 'reasoning'].includes(part.type) && String(part.text || '').trim())
+        ))
+      ));
+      if (unsafeSuffix) throw new Error('Rejected turn has subsequent activity');
+      const prefix = comparable(messages.slice(0, boundary));
+      // Fork excludes the named message; an absent ID would copy all history.
+      const fork = await postJson(historyPath + '/fork', { messageID: rejected.messageId }, controller.signal);
+      assertOwner();
+      if (!fork?.id || fork.id === rejected.sessionId) throw new Error('Invalid recovery session');
+      const restored = await requestJson('/session/' + encodeURIComponent(fork.id) + '/message', { signal: controller.signal });
+      assertOwner();
+      if (!Array.isArray(restored) || comparable(restored) !== prefix) throw new Error('Recovery context differs');
+      copiedMessageIds = new Set(restored.map((message) => message.info.id));
+      sessionId = fork.id;
+      adoptedSessionId = fork.id;
+      sessionWasAdopted = false;
+      rejectedMediaTurn = null;
+      emit({ type: 'session-ref', ref: { kind: 'opencode-session', id: sessionId } });
+      return sessionId;
+    } finally {
+      clearTimeoutImpl(timer);
+      if (messageAbortController === controller) messageAbortController = null;
+    }
+  }
+
   async function prepareTurnSession() {
     if (!proc || !baseUrl || sseClosed) emitTurnProgress('spawn');
     else if (!sessionId) emitTurnProgress('session');
-    return ensureSession();
+    const id = await ensureSession();
+    if (!rejectedMediaTurn) return id;
+    if (rejectedMediaTurn.sessionId !== id) {
+      rejectedMediaTurn = null;
+      return id;
+    }
+    return recoverRejectedMedia(rejectedMediaTurn, activeTurn);
   }
 
   async function dispatchTurnMessage(id, turn) {
-    const messageBody = { parts: openCodeParts(turn) };
+    const model = parseModel(getModel ? getModel() : DEFAULT_MODEL_ID);
+    const messageBody = {
+      parts: openCodeParts(turn),
+      model: { providerID: model.providerID, modelID: model.id },
+    };
     try {
       messageDispatched = true;
       armStallWatchdog();
       const controller = new AbortController();
       messageAbortController = controller;
       const messageRequest = postJson('/session/' + encodeURIComponent(id) + '/message', messageBody, controller.signal);
+      lastMessageRequest = messageRequest.catch(() => {});
       emitTurnProgress('dispatch');
       await messageRequest;
     } catch (error) {
@@ -1687,6 +1786,7 @@ export function createOpenCodeBackend({
         messageBody,
         controller.signal,
       );
+      lastMessageRequest = replacementRequest.catch(() => {});
       emitTurnProgress('dispatch');
       await replacementRequest;
     }
@@ -1711,6 +1811,7 @@ export function createOpenCodeBackend({
     }
     activeAssistantText = '';
     activeTurn = turn;
+    activeUserMessageId = null;
     activeTurnAccepted = false;
     messageDispatched = false;
     aeMcpRecoveryAttempts = 0;
@@ -1723,6 +1824,7 @@ export function createOpenCodeBackend({
     activeRun = new Promise((resolve) => {
       activeResolve = resolve;
     });
+    const turnRun = activeRun;
     try {
       const id = await prepareTurnSession();
       const userText = turn.text;
@@ -1739,7 +1841,18 @@ export function createOpenCodeBackend({
       }
       await dispatchTurnMessage(id, turn);
     } catch (e) {
-      if (stopRequested || !activeRun) return;
+      if (stopRequested || activeTurn !== turn) return;
+      if (rejectedMediaTurn && !messageDispatched) {
+        emitAfterText({
+          type: 'error', kind: 'attachment', code: 'ATTACHMENT_RETRY_BLOCKED',
+          message: currentLang() === 'zh'
+            ? '无法确认失败附件之前的对话已恢复，本次消息未发送。原有历史和草稿已保留，请新建会话后重试。'
+            : 'The conversation before the rejected attachment could not be restored. This message was not sent. History and draft are retained; start a new conversation to retry.',
+          ...activeTurnFailureFields(), dispatchState: 'not-started',
+        });
+        finishActive();
+        return;
+      }
       if (aeMcpRecoveryStarted) {
         if (aeMcpRecoveryPromise) await aeMcpRecoveryPromise;
         return activeRun;
@@ -1783,7 +1896,7 @@ export function createOpenCodeBackend({
       });
       finishActive();
     }
-    return activeRun;
+    return turnRun;
   }
 
   async function approve(toolUseId, decision) {
@@ -1878,6 +1991,10 @@ export function createOpenCodeBackend({
       finishActive();
     }
     generation += 1;
+    rejectedMediaTurn = null;
+    copiedMessageIds.clear();
+    activeUserMessageId = null;
+    lastMessageRequest = null;
     const stoppedProc = proc;
     const stoppedHome = configHome;
     stopping = true;
@@ -1977,6 +2094,7 @@ export function createOpenCodeBackend({
 
   function adoptSessionRef(ref) {
     settlePendingQuestions();
+    copiedMessageIds.clear();
     partTypes.clear();
     sessionId = null;
     adoptedSessionId = ref && ref.kind === 'opencode-session' && ref.id

--- a/plugin/panel/src/cep/platform/index.js
+++ b/plugin/panel/src/cep/platform/index.js
@@ -1,5 +1,6 @@
 import { createMacosAdapter } from './macos.js';
 import { createWindowsAdapter } from './windows.js';
+import { normalizeCepSystemPath } from './paths.js';
 
 export class PlatformCapabilityError extends Error {
   constructor(code, message) {
@@ -24,7 +25,7 @@ function windowsEnvValue(environment, name) {
 function extensionRootFromPage() {
   try {
     const root = globalThis.window?.__adobe_cep__?.getSystemPath?.('extension');
-    if (typeof root === 'string' && root.trim()) return root;
+    if (typeof root === 'string' && root.trim()) return normalizeCepSystemPath(root);
   } catch {
     // CEP hosts may expose the page before their system-path bridge is ready.
   }

--- a/plugin/panel/src/cep/platform/previewKeyboard.js
+++ b/plugin/panel/src/cep/platform/previewKeyboard.js
@@ -1,0 +1,22 @@
+export function registerPreviewEscape(page = globalThis.window) {
+  const platform = page?.cep_node?.process?.platform || globalThis.process?.platform;
+  const cep = page?.__adobe_cep__;
+  if (platform !== 'win32' || typeof cep?.registerKeyEventsInterest !== 'function') return undefined;
+  try {
+    // CEP otherwise forwards keys from focused buttons to the AE host.
+    cep.registerKeyEventsInterest(JSON.stringify([
+      { keyCode: 27, ctrlKey: false, altKey: false, shiftKey: false },
+    ]));
+  } catch {
+    return undefined;
+  }
+  let active = true;
+  const release = () => {
+    if (!active) return;
+    active = false;
+    page.removeEventListener?.('beforeunload', release);
+    try { cep.registerKeyEventsInterest(''); } catch {}
+  };
+  page.addEventListener?.('beforeunload', release);
+  return release;
+}

--- a/plugin/panel/src/components/chat/ToolCallCard.jsx
+++ b/plugin/panel/src/components/chat/ToolCallCard.jsx
@@ -4,6 +4,7 @@ import { Icon } from '../core/Icon';
 import { Spinner } from '../core/Spinner';
 import { Button } from '../core/Button';
 import { Drawer } from '../shell/Drawer';
+import { registerPreviewEscape } from '../../cep/platform/previewKeyboard.js';
 
 function StatusGlyph({ status }) {
   if (status === 'running') return <Spinner size={12} />;
@@ -80,7 +81,10 @@ function ToolImages({ images, lang }) {
   const dialog = React.useRef(null);
   const close = () => { setOpen(false); inline.current?.querySelector('button')?.focus(); };
   React.useEffect(() => {
-    if (open) dialog.current?.querySelector('button')?.focus();
+    if (!open) return undefined;
+    const release = registerPreviewEscape();
+    dialog.current?.querySelector('button')?.focus();
+    return release;
   }, [open]);
   const dialogKey = (event) => {
     if (event.key === 'Escape') { event.preventDefault(); close(); }

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -631,6 +631,7 @@ test('createOpenCodeBackend sends official file parts and accepts at dispatch', 
 
   const message = fetched.calls.find((call) => call.path === '/session/session_1/message');
   assert.deepEqual(message.body, {
+    model: { providerID: 'opencode', modelID: 'hy3-free' },
     parts: [
       { type: 'text', text: 'inspect' },
       {
@@ -2679,4 +2680,128 @@ test('OpenCode completion clears the stream watchdog timer', async () => {
   await run;
   assert.ok(timers.cleared.length > 0);
   assert.equal(timers.latest(), undefined);
+});
+
+for (const previousContext of [false, true]) {
+  test(`media retry preserves earlier context and excludes rejected files (${previousContext})`, async () => {
+    const fetched = makeFetch();
+    const prefix = previousContext ? [{ info: { id: 'msg_prior', sessionID: 'session_1', role: 'user' },
+      parts: [{ id: 'prt_prior', messageID: 'msg_prior', sessionID: 'session_1', type: 'text', text: 'Remember ORBIT731' }] },
+    { info: { id: 'msg_answer', sessionID: 'session_1', role: 'assistant', parentID: 'msg_prior' },
+      parts: [{ id: 'prt_tool', messageID: 'msg_answer', sessionID: 'session_1', type: 'tool', tool: 'ae_ae_read',
+        state: { status: 'completed', input: {}, output: 'verified prior state' } }] },
+    { info: { id: 'msg_compact', sessionID: 'session_1', role: 'user' }, parts: [
+      { id: 'prt_compact', messageID: 'msg_compact', sessionID: 'session_1', type: 'compaction', auto: true, tail_start_id: 'msg_prior' },
+    ] }] : [];
+    const history = [...prefix, { info: { id: 'msg_bad', sessionID: 'session_1', role: 'user' },
+      parts: [{ type: 'file', mime: 'audio/wav', url: 'file:///C:/tmp/clip.wav' }] },
+    { info: { id: 'msg_error', sessionID: 'session_1', role: 'assistant', parentID: 'msg_bad' }, parts: [] }];
+    const original = JSON.stringify(history);
+    const restored = prefix.map(message => ({ info: { ...message.info, id: message.info.id + '_copy', sessionID: 'session_clean' },
+      parts: message.parts.map(part => ({ ...part,
+        ...(part.type === 'compaction' ? { tail_start_id: part.tail_start_id + '_copy' } : {}),
+        id: part.id + '_copy', sessionID: 'session_clean', messageID: message.info.id + '_copy' })) }));
+    const requests = [];
+    const h = makeBackend({ getModel: () => 'aemcp-test/gpt-5.6-sol', fetchImpl: async (url, options = {}) => {
+      const route = new URL(url).pathname;
+      const method = options.method || 'GET';
+      const body = options.body ? JSON.parse(options.body) : null;
+      requests.push({ route, method, body });
+      if (route === '/session/status') return jsonResponse({});
+      if (route === '/session/session_1/message' && method === 'GET') return jsonResponse(history);
+      if (route === '/session/session_1/fork') {
+        assert.deepEqual(body, { messageID: 'msg_bad' });
+        return jsonResponse({ id: 'session_clean' });
+      }
+      if (route === '/session/session_clean/message' && method === 'GET') return jsonResponse(restored);
+      return fetched.fetchImpl(url, options);
+    } });
+    try {
+      const failed = h.backend.sendUser({ turnId: 'bad-media', text: 'Inspect', attachments: [
+        { id: 'audio', name: 'clip.wav', localPath: 'C:\\tmp\\clip.wav', mediaType: 'audio/wav', size: 4, temporary: false },
+      ] });
+      await flush();
+      fetched.sse.push({ type: 'message.updated', properties: { info: history[prefix.length].info } });
+      fetched.sse.push({ type: 'session.error', properties: { sessionID: 'session_1', error: {
+        name: 'UnknownError', data: { message: "'media type: audio/wav' functionality not supported." },
+      } } });
+      await failed;
+      assert.equal(requests.filter(call => call.route.endsWith('/fork')).length, 0);
+      assert.equal(requests.filter(call => call.method === 'POST' && call.route.endsWith('/message')).length, 1);
+      const retry = h.backend.sendUser({ turnId: 'fixed-media', text: 'Inspect the picture', attachments: [
+        { id: 'picture', name: 'sample.png', localPath: 'C:\\tmp\\sample.png', mediaType: 'image/png', size: 4, temporary: false },
+      ] });
+      for (let i = 0; i < 20 && !requests.some(call => call.route === '/session/session_clean/message' && call.method === 'POST'); i++) await flush();
+      const sent = requests.filter(call => call.route === '/session/session_clean/message' && call.method === 'POST');
+      assert.equal(sent.length, 1);
+      assert.deepEqual(sent[0].body.model, { providerID: 'aemcp-test', modelID: 'gpt-5.6-sol' });
+      assert.deepEqual(sent[0].body.parts.filter(part => part.type === 'file').map(part => part.mime), ['image/png']);
+      assert.equal(JSON.stringify(history), original);
+      assert.deepEqual(h.backend.getSessionRef(), { kind: 'opencode-session', id: 'session_clean' });
+      const beforeReplay = h.events.length;
+      for (const message of restored) {
+        fetched.sse.push({ type: 'message.updated', properties: { info: message.info } });
+        for (const part of message.parts) fetched.sse.push({ type: 'message.part.updated', properties: {
+          sessionID: 'session_clean', part: { ...part, callID: 'old-call' },
+        } });
+        fetched.sse.push({ type: 'message.part.updated', properties: { sessionID: 'session_clean',
+          part: { id: 'old-reasoning', messageID: message.info.id, type: 'reasoning', text: 'old' } } });
+        fetched.sse.push({ type: 'message.part.delta', properties: { sessionID: 'session_clean',
+          messageID: message.info.id, partID: 'old-reasoning', field: 'reasoning', delta: 'old' } });
+      }
+      await flush();
+      assert.equal(h.events.slice(beforeReplay).some(event => ['tool-start', 'tool-result', 'thinking'].includes(event.type)), false);
+      fetched.sse.push({ type: 'message.updated', properties: { info: {
+        id: 'msg_current', sessionID: 'session_clean', role: 'user',
+      } } });
+      fetched.sse.push({ type: 'message.part.delta', properties: {
+        sessionID: 'session_clean', messageID: 'msg_reply', field: 'text', delta: 'ORBIT731',
+      } });
+      completeTurn(fetched, 'session_clean');
+      await retry;
+      assert.ok(h.events.some(event => event.type === 'assistant-text' && event.text === 'ORBIT731')
+        || h.backend.getMessages().some(message => message.role === 'assistant' && message.text === 'ORBIT731'));
+    } finally { h.backend.reset(); }
+  });
+}
+
+test('unverified or interrupted media recovery never sends another model request', async () => {
+  for (const failure of ['missing-id', 'busy', 'tool-activity', 'fork-failed', 'changed-prefix', 'reset']) {
+    const fetched = makeFetch();
+    let h;
+    const requests = [];
+    const history = [{ info: { id: 'msg_bad', role: 'user', sessionID: 'session_1' }, parts: [{ type: 'file', mime: 'audio/wav' }] }];
+    if (failure === 'tool-activity') history.push({ info: { id: 'msg_write', role: 'assistant', parentID: 'msg_bad' },
+      parts: [{ type: 'tool', state: { status: 'completed' } }] });
+    h = makeBackend({ fetchImpl: async (url, options = {}) => {
+      const route = new URL(url).pathname;
+      const method = options.method || 'GET';
+      requests.push({ route, method });
+      if (route === '/session/status') return jsonResponse(failure === 'busy' ? { session_1: { type: 'busy' } } : {});
+      if (route === '/session/session_1/message' && method === 'GET') return jsonResponse(history);
+      if (route.endsWith('/fork')) {
+        if (failure === 'reset') h.backend.reset();
+        return jsonResponse({ id: 'session_clean' }, failure !== 'fork-failed', failure === 'fork-failed' ? 500 : 200);
+      }
+      if (route === '/session/session_clean/message' && method === 'GET') return jsonResponse(history);
+      return fetched.fetchImpl(url, options);
+    } });
+    try {
+      const failed = h.backend.sendUser({ turnId: 'bad', text: 'inspect', attachments: [
+        { id: 'audio', name: 'a.wav', localPath: 'C:\\tmp\\a.wav', size: 4, mediaType: 'audio/wav', temporary: false },
+      ] });
+      await flush();
+      if (failure !== 'missing-id') fetched.sse.push({ type: 'message.updated', properties: { info: history[0].info } });
+      fetched.sse.push({ type: 'session.error', properties: { sessionID: 'session_1', error: {
+        name: 'UnknownError', data: { message: "'media type: audio/wav' functionality not supported." },
+      } } });
+      await failed;
+      await h.backend.sendUser({ turnId: 'retry', text: 'try text instead', attachments: [] });
+      assert.equal(requests.filter(call => call.method === 'POST' && call.route.endsWith('/message')).length, 1, failure);
+      if (failure !== 'reset') {
+        assert.deepEqual(h.backend.getSessionRef(), { kind: 'opencode-session', id: 'session_1' }, failure);
+        assert.equal(h.events.findLast(event => event.type === 'error').code, 'ATTACHMENT_RETRY_BLOCKED', failure);
+      } else assert.equal(h.backend.getSessionRef(), null);
+    } finally { h.backend.reset(); }
+  }
 });

--- a/plugin/panel/test/platform-process.test.js
+++ b/plugin/panel/test/platform-process.test.js
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import { readFileSync } from 'node:fs';
 import { createMacosAdapter } from '../src/cep/platform/macos.js';
 import { createWindowsAdapter } from '../src/cep/platform/windows.js';
+import { createPlatformAdapter } from '../src/cep/platform/index.js';
 
 // Static golden outputs copied from the longProg branches of npm/cmd-shim
 // v6.0.3, v7.0.0, and main. Source URLs are stored beside each fixture; these
@@ -181,6 +182,30 @@ test('Windows prefers the bundled OpenCode runtime after an explicit override', 
 
   const result = await adapter.resolveExecutable('opencode', { requiredArch: 'x64' });
 
+  assert.equal(result.ok, true);
+  assert.equal(result.path, bundled);
+  assert.equal(result.source, 'runtime');
+  assert.deepEqual(calls.map((call) => call.file), [bundled]);
+});
+
+test('raw CEP file URLs select bundled OpenCode ahead of PATH', async (t) => {
+  const previous = globalThis.window;
+  t.after(() => { if (previous === undefined) delete globalThis.window; else globalThis.window = previous; });
+  const bundled = 'C:\\Program Files (x86)\\Common Files\\Adobe\\CEP\\extensions\\com.aemcp.panel\\runtime\\opencode\\opencode.exe';
+  const pathCopy = 'C:\\Tools\\opencode.exe';
+  const calls = [];
+  const modules = {
+    fs: fakeFs(new Set([bundled, pathCopy]), {}, { [bundled]: pe64(0x8664), [pathCopy]: pe64(0x8664) }),
+    os: { homedir: () => 'C:\\Users\\fixture', tmpdir: () => 'C:\\Temp' },
+    http: {}, https: {}, child_process: { spawn: processFactory([{ stdout: 'opencode 1.18.23' }], calls) },
+  };
+  globalThis.window = {
+    __adobe_cep__: { getSystemPath: () => 'file:///C:/Program%20Files%20(x86)/Common%20Files/Adobe/CEP/extensions/com.aemcp.panel' },
+    cep_node: { require: (id) => modules[id], process: {
+      platform: 'win32', arch: 'x64', pid: 100, env: { USERPROFILE: 'C:\\Users\\fixture', Path: 'C:\\Tools' },
+    } },
+  };
+  const result = await createPlatformAdapter().resolveExecutable('opencode', { requiredArch: 'x64' });
   assert.equal(result.ok, true);
   assert.equal(result.path, bundled);
   assert.equal(result.source, 'runtime');

--- a/plugin/panel/test/preview-keyboard.test.js
+++ b/plugin/panel/test/preview-keyboard.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerPreviewEscape } from '../src/cep/platform/previewKeyboard.js';
+function fixture(platform = 'win32') {
+  const page = new EventTarget();
+  const calls = [];
+  page.cep_node = { process: { platform } };
+  page.__adobe_cep__ = { registerKeyEventsInterest: value => calls.push(value) };
+  return { page, calls };
+}
+test('preview requests only bare Windows Escape and releases on close once', () => {
+  const { page, calls } = fixture();
+  const release = registerPreviewEscape(page);
+  assert.deepEqual(JSON.parse(calls[0]), [{ keyCode: 27, ctrlKey: false, altKey: false, shiftKey: false }]);
+  release(); release(); page.dispatchEvent(new Event('beforeunload'));
+  assert.deepEqual(calls.slice(1), ['']);
+  const reopened = registerPreviewEscape(page);
+  reopened();
+  assert.deepEqual(calls.slice(2), [calls[0], '']);
+});
+test('panel unload releases key interest and later component cleanup is harmless', () => {
+  const { page, calls } = fixture();
+  const release = registerPreviewEscape(page);
+  page.dispatchEvent(new Event('beforeunload'));
+  release();
+  assert.deepEqual(calls.slice(1), ['']);
+});
+test('macOS and pages without CEP keep their existing key handling', () => {
+  const { page, calls } = fixture('darwin');
+  assert.equal(registerPreviewEscape(page), undefined);
+  assert.deepEqual(calls, []);
+  assert.equal(registerPreviewEscape({}), undefined);
+});
+test('an unavailable host key registration does not prevent the preview opening', () => {
+  const { page } = fixture();
+  page.__adobe_cep__.registerKeyEventsInterest = () => { throw new Error('unavailable'); };
+  assert.equal(registerPreviewEscape(page), undefined);
+});
+

--- a/plugin/panel/validation/tool-images.mjs
+++ b/plugin/panel/validation/tool-images.mjs
@@ -20,6 +20,10 @@ const fixture = await build({
     import { StatusBar } from './src/components/shell/StatusBar.jsx';
     import { TabBar } from './src/components/shell/TabBar.jsx';
     const root = createRoot(document.getElementById('root'));
+    window.keyInterests=[];
+    window.cep_node={process:{platform:'win32'}};
+    window.__adobe_cep__={registerKeyEventsInterest:value=>window.keyInterests.push(value)};
+    window.clearPreview=()=>root.render(null);
     const canvas = document.createElement('canvas'); canvas.width=1600; canvas.height=900;
     const ctx=canvas.getContext('2d');
     window.images=['#c54d37','#276f60'].map((color,i)=>{ctx.fillStyle=color;ctx.fillRect(0,0,1600,900);
@@ -86,16 +90,21 @@ try {
     await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).click();
     const dialog=page.getByRole('dialog');
     await dialog.waitFor();
+    const interest=JSON.stringify([{keyCode:27,ctrlKey:false,altKey:false,shiftKey:false}]);
+    assert.deepEqual(await page.evaluate(()=>window.keyInterests),[interest]);
     const large=await dialog.locator('img').boundingBox();
     assert.ok(large.width>=250 && large.height>=180,label+' readable enlarged preview');
     await dialog.getByTitle(lang==='zh'?'上一张':'Previous image',{exact:true}).click();
     assert.equal(await dialog.locator('img').getAttribute('src'),first);
+    assert.deepEqual(await page.evaluate(()=>window.keyInterests),[interest]);
     await page.screenshot({path:path.join(output,label+'-large.png')});
     await dialog.getByTitle(lang==='zh'?'关闭预览':'Close preview',{exact:true}).press('Escape');
     assert.equal(await page.getByRole('dialog').count(),0);
+    assert.deepEqual(await page.evaluate(()=>window.keyInterests),[interest,'']);
     assert.ok(await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).evaluate(el=>el===document.activeElement));
     await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).click();
     await page.getByTitle(lang==='zh'?'关闭预览':'Close preview',{exact:true}).click();
+    assert.deepEqual(await page.evaluate(()=>window.keyInterests),[interest,'',interest,'']);
     assert.deepEqual(await geometry(label+' close large'),before);
     await page.locator('textarea').focus();
     assert.ok(await page.locator('textarea').evaluate(el=>el===document.activeElement));
@@ -110,6 +119,11 @@ try {
     assert.equal(await page.getByRole('status').count(),0);
     assert.equal(await page.locator('[data-tool-images] img').getAttribute('src'),first);
     await geometry(label+' restored');
+    await page.getByTitle(lang==='zh'?'查看大图':'View larger image',{exact:true}).click();
+    await page.getByRole('dialog').waitFor();
+    await page.evaluate(()=>window.clearPreview());
+    await page.waitForFunction(()=>!document.querySelector('[data-tool-images]'));
+    assert.deepEqual(await page.evaluate(()=>window.keyInterests),[interest,'',interest,'',interest,'']);
   }
   await fs.writeFile(path.join(output,'summary.json'),JSON.stringify({validationProfile:'offline',cases:ledger},null,2));
   console.log(JSON.stringify({passed:ledger.length}));


### PR DESCRIPTION
The Windows release candidate exposed three failures: CEP returned a file URL that bypassed bundled OpenCode discovery; AE intercepted Escape in enlarged previews; rejected OpenCode attachments remained in upstream history and broke an image-only retry.

Normalize the CEP path, request bare Windows Escape only while a preview is open, and recover a user-edited media retry from the verified conversation prefix before the rejected message. Preserve the original history, selected model, and ordinary network-error retries; block sending when recovery cannot be verified. Ignore copied historical SSE events and retain compaction references when checking the restored prefix.

Validation: independent focused review approved; 43 platform/keyboard tests, 80 OpenCode tests, 24 offline preview layout cases, and bundle verification passed. Full T3 regression passed (1,078 passed, 93 environment skips, zero failures); required CI run 33955092672 passed all three jobs. Focused Windows AE 26.3x87 development hardware verification passed on eb69e45: automatic bundled OpenCode 1.18.23 discovery, context-preserving PNG retry after a real WAV rejection with the selected model retained, and native Escape from both navigation-button and close-button focus. Final independent AE readback found the same saved five-item/five-layer fixture, an empty composition comment, and no dirty state. Status: development-verified; fixture and preferences are being reconciled for the packaged handoff. A separate signed replacement candidate will receive packaged acceptance; candidate 1 remains failed diagnostic evidence. macOS hardware and assets are deferred by the maintainer.

Scope: 4 implementation files, 3 test files, 1 existing browser validation fixture, CHANGELOG, and the generated bundle. No native primitive, provider, dependency, installer, or workflow change.

