### PR TITLE
fix(panel): wait for session reset before OpenCode reprobe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format based on Keep a Changelog; versioning follows SemVer.
 
 ### [0.10.7] — 2026-09-05
 
+- 切回 OpenCode 时等待会话重置完成后再自动探测，避免启动被自身重置取消而要求手动重新检测。
 - 修复 Windows CEP 文件 URL 路径识别，确保自动选择包内 OpenCode；预览大图打开时接收 Escape，关闭后释放按键。
 - OpenCode 明确拒绝附件格式后，修改草稿重试会保留失败消息之前的对话，排除已拒绝附件，并继续使用所选模型；无法核实恢复时停止发送，保留原历史和草稿。
 
@@ -399,6 +400,7 @@ Atom 级 After Effects 插件 MVP：30 个 `ae.*` 工具，覆盖 MCP → Python
 
 ### [0.10.7] — 2026-09-05
 
+- Returning to OpenCode waits for the session reset before probing, so the reset cannot cancel startup and require a manual recheck.
 - Normalize Windows CEP file URLs so the bundled OpenCode is discovered automatically. Enlarged previews receive Escape while open and release the key when closed.
 - After an explicit OpenCode media-format rejection, a user-edited retry preserves the preceding conversation, excludes the rejected attachments, and uses the selected model. Unverified recovery stops the send and retains history and draft.
 

--- a/plugin/client/dist/app.js
+++ b/plugin/client/dist/app.js
@@ -39108,6 +39108,7 @@ ${draft.baseUrl}`)) return;
     const activeBackendInstanceRef = import_react49.default.useRef(activeBackend);
     activeBackendInstanceRef.current = activeBackend;
     const pendingSessionLoadRef = import_react49.default.useRef(null);
+    const backendResetPromiseRef = import_react49.default.useRef(null);
     const [sessionSnapshot, setSessionSnapshot] = import_react49.default.useState({ sessions: [], activeId: null });
     const sessionController = import_react49.default.useMemo(() => createSessionController({
       store: sessionStore,
@@ -39417,11 +39418,6 @@ ${draft.baseUrl}`)) return;
       return () => clearTimeout(timer);
     }, [backendPref, openCodeProbe, openCodeProbeAttempt]);
     import_react49.default.useEffect(() => {
-      if (backendPref !== "opencode") return void 0;
-      if (status.state !== "ok" || providerInit.state !== "ready") return void 0;
-      return runOpenCodeProbe();
-    }, [backendPref, status.state, providerInit.state, runOpenCodeProbe]);
-    import_react49.default.useEffect(() => {
       const pendingSessionLoad = pendingSessionLoadRef.current;
       const decision = decideBackendReset({
         lastReal: lastRealBackendRef.current,
@@ -39447,7 +39443,7 @@ ${draft.baseUrl}`)) return;
       setSessionModel(null);
       setSessionEffort(null);
       setSessionFast(null);
-      void sessionController.createSession();
+      backendResetPromiseRef.current = sessionController.createSession();
     }, [
       effective.backend,
       backendPref,
@@ -39457,6 +39453,21 @@ ${draft.baseUrl}`)) return;
       resetAttachmentDraftSession,
       sessionController
     ]);
+    import_react49.default.useEffect(() => {
+      if (backendPref !== "opencode") return void 0;
+      if (status.state !== "ok" || providerInit.state !== "ready") return void 0;
+      let alive = true;
+      let disposeProbe;
+      Promise.resolve(backendResetPromiseRef.current).then(() => {
+        if (alive) disposeProbe = runOpenCodeProbe();
+      }).catch((error) => {
+        if (alive) setOpenCodeProbe({ loggedIn: false, detail: (error == null ? void 0 : error.message) || String(error) });
+      });
+      return () => {
+        alive = false;
+        disposeProbe == null ? void 0 : disposeProbe();
+      };
+    }, [backendPref, status.state, providerInit.state, runOpenCodeProbe]);
     const sendChat = (input) => {
       var _a;
       if (pendingTurnRef.current || catalogEmpty) return;

--- a/plugin/panel/src/app/App.jsx
+++ b/plugin/panel/src/app/App.jsx
@@ -786,6 +786,7 @@ function Shell({ cs }) {
   const activeBackendInstanceRef = React.useRef(activeBackend);
   activeBackendInstanceRef.current = activeBackend;
   const pendingSessionLoadRef = React.useRef(null);
+  const backendResetPromiseRef = React.useRef(null);
   const [sessionSnapshot, setSessionSnapshot] = React.useState({ sessions: [], activeId: null });
   const sessionController = React.useMemo(() => createSessionController({
     store: sessionStore,
@@ -1098,17 +1099,6 @@ function Shell({ cs }) {
   }, [backendPref, openCodeProbe, openCodeProbeAttempt]);
 
   React.useEffect(() => {
-    if (backendPref !== 'opencode') return undefined;
-    // Two boot races (both seen live): the host controller effect runs after
-    // this one on mount (probing before status turns ok fails host-not-running),
-    // and the provider registry loads async (probing before it is ready makes
-    // writeConfig inject an empty provider table, so every send dies with
-    // ProviderModelNotFoundError). Gate on both; readiness re-fires the probe.
-    if (status.state !== 'ok' || providerInit.state !== 'ready') return undefined;
-    return runOpenCodeProbe();
-  }, [backendPref, status.state, providerInit.state, runOpenCodeProbe]);
-
-  React.useEffect(() => {
     const pendingSessionLoad = pendingSessionLoadRef.current;
     const decision = decideBackendReset({
       lastReal: lastRealBackendRef.current,
@@ -1134,7 +1124,7 @@ function Shell({ cs }) {
     setSessionModel(null);
     setSessionEffort(null);
     setSessionFast(null);
-    void sessionController.createSession();
+    backendResetPromiseRef.current = sessionController.createSession();
   }, [
     effective.backend,
     backendPref,
@@ -1144,6 +1134,24 @@ function Shell({ cs }) {
     resetAttachmentDraftSession,
     sessionController,
   ]);
+
+  React.useEffect(() => {
+    if (backendPref !== 'opencode') return undefined;
+    if (status.state !== 'ok' || providerInit.state !== 'ready') return undefined;
+    let alive = true;
+    let disposeProbe;
+    // Session creation also resets the backend asynchronously. Probe only
+    // after that reset and only while this selected channel is still current.
+    Promise.resolve(backendResetPromiseRef.current).then(() => {
+      if (alive) disposeProbe = runOpenCodeProbe();
+    }).catch((error) => {
+      if (alive) setOpenCodeProbe({ loggedIn: false, detail: error?.message || String(error) });
+    });
+    return () => {
+      alive = false;
+      disposeProbe?.();
+    };
+  }, [backendPref, status.state, providerInit.state, runOpenCodeProbe]);
 
   const sendChat = (input) => {
     if (pendingTurnRef.current || catalogEmpty) return;

--- a/plugin/panel/test/openCodeBackend.test.js
+++ b/plugin/panel/test/openCodeBackend.test.js
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createSessionController } from '../src/lib/sessionController.js';
+import { decideBackendReset } from '../src/lib/backendResetDecision.js';
 import {
   createOpenCodeBackend,
   OPEN_CODE_DISABLED_BUILTIN_TOOL_NAMES,
@@ -283,6 +286,61 @@ function makeBackend(options = {}) {
   });
   return { backend, events, spawned, fetched, fsImpl, terminated };
 }
+
+test('App channel effects wait for session reset before probing and cancel a departed channel', async () => {
+  const app = readFileSync(new URL('../src/app/App.jsx', import.meta.url), 'utf8');
+  const start = app.indexOf('  React.useEffect(() => {', app.indexOf('}, [backendPref, openCodeProbe, openCodeProbeAttempt]);'));
+  const effectsSource = app.slice(start, app.indexOf('  const sendChat =', start));
+  assert.ok(start > 0 && effectsSource.includes('decideBackendReset'));
+  for (const leaveChannel of [false, true]) {
+    const h = makeBackend();
+    let backend = 'subscription';
+    let nextId = 0;
+    let probePromise;
+    const sessionController = createSessionController({
+      store: { loadIndex: () => null, saveIndex() {}, saveTranscript() {} },
+      uuid: () => String(++nextId),
+      deps: {
+        currentBackend: () => backend, currentChannel: () => 'provider', currentModel: () => 'hy3-free',
+        stopActiveTurn: () => h.backend.stop(), resetActiveBackend: () => h.backend.reset(),
+      },
+    });
+    await sessionController.boot();
+    backend = 'opencode';
+    const effects = [];
+    const noop = () => {};
+    const scope = {
+      React: { useEffect: (effect) => effects.push(effect) }, decideBackendReset,
+      pendingSessionLoadRef: { current: null }, lastRealBackendRef: { current: 'subscription' },
+      backendResetPromiseRef: { current: null }, preserveAttachmentDraftRef: { current: false },
+      pendingTurnRef: { current: null }, effective: { backend }, backendPref: backend,
+      claudeBackend: { reset: noop }, codexBackend: { reset: noop }, openCodeBackend: h.backend,
+      resetAttachmentDraftSession: noop, setChatStreaming: noop, setThinkingActive: noop,
+      setTurnStage: noop, setTurnProgress: noop, setSessionModel: noop, setSessionEffort: noop,
+      setSessionFast: noop, sessionController, status: { state: 'ok' }, providerInit: { state: 'ready' },
+      setOpenCodeProbe: noop,
+      runOpenCodeProbe: () => { probePromise = h.backend.probeAccount(); return noop; },
+    };
+    const cleanups = [];
+    try {
+      Function(...Object.keys(scope), effectsSource)(...Object.values(scope));
+      for (const effect of effects) cleanups.push(effect());
+      if (leaveChannel) for (const cleanup of cleanups) cleanup?.();
+      await scope.backendResetPromiseRef.current;
+      await flush();
+      if (leaveChannel) assert.equal(probePromise, undefined);
+      else {
+        assert.ok(probePromise);
+        assert.equal((await probePromise).loggedIn, true);
+        assert.equal(h.spawned.procs.at(-1).killed, false);
+      }
+      assert.equal(h.fetched.calls.some((call) => call.path.endsWith('/message')), false);
+    } finally {
+      for (const cleanup of cleanups) cleanup?.();
+      h.backend.reset();
+    }
+  }
+});
 
 function makeSweepFs(marker, removeImpl) {
   const files = new Map([


### PR DESCRIPTION
Returning from Claude to an already-probed OpenCode channel started a probe before the channel and session resets finished. Those resets cancelled startup, leaving the panel unavailable until a manual recheck.

Run the automatic probe after the reset effect and await the existing session-creation promise. Cancel the pending probe when the selected channel leaves. The existing draft, history restoration, pending-session guards, and manual recheck flow are retained.

Validation: the existing Windows development installation reproduced the failure twice with no model requests or AE writes. The regression executes the actual App effect callbacks with the real session controller and OpenCode backend using fake IO: the original source fails, the fix succeeds, and leaving the channel while waiting does not start a probe. All 108 affected tests and bundle verification pass; independent focused review APPROVE. Full T3 passed (1,079 passed, 93 environment skips, zero failures); required CI run 33957496548 passed all three jobs. Focused Windows AE 26.3x87 hardware replay passed on ebd76bf: one OpenCode to Claude to OpenCode roundtrip restarted the bundled 1.18.23 runtime automatically with zero manual rechecks; the unsent PNG draft survived; loading the owned archived OpenCode conversation preserved its backend reference and all six history entries. Public ae_status passed before and after with no pending JSX calls. Zero model requests, zero AE writes, no unknown side effects. Status: development-verified. Final packaged acceptance remains separate. This is the final observed blocker in the already approved Windows v0.10.7 release; macOS hardware and assets remain deferred.

Scope: App, one existing regression test file, CHANGELOG, and generated app.js; no new runtime, provider, dependency, installer, or delivery mechanism. The original three PR #385 cases remain development-verified; no signed replacement ZXP has been frozen or deployed.